### PR TITLE
[Shapes] for line tool, have _fixed_aspect (shift) enable 45 degree rotations if shift held first.

### DIFF
--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -257,6 +257,8 @@ def _add_line_rectangle_ellipse(
         String indicating the type of shape to be added.
     """
     # on press
+    # reset layer._aspect_ratio for a new shape
+    layer._aspect_ratio = 1
     # Start drawing rectangle / ellipse / line
     layer.add(data, shape_type=shape_type, gui=True)
     layer.selected_data = {layer.nshapes - 1}
@@ -724,6 +726,7 @@ def _move_active_element_under_cursor(
             layer.refresh()
         elif vertex < Box.LEN:
             # Corner / edge vertex is being dragged so resize object
+            # Also applies while drawing line, rectangle, ellipse
             box = layer._selected_box
             if layer._fixed_vertex is None:
                 layer._fixed_index = (vertex + 4) % Box.LEN
@@ -744,13 +747,23 @@ def _move_active_element_under_cursor(
 
             fixed = layer._fixed_vertex
             new = list(coord)
-
             box_center = box[Box.CENTER]
             if layer._fixed_aspect and layer._fixed_index % 2 == 0:
                 # corner
-                new = (box[vertex] - box_center) / np.linalg.norm(
-                    box[vertex] - box_center
-                ) * np.linalg.norm(new - box_center) + box_center
+                # ensure line rotates through 45 degree steps if aspect ratio is 1
+                if layer._mode == Mode.ADD_LINE and layer._aspect_ratio == 1:
+                    new_offset = coord - layer._fixed_vertex
+                    angle_rad = np.arctan2(new_offset[0], -new_offset[1])
+                    angle_rad = np.round(angle_rad / (np.pi / 4)) * (np.pi / 4)
+                    new = (
+                        np.array([np.sin(angle_rad), -np.cos(angle_rad)])
+                        * np.linalg.norm(new - box_center)
+                        + box_center
+                    )
+                else:
+                    new = (box[vertex] - box_center) / np.linalg.norm(
+                        box[vertex] - box_center
+                    ) * np.linalg.norm(new - box_center) + box_center
 
             if layer._fixed_index % 2 == 0:
                 # corner selected


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7042

# Description
In this PR I first ensure that when drawing a new shape the aspect ratio is reset to 1.
Previously, because a shape could be selected when drawing is begun (e.g. drawing multiple lines back to back), the wrong aspect ratio (that of the previous shape) would be returned by layer._aspect_ratio when Shift is pressed.  This had no ill effects, because it wasn't used with shape drawing.
Next, with this information, I can check whether a line was being drawn with Shift already pressed (_aspect_ratio ==1 ) and if so, allow it to rotate through fixed 45 degree angles. If Shift is pressed *during* drawing, the current behavior is maintained, where the current aspect ratio is fixed.
I added a test for the new behavior.