### PR TITLE
More numpy 2.0 related fixes

### DIFF
--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -550,6 +550,12 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
 
     def _update_thumbnail(self):
         """Update thumbnail with current image data and colormap."""
+        # don't bother updating thumbnail if we don't have any data
+        # this also avoids possible dtype mismatch issues below
+        # for example np.clip may raise an OverflowError (in numpy 2.0)
+        if self._slice.empty:
+            return
+
         image = self._slice.thumbnail.raw
 
         if self._slice_input.ndisplay == 3 and self.ndim > 2:

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -11,7 +11,6 @@ import pandas as pd
 import pytest
 import xarray as xr
 import zarr
-from numpy.core.numerictypes import issubdtype
 from skimage import data as sk_data
 
 from napari._tests.utils import check_layer_world_data_extent
@@ -110,13 +109,13 @@ def test_bool_labels():
     """Test instantiating labels layer with bools"""
     data = np.zeros((10, 10), dtype=bool)
     layer = Labels(data)
-    assert issubdtype(layer.data.dtype, np.integer)
+    assert np.issubdtype(layer.data.dtype, np.integer)
 
     data0 = np.zeros((20, 20), dtype=bool)
     data1 = data0[::2, ::2].astype(np.int32)
     data = [data0, data1]
     layer = Labels(data)
-    assert all(issubdtype(d.dtype, np.integer) for d in layer.data)
+    assert all(np.issubdtype(d.dtype, np.integer) for d in layer.data)
 
 
 def test_changing_labels():

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -301,8 +301,11 @@ def point_to_lines(point, lines):
     norm_lines[reject] = 1
     unit_lines = lines_vectors / norm_lines
 
-    # calculate distance to line
-    line_dist = abs(np.cross(unit_lines, point_vectors))
+    # calculate distance to line (2D cross-product)
+    line_dist = abs(
+        unit_lines[..., 0] * point_vectors[..., 1]
+        - unit_lines[..., 1] * point_vectors[..., 0]
+    )
 
     # calculate scale
     line_loc = (unit_lines * point_vectors).sum(axis=1) / norm_lines.squeeze()

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1451,7 +1451,7 @@ class Shapes(Layer):
                 # and update_color_mapping==False
                 color_cycle_map = getattr(self, f'{attribute}_color_cycle_map')
                 color_cycle_keys = [*color_cycle_map]
-                props_in_map = np.in1d(color_properties, color_cycle_keys)
+                props_in_map = np.isin(color_properties, color_cycle_keys)
                 if not np.all(props_in_map):
                     props_to_add = np.unique(
                         color_properties[np.logical_not(props_in_map)]

--- a/napari/utils/colormaps/categorical_colormap.py
+++ b/napari/utils/colormaps/categorical_colormap.py
@@ -51,7 +51,7 @@ class CategoricalColormap(EventedModel):
 
         # add properties if they are not in the colormap
         color_cycle_keys = [*self.colormap]
-        props_in_map = np.in1d(color_properties, color_cycle_keys)
+        props_in_map = np.isin(color_properties, color_cycle_keys)
         if not np.all(props_in_map):
             new_prop_values = color_properties[np.logical_not(props_in_map)]
             indices_to_add = np.unique(new_prop_values, return_index=True)[1]


### PR DESCRIPTION
# References and relevant issues
I don't see a tracking issue for numpy 2.0 support, but here are some previous PRs I've found:
https://github.com/napari/napari/pull/6932
https://github.com/napari/napari/pull/6776

And a zulip thread:
https://napari.zulipchat.com/#narrow/stream/212875-general/topic/handling.20the.20numpy.202.2E0.20release/near/381330412

# Description
This fixes a few more numpy-2.0 related issues. I will comment on some of them inline.

I tested locally using [a wheel from my vispy PR](https://github.com/vispy/vispy/actions/runs/9424977460?pr=2599). I also uninstalled `tensorstore` to skip related tests (see https://github.com/google/tensorstore/issues/165).

There are still a few test failures in `napari/layers/image/_tests/test_image.py` that look possibly related to Xarray:
```
napari/layers/image/_tests/test_image.py:649 test_image_scale[scale5] - DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and… [1012/3861]
```

I also get a failure on `napari/_qt/widgets/_tests/test_qt_tooltip.py::test_qt_tooltip_label`, but I think this may be a macOS thing (it passes if I mouse over it).

Other than that, local tests with `pytest napari` are all green.