### PR TITLE
Fix `pytest.fail` msg in `fail_obj_graph`

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -72,7 +72,7 @@ def fail_obj_graph(Klass):
 
         # DO not remove len, this can break as C++ obj are gone, but python objects
         # still hang around and _repr_ would crash.
-        pytest.fail(len(Klass._instances))
+        pytest.fail(str(len(Klass._instances)))
 
 
 @pytest.fixture()


### PR DESCRIPTION
# References and relevant issues
#6842

# Description

This was amended in #6842 but [`pytest.fail`](https://docs.pytest.org/en/6.2.x/reference.html?highlight=pytest%20fail#pytest-fail) `msg` needs to be a string.

Noted in failed CI: https://github.com/napari/napari/actions/runs/8932333235/job/24536346859?pr=6848#step:12:520
from #6848 :

```
               # DO not remove len, this can break as C++ obj are gone, but python objects
              # still hang around and _repr_ would crash.
  >           pytest.fail(len(Klass._instances))
  E           TypeError: Failed expected string as 'msg' parameter, got 'int' instead.
  E           Perhaps you meant to use a mark?
```