### PR TITLE
Sort docstring and kwargs of Vectors layer

### DIFF
--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -9,6 +9,10 @@ from napari._tests.utils import (
 )
 from napari.components.dims import Dims
 from napari.layers import Vectors
+from napari.utils._test_utils import (
+    validate_all_params_in_docstring,
+    validate_kwargs_sorted,
+)
 from napari.utils.colormaps.standardize_color import transform_color
 
 # Set random seed for testing
@@ -694,3 +698,8 @@ def test_empty_data_from_tuple():
     layer = Vectors(name='vector', ndim=3)
     layer2 = Vectors.create(*layer.as_layer_data_tuple())
     assert layer2.data.size == 0
+
+
+def test_docstring():
+    validate_all_params_in_docstring(Vectors)
+    validate_kwargs_sorted(Vectors)


### PR DESCRIPTION
# References and relevant issues

Similar to #6784, #6786, #6787, #6788, required for #6780

# Description

Sort kwargs of Vectors layer constructor, ensure that arguments in docstrings are in the same order. 

Added docstring for `experimental_clipping_planes`, `feature_defaults` and `projection_mode`