### PR TITLE
Add possibility to test consistency of docstring content between base class and class

### DIFF
--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -25,6 +25,7 @@ from napari.layers.utils.color_encoding import ConstantColorEncoding
 from napari.layers.utils.color_manager import ColorProperties
 from napari.utils._test_utils import (
     validate_all_params_in_docstring,
+    validate_docstring_parent_class_consistency,
     validate_kwargs_sorted,
 )
 from napari.utils.colormaps.standardize_color import transform_color
@@ -2647,3 +2648,4 @@ def test_events_callback(old_name, new_name, value):
 def test_docstring():
     validate_all_params_in_docstring(Points)
     validate_kwargs_sorted(Points)
+    validate_docstring_parent_class_consistency(Points)

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -85,7 +85,7 @@ class Points(Layer):
     blending : str
         One of a list of preset blending modes that determines how RGB and
         alpha values of the layer visual get mixed. Allowed values are
-        {'opaque', 'translucent', and 'additive'}.
+        {'opaque', 'translucent', 'translucent_no_depth', 'additive', and 'minimum'}.
     border_color : str, array-like, dict
         Color of the point marker border. Numeric color values should be RGB(A).
     border_color_cycle : np.ndarray, list
@@ -134,7 +134,7 @@ class Points(Layer):
         This property will soon be deprecated in favor of 'out_of_slice_display'.
         Use that instead.
     name : str
-        Name of the layer.
+        Name of the layer. If not provided then will be guessed using heuristics
     opacity : float
         Opacity of the layer visual, between 0.0 and 1.0.
     out_of_slice_display : bool

--- a/napari/utils/_test_utils.py
+++ b/napari/utils/_test_utils.py
@@ -110,7 +110,7 @@ def validate_docstring_parent_class_consistency(klass, skip=('data', 'ndim')):
                 continue
             assert (
                 doc.description == base_parsed[name].description
-            ), f'Description of parameter {name} in {klass} and {base_klass} do not match'
+            ), f'Description of parameter "{name}" in {klass} and {base_klass} do not match'
             assert (
                 doc.type_name == base_parsed[name].type_name
-            ), f'Type of parameter {name} in {klass} and {base_klass} do not match'
+            ), f'Type annotation of parameter "{name}" in {klass} ({doc.type_name}) and {base_klass} ({base_parsed[name].type_name}) do not match'

--- a/napari/utils/_test_utils.py
+++ b/napari/utils/_test_utils.py
@@ -77,7 +77,7 @@ def validate_kwargs_sorted(func):
 
 def validate_docstring_parent_class_consistency(klass, skip=('data', 'ndim')):
     """
-    Validate is the docstrings of the class parameters and type information
+    Validate if the docstrings of the class parameters and type information
     are consistent with the parent class.
 
     Parameters

--- a/napari/utils/_test_utils.py
+++ b/napari/utils/_test_utils.py
@@ -67,3 +67,27 @@ def validate_kwargs_sorted(func):
     assert kwargs_list == sorted(
         kwargs_list
     ), 'Keyword arguments are not sorted in function signature'
+
+
+def validate_docstring_parent_class_consistency(klass, skip=('data', 'ndim')):
+    parsed = parse(klass.__doc__)
+    params = {
+        x.arg_name: x
+        for x in parsed.params
+        if x.args[0] == 'param' and x.arg_name not in skip
+    }
+    for base_klass in klass.__bases__:
+        base_parsed = {
+            x.arg_name: x
+            for x in parse(base_klass.__doc__).params
+            if x.args[0] == 'param'
+        }
+        for name, doc in params.items():
+            if name not in base_parsed:
+                continue
+            assert (
+                doc.description == base_parsed[name].description
+            ), f'Description of parameter {name} in {klass} and {base_klass} do not match'
+            assert (
+                doc.type_name == base_parsed[name].type_name
+            ), f'Type of parameter {name} in {klass} and {base_klass} do not match'

--- a/napari/utils/_test_utils.py
+++ b/napari/utils/_test_utils.py
@@ -40,6 +40,9 @@ def read_only_mouse_event(*args, **kwargs):
 
 
 def validate_all_params_in_docstring(func):
+    """
+    Validate if all the parameters in the function signature are present in the docstring.
+    """
     assert func.__doc__ is not None, f'Function {func} has no docstring'
 
     parsed = parse(func.__doc__)
@@ -58,6 +61,9 @@ def validate_all_params_in_docstring(func):
 
 
 def validate_kwargs_sorted(func):
+    """
+    Validate if the keyword arguments in the function signature are sorted alphabetically.
+    """
     signature = inspect.signature(func)
     kwargs_list = [
         x.name
@@ -70,6 +76,23 @@ def validate_kwargs_sorted(func):
 
 
 def validate_docstring_parent_class_consistency(klass, skip=('data', 'ndim')):
+    """
+    Validate is the docstrings of the class parameters and type information
+    are consistent with the parent class.
+
+    Parameters
+    ----------
+    klass : type
+        The class to validate.
+    skip : tuple or set, optional
+        Name of parameters that we know are different from the parent class.
+        By default, ('data', 'ndim').
+
+    Raises
+    ------
+    AssertionError
+        If the docstrings of the parameters are not consistent with the parent class.
+    """
     parsed = parse(klass.__doc__)
     params = {
         x.arg_name: x


### PR DESCRIPTION
# Description

This PR add `validate_docstring_parent_class_consistency` function that is designed to validate consistency between base class and class docstring. 

In many places we update docstring in one class, but not in another. Good example is docstring of blending for Points layer, that is updated in this PR. 