### PR TITLE
Handle also alpha and beta releases in `make_release.yml`

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -32,7 +32,7 @@ jobs:
         id: release_notes
         run: |
           TAG="${GITHUB_REF/refs\/tags\/v/}"  # clean tag
-          if [[ "$TAG" != *"rc"* ]]; then
+          if [[ "$TAG" != *"rc"* && "$TAG" != *"a"* && "$TAG" != *"b"*]]; then
             VER="${TAG/rc*/}"  # remove pre-release identifier
             RELEASE_NOTES="$(cat docs/release/release_${VER//./_}.md)"
             # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/actions/runs/9681576465/job/26712483416

# Description

This PR is fixing release workflow by accepting tags that contain alpha and beta releases. I do not like this solution, but this change will allow to fast release the first release of 0.5.0 line. 


At some moment, we have used [v0.5.0a1](https://github.com/napari/napari/tree/v0.5.0a1) release to cut of from v0.4.x line. Such change will lead to push such commit to pypi and will require to yank it. 

Other option is to do only fix for beta and release `0.5.0b1`, but I'm not sure if current state could be named beta. 