### PR TITLE
[UX/UI] flip the default for the reader plugin dialog to *not* have the Remember box checked

### DIFF
--- a/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -42,7 +42,7 @@ def test_reader_defaults(reader_dialog, tmpdir):
 
     assert widg.findChild(QLabel).text().startswith('Choose reader')
     assert widg._get_plugin_choice() == 'p1'
-    assert widg.persist_checkbox.isChecked()
+    assert not widg.persist_checkbox.isChecked()
 
 
 def test_reader_with_error_message(reader_dialog):
@@ -84,10 +84,10 @@ def test_get_plugin_choice(tmpdir, reader_dialog):
 def test_get_persist_choice(tmpdir, reader_dialog):
     file_pth = tmpdir.join('my_file.tif')
     widg = reader_dialog(pth=file_pth, readers={'p1': 'p1', 'p2': 'p2'})
-    assert widg._get_persist_choice()
+    assert not widg._get_persist_choice()
 
     widg.persist_checkbox.toggle()
-    assert not widg._get_persist_choice()
+    assert widg._get_persist_choice()
 
 
 def test_prepare_dialog_options_no_readers():

--- a/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/napari/_qt/dialogs/qt_reader_dialog.py
@@ -27,7 +27,7 @@ class QtReaderDialog(QDialog):
         parent: QWidget = None,
         readers: Optional[dict[str, str]] = None,
         error_message: str = '',
-        persist_checked: bool = True,
+        persist_checked: bool = False,
     ) -> None:
         if readers is None:
             readers = {}
@@ -194,7 +194,7 @@ def handle_gui_reading(
         pth=_path,
         error_message=error_message,
         readers=readers,
-        persist_checked=not plugin_override,
+        persist_checked=plugin_override,
     )
     display_name, persist = readerDialog.get_user_choices()
     if display_name:


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7010

# Description
- flip the defaults for the reader plugin dialog for the `Remember this plugin` checkbox from True (checked) to False (unchecked)
- flip the tests to match
