### PR TITLE
[bugfix] Drop if guard on notification_manager to enable show_info from Jupyter

### DIFF
--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -188,13 +188,10 @@ def get_app(
     if _IPYTHON_WAS_HERE_FIRST:
         _try_enable_ipython_gui('qt' if ipy_interactive else None)
 
-    if not _ipython_has_eventloop():
-        notification_manager.notification_ready.connect(
-            NapariQtNotification.show_notification
-        )
-        notification_manager.notification_ready.connect(
-            show_console_notification
-        )
+    notification_manager.notification_ready.connect(
+        NapariQtNotification.show_notification
+    )
+    notification_manager.notification_ready.connect(show_console_notification)
 
     if perf_config and not perf_config.patched:
         # Will patch based on config file.


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/6455

# Description
The if statement removed was supposed to block ipython, but wasn't doing that.
Dropping it so that notifications JustWork.
