### PR TITLE
Do not crash test on graphviz installation fail

### DIFF
--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
+        continue-on-error: true
 
       # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL


### PR DESCRIPTION
# References and relevant issues

# Description
In #6554 I have added the graphviz installation step to produce a leaked widgets graph. Unfortunately, brew is reporting some errors on installing python 3.12 during installation of graphviz. 

This PR makes graphviz installation steep optional. So in post cases we will still have leaked widgets graph, but do not crash the test suite. 
