### PR TITLE
Remove "ready to merge" label action part 3

### DIFF
--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,7 +1,7 @@
 name: Remove "ready to merge" label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove label
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
# Description

Bump action to version 7. 

Use `pull_request_target` instead of `pull_request` as trigger because of permissions. 