### PR TITLE
Add attributes to `DummyTimer`

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_debug.py
+++ b/napari/_qt/_qapp_model/qactions/_debug.py
@@ -51,7 +51,7 @@ def _start_trace_dialog(qt_viewer: QtViewer) -> None:
 def _start_trace(path: str) -> None:
     """Start recording a trace file."""
     if start_trace := perf.timers.start_trace_file:
-        start_trace()
+        start_trace(path)
 
 
 def _stop_trace() -> None:

--- a/napari/_qt/_qapp_model/qactions/_debug.py
+++ b/napari/_qt/_qapp_model/qactions/_debug.py
@@ -50,24 +50,19 @@ def _start_trace_dialog(qt_viewer: QtViewer) -> None:
 
 def _start_trace(path: str) -> None:
     """Start recording a trace file."""
-    # `DummyTimer` has no `start_trace_file`
-    start_trace = getattr(perf.timers, 'start_trace_file', None)
-    if start_trace:
-        start_trace(path)
+    if start_trace := perf.timers.start_trace_file:
+        start_trace()
 
 
 def _stop_trace() -> None:
     """Stop recording a trace file."""
-    # `DummyTimer` has no `stop_trace_file`
-    stop_trace = getattr(perf.timers, 'stop_trace_file', None)
-    if stop_trace:
+    if stop_trace := perf.timers.stop_trace_file:
         stop_trace()
 
 
 def _is_set_trace_active() -> bool:
     """Whether we are currently recording a set trace."""
-    trace_file = getattr(perf.timers, 'trace_file', None)
-    return trace_file is not None
+    return perf.timers.trace_file is not None
 
 
 Q_DEBUG_ACTIONS: list[Action] = [

--- a/napari/_qt/_qapp_model/qactions/_debug.py
+++ b/napari/_qt/_qapp_model/qactions/_debug.py
@@ -50,16 +50,12 @@ def _start_trace_dialog(qt_viewer: QtViewer) -> None:
 
 def _start_trace(path: str) -> None:
     """Start recording a trace file."""
-    # `DummyTimer` has no `start_trace_file`
-    if start_trace := perf.timers.start_trace_file:
-        start_trace(path)
+    perf.timers.start_trace_file(path)
 
 
 def _stop_trace() -> None:
     """Stop recording a trace file."""
-    # `DummyTimer` has no `stop_trace_file`
-    if stop_trace := perf.timers.stop_trace_file:
-        stop_trace()
+    perf.timers.stop_trace_file()
 
 
 def _is_set_trace_active() -> bool:

--- a/napari/_qt/_qapp_model/qactions/_debug.py
+++ b/napari/_qt/_qapp_model/qactions/_debug.py
@@ -50,12 +50,14 @@ def _start_trace_dialog(qt_viewer: QtViewer) -> None:
 
 def _start_trace(path: str) -> None:
     """Start recording a trace file."""
+    # `DummyTimer` has no `start_trace_file`
     if start_trace := perf.timers.start_trace_file:
         start_trace(path)
 
 
 def _stop_trace() -> None:
     """Stop recording a trace file."""
+    # `DummyTimer` has no `stop_trace_file`
     if stop_trace := perf.timers.stop_trace_file:
         stop_trace()
 

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -238,6 +238,9 @@ class DummyTimer:
     It implements the same interface as PerfTimers.
     """
 
+    def __init__(self) -> None:
+        self.trace_file = None
+
     def add_instant_event(
         self, name: str, **kwargs: Union[str, float, None]
     ) -> None:
@@ -247,6 +250,12 @@ class DummyTimer:
         """empty timer to use when perfmon is disabled"""
 
     def add_event(self, event: PerfEvent) -> None:
+        """empty timer to use when perfmon is disabled"""
+
+    def start_trace_file(self, path: str) -> None:
+        """empty timer to use when perfmon is disabled"""
+
+    def stop_trace_file(self) -> None:
         """empty timer to use when perfmon is disabled"""
 
 

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -240,8 +240,6 @@ class DummyTimer:
 
     def __init__(self) -> None:
         self.trace_file = None
-        self.start_trace_file = None
-        self.stop_trace_file = None
 
     def add_instant_event(
         self, name: str, **kwargs: Union[str, float, None]
@@ -252,6 +250,12 @@ class DummyTimer:
         """empty timer to use when perfmon is disabled"""
 
     def add_event(self, event: PerfEvent) -> None:
+        """empty timer to use when perfmon is disabled"""
+
+    def start_trace_file(self, path: str) -> None:
+        """empty timer to use when perfmon is disabled"""
+
+    def stop_trace_file(self) -> None:
         """empty timer to use when perfmon is disabled"""
 
 

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -240,6 +240,8 @@ class DummyTimer:
 
     def __init__(self) -> None:
         self.trace_file = None
+        self.start_trace_file = None
+        self.stop_trace_file = None
 
     def add_instant_event(
         self, name: str, **kwargs: Union[str, float, None]
@@ -250,12 +252,6 @@ class DummyTimer:
         """empty timer to use when perfmon is disabled"""
 
     def add_event(self, event: PerfEvent) -> None:
-        """empty timer to use when perfmon is disabled"""
-
-    def start_trace_file(self, path: str) -> None:
-        """empty timer to use when perfmon is disabled"""
-
-    def stop_trace_file(self) -> None:
         """empty timer to use when perfmon is disabled"""
 
 


### PR DESCRIPTION
# References and relevant issues
Follow up to #6915

# Description
Adds attributes to `DummyTimer`, allowing us to remove `getattr` in the debug menu functions. See https://github.com/napari/napari/pull/6915#discussion_r1627108730

