### PR TITLE
Add warning notification when connectivity errors occur in when opening the plugin manager

### DIFF
--- a/napari/plugins/npe2api.py
+++ b/napari/plugins/npe2api.py
@@ -84,8 +84,6 @@ def conda_map() -> dict[PyPIname, Optional[str]]:
 
 def iter_napari_plugin_info() -> Iterator[tuple[PackageMetadata, bool, dict]]:
     """Iterator of tuples of ProjectInfo, Conda availability for all napari plugins."""
-    conda_set = {}
-    data_set = {}
     try:
         with ThreadPoolExecutor() as executor:
             data = executor.submit(plugin_summaries)
@@ -98,6 +96,7 @@ def iter_napari_plugin_info() -> Iterator[tuple[PackageMetadata, bool, dict]]:
             'There seems to be an issue with network connectivity. '
             'Remote plugins cannot be installed, only local ones.\n'
         )
+        return
 
     conda_set = {normalized_name(x) for x in conda}
     for info in data_set:

--- a/napari/plugins/npe2api.py
+++ b/napari/plugins/npe2api.py
@@ -12,12 +12,14 @@ from typing import (
     TypedDict,
     cast,
 )
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from npe2 import PackageMetadata
 from typing_extensions import NotRequired
 
 from napari.plugins.utils import normalized_name
+from napari.utils.notifications import show_warning
 
 PyPIname = str
 
@@ -65,7 +67,6 @@ class SummaryDict(_ShortSummaryDict):
     conda_versions: NotRequired[list[str]]
 
 
-@lru_cache
 def plugin_summaries() -> list[SummaryDict]:
     """Return PackageMetadata object for all known napari plugins."""
     url = 'https://npe2api.vercel.app/api/extended_summary'
@@ -83,13 +84,23 @@ def conda_map() -> dict[PyPIname, Optional[str]]:
 
 def iter_napari_plugin_info() -> Iterator[tuple[PackageMetadata, bool, dict]]:
     """Iterator of tuples of ProjectInfo, Conda availability for all napari plugins."""
-    with ThreadPoolExecutor() as executor:
-        data = executor.submit(plugin_summaries)
-        _conda = executor.submit(conda_map)
+    conda_set = {}
+    data_set = {}
+    try:
+        with ThreadPoolExecutor() as executor:
+            data = executor.submit(plugin_summaries)
+            _conda = executor.submit(conda_map)
 
-    conda = _conda.result()
+        conda = _conda.result()
+        data_set = data.result()
+    except (HTTPError, URLError):
+        show_warning(
+            'There seems to be an issue with network connectivity. '
+            'Remote plugins cannot be installed, only local ones.\n'
+        )
+
     conda_set = {normalized_name(x) for x in conda}
-    for info in data.result():
+    for info in data_set:
         info_copy = dict(info)
         info_copy.pop('display_name', None)
         pypi_versions = info_copy.pop('pypi_versions')


### PR DESCRIPTION
Fixes https://github.com/napari/napari-plugin-manager/issues/26

# Description

Catches connectivity errors when fetching for plugin information when opening the plugin manager.

Although the issue lives in the plugin manager repo, the code that fetches the code still lives in napari, hence with the PR seem to be better resolved on this side.

# Result

## Before this PR

![napari-before](https://github.com/napari/napari/assets/3627835/6e704463-2dd3-4701-9aa5-93f2501e48fd)


## With this PR

![napari](https://github.com/napari/napari/assets/3627835/ffa3ad0a-da18-4e76-a4aa-8a007f90ce36)

The warning reads: 
>There seems to be an issue with network connectivity. Remote plugins cannot be installed, only local ones.