### PR TITLE
Ensure bounding_box lines stay up to date between 2D and 3D

### DIFF
--- a/napari/_vispy/overlays/bounding_box.py
+++ b/napari/_vispy/overlays/bounding_box.py
@@ -31,7 +31,6 @@ class VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
             bounds = np.pad(bounds, ((1, 0), (0, 0)))
 
         self.node.set_bounds(bounds[::-1])  # invert for vispy
-        self._on_lines_change()
 
     def _on_lines_change(self):
         self.node.lines.visible = self.overlay.lines
@@ -40,10 +39,12 @@ class VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
         self.node.markers.visible = self.overlay.points
 
     def _on_line_thickness_change(self):
-        self.node.lines.set_data(width=self.overlay.line_thickness)
+        self.node._line_thickness = self.overlay.line_thickness
+        self._on_bounds_change()
 
     def _on_line_color_change(self):
-        self.node.lines.set_data(color=self.overlay.line_color)
+        self.node._line_color = self.overlay.line_color
+        self._on_bounds_change()
 
     def _on_point_size_change(self):
         self.node._marker_size = self.overlay.point_size

--- a/napari/_vispy/visuals/bounding_box.py
+++ b/napari/_vispy/visuals/bounding_box.py
@@ -33,6 +33,8 @@ class BoundingBox(Compound):
     )
 
     def __init__(self, *args, **kwargs):
+        self._line_color = 'red'
+        self._line_thickness = 2
         self._marker_color = (1, 1, 1, 1)
         self._marker_size = 1
 
@@ -54,7 +56,10 @@ class BoundingBox(Compound):
         vertices = np.array(list(product(*bounds)))
 
         self.lines.set_data(
-            pos=vertices, connect=self._edges.copy(), color='red', width=2
+            pos=vertices,
+            connect=self._edges.copy(),
+            color=self._line_color,
+            width=self._line_thickness,
         )
         self.lines.visible = True
 


### PR DESCRIPTION
# References and relevant issues
Fixes #6852.

# Description
The overlay already had this mechanism to ensure the vertex points stayed up to date; I just forgot to do the same for lines.

I also removed a superfluous line that was left over from a previous implementation.
