### PR TITLE
[Maint] On PRs, dont run benchmarks unless initial tests pass

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -200,6 +200,7 @@ jobs:
   test_benchmarks:
     name: test benchmarks
     runs-on: ubuntu-latest
+    needs: test_initial
     timeout-minutes: 60
     env:
       GIT_LFS_SKIP_SMUDGE: 1


### PR DESCRIPTION
This PR adds a check for `test_initial` before running the benchmarks.
Even though it's a quick subset of the benchmarks, it's still ~15 min of CI and there isn't much point of running them if tests are failing.
In principle, we could even make sure the full test suite passes, rather than just the initial tests...
