### PR TITLE
Add HiLo colormap

### DIFF
--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -655,6 +655,11 @@ def vispy_or_mpl_colormap(name) -> Colormap:
 
     return colormap
 
+# HiLo colormap
+hilo_colormap = vispy_or_mpl_colormap('gray')
+hilo_colormap.name = 'hilo'
+hilo_colormap.colors[0] = [0, 0, 1, 1]   # blue (lowest pixel values)
+hilo_colormap.colors[-1] = [1, 0, 0, 1]  # red  (highest pixel values)
 
 # A dictionary mapping names to VisPy colormap objects
 ALL_COLORMAPS = {
@@ -663,6 +668,7 @@ ALL_COLORMAPS = {
 ALL_COLORMAPS.update(SIMPLE_COLORMAPS)
 ALL_COLORMAPS.update(BOP_COLORMAPS)
 ALL_COLORMAPS.update(INVERSE_COLORMAPS)
+ALL_COLORMAPS.update({'hilo': hilo_colormap})
 
 # ... sorted alphabetically by name
 AVAILABLE_COLORMAPS = dict(

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -655,10 +655,11 @@ def vispy_or_mpl_colormap(name) -> Colormap:
 
     return colormap
 
+
 # HiLo colormap
 hilo_colormap = vispy_or_mpl_colormap('gray')
 hilo_colormap.name = 'hilo'
-hilo_colormap.colors[0] = [0, 0, 1, 1]   # blue (lowest pixel values)
+hilo_colormap.colors[0] = [0, 0, 1, 1]  # blue (lowest pixel values)
 hilo_colormap.colors[-1] = [1, 0, 0, 1]  # red  (highest pixel values)
 
 # A dictionary mapping names to VisPy colormap objects


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/6878
Reference: https://forum.image.sc/t/add-hilo-colormap-to-napari/95601

# Description
Adds a HiLo colormap.
A HiLo colormap is a grayscale colormap, with the exception that the maximum pixel value is shown in red, and the minimum pixel value shown in blue.

This type of colormap is useful for quickly scanning images to see if there is unintended clipping of image values at the top and/or bottom of the intensity range.


