### PR TITLE
Fix and simplify release workfow

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Checkout docs
+        uses: actions/checkout@v4
+        with:
+          repository: napari/docs
+          path: docs
+
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -32,26 +38,21 @@ jobs:
         id: release_notes
         run: |
           TAG="${GITHUB_REF/refs\/tags\/v/}"  # clean tag
-          if [[ "$TAG" != *"rc"* && "$TAG" != *"a"* && "$TAG" != *"b"* ]]; then
-            VER="${TAG/rc*/}"  # remove pre-release identifier
-            RELEASE_NOTES="$(cat docs/release/release_${VER//./_}.md)"
-            # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-            RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
-            RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-            RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-          else
-            RELEASE_NOTES="pre-release $TAG"
-          fi
+          VER="${VER/a*/}"  # remove alpha identifier
+          VER="${VER/b*/}"  # remove beta identifier
+          VER="${TAG/rc*/}"  # remove rc identifier
+          RELEASE_NOTES_PATH="docs/release/release_${VER//./_}.md"
+
           echo "tag=${TAG}" >> $GITHUB_ENV
-          # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
-          echo "contents=${RELEASE_NOTES}" >> "$GITHUB_OUTPUT"
+          echo "release_notes_path=${RELEASE_NOTES_PATH}" >> $GITHUB_ENV
 
       - name: Create Release
         uses: "softprops/action-gh-release@v2"
         with:
           tag_name: ${{ github.ref }}
           name: ${{ env.tag }}
-          body: ${{ steps.release_notes.outputs.contents }}
+          body: pre-release ${{ env.tag }}
+          body_path: ${{ env.release_notes_path }}
           draft: false
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
           files: |

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -46,23 +46,6 @@ jobs:
           # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
           echo "contents=${RELEASE_NOTES}" >> "$GITHUB_OUTPUT"
 
-      - name: check if prerelease
-        id: prerelease
-        run: |
-          regex='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+|rc[0-9]+)$'
-
-          check_version() {
-              if [[ $1 =~ $regex ]]; then
-                  echo "true"
-              else
-                  echo "false"
-              fi
-          }
-          echo ${{ github.ref }}
-          check_version ${{ github.ref }}
-          echo "prerelease=$(check_version ${{ github.ref }})" >> "$GITHUB_OUTPUT"
-        shell: bash
-
       - name: Create Release
         uses: "softprops/action-gh-release@v2"
         with:
@@ -70,7 +53,7 @@ jobs:
           name: ${{ env.tag }}
           body: ${{ steps.release_notes.outputs.contents }}
           draft: false
-          prerelease: ${{ steps.prerelease.outputs.prerelease  == 'true' }}
+          prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
           files: |
             dist/*
       - name: Publish PyPI Package

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+docs
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
# Description

This PR fix release workflow by adding cloning of napari/docs to fetch release notes. 

It updates usage of softprops/action-gh-release by using path to release body instead of encoding it into an environment variable 

It simplifies workflow by checking if prerelease by checking `env.tag` instead of `github.ref` (tested in PartSeg repository) 