### PR TITLE
Add workflow for automatically remove `ready to merge` label

### DIFF
--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,0 +1,29 @@
+name: Remove "ready to merge" label
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { owner, repo, number: pull_number } = context.issue;
+            const { data: pullRequest } = await github.rest.pulls.get({ owner, repo, pull_number });
+            if (!pullRequest.merged) {
+              console.log("Pull request not merged, skipping.");
+              return;
+            }
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: pull_number });
+            const labelToRemove = labels.find(label => label.name === "ready to merge");
+            if (!labelToRemove) {
+              console.log("Label not found on pull request, skipping.");
+              return;
+            }
+            await github.rest.issues.removeLabel({ owner, repo, issue_number: pull_number, name: "ready to merge" });
+            console.log("Label removed.");


### PR DESCRIPTION
# Description

Time to time, I find that some of the core dev (sometime me) forget to remove the "ready to merge" label after merge. This PR introduces workflow to do this. 

Looking at the documentation, it should work. I do not know how to test it without merge. 