### PR TITLE
Keep `qtpy` in headless tests and fix resulting failure

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -142,7 +142,7 @@ jobs:
             platform: ubuntu-20.04
             backend: headless
             coverage: no_cov
-          - python: 3.10
+          - python: "3.10"
             platform: ubuntu-latest
             backend: headless
             coverage: no_cov

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -142,10 +142,6 @@ jobs:
             platform: ubuntu-20.04
             backend: headless
             coverage: no_cov
-          - python: "3.10"
-            platform: ubuntu-latest
-            backend: headless
-            coverage: no_cov
           - python: 3.11
             platform: ubuntu-latest
             backend: pyqt6,pyside6

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -142,6 +142,10 @@ jobs:
             platform: ubuntu-20.04
             backend: headless
             coverage: no_cov
+          - python: 3.10
+            platform: ubuntu-latest
+            backend: headless
+            coverage: no_cov
           - python: 3.11
             platform: ubuntu-latest
             backend: pyqt6,pyside6

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -366,6 +366,8 @@ def _safe_register_qt_actions(mf: PluginManifest) -> None:
     try:
         from napari._qt._qplugins import _register_qt_actions
     except ImportError:  # pragma: no cover
+        # if no Qt bindings are installed (PyQt/PySide), then trying to import
+        # qtpy will raise an ImportError, *not* a ModuleNotFoundError
         pass
     else:
         _register_qt_actions(mf)

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -365,8 +365,7 @@ def _safe_register_qt_actions(mf: PluginManifest) -> None:
     """Register samples and widget `Actions` if Qt available."""
     try:
         from napari._qt._qplugins import _register_qt_actions
-    # except (ImportError, ModuleNotFoundError):  # pragma: no cover
-    except ModuleNotFoundError:  # pragma: no cover
+    except ImportError:  # pragma: no cover
         pass
     else:
         _register_qt_actions(mf)

--- a/napari/plugins/_npe2.py
+++ b/napari/plugins/_npe2.py
@@ -365,6 +365,7 @@ def _safe_register_qt_actions(mf: PluginManifest) -> None:
     """Register samples and widget `Actions` if Qt available."""
     try:
         from napari._qt._qplugins import _register_qt_actions
+    # except (ImportError, ModuleNotFoundError):  # pragma: no cover
     except ModuleNotFoundError:  # pragma: no cover
         pass
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ commands =
 
 [testenv:py{38,39,310,311}-{linux,macos,windows}-headless-{cov,no_cov}]
 commands_pre =
-    pip uninstall -y pyautogui pytest-qt qtpy pyqt5 pyside2 pyside6 pyqt6
+    pip uninstall -y pyautogui pytest-qt pyqt5 pyside2 pyside6 pyqt6
 
 commands =
     cov: coverage run \


### PR DESCRIPTION
# Description

This pull request updates the `tox` configuration for our headless tests to keep `qtpy` in the environment when running tests, and fixes the resulting failure by updating the `_safe_register_qt_actions` function to catch a more generic `ImportError`. 

As we can see in [this test run](https://github.com/napari/napari/actions/runs/8382772241/job/22957514533?pr=6764), if we keep `qtpy` in the environment when running headless tests (mimicking what a user would have if they ran `pip install napari`), tests initially fail because our code was catching a more specific `ModuleNotFoundError`. Users should not have to explicitly uninstall a required dependency to make use of `headless` mode. Now with a more generic `ImportError`, headless is available with or without `qtpy` in the environment.

# References

See [the npe2 PR](https://github.com/napari/npe2/pull/344) where this was first observed for more detail.