### PR TITLE
Ensure out-of-bounds layers are loaded

### DIFF
--- a/napari/_qt/_tests/test_async_slicing.py
+++ b/napari/_qt/_tests/test_async_slicing.py
@@ -1,5 +1,6 @@
 # The tests in this module for the new style of async slicing in napari:
 # https://napari.org/dev/naps/4-async-slicing.html
+from functools import partial
 
 import numpy as np
 import pytest
@@ -47,6 +48,26 @@ def test_async_slice_image_on_current_step_change(
     viewer.dims.current_step = (2, 0, 0)
 
     wait_until_vispy_image_data_equal(qtbot, vispy_image, data[2, :, :])
+
+
+@pytest.mark.usefixtures('_enable_async')
+def test_async_out_of_bounds_layer_loaded(make_napari_viewer, qtbot):
+    """Check that images that are out of bounds when slicing appear loaded.
+
+    See https://github.com/napari/napari/issues/7070.
+    """
+    viewer = make_napari_viewer()
+    l0 = viewer.add_image(np.random.random((5, 5, 5)))
+    l1 = viewer.add_image(np.random.random((5, 5, 5)), translate=(5, 0, 0))
+    assert viewer.dims.nsteps == (10, 5, 5)
+
+    def layer_loaded(ly):
+        return ly.loaded
+
+    for i in range(viewer.dims.nsteps[0]):
+        viewer.dims.current_step = (i, 0, 0)
+        qtbot.waitUntil(partial(layer_loaded, l0), timeout=50)
+        qtbot.waitUntil(partial(layer_loaded, l1), timeout=50)
 
 
 @pytest.mark.usefixtures('_enable_async')


### PR DESCRIPTION
Closes #7070

In #7070, @psobolewskiPhD reported that layers that are out of bounds of the dims slicer never appear loaded. This caused the layer thumbnail spinner to spin forever, which is jarring to users — it makes it impossible to know whether there is no data on that slice or whether some other error (e.g. slow network) is causing the layer to not load.

Some investigation showed that the problem comes from out-of-bounds layers using _ImageSliceResponse.make_empty, which always returns a new slice ID — never the slice ID that was requested. When the layer checks whether the returned (correctly empty) slice is the slice it requested, it finds that it isn't, so it does not change its state to loaded.

Always returning the requested slice ID was not a good option because empty slices are also used on layer construction, before any data is requested. In those cases, returning a new slice ID is the correct behaviour.

This PR adds a new, optional "request_id" argument to _ImageSliceRequest.make_empty, and sets it correctly when requesting an out of bounds slice for an image.

I've added a new test for this behaviour and have confirmed that it fails on main:

```
>           qtbot.waitUntil(partial(layer_loaded, l1), timeout=50)
E           pytestqt.exceptions.TimeoutError: waitUntil timed out in 50 milliseconds

test_async_slicing.py:70: TimeoutError
```

But passes with the changes in this PR.
