### PR TITLE
Fix label conversion with proj mode

### DIFF
--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import numpy.typing as npt
 
+from napari import layers
 from napari.layers import Image, Labels, Layer
 from napari.layers._source import layer_source
 from napari.layers.utils import stack_utils
@@ -53,7 +54,6 @@ def _convert(ll: LayerList, type_: str) -> None:
 
     for lay in list(ll.selection):
         idx = ll.index(lay)
-
         if isinstance(lay, Shapes) and type_ == 'labels':
             data = lay.to_labels()
             idx += 1
@@ -66,7 +66,15 @@ def _convert(ll: LayerList, type_: str) -> None:
             data = lay.data
             # int image layer to labels is fully reversible
             ll.pop(idx)
-        new_layer = Layer.create(data, lay._get_base_state(), type_)
+        # projection mode may not be compatible with new type,
+        # we're ok with dropping it in that case
+        layer_type = getattr(layers, type_.title())
+        state = lay._get_base_state()
+        try:
+            layer_type._projectionclass(state['projection_mode'])
+        except ValueError:
+            state['projection_mode'] = 'none'
+        new_layer = Layer.create(data, state, type_)
         ll.insert(idx, new_layer)
 
 

--- a/napari/layers/_layer_actions.py
+++ b/napari/layers/_layer_actions.py
@@ -5,6 +5,7 @@ on a layer in the LayerList.
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -71,9 +72,19 @@ def _convert(ll: LayerList, type_: str) -> None:
         layer_type = getattr(layers, type_.title())
         state = lay._get_base_state()
         try:
-            layer_type._projectionclass(state['projection_mode'])
+            layer_type._projectionclass(state['projection_mode'].value)
         except ValueError:
             state['projection_mode'] = 'none'
+            warnings.warn(
+                trans._(
+                    'projection mode "{mode}" is not compatible with {type_} layers. Falling back to "none".',
+                    mode=state['projection_mode'],
+                    type_=type_.title(),
+                    deferred=True,
+                ),
+                category=UserWarning,
+                stacklevel=1,
+            )
         new_layer = Layer.create(data, state, type_)
         ll.insert(idx, new_layer)
 

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -288,6 +288,12 @@ def test_convert_layer(layer, type_):
         )  # check array data not copied unnecessarily
 
 
+def test_convert_warns_with_projecton_mode():
+    ll = LayerList([Image(np.random.rand(10, 10), projection_mode='mean')])
+    with pytest.warns(UserWarning, match='projection mode'):
+        _convert(ll, 'labels')
+
+
 def make_three_layer_layerlist():
     layer_list = LayerList()
     layer_list.append(Points([[0, 0]], name='test'))

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -289,9 +289,18 @@ def test_convert_layer(layer, type_):
 
 
 def test_convert_warns_with_projecton_mode():
+    # inplace
+    ll = LayerList(
+        [Image(np.random.rand(10, 10).astype(int), projection_mode='mean')]
+    )
+    with pytest.warns(UserWarning, match='projection mode'):
+        _convert(ll, 'labels')
+    assert isinstance(ll['Image'], Labels)
+    # not inplace
     ll = LayerList([Image(np.random.rand(10, 10), projection_mode='mean')])
     with pytest.warns(UserWarning, match='projection mode'):
         _convert(ll, 'labels')
+    assert isinstance(ll['Image [1]'], Labels)
 
 
 def make_three_layer_layerlist():


### PR DESCRIPTION
# References and relevant issues

Fixes #7092

# Description

Ignore incompatible projection modes when converting between layer types. If no corresponding mode exists, a warning is now raised and the mode is ignored.