### PR TITLE
Update `rename_argument` to use `FutureWarning` instead of `DeprecationWarning`

### DIFF
--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -58,7 +58,7 @@ def rename_argument(
                         version=version,
                         since_version=since_version,
                     ),
-                    category=DeprecationWarning,
+                    category=FutureWarning,
                     stacklevel=2,
                 )
                 kwargs = kwargs.copy()


### PR DESCRIPTION


# References and relevant issues

Pointed here https://github.com/napari/napari/issues/6978#issuecomment-2161771175


# Description

Use `FutureWarning` instead of `DeprectionWarning` to have warnings rendered in the user interface. 