### PR TITLE
fix: set `target_commitish` for commit sha to fix benchmarks

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -62,6 +62,7 @@ jobs:
           body_path: ${{ env.release_notes_path }}
           draft: false
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
+          target_commitish: ${{ github.sha }}
           files: |
             dist/*
       - name: Publish PyPI Package


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/actions/runs/9906244320/job/27367444458?pr=7089#step:9:61

# Description

In benchmark testing, we use `target_commitish` to determine which commit use for comparison.

https://github.com/napari/napari/blob/157b144d90e0a605a5dac68321dcd34250cd6590/.github/workflows/test_pull_requests.yml#L253

Hovewer action that we are using is setting by default `target_commitish` to the default repository branch:
https://github.com/softprops/action-gh-release?tab=readme-ov-file#-customizing

This means that since few releases, I need to manually fix this value. Otherwise, we get failing benchmarks (as in first link)  

To see JSON describing current release, one may use:

```bash
gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/napari/napari/releases/latest
```

I have patched v0.5.0 release using this command 

```bash 
gh api --method PATCH  \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/napari/napari/releases/164963500 \
-f "target_commitish=157b144d90e0a605a5dac68321dcd34250cd6590"
```