### PR TITLE
DOC Update `_mock_app` docstring

### DIFF
--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -137,17 +137,21 @@ def pytest_runtest_makereport(item, call):
 def mock_app():
     """Mock clean 'test_app' `NapariApplication` instance.
 
-    This fixture must be used whenever `napari._app_model.get_app()` is called to return
-    a 'test_app' `NapariApplication` instead of the 'napari'
+    This fixture must be used whenever `napari._app_model.get_app()` is called to
+    return a 'test_app' `NapariApplication` instead of the 'napari'
     `NapariApplication`. The `make_napari_viewer` fixture is already equipped with
     a `mock_app`.
 
-    Note that `NapariApplication` registers app-model actions, providers and
-    processors. If this is not desired, please create a clean
-    `app_model.Application` in the test. It does not however, register Qt
-    related actions or providers or register plugins.
+    Note that `NapariApplication` registers app-model actions.
+    If this is not desired, please create a clean
+    `app_model.Application` in the test.
+
+    It does not register Qt related actions, providers or processors, which is done
+    via `init_qactions()`. Nor does it register plugins, done via `_initialize_plugins`.
     If these are required, the `make_napari_viewer` fixture can be used, which
-    will run both these function and automatically clear the lru cache.
+    will register ALL actions, providers and processors and register plugins.
+    It will also automatically clear the lru cache.
+
     Alternatively, you can specifically run `init_qactions()` or
     `_initialize_plugins` within the test, ensuring that you `cache_clear()`
     first.


### PR DESCRIPTION
# Description
There are now no more 'non-qt' providers and processors since #6743
Amended some wording to clarify.