### PR TITLE
Use `dev` links for pre-release

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_help.py
+++ b/napari/_qt/_qapp_model/qactions/_help.py
@@ -19,7 +19,7 @@ def _show_about(window: Window):
 
 
 v = parse(__version__)
-VERSION = 'dev' if v.is_devrelease else str(v)
+VERSION = 'dev' if v.is_devrelease or v.is_prerelease else str(v.base_version)
 
 HELP_URLS: dict[str, str] = {
     'getting_started': f'https://napari.org/{VERSION}/tutorials/start_index.html',


### PR DESCRIPTION
# References and relevant issues

# Description

To avoid crash `test_help_urls` on pre releases commits. 
