### PR TITLE
Measure fps

### DIFF
--- a/examples/viewer_fps_label.py
+++ b/examples/viewer_fps_label.py
@@ -21,7 +21,7 @@ viewer.add_image(np.random.random((5, 5, 5)), colormap='red', opacity=0.8)
 viewer.text_overlay.visible = True
 # note: this is using a private attribute, so it might break
 # without warningin future versions!
-viewer.window._qt_viewer.canvas._scene_canvas.measure_fps(callback=update_fps)
+viewer.measure_fps(callback=update_fps)
 
 if __name__ == '__main__':
     napari.run()

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -88,7 +88,14 @@ class Viewer(ViewerModel):
             return
         self.window._qt_viewer.console.push(variables)
 
-    def measure_fps(self, callback: Callable[[float], typing.Any]):
+    def measure_fps(self, callback: Callable[[float], typing.Any]) -> None:
+        """Measure fps of the canvas.
+
+        Parameters
+        ----------
+        callback : Callable[[float], typing.Any]
+            A callback function accepting as parameter a float representing the fps.
+        """
         return self.window._qt_viewer.canvas._scene_canvas.measure_fps(
             callback=callback
         )

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -88,8 +88,8 @@ class Viewer(ViewerModel):
             return
         self.window._qt_viewer.console.push(variables)
 
-    def measure_fps(self, callback: Callable):
-        return self.window.qt_viewer.canvas._scene_canvas.measure_fps(
+    def measure_fps(self, callback: Callable[[float], typing.Any]):
+        return self.window._qt_viewer.canvas._scene_canvas.measure_fps(
             callback=callback
         )
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,5 +1,5 @@
 import typing
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 from weakref import WeakSet
 
 import magicgui as mgui
@@ -87,6 +87,11 @@ class Viewer(ViewerModel):
             self.window._qt_viewer.add_to_console_backlog(variables)
             return
         self.window._qt_viewer.console.push(variables)
+
+    def measure_fps(self, callback: Callable):
+        return self.window.qt_viewer.canvas._scene_canvas.measure_fps(
+            callback=callback
+        )
 
     def screenshot(
         self,


### PR DESCRIPTION
# References and relevant issues
closes #7035

# Description
This PR fixes an issue reported @rjlopez2. Due to the refactor in #5432 in which we put the actual VispyCanvas as an attribute in the VispyCanvas class, the `measure_fps` method of canvas in Vispy was not accesible the same way as it used to be. Furthermore, because of the planned deprecation of public access to the qt viewer in due time this part of the code would not be accessible. This PR adds the `measure_fps` to the napari `Viewer` and also updates the `viewer_fps_label.py` example.