### PR TITLE
[Maint, CI] Fix upgrade_test_constraints.yml to use pyproject.toml

### DIFF
--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -177,7 +177,6 @@ jobs:
           # pyproject.toml resources/constraints/version_denylist.txt - source files. the resources/constraints/version_denylist.txt - contains our test specific constraints like pytes-cov`
           #
           # --extra pyqt5 etc - names of extra sections from pyproject.toml that should be checked for the dependencies list (maybe we could create a super extra section to collect them all in)
-          flags+=" --extra all"
           flags+=" --extra pyqt5"
           flags+=" --extra pyqt6_experimental"
           flags+=" --extra pyside2"
@@ -186,7 +185,7 @@ jobs:
           flags+=" --extra testing_extra"
           flags+=" --extra optional"
           prefix="napari_repo"
-          setup_cfg="${prefix}/pyproject.toml"
+          pyproject_toml="${prefix}/pyproject.toml"
           constraints="${prefix}/resources/constraints"
 
 
@@ -201,12 +200,12 @@ jobs:
 
           for pyv in 3.8 3.9 3.10 3.11; do
             python${pyv}  -m pip install -U pip pip-tools
-            python${pyv}  -m piptools compile --upgrade -o $constraints/constraints_py${pyv}.txt  $setup_cfg $constraints/version_denylist.txt ${flags}
-            python${pyv}  -m piptools compile --upgrade -o $constraints/constraints_py${pyv}_pydantic_1.txt  $setup_cfg $constraints/version_denylist.txt $constraints/pydantic_le_2.txt ${flags}
+            python${pyv}  -m piptools compile --upgrade -o $constraints/constraints_py${pyv}.txt  $pyproject_toml $constraints/version_denylist.txt ${flags}
+            python${pyv}  -m piptools compile --upgrade -o $constraints/constraints_py${pyv}_pydantic_1.txt  $pyproject_toml $constraints/version_denylist.txt $constraints/pydantic_le_2.txt ${flags}
           done
 
-          python3.9 -m piptools compile --upgrade -o $constraints/constraints_py3.9_examples.txt $setup_cfg $constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt ${flags}
-          python3.10 -m piptools compile --upgrade -o $constraints/constraints_py3.10_docs.txt $setup_cfg $constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt docs/requirements.txt $constraints/pydantic_le_2.txt ${flags}
+          python3.9 -m piptools compile --upgrade -o $constraints/constraints_py3.9_examples.txt $pyproject_toml $constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt ${flags}
+          python3.10 -m piptools compile --upgrade -o $constraints/constraints_py3.10_docs.txt $pyproject_toml $constraints/version_denylist.txt resources/constraints/version_denylist_examples.txt docs/requirements.txt $constraints/pydantic_le_2.txt ${flags}
           python3.11 -m piptools compile --upgrade -o resources/requirements_mypy.txt resources/requirements_mypy.in --resolver=backtracking
 
       # END PYTHON DEPENDENCIES

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -149,22 +149,22 @@ jobs:
         with:
           python-version: "3.8"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: pip
-          cache-dependency-path: 'setup.cfg'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Upgrade Python dependencies
         # ADD YOUR CUSTOM DEPENDENCY UPGRADE COMMANDS BELOW
@@ -174,9 +174,10 @@ jobs:
           # python3.8 -m piptools compile - call pip-compile but ensure proper interpreter
           # --upgrade upgrade to the latest possible version. Without this pip-compile will take a look to output files and reuse versions (so will ad something on when adding dependency.
           # -o resources/constraints/constraints_py3.8.txt - output file
-          # setup.cfg resources/constraints/version_denylist.txt - source files. the resources/constraints/version_denylist.txt - contains our test specific constraints like pytes-cov`
+          # pyproject.toml resources/constraints/version_denylist.txt - source files. the resources/constraints/version_denylist.txt - contains our test specific constraints like pytes-cov`
           #
-          # --extra pyqt5 etc - names of extra sections from setup.cfg that should be checked for the dependencies list (maybe we could create a super extra section to collect them all in)
+          # --extra pyqt5 etc - names of extra sections from pyproject.toml that should be checked for the dependencies list (maybe we could create a super extra section to collect them all in)
+          flags+=" --extra all"
           flags+=" --extra pyqt5"
           flags+=" --extra pyqt6_experimental"
           flags+=" --extra pyside2"
@@ -185,7 +186,7 @@ jobs:
           flags+=" --extra testing_extra"
           flags+=" --extra optional"
           prefix="napari_repo"
-          setup_cfg="${prefix}/setup.cfg"
+          setup_cfg="${prefix}/pyproject.toml"
           constraints="${prefix}/resources/constraints"
 
 


### PR DESCRIPTION
# References and relevant issues
The upgrade dependencies/constraints action has been failing:
https://github.com/napari/napari/actions/runs/8289168912/job/22685097128?pr=6748#step:15:93

# Description
Switches from using setup.cfg to pyproject.toml
