### PR TITLE
Fix selection size when canvas limits are set for Points

### DIFF
--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -192,7 +192,18 @@ class VispyPointsLayer(VispyBaseLayer):
         self.node.spherical = shading == 'spherical'
 
     def _on_canvas_size_limits_change(self):
-        self.node.canvas_size_limits = self.layer.canvas_size_limits
+        self.node.points_markers.canvas_size_limits = (
+            self.layer.canvas_size_limits
+        )
+        scaled_highlight = (
+            get_settings().appearance.highlight.highlight_thickness
+            * self.layer.scale_factor
+        )
+        low, high = self.layer.canvas_size_limits
+        self.node.selection_markers.canvas_size_limits = (
+            low,
+            high + scaled_highlight,
+        )
 
     def reset(self):
         super().reset()

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -201,7 +201,7 @@ class VispyPointsLayer(VispyBaseLayer):
         )
         low, high = self.layer.canvas_size_limits
         self.node.selection_markers.canvas_size_limits = (
-            low,
+            low + scaled_highlight,
             high + scaled_highlight,
         )
 

--- a/napari/_vispy/visuals/points.py
+++ b/napari/_vispy/visuals/points.py
@@ -87,3 +87,4 @@ class PointsVisual(ClippingPlanesMixin, Compound):
     @canvas_size_limits.setter
     def canvas_size_limits(self, value: tuple[int, int]) -> None:
         self.points_markers.canvas_size_limits = value
+        self.selection_markers.canvas_size_limits = value


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/6682

# Description
The selection markers were not updated accordingly.

This is still not perfect (zooming in and out beyond the limits will change the thickness of the highlight), but it's a limitation of how hilight is implemented (by just using extra markers). Ideally we want to have a single marker take care of hilight as well, but this requires rewriting the shaders and it's not trivial.
