### PR TITLE
Fix zarr reading with unrelated files

### DIFF
--- a/napari_builtins/_tests/test_io.py
+++ b/napari_builtins/_tests/test_io.py
@@ -91,6 +91,20 @@ def test_zarr_nested(tmp_path):
     np.testing.assert_array_equal(image, image_in)
 
 
+def test_zarr_with_unrelated_file(tmp_path):
+    image = np.random.random((10, 20, 20))
+    image_name = 'my_image'
+    root_path = tmp_path / 'dataset.zarr'
+    grp = zarr.open(str(root_path), mode='a')
+    grp.create_dataset(image_name, data=image)
+
+    txt_file_path = root_path / 'unrelated.txt'
+    txt_file_path.touch()
+
+    image_in = magic_imread([str(root_path)])
+    np.testing.assert_array_equal(image, image_in[0])
+
+
 def test_zarr_multiscale():
     multiscale = [
         np.random.random((20, 20)),

--- a/napari_builtins/io/_read.py
+++ b/napari_builtins/io/_read.py
@@ -103,7 +103,7 @@ def _guess_zarr_path(path: str) -> bool:
     return any(part.endswith('.zarr') for part in Path(path).parts)
 
 
-def read_zarr_dataset(path):
+def read_zarr_dataset(path: str):
     """Read a zarr dataset, including an array or a group of arrays.
 
     Parameters
@@ -119,16 +119,17 @@ def read_zarr_dataset(path):
     shape : tuple
         Shape of array or first array in list
     """
-    if os.path.exists(os.path.join(path, '.zarray')):
+    path = Path(path)
+    if (path / '.zarray').exists():
         # load zarr array
         image = da.from_zarr(path)
         shape = image.shape
-    elif os.path.exists(os.path.join(path, '.zgroup')):
+    elif (path / '.zgroup').exists():
         # else load zarr all arrays inside file, useful for multiscale data
         image = [
-            read_zarr_dataset(os.path.join(path, subpath))[0]
-            for subpath in sorted(os.listdir(path))
-            if not subpath.startswith('.')
+            read_zarr_dataset(subpath)[0]
+            for subpath in sorted(path.iterdir())
+            if not subpath.name.startswith('.') and subpath.is_dir()
         ]
         assert image, 'No arrays found in zarr group'
         shape = image[0].shape


### PR DESCRIPTION
Also add a test reading a zarr dataset that contains an unrelated file.

# References and relevant issues
Closes #6850.

# Description
This PR implements the fix suggested by @jni in https://github.com/napari/napari/issues/6850#issuecomment-2062805100, including changes from `os.path` to `pathlib.Path`.


