### PR TITLE
User `perf.perf_config` everywhere

### DIFF
--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -243,7 +243,7 @@ def quit_app():
     else:
         QApplication.setWindowIcon(QIcon())
 
-    if perf.USE_PERFMON:
+    if perf.perf_config is not None:
         # Write trace file before exit, if we were writing one.
         # Is there a better place to make sure this is done on exit?
         perf.timers.stop_trace_file()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -686,7 +686,7 @@ class Window:
         self._add_viewer_dock_widget(
             self._qt_viewer.dockLayerList, tabify=False
         )
-        if perf.USE_PERFMON:
+        if perf.perf_config is not None:
             self._add_viewer_dock_widget(
                 self._qt_viewer.dockPerformance, menu=self.window_menu
             )

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -439,7 +439,7 @@ class QtViewer(QSplitter):
 
     def _create_performance_dock_widget(self):
         """Create the dock widget that shows performance metrics."""
-        if perf.USE_PERFMON:
+        if perf.perf_config is not None:
             return QtViewerDockWidget(
                 self,
                 QtPerformance(),

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -1,14 +1,16 @@
 """PerfTimers class and global instance."""
 
 import contextlib
+import os
 from collections.abc import Generator
 from time import perf_counter_ns
 from typing import Optional, Union
 
-from napari.utils import perf
 from napari.utils.perf._event import PerfEvent
 from napari.utils.perf._stat import Stat
 from napari.utils.perf._trace_file import PerfTraceFile
+
+USE_PERFMON = os.getenv('NAPARI_PERFMON', '0') != '0'
 
 
 class PerfTimers:
@@ -308,7 +310,7 @@ def add_counter_event(name: str, **kwargs: float) -> None:
 
 timers: Union[DummyTimer, PerfTimers]
 
-if perf.perf_config is not None:
+if USE_PERFMON:
     timers = PerfTimers()
     perf_timer = block_timer
 

--- a/napari/utils/perf/_timers.py
+++ b/napari/utils/perf/_timers.py
@@ -1,16 +1,14 @@
 """PerfTimers class and global instance."""
 
 import contextlib
-import os
 from collections.abc import Generator
 from time import perf_counter_ns
 from typing import Optional, Union
 
+from napari.utils import perf
 from napari.utils.perf._event import PerfEvent
 from napari.utils.perf._stat import Stat
 from napari.utils.perf._trace_file import PerfTraceFile
-
-USE_PERFMON = os.getenv('NAPARI_PERFMON', '0') != '0'
 
 
 class PerfTimers:
@@ -310,7 +308,7 @@ def add_counter_event(name: str, **kwargs: float) -> None:
 
 timers: Union[DummyTimer, PerfTimers]
 
-if USE_PERFMON:
+if perf.perf_config is not None:
     timers = PerfTimers()
     perf_timer = block_timer
 


### PR DESCRIPTION
# References and relevant issues

See: https://github.com/napari/napari/pull/6975#discussion_r1638433622

# Description

Uses `perf.perf_config` of everywhere (replaces some instances of env `NAPARI_PERFMON`) which I think makes sense as it is meant to be one global config and it's consistent. My naive check says the change keeps functionality the same but best for someone more knowledgable to check.


