### PR TITLE
Provide default colors automatically in DirectLabelsColormap

### DIFF
--- a/napari/utils/colormaps/_tests/test_colormap.py
+++ b/napari/utils/colormaps/_tests/test_colormap.py
@@ -448,7 +448,7 @@ def test_direct_colormap_with_values_outside_data_dtype():
 
 def test_direct_colormap_with_empty_color_dict():
     # Create a DirectLabelColormap with an empty color_dict
-    with pytest.raises(ValueError, match='color_dict must contain None'):
+    with pytest.warns(Warning, match='color_dict did not provide'):
         DirectLabelColormap(color_dict={})
 
 

--- a/napari/utils/colormaps/colormap.py
+++ b/napari/utils/colormaps/colormap.py
@@ -10,6 +10,7 @@ from typing import (
     cast,
     overload,
 )
+from warnings import warn
 
 import numpy as np
 from typing_extensions import Self
@@ -418,7 +419,8 @@ class DirectLabelColormap(LabelColormapBase):
         v : MutableMapping
             A mapping from integers to colors. It *may* have None as a key,
             which indicates the color to map items not in the dictionary.
-            Alternatively, it could be a defaultdict.
+            Alternatively, it could be a defaultdict. If neither is provided,
+            missing colors are not rendered (rendered as fully transparent).
         values : dict[str, Any]
             A dictionary mapping previously-validated attributes to their
             validated values. Attributes are validated in the order in which
@@ -430,9 +432,13 @@ class DirectLabelColormap(LabelColormapBase):
             A properly-formatted dictionary mapping labels to RGBA arrays.
         """
         if not isinstance(v, defaultdict) and None not in v:
-            raise ValueError(
-                'color_dict must contain None or be defaultdict instance'
+            warn(
+                'color_dict did not provide a default color. '
+                'Missing keys will be transparent. '
+                'To provide a default color, use the key `None`, '
+                'or provide a defaultdict instance.'
             )
+            v = {**v, None: 'transparent'}
         res = {
             label: transform_color(color_str)[0]
             for label, color_str in v.items()


### PR DESCRIPTION
While trying to fix ome/napari-ome-zarr#109 on the ome side after #7025, I found that I was still getting errors — now by the color_dict validator, which requires a None key or a defaultdict. Ultimately, I think this is a quirky interface that I don't think we should impose on ome-zarr or their readers. Therefore, I've changed the ValueError to a warning. I'd consider removing the warning altogether.
