### PR TITLE
[maint] Update docker-singularity-publish.yml to run on PR

### DIFF
--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -8,6 +8,10 @@ name: Docker and Singularity build
 on:
   workflow_dispatch:
 
+  pull_request:
+    paths:
+      - '.github/workflows/docker-singularity-publish.yaml'
+
 #  schedule:
 #    - cron: '31 0 * * *'
   push:

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -104,7 +104,7 @@ jobs:
     needs: build1
     runs-on: ubuntu-latest
     container:
-      image: quay.io/singularity/docker2singularity:v3.11.5
+      image: quay.io/singularity/docker2singularity:v4.1.0
       options: --privileged
     permissions:
       contents: read


### PR DESCRIPTION
# References and relevant issues
The singularity part of the container building action has begun failing:
https://github.com/napari/napari/actions/runs/9410320408/job/25921910262
It looks like it might be related to the version within the container used for the action.


# Description
- run the build step on PR to the action, for easier testing
- Update the singularity build step to use a newer version of the action which has a newer container image.

