### PR TITLE
[enh] add a clipping plane on layer init

### DIFF
--- a/napari/layers/_tests/test_layer_attributes.py
+++ b/napari/layers/_tests/test_layer_attributes.py
@@ -174,3 +174,9 @@ def test_async_refresh_block(Layer, data, ndim):
 
     my_layer.refresh()
     mock.assert_called_once()
+
+
+def test_layers_have_clipping_plane(layer):
+    """Test that layers have a clipping planes."""
+    assert len(layer.experimental_clipping_planes) == 1
+    assert not layer.experimental_clipping_planes[0].enabled

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -419,6 +419,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         self._name = ''
         self.experimental_clipping_planes = experimental_clipping_planes
 
+        if experimental_clipping_planes is None:
+            clipping_plane = ClippingPlane(enabled=False)
+            self.experimental_clipping_planes.append(clipping_plane)
+
         # circular import
         from napari.components.overlays.bounding_box import BoundingBoxOverlay
         from napari.components.overlays.interaction_box import (

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -420,8 +420,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         self.experimental_clipping_planes = experimental_clipping_planes
 
         if experimental_clipping_planes is None:
-            clipping_plane = ClippingPlane(enabled=False)
-            self.experimental_clipping_planes.append(clipping_plane)
+            self.experimental_clipping_planes.append(
+                ClippingPlane(enabled=False)
+            )
 
         # circular import
         from napari.components.overlays.bounding_box import BoundingBoxOverlay


### PR DESCRIPTION
# References and relevant issues
Discussed here
https://napari.zulipchat.com/#narrow/stream/212875-general/topic/clipping.20planes.20and.20slicing.20planes

# Description
This PR adds creating and appending a (disabled) ClippingPlane to the ClippingPlaneList in the base Layer `init`. This will making using ClippingPlanes easier, particularly from plugins. For example, if this is merged, it will be trivial to add a manipulator for clipping planes in napari-threedee.
I've added a simple test for the new behavior.