### PR TITLE
fix call of np.clip in _update_thumbnail

### DIFF
--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -1031,6 +1031,12 @@ def test_thick_slice_multiscale():
     )
 
 
+def test_contrast_outside_range():
+    data = np.zeros((64, 64), dtype=np.uint8)
+
+    Image(data, contrast_limits=(0, 1000))
+
+
 def test_docstring():
     validate_all_params_in_docstring(Image)
     validate_kwargs_sorted(Image)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -612,6 +612,9 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
                 image, zoom_factor, prefilter=False, order=0
             )
             low, high = self.contrast_limits
+            if np.issubdtype(downsampled.dtype, np.integer):
+                low = max(low, np.iinfo(downsampled.dtype).min)
+                high = min(high, np.iinfo(downsampled.dtype).max)
             downsampled = np.clip(downsampled, low, high)
             color_range = high - low
             if color_range != 0:


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari-plugin-manager/pull/70#issuecomment-2234237753


# Description

Without this fix provided test fails with:

```python
napari/layers/image/_tests/test_image.py:1033 (test_contrast_outside_range)
def test_contrast_outside_range():
        data = np.zeros((64, 64), dtype=np.uint8)
    
>       Image(data, contrast_limits=(0, 1000))

napari/layers/image/_tests/test_image.py:1037: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
napari/layers/base/base.py:115: in __call__
    obj._post_init()
napari/layers/_scalar_field/scalar_field.py:310: in _post_init
    self.refresh()
napari/layers/base/base.py:1529: in refresh
    self._refresh_sync()
napari/layers/base/base.py:1536: in _refresh_sync
    self._update_thumbnail()
napari/layers/image/image.py:618: in _update_thumbnail
    downsampled = np.clip(downsampled, low, high)
../../.pyenv/versions/napari_3.11/lib/python3.11/site-packages/numpy/_core/fromnumeric.py:2247: in clip
    return _wrapfunc(a, 'clip', a_min, a_max, out=out, **kwargs)
../../.pyenv/versions/napari_3.11/lib/python3.11/site-packages/numpy/_core/fromnumeric.py:57: in _wrapfunc
    return bound(*args, **kwds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = array([[0, 0, 0, ..., 0, 0, 0],
       [0, 0, 0, ..., 0, 0, 0],
       [0, 0, 0, ..., 0, 0, 0],
       ...,
       [0, 0, 0, ..., 0, 0, 0],
       [0, 0, 0, ..., 0, 0, 0],
       [0, 0, 0, ..., 0, 0, 0]], dtype=uint8)
min = 0, max = 1000, out = None, kwargs = {}

    def _clip(a, min=None, max=None, out=None, **kwargs):
        if min is None and max is None:
            raise ValueError("One of max or min must be given")
    
        if min is None:
            return um.minimum(a, max, out=out, **kwargs)
        elif max is None:
            return um.maximum(a, min, out=out, **kwargs)
        else:
>           return um.clip(a, min, max, out=out, **kwargs)
E           OverflowError: Python integer 1000 out of bounds for uint8

```
