### PR TITLE
Add style collection for applying and storing multiple encodings

### DIFF
--- a/napari/layers/utils/_tests/test_style_encoding.py
+++ b/napari/layers/utils/_tests/test_style_encoding.py
@@ -296,6 +296,16 @@ class Style(StyleCollection):
     direct: ScalarDirectEncoding = ScalarDirectEncoding(feature='scalar')
 
 
+def test_style_collection_call(features: pd.DataFrame):
+    style = Style()
+
+    values = style(features)
+
+    np.testing.assert_equal(values['constant'], 2)
+    np.testing.assert_equal(values['manual'], [2, 4, 6])
+    np.testing.assert_equal(values['direct'], features['scalar'])
+
+
 def test_style_collection_apply(features: pd.DataFrame):
     style = Style()
 

--- a/napari/layers/utils/_tests/test_style_encoding.py
+++ b/napari/layers/utils/_tests/test_style_encoding.py
@@ -16,6 +16,7 @@ import pytest
 
 from napari._pydantic_compat import Field
 from napari.layers.utils.style_encoding import (
+    StyleCollection,
     _ConstantStyleEncoding,
     _DerivedStyleEncoding,
     _ManualStyleEncoding,
@@ -287,3 +288,67 @@ def test_vector_derived_encoding_clear():
     encoding._clear()
 
     np.testing.assert_array_equal(encoding._values, np.empty((0, 2)))
+
+
+class Style(StyleCollection):
+    constant: ScalarConstantEncoding = ScalarConstantEncoding(constant=2)
+    manual: ScalarManualEncoding = ScalarManualEncoding(array=[2, 4, 6])
+    direct: ScalarDirectEncoding = ScalarDirectEncoding(feature='scalar')
+
+
+def test_style_collection_apply(features: pd.DataFrame):
+    style = Style()
+
+    style._apply(features)
+
+    np.testing.assert_equal(style.constant._values, 2)
+    np.testing.assert_equal(style.manual._values, [2, 4, 6])
+    np.testing.assert_equal(style.direct._values, features['scalar'])
+
+
+def test_style_collection_clear(features: pd.DataFrame):
+    style = Style()
+    style._apply(features)
+
+    style._clear()
+
+    np.testing.assert_equal(style.constant._values, 2)
+    np.testing.assert_equal(style.manual._values, [2, 4, 6])
+    np.testing.assert_equal(style.direct._values, [])
+
+
+def test_style_collection_refresh(features: pd.DataFrame):
+    style = Style()
+    style._apply(features)
+
+    features['scalar'] *= 2
+    style._refresh(features)
+
+    np.testing.assert_equal(style.constant._values, 2)
+    np.testing.assert_equal(style.manual._values, [2, 4, 6])
+    np.testing.assert_equal(style.direct._values, features['scalar'])
+
+
+def test_style_collection_delete(features: pd.DataFrame):
+    style = Style()
+    style._apply(features)
+
+    style._delete([1])
+
+    np.testing.assert_equal(style.constant._values, 2)
+    np.testing.assert_equal(style.manual._values, [2, 6])
+    np.testing.assert_equal(style.direct._values, features['scalar'][[0, 2]])
+
+
+def test_style_collection_copy_paste(features: pd.DataFrame):
+    style = Style()
+    style._apply(features)
+
+    copied = style._copy([0, 2])
+    style._paste(**copied)
+
+    np.testing.assert_equal(style.constant._values, 2)
+    np.testing.assert_equal(style.manual._values, [2, 4, 6, 2, 6])
+    np.testing.assert_equal(
+        style.direct._values, features['scalar'][[0, 1, 2, 0, 2]]
+    )

--- a/napari/layers/utils/style_encoding.py
+++ b/napari/layers/utils/style_encoding.py
@@ -171,7 +171,7 @@ class StyleCollection(EventedModel):
     def _channels(self) -> tuple[str, ...]:
         """Channel names in this style collection.
 
-        Example: ['face_color', 'edge_color', 'size'].
+        Example: ('face_color', 'edge_color', 'size').
         """
         return tuple(self.__fields__)
 
@@ -201,15 +201,15 @@ class StyleCollection(EventedModel):
         for encoding in self._encodings:
             encoding._delete(indices)
 
-    def _copy(self, indices) -> dict:
+    def _copy(self, indices) -> dict[str, Union[StyleValue, StyleArray]]:
         return {
-            ch: _get_style_values(prop, indices)
-            for ch, prop in zip(self._channels, self._encodings)
+            channel: _get_style_values(encoding, indices)
+            for channel, encoding in zip(self._channels, self._encodings)
         }
 
-    def _paste(self, **elements):
-        for channel, styled_values in elements.items():
-            getattr(self, channel)._append(styled_values)
+    def _paste(self, **elements) -> None:
+        for channel, values in elements.items():
+            getattr(self, channel)._append(values)
 
 
 class _StyleEncodingModel(EventedModel):

--- a/napari/layers/utils/style_encoding.py
+++ b/napari/layers/utils/style_encoding.py
@@ -114,23 +114,72 @@ class StyleCollection(EventedModel):
 
     Examples
     --------
-    class Style(StyleCollection):
-        edge_color: ColorEncoding = QuantitativeColorEncoding(feature='confidence', colormap='gray', contrast_limits=(0, 1))
-        face_color: ColorEncoding = NominalColorEncoding(feature='class', colormap={'cat': 'red', 'dog': 'blue'})
-    features = pd.DataFrame
+    >>> import pandas as pd
+    >>> class Style(StyleCollection):
+    >>>     edge_color: ColorEncoding
+    >>>     face_color: ColorEncoding
+    >>> style = Style(
+    >>>     edge_color={
+    >>>         'feature': 'confidence',
+    >>>         'colormap': 'gray',
+    >>>         'contrast_limits': (0, 1),
+    >>>     },
+    >>>     face_color={
+    >>>         'feature': 'good_point',
+    >>>         'colormap': {False: 'green', True: 'blue'},
+    >>>     },
+    >>> )
+    >>> features = pd.DataFrame({
+    >>>     'confidence': [1, 0.5, 0],
+    >>>     'good_point': [True, False, False],
+    >>> })
+    >>> style(features)
+    {
+        'edge_color': array([[1, 1, 1, 1], [0.5, 0.5, 0.5, 1], [0, 0, 0, 1]]),
+        'face_color': array([[0, 1, 0, 1], [0, 0, 1, 1]]),
+    }
     """
+
+    def __call__(
+        self, features: Any
+    ) -> dict[str, Union[StyleValue, StyleArray]]:
+        """Apply all encodings with the given features to generate style values.
+
+        Parameters
+        ----------
+        features : Dataframe-like
+            The layer features table from which to derive the output values.
+
+        Returns
+        -------
+        dict[str, Union[StyleValue, StyleArray]]
+            Maps from channel/field name to either a single style value
+            (e.g. from a constant encoding) or an array of encoded values the
+            same length as the given features.
+
+        Raises
+        ------
+        KeyError, ValueError
+            If generating values from the given features fails.
+        """
+        return {
+            channel: encoding(features)
+            for channel, encoding in zip(self._channels, self._encodings)
+        }
 
     @property
     def _channels(self) -> tuple[str, ...]:
-        """List of channel names implemented in the Style.
+        """Channel names in this style collection.
+
         Example: ['face_color', 'edge_color', 'size'].
         """
         return tuple(self.__fields__)
 
     @property
     def _encodings(self) -> tuple[StyleEncoding, ...]:
-        """List of StyleEncodings, one per visual channel.
-        The order must match the order of `_channels`.
+        """Encodings in this style collection, one per visual channel.
+
+        The order matches the order of `_channels`.
         """
         return tuple(
             getattr(self, channel_name) for channel_name in self._channels

--- a/napari/layers/utils/style_encoding.py
+++ b/napari/layers/utils/style_encoding.py
@@ -201,7 +201,9 @@ class StyleCollection(EventedModel):
         for encoding in self._encodings:
             encoding._delete(indices)
 
-    def _copy(self, indices) -> dict[str, Union[StyleValue, StyleArray]]:
+    def _copy(
+        self, indices: IndicesType
+    ) -> dict[str, Union[StyleValue, StyleArray]]:
         return {
             channel: _get_style_values(encoding, indices)
             for channel, encoding in zip(self._channels, self._encodings)


### PR DESCRIPTION
# References and relevant issues
Part of #2866

# Description
This adds a utility class for storing a collection of style encodings. The intent is to use this class in a napari layer as a way to replace lots of individual style attributes (e.g. `face_color`, `face_color_cycle`, `face_colormap`). See https://github.com/andy-sweet/napari/pull/6 to see roughly what this would look like.

Credit to @jni for devising this abstraction in https://github.com/andy-sweet/napari/pull/6