### PR TITLE
[Maint] Update CircleCI config.yml for changes in napari/docs Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,11 @@ jobs:
           environment:
             PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
       - store_artifacts:
-          path: docs/docs/_build/
+          path: docs/docs/_build/html/
       - persist_to_workspace:
           root: .
           paths:
-            - docs/docs/_build/
+            - docs/docs/_build/html/
 workflows:
   build-docs:
     jobs:

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: 0/docs/docs/_build/index.html
+          artifact-path: 0/docs/docs/_build/html/index.html
           circleci-jobs: build-docs
           job-title: Check the rendered docs here!


### PR DESCRIPTION
# References and relevant issues
I noticed CircleCI docs redirector is not working since
https://github.com/napari/docs/pull/348
See, e.g. https://output.circle-artifacts.com/output/job/f7b7b3bf-0e97-4ca0-a6dd-2f30998c625d/artifacts/0/docs/docs/_build/index.html?pr=6807

The docs build correctly, but the structure is different because of the change to the Makefile to put the html in `/html`

# Description
Updates config.yml to match the one in napari/docs
https://github.com/napari/docs/blob/main/.circleci/config.yml
and also fixes the redirector workflow to point to the right location.