### PR TITLE
Fix switching from 2d to 3d with 2d points

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -1076,3 +1076,14 @@ def test_more_than_uint16_colors(qt_viewer):
         npt.assert_equal(
             midd_pixel, layer.colormap.map(i) * 255, err_msg=f'{i}'
         )
+
+
+def test_points_2d_to_3d(make_napari_viewer):
+    """See https://github.com/napari/napari/issues/6925"""
+    # this requires a full viewer cause some issues are caused only by
+    # qt processing events
+    viewer = make_napari_viewer(ndisplay=2, show=True)
+    viewer.add_points()
+    QApplication.processEvents()
+    viewer.dims.ndisplay = 3
+    QApplication.processEvents()

--- a/napari/_vispy/layers/points.py
+++ b/napari/_vispy/layers/points.py
@@ -130,6 +130,7 @@ class VispyPointsLayer(VispyBaseLayer):
             or 0 in self.layer._highlight_box.shape
         ):
             pos = np.zeros((1, self.layer._slice_input.ndisplay))
+            highlight_thickness = 0
         else:
             pos = self.layer._highlight_box
 


### PR DESCRIPTION
# References and relevant issues
Fixes #6925.

# Description
This was introduced by me in https://github.com/napari/napari/pull/6896/files#r1602264036, and as pointed out by @psobolewskiPhD for some reason tests weren't catching it. Turns out, as found by @andy-sweet (https://github.com/napari/napari/issues/6925#issuecomment-2163682679), we need a test with full qt events.

I'm not sure whether there's a smarter way to do this, but I confirmed that this test fails before the fix and works after.
