### PR TITLE
Enable ruff SLOT linting rule

### DIFF
--- a/napari/settings/_fields.py
+++ b/napari/settings/_fields.py
@@ -14,6 +14,8 @@ class Theme(str):
 
     # https://pydantic-docs.helpmanual.io/usage/types/#custom-data-types
 
+    __slots__ = ()
+
     @classmethod
     def __get_validators__(cls):
         yield cls.validate
@@ -49,6 +51,8 @@ class Language(str):
     """
 
     # https://pydantic-docs.helpmanual.io/usage/types/#custom-data-types
+
+    __slots__ = ()
 
     @classmethod
     def __get_validators__(cls):

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -170,6 +170,16 @@ class TranslationString(str):
     of the arguments to __new__ and __init__ in this class.
     """
 
+    __slots__ = (
+        '_domain',
+        '_msgctxt',
+        '_msgid',
+        '_msgid_plural',
+        '_n',
+        '_deferred',
+        '_kwargs',
+    )
+
     def __deepcopy__(self, memo):
         from copy import deepcopy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,7 @@ select = [
     "TRY", # tryceratops
     "ICN", # flake8-import-conventions
     "RUF", # ruff specyfic rules
+    "SLOT", # flake8-slots
 ]
 ignore = [
     "E501", "TCH001", "TCH002", "TCH003",


### PR DESCRIPTION
# References and relevant issues

Updating ruff linting rules is tracked by #5589.

Documentation for the SLOT linting rule can be found at:
https://docs.astral.sh/ruff/rules/#flake8-slots-slot

> Subclasses of `str` should define `__slots__`
> Subclasses of `tuple` should define `__slots__`
> Subclasses of `{namedtuple_kind}` should define `__slots__`

# Description

The benefit of these rules is memory savings, because classes with `__slots__` are more compact than classes with arbitrary attribute dictionaries. This is typically a small benefit, but could speed up some stuff like translations.
