### PR TITLE
remove error reporter code

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_help.py
+++ b/napari/_qt/_qapp_model/qactions/_help.py
@@ -17,11 +17,6 @@ from napari._qt.dialogs.qt_about import QtAbout
 from napari._qt.qt_main_window import Window
 from napari.utils.translations import trans
 
-try:
-    from napari_error_reporter import ask_opt_in
-except ModuleNotFoundError:
-    ask_opt_in = None
-
 
 def _show_about(window: Window):
     QtAbout.showAbout(window._qt_window)
@@ -118,12 +113,3 @@ Q_HELP_ACTIONS: list[Action] = [
     ),
 ]
 
-if ask_opt_in is not None:
-    Q_HELP_ACTIONS.append(
-        Action(
-            id='napari.window.help.bug_report_opt_in',
-            title=trans._('Bug Reporting Opt In/Out...'),
-            callback=lambda: ask_opt_in(force=True),
-            menus=[{'id': MenuId.MENUBAR_HELP}],
-        )
-    )

--- a/napari/_qt/_qapp_model/qactions/_help.py
+++ b/napari/_qt/_qapp_model/qactions/_help.py
@@ -112,4 +112,3 @@ Q_HELP_ACTIONS: list[Action] = [
         menus=[{'id': MenuId.MENUBAR_HELP, 'group': MenuGroup.NAVIGATION}],
     ),
 ]
-

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -266,18 +266,6 @@ def napari_svg_name():
     return 'napari-svg'
 
 
-@pytest.fixture(autouse=True, scope='session')
-def _no_error_reports():
-    """Turn off napari_error_reporter if it's installed."""
-    try:
-        p1 = patch('napari_error_reporter.capture_exception')
-        p2 = patch('napari_error_reporter.install_error_reporter')
-        with p1, p2:
-            yield
-    except (ModuleNotFoundError, AttributeError):
-        yield
-
-
 @pytest.fixture(autouse=True)
 def npe2pm_(npe2pm, monkeypatch):
     """Autouse npe2 & npe1 mock plugin managers with no registered plugins."""

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -39,7 +39,6 @@ from itertools import chain
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
-from unittest.mock import patch
 from weakref import WeakKeyDictionary
 
 from npe2 import PackageMetadata

--- a/napari/utils/notifications.py
+++ b/napari/utils/notifications.py
@@ -13,17 +13,6 @@ from typing import Callable, Optional, Union
 from napari.utils.events import Event, EventEmitter
 from napari.utils.misc import StringEnum
 
-try:
-    from napari_error_reporter import capture_exception, install_error_reporter
-except ImportError:
-
-    def _noop(*_, **__):
-        pass
-
-    install_error_reporter = _noop
-    capture_exception = _noop
-
-
 name2num = {
     'error': 40,
     'warning': 30,
@@ -269,7 +258,6 @@ class NotificationManager:
             # Patch for Python < 3.8
             _setup_thread_excepthook()
 
-        install_error_reporter()
         self._originals_except_hooks.append(sys.excepthook)
         self._original_showwarnings_hooks.append(warnings.showwarning)
 
@@ -311,8 +299,6 @@ class NotificationManager:
     ):
         if isinstance(value, KeyboardInterrupt):
             sys.exit('Closed by KeyboardInterrupt')
-
-        capture_exception(value)
 
         if self.exit_on_error:
             sys.__excepthook__(exctype, value, traceback)


### PR DESCRIPTION
[napari-error-reporter](https://github.com/tlambert03/napari-error-reporter) is archived and unmaintained, and the project is removed from sentry.  This PR removes the few lines that looked for the plugin if it was installed