### PR TITLE
Improve widget clean up in `test_widget_hide_destroy`

### DIFF
--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -156,21 +156,24 @@ def test_get_widget_viewer_param_error():
     assert "'widget_name' must be `QtWidgets.QWidget`" in str(e)
 
 
-def test_widget_hide_destroy(make_napari_viewer):
+def test_widget_hide_destroy(make_napari_viewer, qtbot):
     """Test that widget hide and destroy works."""
     viewer = make_napari_viewer()
     viewer.window.add_dock_widget(QWidget_example(viewer), name='test')
-    widget = viewer.window._dock_widgets['test']
+    dock_widget = viewer.window._dock_widgets['test']
 
     # Check widget persists after hide
-    ww = widget.widget()
-    widget.title.hide_button.click()
-    assert ww
+    widget = dock_widget.widget()
+    dock_widget.title.hide_button.click()
+    assert widget
     # Check that widget removed from `_dock_widgets` dict and parent
     # `QtViewerDockWidget` is `None` when closed
-    widget.destroyOnClose()
+    dock_widget.destroyOnClose()
     assert 'test' not in viewer.window._dock_widgets
-    assert ww.parent() is None
+    assert widget.parent() is None
+    widget.deleteLater()
+    widget.close()
+    qtbot.wait(50)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# References and relevant issues
Follow on from #4991 
see: https://github.com/napari/napari/pull/4991#discussion_r1518553921

# Description
Better naming in `test_widget_hide_destroy`
Adds more widget clean up steps. The tests passes fine currently but Draga suggested it was best to add these back.


