### PR TITLE
Implement validation of docstrings and kwargs order

### DIFF
--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -10,6 +10,10 @@ from napari.layers import Image
 from napari.layers.image._image_constants import ImageRendering
 from napari.layers.utils.plane import ClippingPlaneList, SlicingPlane
 from napari.utils import Colormap
+from napari.utils._test_utils import (
+    validate_docstring_all_params_in,
+    validate_kwargs_sorted,
+)
 from napari.utils.transforms.transform_utils import rotate_to_matrix
 
 
@@ -1022,3 +1026,8 @@ def test_thick_slice_multiscale():
     np.testing.assert_array_equal(
         layer._slice.image.raw, np.mean(data[2:5], axis=0)
     )
+
+
+def test_docstring():
+    validate_docstring_all_params_in(Image)
+    validate_kwargs_sorted(Image)

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -11,7 +11,7 @@ from napari.layers.image._image_constants import ImageRendering
 from napari.layers.utils.plane import ClippingPlaneList, SlicingPlane
 from napari.utils import Colormap
 from napari.utils._test_utils import (
-    validate_docstring_all_params_in,
+    validate_all_params_in_docstring,
     validate_kwargs_sorted,
 )
 from napari.utils.transforms.transform_utils import rotate_to_matrix
@@ -1029,5 +1029,5 @@ def test_thick_slice_multiscale():
 
 
 def test_docstring():
-    validate_docstring_all_params_in(Image)
+    validate_all_params_in_docstring(Image)
     validate_kwargs_sorted(Image)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -22,7 +22,7 @@ from napari.layers.labels._labels_constants import LabelsRendering
 from napari.layers.labels._labels_utils import get_contours
 from napari.utils import Colormap
 from napari.utils._test_utils import (
-    validate_docstring_all_params_in,
+    validate_all_params_in_docstring,
     validate_kwargs_sorted,
 )
 from napari.utils.colormaps import (
@@ -1727,5 +1727,5 @@ class TestLabels:
 
 
 def test_docstring():
-    validate_docstring_all_params_in(Labels)
+    validate_all_params_in_docstring(Labels)
     validate_kwargs_sorted(Labels)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -21,6 +21,10 @@ from napari.layers import Labels
 from napari.layers.labels._labels_constants import LabelsRendering
 from napari.layers.labels._labels_utils import get_contours
 from napari.utils import Colormap
+from napari.utils._test_utils import (
+    validate_docstring_all_params_in,
+    validate_kwargs_sorted,
+)
 from napari.utils.colormaps import (
     CyclicLabelColormap,
     DirectLabelColormap,
@@ -1720,3 +1724,8 @@ class TestLabels:
             obj,
             {'seed', 'num_colors', 'color', 'seed_rng'},
         )
+
+
+def test_docstring():
+    validate_docstring_all_params_in(Labels)
+    validate_kwargs_sorted(Labels)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -122,13 +122,13 @@ class Labels(ScalarFieldBase):
         Properties defining plane rendering in 3D. Properties are defined in
         data coordinates. Valid dictionary keys are
         {'position', 'normal', 'thickness', and 'enabled'}.
+    projection_mode : str
+        How data outside the viewed dimensions but inside the thick Dims slice will
+        be projected onto the viewed dimensions
     properties : dict {str: array (N,)} or DataFrame
         Properties for each label. Each property should be an array of length
         N, where N is the number of labels, and the first property corresponds
         to background.
-    projection_mode : str
-        How data outside the viewed dimensions but inside the thick Dims slice will
-        be projected onto the viewed dimensions
     rendering : str
         3D Rendering mode used by vispy. Must be one {'translucent', 'iso_categorical'}.
         'translucent' renders without lighting. 'iso_categorical' uses isosurface
@@ -288,8 +288,8 @@ class Labels(ScalarFieldBase):
         name=None,
         opacity=0.7,
         plane=None,
-        properties=None,
         projection_mode='none',
+        properties=None,
         rendering='iso_categorical',
         rotate=None,
         scale=None,

--- a/napari/utils/_test_utils.py
+++ b/napari/utils/_test_utils.py
@@ -2,10 +2,12 @@
 File with things that are useful for testing, but not to be fixtures
 """
 
+import inspect
 from dataclasses import dataclass, field
 from typing import Optional, Union
 
 import numpy as np
+from docstring_parser import parse
 
 from napari.utils._proxies import ReadOnlyWrapper
 
@@ -35,3 +37,33 @@ def read_only_mouse_event(*args, **kwargs):
     return ReadOnlyWrapper(
         MouseEvent(*args, **kwargs), exceptions=('handled',)
     )
+
+
+def validate_docstring_all_params_in(func):
+    assert func.__doc__ is not None, f'Function {func} has no docstring'
+
+    parsed = parse(func.__doc__)
+    params = [x for x in parsed.params if x.args[0] == 'param']
+    # get only parameters from docstring
+
+    signature = inspect.signature(func)
+    assert set(signature.parameters.keys()) == {
+        x.arg_name for x in params
+    }, 'Parameters in signature and docstring do not match'
+    for sig, doc in zip(signature.parameters.values(), params):
+        assert (
+            sig.name == doc.arg_name
+        ), 'Parameters in signature and docstring do not in same order.'
+        # assert sig.annotation == doc.type_name, f"Type of parameter {sig.name} in signature and docstring do not match"
+
+
+def validate_kwargs_sorted(func):
+    signature = inspect.signature(func)
+    kwargs_list = [
+        x.name
+        for x in signature.parameters.values()
+        if x.kind == inspect.Parameter.KEYWORD_ONLY
+    ]
+    assert kwargs_list == sorted(
+        kwargs_list
+    ), 'Keyword arguments are not sorted in function signature'

--- a/napari/utils/_test_utils.py
+++ b/napari/utils/_test_utils.py
@@ -53,7 +53,7 @@ def validate_docstring_all_params_in(func):
     for sig, doc in zip(signature.parameters.values(), params):
         assert (
             sig.name == doc.arg_name
-        ), 'Parameters in signature and docstring do not in same order.'
+        ), 'Parameters in signature and docstring are not in the same order.'
         # assert sig.annotation == doc.type_name, f"Type of parameter {sig.name} in signature and docstring do not match"
 
 

--- a/napari/utils/_test_utils.py
+++ b/napari/utils/_test_utils.py
@@ -39,7 +39,7 @@ def read_only_mouse_event(*args, **kwargs):
     )
 
 
-def validate_docstring_all_params_in(func):
+def validate_all_params_in_docstring(func):
     assert func.__doc__ is not None, f'Function {func} has no docstring'
 
     parsed = parse(func.__doc__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ testing = [
     "numba>=0.57.1",
     "pooch>=1.6.0",
     "coverage>7",
+    "docstring_parser>=0.15",
     "pretend>=1.0.9",
     "pyautogui>=0.9.54",
     "pytest-qt>=4.3.1",


### PR DESCRIPTION
# References and relevant issues
requested https://github.com/napari/napari/pull/6779#pullrequestreview-1963287570

# Description

This PR adds two test utils functions. 

First is to check if all functions are mentioned in docstring (and if there is not abandoned attribute in docstring). Then it checks if all parameters are in the same order in both signature and docstring. 

The second function checks if keyword-only arguments are declared in alphabetical order.

Both are used for Image layers as it is sorted in #6428. It could be applied to #6779 and other future PR. 