### PR TITLE
Add compatibility for PySide6 6.5+

### DIFF
--- a/napari/_qt/containers/_base_item_model.py
+++ b/napari/_qt/containers/_base_item_model.py
@@ -29,7 +29,7 @@ _BASE_FLAGS = (
 )
 
 
-class _BaseEventedItemModel(QAbstractItemModel, Generic[ItemType]):
+class _BaseEventedItemModel(Generic[ItemType], QAbstractItemModel):
     """A QAbstractItemModel desigend to work with `SelectableEventedList`.
 
     :class:`~napari.utils.events.SelectableEventedList` is our pure python


### PR DESCRIPTION
# References and relevant issues
I understand the reasons for closing https://github.com/napari/napari/pull/6062

but it seems to me that this one particular line should be merged in regardless unless an upcoming fix is coming in 6.7.1+ that I am unaware of.

# Description

There seems to be 2 more fixes that I haven't had time to go through, but I know in my testing that without this modification, Napari simply doesn't open with pyside 6.7+ locally.


