### PR TITLE
feat: Add right click menu position to copy spatial information

### DIFF
--- a/napari/_app_model/actions/_layer_actions.py
+++ b/napari/_app_model/actions/_layer_actions.py
@@ -108,6 +108,17 @@ LAYER_ACTIONS: list[Action] = [
         ],
     ),
     Action(
+        id='napari.layer.copy_spatial_information',
+        title=trans._('Copy Spatial Information'),
+        callback=_layer_actions._copy_spatial_information,
+        menus=[
+            {
+                'id': MenuId.LAYERLIST_CONTEXT,
+                'group': MenuGroup.NAVIGATION,
+            }
+        ],
+    ),
+    Action(
         id='napari.layer.link_selected_layers',
         title=trans._('Link Layers'),
         callback=_layer_actions._link_selected_layers,

--- a/napari/_qt/_qapp_model/injection/_qproviders.py
+++ b/napari/_qt/_qapp_model/injection/_qproviders.py
@@ -81,8 +81,8 @@ class LayerPopup(QtPopup):
         self._layput.addWidget(self.select)
         self.frame.setLayout(self._layput)
 
-    def _accept(self):
-        self.selected_layer = self.select_combo.value
+    def _accept(self) -> None:
+        self.selected_layer = self.select_combo.value  # type: ignore[attr-defined]
         self.close()
 
 
@@ -92,7 +92,7 @@ def _provide_source_layer() -> Optional[SourceLayer]:
     if viewer is None:
         return None
     pop = LayerPopup(viewer)
-    pop.exec_()
+    pop.exec_()  # type: ignore[attr-defined]
     return pop.selected_layer
 
 

--- a/napari/_qt/_qapp_model/injection/_qproviders.py
+++ b/napari/_qt/_qapp_model/injection/_qproviders.py
@@ -7,11 +7,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
 
+from magicgui.widgets import create_widget
+from qtpy.QtWidgets import QHBoxLayout, QPushButton
+
+from napari._qt.dialogs.qt_modal import QtPopup
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from napari._qt.qt_main_window import Window
     from napari._qt.qt_viewer import QtViewer
+    from napari.layers import SourceLayer
 
 
 def _provide_qt_viewer() -> Optional[QtViewer]:
@@ -60,7 +65,39 @@ def _provide_window_or_raise(msg: str = '') -> Window:
     )
 
 
+class LayerPopup(QtPopup):
+    def __init__(self, qt_viewer: QtViewer):
+        super().__init__(qt_viewer.layers)
+        self.selected_layer = None
+
+        self.setObjectName('LayerPopup')
+        self.select = QPushButton('Select')
+        self.select_combo = create_widget(annotation='napari.layers.Layer')
+        self.select.clicked.connect(self._accept)
+
+        self._layput = QHBoxLayout()
+        self._layput.setContentsMargins(10, 16, 10, 16)
+        self._layput.addWidget(self.select_combo.native)
+        self._layput.addWidget(self.select)
+        self.frame.setLayout(self._layput)
+
+    def _accept(self):
+        self.selected_layer = self.select_combo.value
+        self.close()
+
+
+def _provide_source_layer() -> Optional[SourceLayer]:
+    viewer = _provide_qt_viewer()
+
+    if viewer is None:
+        return None
+    pop = LayerPopup(viewer)
+    pop.exec_()
+    return pop.selected_layer
+
+
 QPROVIDERS = [
     (_provide_qt_viewer,),
     (_provide_window,),
+    (_provide_source_layer,),
 ]

--- a/napari/_qt/_qapp_model/qactions/__init__.py
+++ b/napari/_qt/_qapp_model/qactions/__init__.py
@@ -32,6 +32,7 @@ def init_qactions() -> None:
     from napari._qt._qapp_model.qactions._view import Q_VIEW_ACTIONS
     from napari._qt.qt_main_window import Window
     from napari._qt.qt_viewer import QtViewer
+    from napari.layers import SourceLayer
 
     # update the namespace with the Qt-specific types/providers/processors
     app = get_app()
@@ -40,6 +41,7 @@ def init_qactions() -> None:
         **store.namespace,
         'Window': Window,
         'QtViewer': QtViewer,
+        'SourceLayer': SourceLayer,
     }
 
     # Qt-specific providers/processors

--- a/napari/layers/__init__.py
+++ b/napari/layers/__init__.py
@@ -6,6 +6,7 @@ to the super constructor.
 """
 
 import inspect as _inspect
+from typing import TypeVar
 
 from napari.layers.base import Layer
 from napari.layers.image import Image
@@ -16,6 +17,8 @@ from napari.layers.surface import Surface
 from napari.layers.tracks import Tracks
 from napari.layers.vectors import Vectors
 from napari.utils.misc import all_subclasses as _all_subcls
+
+SourceLayer = TypeVar('SourceLayer', bound=Layer)
 
 # isabstact check is to exclude _ImageBase class
 NAMES: set[str] = {
@@ -29,6 +32,7 @@ __all__ = [
     'Labels',
     'Layer',
     'Points',
+    'SourceLayer',
     'Shapes',
     'Surface',
     'Tracks',


### PR DESCRIPTION
# References and relevant issues
depends on https://github.com/pyapp-kit/in-n-out/pull/110

# Description

Currently, we do not provide any mechanism to adjust spatial information from GUI. 
This PR add option to copy information from one layer to list of another one (selection). 

https://github.com/napari/napari/assets/3826210/4152aa06-00cf-4360-826f-5f6959328e02

Currently, it only copies `scale` and `translate`, as I would like to ask if you are happy with such workflow. 

This workflow requires opening a modal window to select the source layer. 

It is part of #6780