### PR TITLE
[Maint] fix benchmarks_report workflow: ensure artifactName matches the uploaded artifact name

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,6 +18,9 @@ on:
       contender_ref:
         description: "Contender commit or git reference"
         required: true
+  push:
+    paths:
+      - '.github/workflows/benchmarks**'
 
 # This is the main configuration section that needs to be fine tuned to napari's needs
 # All the *_THREADS options is just to make the benchmarks more robust by not using parallelism

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -28,7 +28,7 @@ jobs:
                repo: context.repo.repo,
                run_id: context.payload.workflow_run.id,
             });
-            let artifactName = `asv-benchmark-results-${context.payload.workflow_run.id}-${context.payload.workflow_run.run_number}-${context.payload.workflow_run.run_attempt}`
+            let artifactName = `asv-benchmark-results-${context.payload.workflow_run.id}-${context.payload.workflow_run.run_number}-${context.payload.workflow_run.run_attempt}-${context.payload.matrix.benchmark-name}`
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == artifactName
             })[0];

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Download artifact"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -32,6 +32,9 @@ jobs:
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == artifactName
             })[0];
+            if (matchArtifact === undefined) {
+              throw TypeError('Build Artifact not found!');
+            }
             let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,


### PR DESCRIPTION
# References and relevant issues
In https://github.com/napari/napari/pull/6697 the uploaded benchmark artifacts in `benchmark` workflow were given unique names. But now `benchmark_report` has an error:
https://github.com/napari/napari/actions/runs/8411757538/job/23031730425#step:2:28
This is because there is no artifact with the name that is used by that workflow.

# Description
Fixes the artifactName to match the uploaded artifact names.