### PR TITLE
fix rename_argument futurewarning to deprecationwarning

### DIFF
--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -65,7 +65,7 @@ def rename_argument(
                         version=version,
                         since_version=since_version,
                     ),
-                    category=FutureWarning,
+                    category=DeprecationWarning,
                     stacklevel=2,
                 )
                 kwargs = kwargs.copy()


### PR DESCRIPTION
# Description
Fixes issue with napari failing on main due to `rename_argument` giving a `FutureWarning`. Since we are talking about `has been deprecated` I believe this should be a `DeprecationWarning` and the test is correct.
