### PR TITLE
Fix release workflow, fix names of env variable

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -38,9 +38,9 @@ jobs:
         id: release_notes
         run: |
           TAG="${GITHUB_REF/refs\/tags\/v/}"  # clean tag
-          VER="${VER/a*/}"  # remove alpha identifier
+          VER="${TAG/a*/}"  # remove alpha identifier
           VER="${VER/b*/}"  # remove beta identifier
-          VER="${TAG/rc*/}"  # remove rc identifier
+          VER="${VER/rc*/}"  # remove rc identifier
           RELEASE_NOTES_PATH="docs/release/release_${VER//./_}.md"
 
           echo "tag=${TAG}" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

After I created and validated #7078 I spot that first I remove rc, and then alpha and beta from the version. I have an idea that it will be more readable to first remove alpha, then beta, then rc. So reorder command without thinking about starting argument. 

This PR fixes it. 
