### PR TITLE
Fix numpy dtype check in guess_continuous

### DIFF
--- a/napari/layers/utils/_tests/test_color_manager_utils.py
+++ b/napari/layers/utils/_tests/test_color_manager_utils.py
@@ -16,6 +16,9 @@ def test_guess_continuous():
     categorical_annotation_2 = np.array([1, 2, 3], dtype=int)
     assert not guess_continuous(categorical_annotation_2)
 
+    categorical_annotation_3 = np.arange(20, dtype=int)
+    assert guess_continuous(categorical_annotation_3)
+
 
 def test_is_colormapped_string():
     color = 'hello'

--- a/napari/layers/utils/color_manager_utils.py
+++ b/napari/layers/utils/color_manager_utils.py
@@ -24,7 +24,7 @@ def guess_continuous(color_map: np.ndarray) -> bool:
     # if the property is a floating type, guess continuous
     return issubclass(color_map.dtype.type, np.floating) or (
         len(np.unique(color_map)) > 16
-        and isinstance(color_map.dtype.type, np.integer)
+        and issubclass(color_map.dtype.type, np.integer)
     )
 
 


### PR DESCRIPTION
# References and relevant issues
See Zulip discussion and corresponding bug in skan: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/colormapping.20shapes

# Description
This fixes the numpy dtype check in `guess_continuous` to use `issubclass` instead of `isinstance`, so that integer valued arrays with more than 16 values return `True`.

This should fix the behavior or guessing a color mode in `Shapes` layer and some other layer types via `ColorManager`.

I added an assertion to `test_guess_continuous` which failed before this fix.

I think we could use `np.issubdtype` with `dtype` instead of `issubclass` with `dtype.type`, but I don't feel too strongly about this.