### PR TITLE
Fix callback for `File -> Open Folder...` action

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_file.py
+++ b/napari/_qt/_qapp_model/qactions/_file.py
@@ -68,7 +68,7 @@ Q_FILE_ACTIONS: list[Action] = [
     Action(
         id='napari.window.file.open_folder_dialog',
         title=trans._('Open Folder...'),
-        callback=QtViewer._open_files_dialog,
+        callback=QtViewer._open_folder_dialog,
         menus=[{'id': MenuId.MENUBAR_FILE, 'group': MenuGroup.NAVIGATION}],
         keybindings=[
             {'primary': KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyO}


### PR DESCRIPTION
# References and relevant issues
Closes #6934

# Description
Incorrect callback was being used for the `Open Folder` action. This PR fixes it. We need a testing framework for the actions and menus @lucyleeow, which we knew, but maybe we should prioritize ahead of converting the layer actions.


