### PR TITLE
Fix viewer scale bar color update

### DIFF
--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -142,8 +142,11 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
                 # set scale color negative of theme background.
                 # the reason for using the `as_hex` here is to avoid
                 # `UserWarning` which is emitted when RGB values are above 1
-                if self.node.parent is not None and self.node.parent.bgcolor:
-                    background_color = self.node.parent.bgcolor.rgba
+                if (
+                    self.node.parent is not None
+                    and self.node.parent.canvas.bgcolor
+                ):
+                    background_color = self.node.parent.canvas.bgcolor.rgba
                 else:
                     background_color = get_theme(
                         self.viewer.theme


### PR DESCRIPTION
# References and relevant issues

Closes #6959 
Closes #6961 

# Description

Use `node.parent.canvas` instead of `node.parent` to get background color that affects scale bar color.

A preview of the functionality:

![scale_bar_attrs](https://github.com/napari/napari/assets/16781833/b1568853-3157-4f3d-89c7-9fbcfa4a5749)


