### PR TITLE
Fix some rst syntax in docstrings

### DIFF
--- a/napari/_qt/qthreading.py
+++ b/napari/_qt/qthreading.py
@@ -212,10 +212,10 @@ def thread_worker(
 
     The returned worker will have these signals:
 
-        - *started*: emitted when the work is started
-        - *finished*: emitted when the work is finished
-        - *returned*: emitted with return value
-        - *errored*: emitted with error object on Exception
+    - *started*: emitted when the work is started
+    - *finished*: emitted when the work is finished
+    - *returned*: emitted with return value
+    - *errored*: emitted with error object on Exception
 
     It will also have a ``worker.start()`` method that can be used to start
     execution of the function in another thread. (useful if you need to connect
@@ -224,17 +224,17 @@ def thread_worker(
     If the decorated function is a generator, the returned worker will also
     provide these signals:
 
-        - *yielded*: emitted with yielded values
-        - *paused*: emitted when a running job has successfully paused
-        - *resumed*: emitted when a paused job has successfully resumed
-        - *aborted*: emitted when a running job is successfully aborted
+    - *yielded*: emitted with yielded values
+    - *paused*: emitted when a running job has successfully paused
+    - *resumed*: emitted when a paused job has successfully resumed
+    - *aborted*: emitted when a running job is successfully aborted
 
     And these methods:
 
-        - *quit*: ask the thread to quit
-        - *toggle_paused*: toggle the running state of the thread.
-        - *send*: send a value into the generator.  (This requires that your
-          decorator function uses the ``value = yield`` syntax)
+    - *quit*: ask the thread to quit
+    - *toggle_paused*: toggle the running state of the thread.
+    - *send*: send a value into the generator.  (This requires that your
+        decorator function uses the ``value = yield`` syntax)
 
     Parameters
     ----------

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -531,7 +531,7 @@ class Labels(ScalarFieldBase):
         """Dataframe-like features table.
 
         It is an implementation detail that this is a `pandas.DataFrame`. In the future,
-        we will target the currently-in-development Data API dataframe protocol [1].
+        we will target the currently-in-development Data API dataframe protocol [1]_.
         This will enable us to use alternate libraries such as xarray or cuDF for
         additional features without breaking existing usage of this.
 
@@ -540,7 +540,7 @@ class Labels(ScalarFieldBase):
 
         References
         ----------
-        .. [1]: https://data-apis.org/dataframe-protocol/latest/API.html
+        .. [1] https://data-apis.org/dataframe-protocol/latest/API.html
         """
         return self._feature_table.values
 
@@ -1405,7 +1405,7 @@ class Labels(ScalarFieldBase):
         ----------
         indices : tuple of arrays of int
             Indices in data to overwrite. Must be a tuple of arrays of length
-            equal to the number of data dimensions. (Fancy indexing in [1]_).
+            equal to the number of data dimensions. (Fancy indexing in [2]_).
         value : int or array of int
             New label value(s). If more than one value, must match or
             broadcast with the given indices.
@@ -1414,7 +1414,7 @@ class Labels(ScalarFieldBase):
 
         References
         ----------
-        ..[1] https://numpy.org/doc/stable/user/basics.indexing.html
+        .. [2] https://numpy.org/doc/stable/user/basics.indexing.html
         """
         changed_indices = self.data[indices] != value
         indices = tuple(x[changed_indices] for x in indices)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -158,6 +158,7 @@ class Points(Layer):
         Scale factors for the layer.
     shading : str, Shading
         Render lighting and shading on points. Options are:
+
         * 'none'
           No shading is added to the points.
         * 'spherical'

--- a/napari/layers/vectors/vectors.py
+++ b/napari/layers/vectors/vectors.py
@@ -124,11 +124,11 @@ class Vectors(Layer):
         Determines how vectors are displayed.
 
         * ``VectorStyle.LINE``:
-        Vectors are displayed as lines.
+            Vectors are displayed as lines.
         * ``VectorStyle.TRIANGLE``:
-        Vectors are displayed as triangles.
+            Vectors are displayed as triangles.
         * ``VectorStyle.ARROW``:
-        Vectors are displayed as arrows.
+            Vectors are displayed as arrows.
     length : float
         Multiplicative factor on projections for length of all vectors.
     edge_color : str
@@ -472,11 +472,11 @@ class Vectors(Layer):
         """Vectors display mode: Determines how vectors are displayed.
 
         VectorStyle.LINE
-                Displays vectors as rectangular lines.
-            VectorStyle.TRIANGLE
-                Displays vectors as triangles.
-            VectorStyle.ARROW
-                Displays vectors as arrows.
+            Displays vectors as rectangular lines.
+        VectorStyle.TRIANGLE
+            Displays vectors as triangles.
+        VectorStyle.ARROW
+            Displays vectors as arrows.
         """
         return str(self._vector_style)
 

--- a/napari/utils/events/containers/_selection.py
+++ b/napari/utils/events/containers/_selection.py
@@ -22,7 +22,7 @@ _S = TypeVar('_S')
 class Selection(EventedSet[_T]):
     """A model of selected items, with ``active`` and ``current`` item.
 
-    There can only be one ``active`` and one ``current` item, but there can be
+    There can only be one ``active`` and one ``current`` item, but there can be
     multiple selected items.  An "active" item is defined as a single selected
     item (if multiple items are selected, there is no active item).  The
     "current" item is mostly useful for (e.g.) keyboard actions: even with
@@ -54,8 +54,7 @@ class Selection(EventedSet[_T]):
     Events
     ------
     changed (added: Set[_T], removed: Set[_T])
-        Emitted when the set changes, includes item(s) that have been added
-        and/or removed from the set.
+        Emitted when the set changes, includes item(s) that have been added and/or removed from the set.
     active (value: _T)
         emitted when the current item has changed.
     _current (value: _T)

--- a/napari/utils/transforms/transforms.py
+++ b/napari/utils/transforms/transforms.py
@@ -415,7 +415,7 @@ class Affine(Transform):
 
     References
     ----------
-    [1] https://en.wikipedia.org/wiki/Homogeneous_coordinates.
+    .. [1] https://en.wikipedia.org/wiki/Homogeneous_coordinates.
     """
 
     def __init__(


### PR DESCRIPTION
# Description
This corrects a few warnings we get when building the docs.
