### PR TITLE
fix `create_func` to respect `rename_argument` decorator

### DIFF
--- a/napari/utils/_register.py
+++ b/napari/utils/_register.py
@@ -2,6 +2,7 @@ import os
 import sys
 from inspect import Parameter, getdoc, signature
 
+from napari.utils.migrations import rename_argument
 from napari.utils.misc import camel_to_snake
 from napari.utils.translations import trans
 
@@ -74,6 +75,7 @@ def create_func(cls, name=None, doc=None):
         ],
         return_annotation=cls,
     )
+
     src = template.format(
         name=name,
         signature=new_sig,
@@ -93,5 +95,16 @@ def create_func(cls, name=None, doc=None):
         ],
         return_annotation=cls,
     )
+
+    if hasattr(cls.__init__, '_rename_argument'):
+        for (
+            from_name,
+            to_name,
+            version,
+            since_version,
+        ) in cls.__init__._rename_argument:
+            func = rename_argument(from_name, to_name, version, since_version)(
+                func
+            )
 
     return func

--- a/napari/utils/_tests/test_register.py
+++ b/napari/utils/_tests/test_register.py
@@ -1,7 +1,12 @@
 from dataclasses import dataclass, field
 
+import pytest
+
 from napari.utils._register import create_func
-from napari.utils.migrations import deprecated_constructor_arg_by_attr
+from napari.utils.migrations import (
+    deprecated_constructor_arg_by_attr,
+    rename_argument,
+)
 
 
 @dataclass
@@ -22,6 +27,7 @@ class SimpleClassDeprecated:
     """Simple class to test create_func"""
 
     @deprecated_constructor_arg_by_attr('b')
+    @deprecated_constructor_arg_by_attr('c')
     def __init__(self, a=1):
         self.a = a
 
@@ -32,6 +38,34 @@ class SimpleClassDeprecated:
     @b.setter
     def b(self, value):
         self.a = value // 2
+
+    @property
+    def c(self):
+        return self.a * 2
+
+    @c.setter
+    def c(self, value):
+        self.a = value // 2
+
+
+class SimpleClassRenamed:
+    """Simple class to test create_func"""
+
+    @rename_argument(
+        from_name='c',
+        to_name='a',
+        version='0.6.0',
+        since_version='0.4.18',
+    )
+    @rename_argument(
+        from_name='d',
+        to_name='b',
+        version='0.6.0',
+        since_version='0.4.18',
+    )
+    def __init__(self, a=1, b=1):
+        self.a = a
+        self.b = b
 
 
 def test_create_func():
@@ -46,3 +80,16 @@ def test_create_func_deprecated():
     dc = DummyClass()
     dc.add_simple_class_deprecated(b=4)
     assert dc.layers[0].a == 2
+    dc.add_simple_class_deprecated(c=8)
+    assert dc.layers[1].a == 4
+
+
+def test_create_func_renamed():
+    DummyClass.add_simple_class_renamed = create_func(SimpleClassRenamed)
+    dc = DummyClass()
+    with pytest.warns(DeprecationWarning, match="Argument 'c' is deprecated"):
+        dc.add_simple_class_renamed(c=4)
+    assert dc.layers[0].a == 4
+    with pytest.warns(DeprecationWarning, match="Argument 'd' is deprecated"):
+        dc.add_simple_class_renamed(d=8)
+    assert dc.layers[1].b == 8

--- a/napari/utils/_tests/test_register.py
+++ b/napari/utils/_tests/test_register.py
@@ -32,7 +32,7 @@ class SimpleClassDeprecated:
         self.a = a
 
     @property
-    def b(self):
+    def b(self):  # pragma: no cover
         return self.a * 2
 
     @b.setter
@@ -40,7 +40,7 @@ class SimpleClassDeprecated:
         self.a = value // 2
 
     @property
-    def c(self):
+    def c(self):  # pragma: no cover
         return self.a * 2
 
     @c.setter

--- a/napari/utils/add_layer.py_tmpl
+++ b/napari/utils/add_layer.py_tmpl
@@ -1,5 +1,5 @@
 def {name}{signature}:
-    kwargs = locals()
+    kwargs = dict(locals())
     kwargs.pop('self', None)
     pos_kwargs = dict()
     for name in getattr({cls_name}.__init__, "_deprecated_constructor_args", []):

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -39,6 +39,13 @@ def rename_argument(
         )
 
     def _wrapper(func):
+        if not hasattr(func, '_rename_argument'):
+            func._rename_argument = []
+
+        func._rename_argument.append(
+            (from_name, to_name, version, since_version)
+        )
+
         @wraps(func)
         def _update_from_dict(*args, **kwargs):
             if from_name in kwargs:


### PR DESCRIPTION
# References and relevant issues
close #6966
close #6789
close #6978

# Description

This PR updates `rename_argument` to store information about rename in `_rename_argument` and adds reading this property in `create_func` function to apply renaming also to `add_xxx` methods. 

In addition, it fixes #6789, as I was able to reproduce the problem. Fix is same as described here https://github.com/napari/napari/issues/6789#issuecomment-2095791556 
