### PR TITLE
Move `IO_Utilities` and `Acquire` submenus to their own group in the `File` menu

### DIFF
--- a/napari/_app_model/constants/_menus.py
+++ b/napari/_app_model/constants/_menus.py
@@ -96,9 +96,10 @@ class MenuGroup:
     PLUGIN_SINGLE_CONTRIBUTIONS = '3_plugin_contributions'
     # File menubar
     OPEN = '1_open'
-    PREFERENCES = '2_preferences'
-    SAVE = '3_save'
-    CLOSE = '4_close'
+    UTIL = '2_util'
+    PREFERENCES = '3_preferences'
+    SAVE = '4_save'
+    CLOSE = '5_close'
 
     class LAYERLIST_CONTEXT:
         CONVERSION = '1_conversion'

--- a/napari/_qt/_qapp_model/qactions/_file.py
+++ b/napari/_qt/_qapp_model/qactions/_file.py
@@ -55,7 +55,7 @@ FILE_SUBMENUS = [
         SubmenuItem(
             submenu=MenuId.FILE_IO_UTILITIES,
             title=trans._('IO Utilities'),
-            group=MenuGroup.OPEN,
+            group=MenuGroup.UTIL,
             order=101,
         ),
     ),
@@ -64,7 +64,7 @@ FILE_SUBMENUS = [
         SubmenuItem(
             submenu=MenuId.FILE_ACQUIRE,
             title=trans._('Acquire'),
-            group=MenuGroup.OPEN,
+            group=MenuGroup.UTIL,
             order=101,
         ),
     ),


### PR DESCRIPTION
# References and relevant issues
Closes #7068 

# Description
Add a new group to the `File` menu for the newly contributable menus, allowing `Open Sample` to remain at the bottom of its group as it previously was.


