### PR TITLE
Restore events to `QtViewer.canvas`

### DIFF
--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -169,6 +169,8 @@ class VispyCanvas:
 
     @property
     def events(self):
+        # This is backwards compatible with the old events system
+        # https://github.com/napari/napari/issues/7054#issuecomment-2205548968
         return self._scene_canvas.events
 
     @property

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -168,6 +168,10 @@ class VispyCanvas:
         self.destroyed.connect(self._disconnect_theme)
 
     @property
+    def events(self):
+        return self._scene_canvas.events
+
+    @property
     def destroyed(self) -> pyqtBoundSignal:
         return self._scene_canvas._backend.destroyed
 


### PR DESCRIPTION
# References and relevant issues

In #7054, I noted that in #5432 we had inadvertently removed access to mouse events from QtViewer.canvas, without a deprecation. @jni [commented](https://github.com/napari/napari/issues/7054#issuecomment-2205548968) that we could temporarily restore access with a property, followed in later versions by an alternate API and deprecation.

# Description

This PR adds an `events` property to QtViewer.canvas, restoring the broken behavior. It does not yet have a deprecation message because we don't have an alternate API.