### PR TITLE
Automatically remove run-benchmarks label once benchmarks are executed

### DIFF
--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -81,3 +81,18 @@ jobs:
               issue_number: issue_number,
               body: body,
             });
+
+      - name: "Remove run-benchmarks label"
+        if: env.PR_NUMBER != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            let issue_number = Number(process.env.PR_NUMBER);
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              name: 'run-benchmarks',
+            });


### PR DESCRIPTION
# Description

Iterating on a performance PR that needs benchmarks is currently more cumbersome than it needs to be: add the run-benchmarks label, get a performance report, act on the report (ie make code changes and push), then, to run the benchmarks again, a core dev needs to *manually remove* the label, then immediately add it again. Instead, this PR automates the removal of the label once the benchmarks are done running and the report has been generated. In fact, it should also remove the label even if the benchmarks fail due to some bug in the code or benchmark code.