### PR TITLE
Disable copying layer transform metadata when selecting multiple layers

### DIFF
--- a/napari/_app_model/_submenus.py
+++ b/napari/_app_model/_submenus.py
@@ -32,6 +32,7 @@ SUBMENUS = [
             title=trans._('Copy scale and transforms'),
             group=MenuGroup.LAYERLIST_CONTEXT.COPY_SPATIAL,
             order=None,
+            enablement=(LLSCK.num_selected_layers == 1),
         ),
     ),
     (

--- a/napari/_qt/_qapp_model/qactions/_layer.py
+++ b/napari/_qt/_qapp_model/qactions/_layer.py
@@ -10,6 +10,7 @@ from qtpy.QtCore import QMimeData
 from qtpy.QtWidgets import QApplication
 
 from napari._app_model.constants import MenuGroup, MenuId
+from napari._app_model.context import LayerListSelectionContextKeys as LLSCK
 from napari.components import LayerList
 from napari.layers import Layer
 from napari.utils.notifications import show_warning
@@ -141,36 +142,42 @@ Q_LAYER_ACTIONS = [
         title=trans._('Copy all to clipboard'),
         callback=_copy_spatial_to_clipboard,
         menus=[{'id': MenuId.LAYERS_COPY_SPATIAL}],
+        enablement=(LLSCK.num_selected_layers == 1),
     ),
     Action(
         id='napari.layer.copy_affine_to_clipboard',
         title=trans._('Copy affine to clipboard'),
         callback=_copy_affine_to_clipboard,
         menus=[{'id': MenuId.LAYERS_COPY_SPATIAL}],
+        enablement=(LLSCK.num_selected_layers == 1),
     ),
     Action(
         id='napari.layer.copy_rotate_to_clipboard',
         title=trans._('Copy rotate to clipboard'),
         callback=_copy_rotate_to_clipboard,
         menus=[{'id': MenuId.LAYERS_COPY_SPATIAL}],
+        enablement=(LLSCK.num_selected_layers == 1),
     ),
     Action(
         id='napari.layer.copy_scale_to_clipboard',
         title=trans._('Copy scale to clipboard'),
         callback=_copy_scale_to_clipboard,
         menus=[{'id': MenuId.LAYERS_COPY_SPATIAL}],
+        enablement=(LLSCK.num_selected_layers == 1),
     ),
     Action(
         id='napari.layer.copy_shear_to_clipboard',
         title=trans._('Copy shear to clipboard'),
         callback=_copy_shear_to_clipboard,
         menus=[{'id': MenuId.LAYERS_COPY_SPATIAL}],
+        enablement=(LLSCK.num_selected_layers == 1),
     ),
     Action(
         id='napari.layer.copy_translate_to_clipboard',
         title=trans._('Copy translate to clipboard'),
         callback=_copy_translate_to_clipboard,
         menus=[{'id': MenuId.LAYERS_COPY_SPATIAL}],
+        enablement=(LLSCK.num_selected_layers == 1),
     ),
     Action(
         id='napari.layer.paste_spatial_from_clipboard',


### PR DESCRIPTION
# Description

In #6864 I do not spot to add `enablement` to action, so copy is active, even if more than layer is selected. This PR fix it. 