### PR TITLE
Expose NotebookScreenshot docstring

### DIFF
--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -5,7 +5,7 @@ from napari.utils.colormaps.colormap import (
     DirectLabelColormap,
 )
 from napari.utils.info import citation_text, sys_info
-from napari.utils.notebook_display import nbscreenshot
+from napari.utils.notebook_display import nbscreenshot, NotebookScreenshot
 from napari.utils.progress import cancelable_progress, progrange, progress
 
 __all__ = (
@@ -15,6 +15,7 @@ __all__ = (
     'cancelable_progress',
     'citation_text',
     'nbscreenshot',
+    'NotebookScreenshot',
     'progrange',
     'progress',
     'resize_dask_cache',

--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -5,7 +5,7 @@ from napari.utils.colormaps.colormap import (
     DirectLabelColormap,
 )
 from napari.utils.info import citation_text, sys_info
-from napari.utils.notebook_display import nbscreenshot, NotebookScreenshot
+from napari.utils.notebook_display import NotebookScreenshot, nbscreenshot
 from napari.utils.progress import cancelable_progress, progrange, progress
 
 __all__ = (

--- a/napari/utils/notebook_display.py
+++ b/napari/utils/notebook_display.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:
 
 from napari.utils.io import imsave_png
 
-__all__ = ['nbscreenshot']
+__all__ = ['nbscreenshot', 'NotebookScreenshot']
 
 
 class NotebookScreenshot:
@@ -35,17 +35,16 @@ class NotebookScreenshot:
 
     Examples
     --------
-    ```
-    import napari
-    from napari.utils import nbscreenshot
-    from skimage.data import chelsea
 
-    viewer = napari.view_image(chelsea(), name='chelsea-the-cat')
-    nbscreenshot(viewer)
+    >>> import napari
+    >>> from napari.utils import nbscreenshot
+    >>> from skimage.data import chelsea
 
+    >>> viewer = napari.view_image(chelsea(), name='chelsea-the-cat')
+    >>> nbscreenshot(viewer)
     # screenshot just the canvas with the napari viewer framing it
-    nbscreenshot(viewer, canvas_only=False)
-    ```
+    >>> nbscreenshot(viewer, canvas_only=False)
+
     """
 
     def __init__(


### PR DESCRIPTION
# References and relevant issues
Closes napari/docs#376

# Description
Exposes the docstring of NotebookScreenshot, which now apppears as a link in the nbscreenshot docstring.

I understand NotebookScreenshot may not be something we want to expose. In that case, I would suggest moving the docstring to nbscreenshot as an alternative.

Also fixes a few syntax errors in the NotebookScreenshot docstring.