### PR TITLE
Do not crash napari viewer if error happen on open file via cli

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -354,7 +354,9 @@ def _run() -> None:
             )
         except ReaderPluginError:
             logging.exception(
-                'Loading %s with %s failed with errors', args.paths, args.plugin
+                'Loading %s with %s failed with errors',
+                args.paths,
+                args.plugin,
             )
 
         if args.with_:

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from textwrap import wrap
 from typing import Any
 
+from napari.errors import ReaderPluginError
 from napari.utils.translations import trans
 
 
@@ -343,13 +344,18 @@ def _run() -> None:
                 stacklevel=3,
             )
             args.stack = True
-        viewer._window._qt_viewer._qt_open(
-            args.paths,
-            stack=args.stack,
-            plugin=args.plugin,
-            layer_type=args.layer_type,
-            **kwargs,
-        )
+        try:
+            viewer._window._qt_viewer._qt_open(
+                args.paths,
+                stack=args.stack,
+                plugin=args.plugin,
+                layer_type=args.layer_type,
+                **kwargs,
+            )
+        except ReaderPluginError:
+            logging.exception(
+                'Error happen during load file while starting napari'
+            )
 
         if args.with_:
             # Non-npe2 plugins disappear on tabify or if tabified npe2 plugins are loaded after them.

--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -354,7 +354,7 @@ def _run() -> None:
             )
         except ReaderPluginError:
             logging.exception(
-                'Error happen during load file while starting napari'
+                'Loading %s with %s failed with errors', args.paths, args.plugin
             )
 
         if args.with_:


### PR DESCRIPTION
# References and relevant issues

Address second error from #6966

# Description

This Pr adds handling error of opening file using while passing file path via CLI