### PR TITLE
Add longer description to pytest fail in `fail_obj_graph`

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -56,6 +56,8 @@ def fail_obj_graph(Klass):
         COUNTER += 1
         import gc
 
+        leaked_objects_count = len(Klass._instances)
+
         gc.collect()
         file_path = Path(
             f'{Klass.__name__}-leak-backref-graph-{COUNTER}.pdf'
@@ -72,7 +74,11 @@ def fail_obj_graph(Klass):
 
         # DO not remove len, this can break as C++ obj are gone, but python objects
         # still hang around and _repr_ would crash.
-        pytest.fail(len(Klass._instances))
+        pytest.fail(
+            f'Test run fail with leaked {leaked_objects_count} instances of {Klass}.'
+            f'The object graph is saved in {file_path}.'
+            f'After cleanup left {len(Klass._instances)} objects'
+        )
 
 
 @pytest.fixture()

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -77,7 +77,7 @@ def fail_obj_graph(Klass):  # pragma: no cover
         pytest.fail(
             f'Test run fail with leaked {leaked_objects_count} instances of {Klass}.'
             f'The object graph is saved in {file_path}.'
-            f'After cleanup left {len(Klass._instances)} objects'
+            f'{len(Klass._instances)} objects left after cleanup'
         )
 
 

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -41,7 +41,7 @@ def pytest_addoption(parser):
 COUNTER = 0
 
 
-def fail_obj_graph(Klass):
+def fail_obj_graph(Klass):  # pragma: no cover
     """
     Fail is a given class _instances weakset is non empty and print the object graph.
     """


### PR DESCRIPTION
# References and relevant issues

Supersedes #6898

# Description

This PR fixes a pytest lint failure by providing a string to `pytest.fail` instead of an integer.

As an added bonus, it makes the pytest failures more descriptive when a leak in the object graph is detected. The new message provides not only the number of leaked objects, but also the type of the leaked objects and the path to a saved log of the object graph.