### PR TITLE
Update `test_create_func_renamed` test to use `FutureWarning` instead of `DeprecationWarning`

### DIFF
--- a/napari/utils/_tests/test_register.py
+++ b/napari/utils/_tests/test_register.py
@@ -87,9 +87,9 @@ def test_create_func_deprecated():
 def test_create_func_renamed():
     DummyClass.add_simple_class_renamed = create_func(SimpleClassRenamed)
     dc = DummyClass()
-    with pytest.warns(DeprecationWarning, match="Argument 'c' is deprecated"):
+    with pytest.warns(FutureWarning, match="Argument 'c' is deprecated"):
         dc.add_simple_class_renamed(c=4)
     assert dc.layers[0].a == 4
-    with pytest.warns(DeprecationWarning, match="Argument 'd' is deprecated"):
+    with pytest.warns(FutureWarning, match="Argument 'd' is deprecated"):
         dc.add_simple_class_renamed(d=8)
     assert dc.layers[1].b == 8


### PR DESCRIPTION
# Description

Seems like there is a need to update `napari/utils/_tests/test_register.py::test_create_func_renamed` following the change from `DeprecationWarning` to `FutureWarning` (#6980). See https://github.com/napari/napari/actions/runs/9517283478/job/26235510264?pr=6975#step:12:4160


