### PR TITLE
Fix `PIP_CONSTRAINT` to not crash python installation on macos arm and python 3.10

### DIFF
--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -49,7 +49,7 @@ jobs:
       PYVISTA_OFF_SCREEN: True
       MIN_REQ: ${{ inputs.min_req }}
       FORCE_COLOR: 1
-      PIP_CONSTRAINT: resources/constraints/constraints_py${{ inputs.python_version }}${{ (((inputs.platform == 'macos-latest') && '_macos_arm') || '') }}${{ inputs.min_req && '_min_req' }}${{ inputs.constraints_suffix }}.txt
+      PIP_CONSTRAINT: ${{ github.workspace }}/resources/constraints/constraints_py${{ inputs.python_version }}${{ (((inputs.platform == 'macos-latest') && '_macos_arm') || '') }}${{ inputs.min_req && '_min_req' }}${{ inputs.constraints_suffix }}.txt
       # Above we calculate path to constraints file based on python version and platform
       # Because there is no single PyQt5-Qt5 package version available for all platforms we was forced to use
       # different constraints files for macOS arm and other platforms

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -94,10 +94,6 @@ jobs:
             backend: pyqt6
             pydantic: ""
             coverage: no_cov
-          - python: "3.10"
-            platform: macos-latest
-            backend: pyqt5
-            coverage: cov
     with:
       python_version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -94,6 +94,10 @@ jobs:
             backend: pyqt6
             pydantic: ""
             coverage: no_cov
+          - python: "3.10"
+            platform: macos-latest
+            backend: pyqt5
+            coverage: cov
     with:
       python_version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}


### PR DESCRIPTION
# Description
Currently, tests are failing on main because of use of relative path. This PR fixes it. 