### PR TITLE
fix "Remove ready to merge label"

### DIFF
--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  pull-requests: write
+
 jobs:
   remove_label:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Remove label
         uses: actions/github-script@v5


### PR DESCRIPTION
# Description

Workflow is still not workig. I check and in `edit_pr_description` we put permissions on the top level, so I move it there. 