### PR TITLE
Fix point highlight thickness

### DIFF
--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -111,15 +111,14 @@ class VispyPointsLayer(VispyBaseLayer):
             border_width = np.array([0])
 
         scale = self.layer.scale[-1]
-        scaled_highlight = (
-            settings.appearance.highlight.highlight_thickness
-            * self.layer.scale_factor
-        )
+        highlight_thickness = settings.appearance.highlight.highlight_thickness
+        scaled_highlight = highlight_thickness * self.layer.scale_factor
+        scaled_size = (size + border_width) * scale
         highlight_color = tuple(settings.appearance.highlight.highlight_color)
 
         self.node.selection_markers.set_data(
             data[:, ::-1],
-            size=(size + border_width) * scale,
+            size=scaled_size,
             symbol=symbol,
             edge_width=scaled_highlight * 2,
             edge_color=highlight_color,
@@ -131,15 +130,13 @@ class VispyPointsLayer(VispyBaseLayer):
             or 0 in self.layer._highlight_box.shape
         ):
             pos = np.zeros((1, self.layer._slice_input.ndisplay))
-            width = 0
         else:
             pos = self.layer._highlight_box
-            width = scaled_highlight
 
         self.node.highlight_lines.set_data(
             pos=pos[:, ::-1],
             color=highlight_color,
-            width=width,
+            width=highlight_thickness,
         )
 
         self.node.update()
@@ -195,14 +192,13 @@ class VispyPointsLayer(VispyBaseLayer):
         self.node.points_markers.canvas_size_limits = (
             self.layer.canvas_size_limits
         )
-        scaled_highlight = (
+        highlight_thickness = (
             get_settings().appearance.highlight.highlight_thickness
-            * self.layer.scale_factor
         )
         low, high = self.layer.canvas_size_limits
         self.node.selection_markers.canvas_size_limits = (
-            low + scaled_highlight,
-            high + scaled_highlight,
+            low + highlight_thickness,
+            high + highlight_thickness,
         )
         self.node.update()
 


### PR DESCRIPTION
# References and relevant issues
Followup on #6853, which had some mistakes.

# Description
`highlight_thickness` is already *canvas space* value, which means it shouldn't be rescaled when used in places that expect *canvas space* values.

Do the following, go to selection mode and drag a selection box. You'll see that in main it comes out way too thick, while here it's correct.

```py
import napari
import numpy as np
v = napari.Viewer()
pl = v.add_points(np.array([[1, 1], [10, 10]]))
v.camera.zoom = 0.2
```

cc @psobolewskiPhD
