### PR TITLE
Remove unnecessary early call to np.asarray before thick slicing

### DIFF
--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -112,7 +112,7 @@ def guess_labels(data: Any) -> Literal['labels', 'image']:
 
 def project_slice(
     data: npt.NDArray, axis: Tuple[int, ...], mode: ImageProjectionMode
-) -> float:
+) -> npt.NDArray:
     """Project a thick slice along axis based on mode."""
     func: Callable
     if mode == ImageProjectionMode.SUM:

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -295,7 +295,7 @@ class _ImageSliceRequest:
         """
         Slice the given data with the given data slice and project the extra dims.
 
-        This is also responsible for materializing the data in-case it is backed
+        This is also responsible for materializing the data if it is backed
         by a lazy store or compute graph (e.g. dask).
         """
 

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -294,6 +294,9 @@ class _ImageSliceRequest:
     ) -> np.ndarray:
         """
         Slice the given data with the given data slice and project the extra dims.
+
+        This is also responsible for materializing the data in-case it is backed
+        by a lazy store or compute graph (e.g. dask).
         """
 
         if self.projection_mode == 'none':

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -254,7 +254,8 @@ class _ImageSliceRequest:
         )
 
         # slice displayed dimensions to get the right tile data
-        data = np.asarray(data[tuple(disp_slice)])
+        data = data[tuple(disp_slice)]
+
         # project the thick slice
         data_slice = self._thick_slice_at_level(level)
         data = self._project_thick_slice(data, data_slice)
@@ -290,7 +291,7 @@ class _ImageSliceRequest:
 
     def _project_thick_slice(
         self, data: ArrayLike, data_slice: _ThickNDSlice
-    ) -> ArrayLike:
+    ) -> np.ndarray:
         """
         Slice the given data with the given data slice and project the extra dims.
         """


### PR DESCRIPTION
# References and relevant issues
Fixes the issue found in https://github.com/napari/docs/pull/132
Also see the [related discussion on Zulip](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/dask_image.20imread.20and.20multiscale)

Credit to @aganders3 for the fix.

# Description

This removes an extra call to `np.asarray` during multi-scale image slicing. Specifically, there is currently a call that will materialize a lazy array (e.g. a dask array with an associated compute graph) in all dimensions with a sub-view of the displayed/visualized dimensions. For 2D slicing of a large 3D dask array, this could trigger a lot of data fetching or compute.

We could push the call to `asarray` to be even later (e.g. when creating `ImageView` or `ImageSliceResponse`), which might also benefit some lazy computations.

I also added a docstring and changed some type annotations to try to make things a little clearer.

# Detailed logic

The asarray that's removed here uses disp_slice, which only "slices" in the displayed dimensions according to corner_pixels. In any non-displayed dimensions, it will ask for everything, which could be a lot!

The following asarray in _project_thick_slice uses different indices that come from _point_to_slices (non-thick slicing) _data_slice_to_slices (thick slicing). These actually work out how much actual data needs to get fetched/computed for those slices. In the case of non-thick slicing, that should only be a single index in each non-displayed dimension.

To take an example for 2D slicing of 3D data (of shape 1000x1000x1000) with corner pixels, the first instance of asarray (removed here) could look like data[None, 200:400, 300:500] (materializing a numpy array of shape 1000x200x200) whereas the following asarray would either be something like data[100, 200:400, 300:500] for thin/default slicing (materializing a numpy array of shape 1x200x200) or data[95:105, 200:400, 300:500] for thick slicing (materializing a numpy array of shape 10x200x200).