### PR TITLE
Solving visual glitch when displaying tracks with missing timepoints

### DIFF
--- a/napari/_vispy/filters/tracks.py
+++ b/napari/_vispy/filters/tracks.py
@@ -49,6 +49,8 @@ class TracksFilter(Filter):
             if ($a_vertex_time > $current_time + $head_length) {
                 // this is a hack to minimize the frag shader rendering ahead
                 // of the current time point due to interpolation
+                // track should cut off sharply at current_time when head length is 0
+                // see #6696 for details
                 if ($head_length == 0){
                     // this prevents a track from being rendered ahead of the
                     // current time point incorrectly due to the interpolation

--- a/napari/_vispy/filters/tracks.py
+++ b/napari/_vispy/filters/tracks.py
@@ -49,8 +49,10 @@ class TracksFilter(Filter):
             if ($a_vertex_time > $current_time + $head_length) {
                 // this is a hack to minimize the frag shader rendering ahead
                 // of the current time point due to interpolation
-                if ($a_vertex_time <= $current_time + 1){
-                    alpha = -100.;
+                if ($head_length == 0){
+                    // this prevents a track from being rendered ahead of the
+                    // current time point incorrectly due to the interpolation
+                    alpha = -1000.;
                 } else {
                     alpha = 0.;
                 }


### PR DESCRIPTION
# References and relevant issues
This PR addresses #6696, which reported that when displaying tracks with missing timepoints (e.g `[1,2,3,5,6]`), an anomalous track fragment (going forward into the future, even with `head_length=0`) appears at the timepoint just before the gap, as seen on the video below (see original issue for reproducer):

https://github.com/napari/napari/assets/94963445/7b16260c-1758-40ba-98e1-090217d4e3fb

# Description
This PR implements @jni's fix, which modifies the `VERT_SHADER` in `napari/_vispy/filters/tracks.py` to specifically mask vertices ahead of the current time when `head_length=0`.

In practice, it replaces 
```c++
if ($a_vertex_time > $current_time + $head_length) {
    // this is a hack to minimize the frag shader rendering ahead
    // of the current time point due to interpolation
    if ($a_vertex_time <= $current_time + 1){
        alpha = -100.;
    } else {
        alpha = 0.;
    }
```
with
```c++
if ($a_vertex_time > $current_time + $head_length) {
    // this is a hack to minimize the frag shader rendering ahead
    // of the current time point due to interpolation
    if ($head_length == 0){
        alpha = -1000.;
    } else {
        alpha = 0.;
    }
```

# Final Checklist
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
