### PR TITLE
Add deprecation message to CallDefault function partly resolves issue#6257

### DIFF
--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -399,7 +399,9 @@ def abspath_or_url(relpath: T, *, must_exist: bool = False) -> T:
 
 class CallDefault(inspect.Parameter):
     warnings.warn(
-        '`CallDefault` is deprecated since 0.4.6 and will be removed in the future',
+        trans._(
+            '`CallDefault` is deprecated since 0.4.6 and will be removed in the future',
+        ),
         category=DeprecationWarning,
     )
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -398,6 +398,11 @@ def abspath_or_url(relpath: T, *, must_exist: bool = False) -> T:
 
 
 class CallDefault(inspect.Parameter):
+    warnings.warn(
+        '`CallDefault` is deprecated since 0.4.6 and will be removed in the future',
+        category=DeprecationWarning,
+    )
+
     def __str__(self) -> str:
         """wrap defaults"""
         kind = self.kind

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -400,7 +400,7 @@ def abspath_or_url(relpath: T, *, must_exist: bool = False) -> T:
 class CallDefault(inspect.Parameter):
     warnings.warn(
         trans._(
-            '`CallDefault` is deprecated since 0.4.6 and will be removed in the future',
+            '`CallDefault` in napari v0.5.0 and will be removed in v0.6.0.',
         ),
         category=DeprecationWarning,
     )


### PR DESCRIPTION
# References and relevant issues

Partly closes #6257 by adding a deprecation message to the CallDefault function that seems to not be used since https://github.com/napari/napari/pull/2266

# Description


- [X] - My PR is the minimum possible work for the desired functionality
- [ ] - I have commented my code, particularly in hard-to-understand areas
- [ ] - I have made corresponding changes to docstrings and documentation (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- [ ] - I have added tests that prove my fix is effective or that my feature works
- [X] - If I included new strings, I have used `trans._("some string")` to make them localizable.
  (For more information see our [translations guide](https://napari.org/developers/translations.html)).