### PR TITLE
DOC Add info to `make_napari_viewer` docstring

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -144,9 +144,9 @@ def make_napari_viewer(
 
     To use this fixture as a function in your tests:
 
-    def test_something_with_a_viewer(make_napari_viewer):
-        # `make_napari_viewer` takes any keyword arguments that napari.Viewer() takes
-        viewer = make_napari_viewer()
+        def test_something_with_a_viewer(make_napari_viewer):
+            # `make_napari_viewer` takes any keyword arguments that napari.Viewer() takes
+            viewer = make_napari_viewer()
 
     It accepts all the same arguments as `napari.Viewer`, notably `show`
     which should be set to `True` for tests that require the `Viewer` to be visible

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -134,16 +134,24 @@ def make_napari_viewer(
     monkeypatch,
     clean_themes,
 ):
-    """A fixture function that creates a napari viewer for use in testing.
+    """A pytest fixture function that creates a napari viewer for use in testing.
 
-    Use this fixture as a function in your tests:
+    This fixture will take care of creating a viewer and cleaning up at the end of the
+    test. When using this function, it is **not** necessary to use a `qtbot` fixture,
+    nor should you do any additional cleanup (such as using `qtbot.addWidget` or
+    calling `viewer.close()`) at the end of the test. Duplicate cleanup may cause
+    an error.
 
+    To use this fixture as a function in your tests:
+
+    def test_something_with_a_viewer(make_napari_viewer):
+        # `make_napari_viewer` takes any keyword arguments that napari.Viewer() takes
         viewer = make_napari_viewer()
 
     It accepts all the same arguments as `napari.Viewer`, notably `show`
     which should be set to `True` for tests that require the `Viewer` to be visible
     (e.g., tests that check aspects of the Qt window or layer rendering).
-    It also accepts the following test-related paramaters:
+    It also accepts the following test-related parameters:
 
     ViewerClass : Type[napari.Viewer], optional
         Override the viewer class being used.  By default, will


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/docs/issues/150

# Description
I would like to include the docstring of `make_napari_viewer` in the docs (so we don't need to update in 2 places). This adds info from the [docs](https://napari.org/dev/developers/contributing/testing.html#testing-with-qt-and-napari-viewer) to the docstring. I can then include just the docstring in the docs.
