### PR TITLE
Fix handling of units and axis_labels in add_image

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -85,6 +85,13 @@ def test_add_image_colormap_variants():
     assert "did you mean to specify a 'channel_axis'" in str(err.value)
 
 
+def test_add_image_accepts_all_arguments_as_sequence():
+    """See https://github.com/napari/napari/pull/7089."""
+    viewer = ViewerModel(ndisplay=3)
+    img = viewer.add_image(np.random.rand(2, 2))
+    viewer.add_image(**img._get_state())
+
+
 def test_add_volume():
     """Test adding volume."""
     viewer = ViewerModel(ndisplay=3)

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -962,6 +962,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             'metadata',
             'experimental_clipping_planes',
             'custom_interpolation_kernel_2d',
+            'axis_labels',
+            'units',
         }
 
         if channel_axis is None:


### PR DESCRIPTION
# Description

The new `axis_labels` and `units` arguments for layers are iterables; they need to be added to the iterable arguments to avoid problems with the channel splitting in the case of an image stack.

Currently, this fails:

```py
import napari
import numpy as np
v = napari.Viewer()
a = np.random.rand(2, 2)
v.add_image(a, axis_labels=('x', 'y'))
```

with:

```
TypeError: Received sequence for argument 'axis_labels', did you mean to specify a 'channel_axis'?
```
