### PR TITLE
fixed _validate_rgb to include values between 0 and 1 inclusive

### DIFF
--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -243,7 +243,7 @@ def _validate_rgb(colors, *, tolerance=0.0):
     """
     lo = 0 - tolerance
     hi = 1 + tolerance
-    valid = np.all((colors > lo) & (colors < hi), axis=1)
+    valid = np.all((colors >= lo) & (colors <= hi), axis=1)
     filtered_colors = np.clip(colors[valid], 0, 1)
     return filtered_colors
 


### PR DESCRIPTION
Fixed check for valid range in _validate_rgb. Example in doc now behave as expected:

>>> colors = np.array([[  0. , 1.,  1.  ],
    ...                    [  1.1, 0., -0.03],
    ...                    [  1.2, 1.,  0.5 ]])
 >>> _validate_rgb(colors)
    array([[0., 1., 1.]])
>>> _validate_rgb(colors, tolerance=0.15)
    array([[0., 1., 1.],
           [1., 0., 0.]])