### PR TITLE
Fix make_release workflow to properly handle alpha and beta releases

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -44,7 +44,25 @@ jobs:
           fi
           echo "tag=${TAG}" >> $GITHUB_ENV
           # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
-          echo "name=contents=${RELEASE_NOTES}" >> $GITHUB_ENV
+          echo "contents=${RELEASE_NOTES}" >> "$GITHUB_OUTPUT"
+
+      - name: check if prerelease
+        id: prerelease
+        run: |
+          regex='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+|rc[0-9]+)$'
+
+          check_version() {
+              if [[ $1 =~ $regex ]]; then
+                  echo "true"
+              else
+                  echo "false"
+              fi
+          }
+          echo ${{ github.ref }}
+          check_version ${{ github.ref }}
+          echo "prerelease=$(check_version ${{ github.ref }})" >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Create Release
         uses: "softprops/action-gh-release@v2"
         with:
@@ -52,7 +70,7 @@ jobs:
           name: ${{ env.tag }}
           body: ${{ steps.release_notes.outputs.contents }}
           draft: false
-          prerelease: ${{ contains(github.ref, 'rc') }}
+          prerelease: ${{ steps.prerelease.outputs.prerelease  == 'true' }}
           files: |
             dist/*
       - name: Publish PyPI Package


### PR DESCRIPTION
# References and relevant issues

# Description

For the current implementation, prerelease is set to true only if `rc` is in reference. So it set to true if `ref` is `refs/tags/v0.5.0rc1` and not set if `refs/tags/v0.5.0` or `refs/tags/v0.5.0a1`

This PR fixes it to properly handle refs like `refs/tags/v0.5.0a1` or `refs/tags/v0.5.0b10`
