### PR TITLE
Add tox-uv to test environment for speedup installation, fix codecov upload

### DIFF
--- a/.github/workflows/reusable_build_wheel.yml
+++ b/.github/workflows/reusable_build_wheel.yml
@@ -27,10 +27,6 @@ jobs:
         run: |
           python -m build --wheel --outdir dist/
 
-      - name: Rename wheel
-        run: |
-          mv dist/*.whl dist/napari-0.0.1-py3-none-any.whl
-
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.codecov_token }}
+          version: v0.6.0

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -68,6 +68,9 @@ jobs:
           name: wheel
           path: dist
 
+      - name: Set wheel path
+        run: echo "WHEEL_PATH=$(ls dist/*.whl)" >> $GITHUB_ENV
+
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v5
         with:
@@ -141,7 +144,7 @@ jobs:
           shell: bash
           run: |
             echo ${{ env.MAIN }}
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.MAIN }}
@@ -154,7 +157,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.SECOND }}
@@ -167,7 +170,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.THIRD }}
@@ -180,7 +183,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/napari-0.0.1-py3-none-any.whl -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.FOURTH }}

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -144,7 +144,7 @@ jobs:
           shell: bash
           run: |
             echo ${{ env.MAIN }}
-            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.MAIN }}
@@ -157,7 +157,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.SECOND }}
@@ -170,7 +170,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.THIRD }}
@@ -183,7 +183,7 @@ jobs:
         with:
           shell: bash
           run: |
-            python -m tox run --installpkg dist/${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+            python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
             rm -r .tox
         env:
           BACKEND: ${{ env.FOURTH }}

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -50,6 +50,7 @@ jobs:
       MIN_REQ: ${{ inputs.min_req }}
       FORCE_COLOR: 1
       PIP_CONSTRAINT: ${{ github.workspace }}/resources/constraints/constraints_py${{ inputs.python_version }}${{ (((inputs.platform == 'macos-latest') && '_macos_arm') || '') }}${{ inputs.min_req && '_min_req' }}${{ inputs.constraints_suffix }}.txt
+      UV_CONSTRAINT: ${{ github.workspace }}/resources/constraints/constraints_py${{ inputs.python_version }}${{ (((inputs.platform == 'macos-latest') && '_macos_arm') || '') }}${{ inputs.min_req && '_min_req' }}${{ inputs.constraints_suffix }}.txt
       # Above we calculate path to constraints file based on python version and platform
       # Because there is no single PyQt5-Qt5 package version available for all platforms we was forced to use
       # different constraints files for macOS arm and other platforms
@@ -98,7 +99,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install setuptools tox tox-gh-actions tox-min-req
+          pip install setuptools tox tox-gh-actions tox-min-req tox-uv
         env:
           PIP_CONSTRAINT: ""
 

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Set wheel path
         run: echo "WHEEL_PATH=$(ls dist/*.whl)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Set up Python ${{ inputs.python_version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
# Description

This PR adds tox-uv plugin to test env for speedup test environment creation. 

For Initial test (3.9, ubuntu-latest, pyqt5, _pydantic_1, no_cov) / ubuntu-latest py 3.9 pyqt5 no_cov it reduced setup time from 55s to 10s 

For macos-latest / macos-latest py 3.12 pyqt5 no_cov it reduces time from 55s to 9s

It also fixes codecov upload by pin codecov cli to 0.6.0. It may need to be reverted once the bug in codecov cli is fixed. 