### PR TITLE
bump tifffile dependency and remove deprecation-handling code

### DIFF
--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -76,30 +76,10 @@ def imsave_tiff(filename, data):
     """
     import tifffile
 
-    compression_instead_of_compress = False
-    try:
-        current_version = tuple(
-            int(x) for x in tifffile.__version__.split('.')[:3]
-        )
-        compression_instead_of_compress = current_version >= (2021, 6, 6)
-    except Exception:  # noqa: BLE001
-        # Just in case anything goes wrong in parsing version number
-        # like repackaging on linux or anything else we fallback to
-        # using compress
-        warnings.warn(
-            trans._(
-                'Error parsing tiffile version number {version_number}',
-                deferred=True,
-                version_number=f'{tifffile.__version__:!r}',
-            )
-        )
-
-    if compression_instead_of_compress:
-        # 'compression' scheme is more complex. See:
-        # https://forum.image.sc/t/problem-saving-generated-labels-in-cellpose-napari/54892/8
-        tifffile.imwrite(filename, data, compression=('zlib', 1))
-    else:  # older version of tifffile since 2021.6.6  this is deprecated
-        tifffile.imwrite(filename, data, compress=1)
+    # 'compression' kwarg since 2021.6.6; we depend on more recent versions
+    # now. See:
+    # https://forum.image.sc/t/problem-saving-generated-labels-in-cellpose-napari/54892/8
+    tifffile.imwrite(filename, data, compression=('zlib', 1))
 
 
 def __getattr__(name: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "scipy>=1.4.1 ; python_version < '3.9'",
     "scipy>=1.5.4 ; python_version >= '3.9'",
     "superqt>=0.5.0",
-    "tifffile>=2020.2.16",
+    "tifffile>=2022.4.8",
     "toolz>=0.10.0",
     "tqdm>=4.56.0",
     "typing_extensions>=4.2.0",


### PR DESCRIPTION
I had a reason to look at our tiff io code and found this rather horrific
workaround for tifffile updating their compression code a few years ago. 😂
SPEC0/NEP29 suggests we can use a more recent tifffile dependency (see below)
so I took the opportunity to bump tifffile and remove a bunch of code.

```
$ nep29 tifffile
|  version   |    date    |
| :--------: | :--------: |
| 2024.2.12  | 2024-02-12 |
| 2024.1.30  | 2024-01-29 |
| 2023.12.9  | 2023-12-09 |
| 2023.9.18  | 2023-09-19 |
| 2023.8.12  | 2023-08-13 |
|  2023.7.4  | 2023-07-04 |
| 2023.4.12  | 2023-04-13 |
| 2023.3.15  | 2023-03-15 |
|  2023.2.2  | 2023-02-03 |
| 2023.1.23  | 2023-01-23 |
| 2022.10.10 | 2022-10-11 |
|  2022.8.3  | 2022-08-03 |
| 2022.7.28  | 2022-07-29 |
|  2022.5.4  | 2022-05-04 |
|  2022.4.8  | 2022-04-08 |
```
