### PR TITLE
Check prereleases testing with macOS + Python 3.12 + PyQt6

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -27,13 +27,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-latest, macos-14, ubuntu-latest]
         python: [3.12]
         backend: [pyqt5, pyqt6]
-        exclude:
-          - platform: macos-latest
-            python: 3.12
-            backend: pyqt6
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-14, ubuntu-latest]
+        platform: [windows-latest, macos-latest, ubuntu-latest]
         python: [3.12]
         backend: [pyqt5, pyqt6]
 

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -125,7 +125,7 @@ jobs:
             backend: pyqt6
             coverage: no_cov
           - python: "3.12"
-            platform: macos-12
+            platform: macos-13
             backend: pyqt5
             coverage: no_cov
           # minimum specified requirements

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -125,7 +125,7 @@ jobs:
             backend: pyqt6
             coverage: no_cov
           - python: "3.12"
-            platform: macos-latest
+            platform: macos-12
             backend: pyqt5
             coverage: no_cov
           # minimum specified requirements

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -143,9 +143,9 @@ def test_keybinding_with_modifiers(
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     window = QApplication.focusWindow()
     # editor = widget._table.focusWidget()
-    # qtbot.wait(1000)
-    qtbot.keyClick(window, key, modifier=modifier, delay=10)
-    # qtbot.wait(1000)
+    qtbot.wait(1000)
+    qtbot.keyClick(window, key, modifier=modifier)
+    qtbot.wait(1000)
     # qtbot.stop()
 
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -142,9 +142,9 @@ def test_keybinding_with_modifiers(
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     editor = widget._table.focusWidget()
+    qtbot.wait(1000)
     with qtbot.waitSignal(editor.editingFinished):
         qtbot.keyClick(editor, key, modifier=modifier)
-        QApplication.processEvents()
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -131,14 +131,18 @@ def test_keybinding_with_modifiers(
     x = widget._table.columnViewportPosition(widget._shortcut_col)
     y = widget._table.rowViewportPosition(0)
     item_pos = QPoint(x, y)
-    qtbot.mouseClick(
-        widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    )
-    qtbot.mouseDClick(
-        widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    )
-    qtbot.waitUntil(lambda: QApplication.focusWidget() is not None)
-    qtbot.keyClick(QApplication.focusWidget(), key, modifier=modifier)
+    # qtbot.mouseClick(
+    #     widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
+    # )
+    # qtbot.mouseDClick(
+    #     widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
+    # )
+    index = widget._table.indexAt(item_pos)
+    widget._table.setCurrentIndex(index)
+    widget._table.edit(index)
+    qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
+    editor = widget._table.focusWidget()
+    qtbot.keyClick(editor, key, modifier=modifier)
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -144,6 +144,7 @@ def test_keybinding_with_modifiers(
     editor = widget._table.focusWidget()
     with qtbot.waitSignal(editor.editingFinished):
         qtbot.keyClick(editor, key, modifier=modifier)
+        QApplication.processEvents()
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -141,17 +141,26 @@ def test_keybinding_with_modifiers(
     widget._table.setCurrentIndex(index)
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
-    window = QApplication.focusWindow()
+    editor = widget._table.focusWidget()
+    # focus_object = focus_window.focusObject()
     # editor = widget._table.focusWidget()
-    qtbot.wait(1000)
-    qtbot.keyClick(window, key, modifier=modifier)
-    qtbot.wait(1000)
+    # qtbot.wait(1000)
+    qtbot.keyPress(editor, key, modifier=modifier)
+    from qtpy.QtWidgets import QAbstractItemDelegate
+
+    widget._table.commitData(editor)
+    widget._table.closeEditor(editor, QAbstractItemDelegate.NoHint)
+    # qtbot.wait(1000)
+    # qtbot.keyRelease(editor, Qt.Key.Key_Enter)
+    # qtbot.wait(1000)
+
     # qtbot.stop()
 
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()
     for key_symbol in key_symbols:
+        print(shortcut)
         assert key_symbol in shortcut
 
 

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pyautogui
 import pytest
 from qtpy.QtCore import QPoint, Qt
-from qtpy.QtWidgets import QApplication, QMessageBox
+from qtpy.QtWidgets import QAbstractItemDelegate, QApplication, QMessageBox
 
 from napari._qt.widgets.qt_keyboard_settings import ShortcutEditor, WarnPopup
 from napari._tests.utils import skip_local_focus, skip_on_mac_ci
@@ -95,30 +95,30 @@ def test_restore_defaults(shortcut_editor_widget):
             META_CONTROL_KEY,
             [KEY_SYMBOLS['Ctrl'], 'U'],
         ),
-        # (
-        #     Qt.Key.Key_Y,
-        #     META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
-        #     [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], 'Y'],
-        # ),
-        # (
-        #     Qt.Key.Key_Backspace,
-        #     META_CONTROL_KEY,
-        #     [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Backspace']],
-        # ),
-        # (
-        #     Qt.Key.Key_Delete,
-        #     META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
-        #     [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], KEY_SYMBOLS['Delete']],
-        # ),
-        # (
-        #     Qt.Key.Key_Backspace,
-        #     META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
-        #     [
-        #         KEY_SYMBOLS['Ctrl'],
-        #         KEY_SYMBOLS['Shift'],
-        #         KEY_SYMBOLS['Backspace'],
-        #     ],
-        # ),
+        (
+            Qt.Key.Key_Y,
+            META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
+            [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], 'Y'],
+        ),
+        (
+            Qt.Key.Key_Backspace,
+            META_CONTROL_KEY,
+            [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Backspace']],
+        ),
+        (
+            Qt.Key.Key_Delete,
+            META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
+            [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], KEY_SYMBOLS['Delete']],
+        ),
+        (
+            Qt.Key.Key_Backspace,
+            META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
+            [
+                KEY_SYMBOLS['Ctrl'],
+                KEY_SYMBOLS['Shift'],
+                KEY_SYMBOLS['Backspace'],
+            ],
+        ),
     ],
 )
 def test_keybinding_with_modifiers(
@@ -131,36 +131,19 @@ def test_keybinding_with_modifiers(
     x = widget._table.columnViewportPosition(widget._shortcut_col)
     y = widget._table.rowViewportPosition(0)
     item_pos = QPoint(x, y)
-    # qtbot.mouseClick(
-    #     widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    # )
-    # qtbot.mouseDClick(
-    #     widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    # )
     index = widget._table.indexAt(item_pos)
     widget._table.setCurrentIndex(index)
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     editor = widget._table.focusWidget()
-    # focus_object = focus_window.focusObject()
-    # editor = widget._table.focusWidget()
-    # qtbot.wait(1000)
     qtbot.keyPress(editor, key, modifier=modifier)
-    from qtpy.QtWidgets import QAbstractItemDelegate
-
     widget._table.commitData(editor)
     widget._table.closeEditor(editor, QAbstractItemDelegate.NoHint)
-    # qtbot.wait(1000)
-    # qtbot.keyRelease(editor, Qt.Key.Key_Enter)
-    # qtbot.wait(1000)
-
-    # qtbot.stop()
 
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()
     for key_symbol in key_symbols:
-        print(shortcut)
         assert key_symbol in shortcut
 
 
@@ -191,21 +174,21 @@ def test_keybinding_with_only_modifiers(
     x = widget._table.columnViewportPosition(widget._shortcut_col)
     y = widget._table.rowViewportPosition(0)
     item_pos = QPoint(x, y)
-    qtbot.mouseClick(
-        widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    )
-    qtbot.mouseDClick(
-        widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    )
-    qtbot.waitUntil(lambda: QApplication.focusWidget() is not None)
+    index = widget._table.indexAt(item_pos)
+    widget._table.setCurrentIndex(index)
+    widget._table.edit(index)
+    qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
+    editor = widget._table.focusWidget()
+
     with patch.object(WarnPopup, 'exec_') as mock:
-        qtbot.keyClick(
-            QApplication.focusWidget(), Qt.Key_Enter, modifier=modifiers
-        )
+        qtbot.keyPress(editor, Qt.Key_Enter, modifier=modifiers)
+        widget._table.commitData(editor)
+        widget._table.closeEditor(editor, QAbstractItemDelegate.NoHint)
         if valid:
             assert not mock.called
         else:
             assert mock.called
+
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()
@@ -229,15 +212,13 @@ def test_remove_shortcut(shortcut_editor_widget, qtbot, removal_trigger_key):
     x = widget._table.columnViewportPosition(widget._shortcut_col)
     y = widget._table.rowViewportPosition(0)
     item_pos = QPoint(x, y)
-    qtbot.mouseClick(
-        widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    )
-    qtbot.mouseDClick(
-        widget._table.viewport(), Qt.MouseButton.LeftButton, pos=item_pos
-    )
-    qtbot.waitUntil(lambda: QApplication.focusWidget() is not None)
-    qtbot.keyClick(QApplication.focusWidget(), removal_trigger_key)
-    qtbot.keyClick(QApplication.focusWidget(), Qt.Key.Key_Enter)
+    index = widget._table.indexAt(item_pos)
+    widget._table.setCurrentIndex(index)
+    widget._table.edit(index)
+    qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
+    editor = widget._table.focusWidget()
+    qtbot.keyClick(editor, removal_trigger_key)
+    qtbot.keyClick(editor, Qt.Key.Key_Enter)
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()
     assert shortcut == ''

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -141,10 +141,9 @@ def test_keybinding_with_modifiers(
     widget._table.setCurrentIndex(index)
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
-    # editor = widget._table.focusWidget()
-    pyautogui.hotkey(['ctrl', 'u'], 0.2)
-    # qtbot.keyClick(editor, key, modifier=modifier)
-    QApplication.processEvents()
+    editor = widget._table.focusWidget()
+    with qtbot.waitSignal(editor.editingFinished):
+        qtbot.keyClick(editor, key, modifier=modifier)
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -143,8 +143,9 @@ def test_keybinding_with_modifiers(
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     editor = widget._table.focusWidget()
     qtbot.wait(1000)
-    with qtbot.waitSignal(editor.editingFinished):
-        qtbot.keyClick(editor, key, modifier=modifier)
+    qtbot.keyClick(editor, key, modifier=modifier)
+    qtbot.wait(1000)
+
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -219,6 +219,8 @@ def test_remove_shortcut(shortcut_editor_widget, qtbot, removal_trigger_key):
     editor = widget._table.focusWidget()
     qtbot.keyClick(editor, removal_trigger_key)
     qtbot.keyClick(editor, Qt.Key.Key_Enter)
+    widget._table.commitData(editor)
+    widget._table.closeEditor(editor, QAbstractItemDelegate.NoHint)
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()
     assert shortcut == ''

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -143,6 +143,7 @@ def test_keybinding_with_modifiers(
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     editor = widget._table.focusWidget()
     qtbot.keyClick(editor, key, modifier=modifier)
+    QApplication.processEvents()
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -141,10 +141,12 @@ def test_keybinding_with_modifiers(
     widget._table.setCurrentIndex(index)
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
-    editor = widget._table.focusWidget()
-    qtbot.wait(1000)
-    qtbot.keyClick(editor, key, modifier=modifier)
-    qtbot.wait(1000)
+    window = QApplication.focusWindow()
+    # editor = widget._table.focusWidget()
+    # qtbot.wait(1000)
+    qtbot.keyClick(window, key, modifier=modifier, delay=10)
+    # qtbot.wait(1000)
+    # qtbot.stop()
 
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -142,6 +142,7 @@ def test_keybinding_with_modifiers(
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     editor = widget._table.focusWidget()
+    QApplication.processEvents()
     qtbot.waitUntil(lambda: editor.hasFocus())
     qtbot.keyClick(editor, key, modifier=modifier)
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -95,30 +95,30 @@ def test_restore_defaults(shortcut_editor_widget):
             META_CONTROL_KEY,
             [KEY_SYMBOLS['Ctrl'], 'U'],
         ),
-        (
-            Qt.Key.Key_Y,
-            META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
-            [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], 'Y'],
-        ),
-        (
-            Qt.Key.Key_Backspace,
-            META_CONTROL_KEY,
-            [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Backspace']],
-        ),
-        (
-            Qt.Key.Key_Delete,
-            META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
-            [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], KEY_SYMBOLS['Delete']],
-        ),
-        (
-            Qt.Key.Key_Backspace,
-            META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
-            [
-                KEY_SYMBOLS['Ctrl'],
-                KEY_SYMBOLS['Shift'],
-                KEY_SYMBOLS['Backspace'],
-            ],
-        ),
+        # (
+        #     Qt.Key.Key_Y,
+        #     META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
+        #     [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], 'Y'],
+        # ),
+        # (
+        #     Qt.Key.Key_Backspace,
+        #     META_CONTROL_KEY,
+        #     [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Backspace']],
+        # ),
+        # (
+        #     Qt.Key.Key_Delete,
+        #     META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
+        #     [KEY_SYMBOLS['Ctrl'], KEY_SYMBOLS['Shift'], KEY_SYMBOLS['Delete']],
+        # ),
+        # (
+        #     Qt.Key.Key_Backspace,
+        #     META_CONTROL_KEY | Qt.KeyboardModifier.ShiftModifier,
+        #     [
+        #         KEY_SYMBOLS['Ctrl'],
+        #         KEY_SYMBOLS['Shift'],
+        #         KEY_SYMBOLS['Backspace'],
+        #     ],
+        # ),
     ],
 )
 def test_keybinding_with_modifiers(
@@ -141,10 +141,10 @@ def test_keybinding_with_modifiers(
     widget._table.setCurrentIndex(index)
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
-    editor = widget._table.focusWidget()
+    # editor = widget._table.focusWidget()
+    pyautogui.hotkey(['ctrl', 'u'], 0.2)
+    # qtbot.keyClick(editor, key, modifier=modifier)
     QApplication.processEvents()
-    qtbot.waitUntil(lambda: editor.hasFocus())
-    qtbot.keyClick(editor, key, modifier=modifier)
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -142,8 +142,8 @@ def test_keybinding_with_modifiers(
     widget._table.edit(index)
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     editor = widget._table.focusWidget()
+    qtbot.waitUntil(lambda: editor.hasFocus())
     qtbot.keyClick(editor, key, modifier=modifier)
-    QApplication.processEvents()
     assert len([warn for warn in recwarn if warn.category is UserWarning]) == 0
 
     shortcut = widget._table.item(0, widget._shortcut_col).text()


### PR DESCRIPTION
# References and relevant issues

Follow up for #6826 (macOS + Python 3.12 + PyQt6 case)

# Description

Explore enabling macOS with Python 3.12 and PyQt6 case for prereleases testing


