### PR TITLE
[maint] Fix deploy_docs.yml for change in napari/docs workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -22,6 +22,6 @@ jobs:
           owner: napari
           repo: docs
           github_token: ${{ secrets.ACTIONS_DEPLOY_DOCS }}
-          workflow_file_name: deploy_docs.yml
+          workflow_file_name: build_and_deploy.yml
           trigger_workflow: true
           wait_workflow: true


### PR DESCRIPTION
# References and relevant issues
After merged, docs deployment is failing, see:
https://github.com/napari/napari/actions/runs/8569580333/job/23485774671
This is due to the napari/docs workflow change: https://github.com/napari/docs/pull/348

# Description
In this PR I change the name of the triggered workflow to the correct new name.
