### PR TITLE
Switch from black to ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,10 @@
 exclude: _vendor|vendored
 repos:
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.3.0
-  hooks:
-  - id: black
-    pass_filenames: true
-    exclude: examples
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.5
   hooks:
+  - id: ruff-format
+    exclude: examples
   - id: ruff
 - repo: https://github.com/seddonym/import-linter
   rev: v2.0

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -240,7 +240,7 @@ def _run() -> None:
         if not args.paths:
             sys.exit(
                 "error: The '--plugin' argument is only valid "
-                "when providing a file name"
+                'when providing a file name'
             )
         # I *think* that Qt is looking in sys.argv for a flag `--plugins`,
         # which emits "WARNING: No such plugin for spec 'builtins'"

--- a/napari/_qt/_qplugins/_qnpe2.py
+++ b/napari/_qt/_qplugins/_qnpe2.py
@@ -71,7 +71,6 @@ def _rebuild_npe1_samples_menu() -> None:  # pragma: no cover
             submenu_id = MenuId.FILE_SAMPLES
 
         for sample_name, sample_dict in samples.items():
-
             _add_sample_partial = partial(
                 _add_sample,
                 plugin=plugin_name,

--- a/napari/_qt/dialogs/qt_plugin_report.py
+++ b/napari/_qt/dialogs/qt_plugin_report.py
@@ -1,5 +1,4 @@
-"""Provides a QtPluginErrReporter that allows the user report plugin errors.
-"""
+"""Provides a QtPluginErrReporter that allows the user report plugin errors."""
 
 import contextlib
 from typing import Optional

--- a/napari/_qt/perf/qt_performance.py
+++ b/napari/_qt/perf/qt_performance.py
@@ -1,5 +1,4 @@
-"""QtPerformance widget to show performance information.
-"""
+"""QtPerformance widget to show performance information."""
 
 import time
 from typing import ClassVar

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -307,7 +307,7 @@ class QtViewer(QSplitter):
 
     @staticmethod
     def _update_dask_cache_settings(
-        dask_setting: Union[DaskSettings, Event] = None
+        dask_setting: Union[DaskSettings, Event] = None,
     ):
         """Update dask cache to match settings."""
         if not dask_setting:

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -1,5 +1,4 @@
-"""Provides a QtPluginSorter that allows the user to change plugin call order.
-"""
+"""Provides a QtPluginSorter that allows the user to change plugin call order."""
 
 from __future__ import annotations
 

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -1,5 +1,4 @@
-"""VispyCanvas class.
-"""
+"""VispyCanvas class."""
 
 from __future__ import annotations
 

--- a/napari/_vispy/layers/image.py
+++ b/napari/_vispy/layers/image.py
@@ -21,7 +21,6 @@ from napari.utils.translations import trans
 
 
 class ImageLayerNode(ScalarFieldLayerNode):
-
     def __init__(
         self, custom_node: Node = None, texture_format: Optional[str] = None
     ) -> None:

--- a/napari/_vispy/utils/gl.py
+++ b/napari/_vispy/utils/gl.py
@@ -1,5 +1,4 @@
-"""OpenGL Utilities.
-"""
+"""OpenGL Utilities."""
 
 from collections.abc import Generator
 from contextlib import contextmanager

--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -233,6 +233,6 @@ def test_multichannel_index_error_hint():
     with pytest.raises(IndexError) as e:
         viewer.add_image(data, channel_axis=0, name=['a', 'b'])
     assert (
-        "Requested channel_axis (0) had length 5, but the "
+        'Requested channel_axis (0) had length 5, but the '
         "'name' argument only provided 2 values." in str(e)
     )

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -112,7 +112,7 @@ def focus_axes_down(viewer: Viewer):
 # Use non-breaking spaces and non-breaking hyphen for Preferences table
 @register_viewer_action(
     trans._(
-        'Change order of the visible axes, e.g.\u00A0[0,\u00A01,\u00A02]\u00A0\u2011>\u00A0[2,\u00A00,\u00A01].'
+        'Change order of the visible axes, e.g.\u00a0[0,\u00a01,\u00a02]\u00a0\u2011>\u00a0[2,\u00a00,\u00a01].'
     ),
 )
 def roll_axes(viewer: Viewer):
@@ -122,7 +122,7 @@ def roll_axes(viewer: Viewer):
 # Use non-breaking spaces and non-breaking hyphen for Preferences table
 @register_viewer_action(
     trans._(
-        'Transpose order of the last two visible axes, e.g.\u00A0[0,\u00A01]\u00A0\u2011>\u00A0[1,\u00A00].'
+        'Transpose order of the last two visible axes, e.g.\u00a0[0,\u00a01]\u00a0\u2011>\u00a0[1,\u00a00].'
     ),
 )
 def transpose_axes(viewer: Viewer):

--- a/napari/components/experimental/commands.py
+++ b/napari/components/experimental/commands.py
@@ -1,5 +1,4 @@
-"""ExperimentalNamespace and CommandProcessor classes.
-"""
+"""ExperimentalNamespace and CommandProcessor classes."""
 
 HELP_STR = """
 Available Commands

--- a/napari/components/experimental/monitor/_api.py
+++ b/napari/components/experimental/monitor/_api.py
@@ -1,5 +1,4 @@
-"""MonitorApi class.
-"""
+"""MonitorApi class."""
 
 import logging
 from multiprocessing.managers import SharedMemoryManager

--- a/napari/components/experimental/monitor/_utils.py
+++ b/napari/components/experimental/monitor/_utils.py
@@ -1,5 +1,4 @@
-"""Monitor Utilities.
-"""
+"""Monitor Utilities."""
 
 import base64
 import json

--- a/napari/components/experimental/remote/_commands.py
+++ b/napari/components/experimental/remote/_commands.py
@@ -1,5 +1,4 @@
-"""RemoteCommands class.
-"""
+"""RemoteCommands class."""
 
 import json
 import logging

--- a/napari/components/experimental/remote/_manager.py
+++ b/napari/components/experimental/remote/_manager.py
@@ -1,5 +1,4 @@
-"""RemoteManager class.
-"""
+"""RemoteManager class."""
 
 import logging
 

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -671,8 +671,8 @@ def dangling_qtimers(monkeypatch, request):
             return (
                 path
                 + " it's possible that there was a problem with unfinished work by a "
-                "qthrottler; to solve this, you can either try to wait (such as with "
-                "`qtbot.wait`) or disable throttling with the disable_throttling fixture"
+                'qthrottler; to solve this, you can either try to wait (such as with '
+                '`qtbot.wait`) or disable throttling with the disable_throttling fixture'
             )
         return path
 

--- a/napari/layers/_data_protocols.py
+++ b/napari/layers/_data_protocols.py
@@ -1,5 +1,4 @@
-"""This module holds Protocols that layer.data objects are expected to provide.
-"""
+"""This module holds Protocols that layer.data objects are expected to provide."""
 
 from __future__ import annotations
 

--- a/napari/layers/_multiscale_data.py
+++ b/napari/layers/_multiscale_data.py
@@ -95,6 +95,6 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
 
     def __repr__(self) -> str:
         return (
-            f"<MultiScaleData at {hex(id(self))}. "
+            f'<MultiScaleData at {hex(id(self))}. '
             f"{len(self)} levels, '{self.dtype}', shapes: {self.shapes}>"
         )

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -50,7 +50,7 @@ def orient_plane_normal_along_view_direction(
         return None
 
     def sync_plane_normal_with_view_direction(
-        event: Union[None, Event] = None
+        event: Union[None, Event] = None,
     ) -> None:
         """Plane normal syncronisation mouse callback."""
         layer.plane.normal = layer._world_to_displayed_data_ray(

--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -1,5 +1,4 @@
-"""guess_rgb, guess_multiscale, guess_labels.
-"""
+"""guess_rgb, guess_multiscale, guess_labels."""
 
 from collections.abc import Sequence
 from typing import Any, Callable, Literal, Union

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -343,7 +343,7 @@ class _ImageSliceRequest:
 
     @staticmethod
     def _point_to_slices(
-        point: tuple[float, ...]
+        point: tuple[float, ...],
     ) -> tuple[Union[slice, int], ...]:
         # no need to check out of bounds here cause it's guaranteed
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -1,5 +1,4 @@
-"""Image class.
-"""
+"""Image class."""
 
 from __future__ import annotations
 

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -250,7 +250,9 @@ class Labels(ScalarFieldBase):
 
     brush_size_on_mouse_move = BrushSizeOnMouseMove(min_brush_size=1)
 
-    _move_modes: ClassVar[dict[StringEnum, Callable[['Labels', Event], None]]] = {  # type: ignore[assignment]
+    _move_modes: ClassVar[
+        dict[StringEnum, Callable[['Labels', Event], None]]
+    ] = {  # type: ignore[assignment]
         Mode.PAN_ZOOM: no_op,
         Mode.TRANSFORM: highlight_box_handles,
         Mode.PICK: no_op,

--- a/napari/layers/utils/_text_utils.py
+++ b/napari/layers/utils/_text_utils.py
@@ -144,7 +144,7 @@ def _calculate_anchor_lower_right(
 
 
 def _calculate_bbox_extents(
-    view_data: Union[np.ndarray, list]
+    view_data: Union[np.ndarray, list],
 ) -> tuple[npt.NDArray, npt.NDArray]:
     """Calculate the extents of the bounding box"""
     if isinstance(view_data, np.ndarray):

--- a/napari/layers/utils/color_manager_utils.py
+++ b/napari/layers/utils/color_manager_utils.py
@@ -74,7 +74,7 @@ def map_property(
 
 
 def _validate_colormap_mode(
-    values: dict[str, Any]
+    values: dict[str, Any],
 ) -> tuple[np.ndarray, dict[str, Any]]:
     """Validate the ColorManager field values specific for colormap mode
     This is called by the root_validator in ColorManager
@@ -118,7 +118,7 @@ def _validate_colormap_mode(
 
 
 def _validate_cycle_mode(
-    values: dict[str, Any]
+    values: dict[str, Any],
 ) -> tuple[np.ndarray, dict[str, Any]]:
     """Validate the ColorManager field values specific for color cycle mode
     This is called by the root_validator in ColorManager

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -466,7 +466,7 @@ def _validate_property_choices(property_choices):
 
 
 def _coerce_current_properties_value(
-    value: Union[float, str, bool, list, tuple, np.ndarray]
+    value: Union[float, str, bool, list, tuple, np.ndarray],
 ) -> np.ndarray:
     """Coerce a value in a current_properties dictionary into the correct type.
 
@@ -498,7 +498,7 @@ def _coerce_current_properties_value(
 def coerce_current_properties(
     current_properties: Mapping[
         str, Union[float, str, int, bool, list, tuple, npt.NDArray]
-    ]
+    ],
 ) -> dict[str, np.ndarray]:
     """Coerce a current_properties dictionary into the correct type.
 

--- a/napari/plugins/_tests/test_hook_specifications.py
+++ b/napari/plugins/_tests/test_hook_specifications.py
@@ -59,7 +59,7 @@ def test_annotation_on_hook_specification(name, func):
                 ), f'Must not name hook_specification argument "{forbidden}".'
             assert param.annotation is not param.empty, (
                 f"in hook specification '{name}', parameter '{param}' "
-                "has no type annotation"
+                'has no type annotation'
             )
     else:
         assert sig.return_annotation is not sig.empty, (
@@ -76,6 +76,6 @@ def test_docs_match_signature(name, func):
     doc_params = {p.name for p in docs.get('Parameters')}
     assert sig_params == doc_params, (
         f"Signature parameters for hook specification '{name}' do "
-        "not match the parameters listed in the docstring:\n"
-        f"{sig_params} != {doc_params}"
+        'not match the parameters listed in the docstring:\n'
+        f'{sig_params} != {doc_params}'
     )

--- a/napari/plugins/hook_specifications.py
+++ b/napari/plugins/hook_specifications.py
@@ -31,6 +31,7 @@ For more general background on the plugin hook calling mechanism, see the
     ``napari_hook_specification`` and ``napari_hook_implementation``,
     respectively.
 """
+
 # These hook specifications also serve as the API reference for plugin
 # developers, so comprehensive documentation with complete type annotations is
 # imperative!

--- a/napari/types.py
+++ b/napari/types.py
@@ -123,7 +123,7 @@ LayerDataTuple = NewType('LayerDataTuple', tuple)
 
 
 def image_reader_to_layerdata_reader(
-    func: Callable[[PathOrPaths], ArrayLike]
+    func: Callable[[PathOrPaths], ArrayLike],
 ) -> ReaderFunction:
     """Convert a PathLike -> ArrayLike function to a PathLike -> LayerData.
 

--- a/napari/utils/_dask_utils.py
+++ b/napari/utils/_dask_utils.py
@@ -1,5 +1,4 @@
-"""Dask cache utilities.
-"""
+"""Dask cache utilities."""
 
 import collections.abc
 import contextlib

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -33,7 +33,7 @@ def pytest_addoption(parser):
         action='store_true',
         default=False,
         help="Try to save a graph of leaked object's reference (need objgraph"
-        "and graphviz installed",
+        'and graphviz installed',
     )
 
 

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -347,9 +347,9 @@ class ActionManager:
                 action = self._actions.get(name, None)
                 if action and layer == action.keymapprovider:
                     for shortcut in shortcuts:
-                        layer_shortcuts[layer][
-                            str(shortcut)
-                        ] = action.description
+                        layer_shortcuts[layer][str(shortcut)] = (
+                            action.description
+                        )
 
         return layer_shortcuts
 

--- a/napari/utils/colormaps/categorical_colormap_utils.py
+++ b/napari/utils/colormaps/categorical_colormap_utils.py
@@ -53,7 +53,7 @@ class ColorCycle:
 
 
 def _coerce_colorcycle_from_dict(
-    val: dict[str, Union[str, list, np.ndarray, cycle]]
+    val: dict[str, Union[str, list, np.ndarray, cycle]],
 ) -> ColorCycle:
     # validate values
     color_values = val.get('values')
@@ -83,7 +83,7 @@ def _coerce_colorcycle_from_dict(
 
 
 def _coerce_colorcycle_from_colors(
-    val: Union[str, list, np.ndarray]
+    val: Union[str, list, np.ndarray],
 ) -> ColorCycle:
     if isinstance(val, str):
         val = [val]

--- a/napari/utils/compat.py
+++ b/napari/utils/compat.py
@@ -1,5 +1,4 @@
-"""compatibility between newer and older python versions
-"""
+"""compatibility between newer and older python versions"""
 
 import sys
 

--- a/napari/utils/config.py
+++ b/napari/utils/config.py
@@ -1,5 +1,4 @@
-"""Napari Configuration.
-"""
+"""Napari Configuration."""
 
 import os
 import warnings

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -149,7 +149,9 @@ class Selection(EventedSet[_T]):
         yield cls.validate
 
     @classmethod
-    def validate(cls, v: Union['Selection', dict], field: 'ModelField') -> 'Selection':  # type: ignore[override]
+    def validate(
+        cls, v: Union['Selection', dict], field: 'ModelField'
+    ) -> 'Selection':  # type: ignore[override]
         """Pydantic validator."""
         from napari._pydantic_compat import sequence_like
 

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -150,8 +150,10 @@ class Selection(EventedSet[_T]):
 
     @classmethod
     def validate(
-        cls, v: Union['Selection', dict], field: 'ModelField'
-    ) -> 'Selection':  # type: ignore[override]
+        cls,
+        v: Union['Selection', dict],  # type: ignore[override]
+        field: 'ModelField',
+    ) -> 'Selection':
         """Pydantic validator."""
         from napari._pydantic_compat import sequence_like
 

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -48,6 +48,7 @@ to emit events. The EmitterGroup groups EventEmitter objects.
 For more information see http://github.com/vispy/vispy/wiki/API_Events
 
 """
+
 import contextlib
 import inspect
 import os
@@ -1041,7 +1042,9 @@ class EmitterGroup(EventEmitter):
 
             if inspect.isclass(emitter) and issubclass(emitter, Event):  # type: ignore
                 emitter = EventEmitter(
-                    source=self.source, type_name=name, event_class=emitter  # type: ignore
+                    source=self.source,
+                    type_name=name,
+                    event_class=emitter,  # type: ignore
                 )
             elif not isinstance(emitter, EventEmitter):
                 raise RuntimeError(

--- a/napari/utils/interactions.py
+++ b/napari/utils/interactions.py
@@ -395,7 +395,7 @@ def get_key_bindings_summary(keymap, col='rgb(134, 142, 147)'):
             "<tr><td width='80' style='text-align: right; padding: 4px;'>"
             f"<span style='color: rgb(66, 72, 80)'>{keycodes}</span></td>"
             "<td style='text-align: left; padding: 4px; color: #CCC;'>"
-            f"{keymap[key]}</td></tr>"
+            f'{keymap[key]}</td></tr>'
         )
     key_bindings_strs.append('</table>')
     return ''.join(key_bindings_strs)

--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -521,8 +521,7 @@ class KeymapHandler:
         """
         if event.key is None or (
             # on linux press down is treated as multiple press and release
-            event.native is not None
-            and event.native.isAutoRepeat()
+            event.native is not None and event.native.isAutoRepeat()
         ):
             return
         kb = _vispy2appmodel(event)

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -1,5 +1,4 @@
-"""Miscellaneous utility functions.
-"""
+"""Miscellaneous utility functions."""
 
 import builtins
 import collections.abc

--- a/napari/utils/naming.py
+++ b/napari/utils/naming.py
@@ -1,5 +1,4 @@
-"""Automatically generate names.
-"""
+"""Automatically generate names."""
 
 import inspect
 import re

--- a/napari/utils/perf/_config.py
+++ b/napari/utils/perf/_config.py
@@ -1,5 +1,4 @@
-"""Perf configuration flags.
-"""
+"""Perf configuration flags."""
 
 import json
 import os

--- a/napari/utils/perf/_event.py
+++ b/napari/utils/perf/_event.py
@@ -1,5 +1,4 @@
-"""PerfEvent class.
-"""
+"""PerfEvent class."""
 
 import os
 import threading

--- a/napari/utils/perf/_stat.py
+++ b/napari/utils/perf/_stat.py
@@ -1,5 +1,4 @@
-"""Stat class.
-"""
+"""Stat class."""
 
 
 class Stat:

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -1,5 +1,4 @@
-"""PerfTimers class and global instance.
-"""
+"""PerfTimers class and global instance."""
 
 import contextlib
 import os

--- a/napari/utils/perf/_trace_file.py
+++ b/napari/utils/perf/_trace_file.py
@@ -1,5 +1,4 @@
-"""PerfTraceFile class to write the chrome://tracing file format (JSON)
-"""
+"""PerfTraceFile class to write the chrome://tracing file format (JSON)"""
 
 import json
 from time import perf_counter_ns

--- a/napari_builtins/io/_read.py
+++ b/napari_builtins/io/_read.py
@@ -491,7 +491,7 @@ def _magic_imreader(path: str) -> list['LayerData']:
 
 
 def napari_get_reader(
-    path: Union[str, list[str]]
+    path: Union[str, list[str]],
 ) -> Optional['ReaderFunction']:
     """Our internal fallback file reader at the end of the reader plugin chain.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,14 +155,13 @@ release = [
     "requests-cache>=0.9.2",
 ]
 dev = [
-    "black",
+    "ruff",
     "check-manifest>=0.42",
     "pre-commit>=2.9.0",
     "pydantic[dotenv]",
     "napari[testing]",
 ]
 build = [
-    "black",
     "ruff",
     "pyqt5",
 ]
@@ -197,32 +196,6 @@ napari_builtins = [
 
 [tool.setuptools_scm]
 write_to = "napari/_version.py"
-
-[tool.black]
-target-version = ['py39', 'py310', 'py311', 'py312']
-skip-string-normalization = true
-line-length = 79
-exclude = '''
-(
-  /(
-      \.eggs
-    | \.git
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-    | examples
-    | vendored
-    | _vendor
-  )/
-  | napari/resources/qt.py
-  | tools/minreq.py
-)
-'''
 
 [tool.check-manifest]
 ignore = [
@@ -267,8 +240,10 @@ exclude = [
     "*_vendor*",
 ]
 
-target-version = "py39"
 fix = true
+
+[tool.ruff.format]
+quote-style = "single"
 
 [tool.ruff.lint]
 select = [
@@ -300,12 +275,14 @@ ignore = [
     "E501", "TCH001", "TCH002", "TCH003",
     "A003", # flake8-builtins - we have class attributes violating these rule
     "COM812", # flake8-commas - we don't like adding comma on single line of arguments
+    "COM819", # conflicts with ruff-format
     "SIM117", # flake8-simplify - we some of merged with statements are not looking great with black, reanble after drop python 3.9
     "RET504", # not fixed yet https://github.com/charliermarsh/ruff/issues/2950
     "TRY003", # require implement multiple exception class
     "RUF005", # problem with numpy compatybility, see https://github.com/charliermarsh/ruff/issues/2142#issuecomment-1451038741
     "B028", # need to be fixed
     "PYI015", # it produces bad looking files (@jni opinion)
+    "W191", "Q000", "Q001", "Q002", "Q003", "ISC001", # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -134,10 +134,10 @@ skip_install = True
 deps = pre-commit
 commands = pre-commit run ruff --all-files
 
-[testenv:black]
+[testenv:ruff-format]
 skip_install = True
 deps = pre-commit
-commands = pre-commit run black --all-files
+commands = pre-commit run ruff-format --all-files
 
 [testenv:import-lint]
 skip_install = True


### PR DESCRIPTION
# References and relevant issues
Re-opening #6383, now that the issues raised by jni https://github.com/napari/napari/pull/6386#issuecomment-1780604381 are resolved by merging #6407.

# Description

Moves away from black in favour of unifying everything under ruff with ruff-format. See 514938c18 for the actual changes to configurations without all the formatting updates.

The formatting updates come from running `pre-commit run --all-files`.
