### PR TITLE
Also remove ready-to-merge label from closed PRs

### DIFF
--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const { owner, repo, number: pull_number } = context.issue;
             const { data: pullRequest } = await github.rest.pulls.get({ owner, repo, pull_number });
-            if (!pullRequest.merged) {
+            if (!(pullRequest.closed || pullRequest.merged)) {
               console.log("Pull request not merged, skipping.");
               return;
             }

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const { owner, repo, number: pull_number } = context.issue;
             const { data: pullRequest } = await github.rest.pulls.get({ owner, repo, pull_number });
-            if (!(pullRequest.closed || pullRequest.merged)) {
+            if (!pullRequest.closed) {
               console.log("Pull request not merged, skipping.");
               return;
             }


### PR DESCRIPTION
I noticed in #6928 that closing a PR that has the ready-to-merge label didn't get the label removed by the bot. That's because the bot only removes it from merged PRs. This change also applies it to closed PRs.

CC @Czaki.

In the GitHub docs on the `pullRequest` object, I couldn't tell whether
"closed" also includes merged (so we could save an ||).

https://docs.github.com/en/graphql/reference/objects#pullrequest

> closed (Boolean!): true if the pull request is closed.

