### PR TITLE
Fix npe1 samples menu building

### DIFF
--- a/napari/_qt/_qplugins/_qnpe2.py
+++ b/napari/_qt/_qplugins/_qnpe2.py
@@ -58,23 +58,20 @@ def _rebuild_npe1_samples_menu() -> None:  # pragma: no cover
     if unreg := plugin_manager._unreg_sample_actions:
         unreg()
 
-    # sample_actions: List[Action] = []
+    sample_actions: List[Action] = []
+    sample_submenus: List[Any] = []
     for plugin_name, samples in plugin_manager._sample_data.items():
         multiprovider = len(samples) > 1
         if multiprovider:
             submenu_id = f'napari/file/samples/{plugin_name}'
-            submenu = [
-                (
-                    MenuId.FILE_SAMPLES,
-                    SubmenuItem(
-                        submenu=submenu_id, title=trans._(plugin_name)
-                    ),
-                ),
-            ]
+            submenu = (
+                MenuId.FILE_SAMPLES,
+                SubmenuItem(submenu=submenu_id, title=trans._(plugin_name)),
+            )
+            sample_submenus.append(submenu)
         else:
             submenu_id = MenuId.FILE_SAMPLES
-            submenu = []
-        sample_actions: List[Action] = []
+
         for sample_name, sample_dict in samples.items():
 
             _add_sample_partial = partial(
@@ -97,8 +94,10 @@ def _rebuild_npe1_samples_menu() -> None:  # pragma: no cover
             )
             sample_actions.append(action)
 
-        unreg_sample_submenus = app.menus.append_menu_items(submenu)
+    if sample_submenus:
+        unreg_sample_submenus = app.menus.append_menu_items(sample_submenus)
         plugin_manager._unreg_sample_submenus = unreg_sample_submenus
+    if sample_actions:
         unreg_sample_actions = app.register_actions(sample_actions)
         plugin_manager._unreg_sample_actions = unreg_sample_actions
 

--- a/napari/_qt/_qplugins/_qnpe2.py
+++ b/napari/_qt/_qplugins/_qnpe2.py
@@ -77,23 +77,11 @@ def _rebuild_npe1_samples_menu() -> None:  # pragma: no cover
         sample_actions: List[Action] = []
         for sample_name, sample_dict in samples.items():
 
-            def _add_sample(
-                qt_viewer: QtViewer,
-                plugin: str = plugin_name,
-                sample: str = sample_name,
-            ) -> None:
-                from napari._qt.dialogs.qt_reader_dialog import (
-                    handle_gui_reading,
-                )
-
-                try:
-                    qt_viewer.viewer.open_sample(plugin, sample)
-                except MultipleReaderError as e:
-                    handle_gui_reading(
-                        [str(p) for p in e.paths],
-                        qt_viewer,
-                        stack=False,
-                    )
+            _add_sample_partial = partial(
+                _add_sample,
+                plugin=plugin_name,
+                sample=sample_name,
+            )
 
             display_name = sample_dict['display_name'].replace('&', '&&')
             if multiprovider:
@@ -105,7 +93,7 @@ def _rebuild_npe1_samples_menu() -> None:  # pragma: no cover
                 id=f'{plugin_name}:{display_name}',
                 title=title,
                 menus=[{'id': submenu_id, 'group': MenuGroup.NAVIGATION}],
-                callback=_add_sample,
+                callback=_add_sample_partial,
             )
             sample_actions.append(action)
 


### PR DESCRIPTION
# References and relevant issues
Follows on from #4991 

# Description

* Use `partial` for the npe1 sample menu build
* Fix the looping, we should have one list of submenus and actions, which gets added at the end of all looping (I've tested in env with 2 npe1 plugins). This also allows us to add all actions and submenus to the `unregister` list, so actions are correct when plugin status is changed.


