### PR TITLE
Always add `Empty` context key, even if `action` is already registered

### DIFF
--- a/napari/_app_model/utils.py
+++ b/napari/_app_model/utils.py
@@ -9,7 +9,7 @@ from napari._app_model.constants import MenuGroup, MenuId
 MenuOrSubmenu = Union[MenuItem, SubmenuItem]
 
 
-def to_id_key(menu_path):
+def to_id_key(menu_path: str) -> str:
     """Return final part of the menu path.
 
     Parameters
@@ -23,6 +23,22 @@ def to_id_key(menu_path):
         final part of the menu path
     """
     return menu_path.split('/')[-1]
+
+
+def to_action_id(id_key: str) -> str:
+    """Return dummy action ID for the given id_key.
+
+    Parameters
+    ----------
+    id_key : str
+        key to use in action ID
+
+    Returns
+    -------
+    str
+        dummy action ID
+    """
+    return f'napari.{id_key}.empty_dummy'
 
 
 def contains_dummy_action(menu_items: list[MenuOrSubmenu]) -> bool:
@@ -96,7 +112,7 @@ def get_dummy_action(menu_id: MenuId) -> tuple[Action, str]:
     # here and this will no longer be a concern.
     id_key = to_id_key(menu_id)
     action = Action(
-        id=f'napari.{id_key}.empty_dummy',
+        id=to_action_id(id_key),
         title='Empty',
         callback=no_op,
         menus=[

--- a/napari/_app_model/utils.py
+++ b/napari/_app_model/utils.py
@@ -10,6 +10,18 @@ MenuOrSubmenu = Union[MenuItem, SubmenuItem]
 
 
 def to_id_key(menu_path):
+    """Return final part of the menu path.
+
+    Parameters
+    ----------
+    menu_path : str
+        full string delineating the menu path
+
+    Returns
+    -------
+    str
+        final part of the menu path
+    """
     return menu_path.split('/')[-1]
 
 

--- a/napari/_app_model/utils.py
+++ b/napari/_app_model/utils.py
@@ -9,6 +9,10 @@ from napari._app_model.constants import MenuGroup, MenuId
 MenuOrSubmenu = Union[MenuItem, SubmenuItem]
 
 
+def to_id_key(menu_path):
+    return menu_path.split('/')[-1]
+
+
 def contains_dummy_action(menu_items: list[MenuOrSubmenu]) -> bool:
     """True if one of the menu_items is the dummy action, otherwise False.
 
@@ -78,7 +82,7 @@ def get_dummy_action(menu_id: MenuId) -> tuple[Action, str]:
     # menu path is unique, otherwise, we will clash. Once we
     # move to using short menu keys, the key itself will be used
     # here and this will no longer be a concern.
-    id_key = menu_id.split('/')[-1]
+    id_key = to_id_key(menu_id)
     action = Action(
         id=f'napari.{id_key}.empty_dummy',
         title='Empty',

--- a/napari/_qt/_qapp_model/_tests/test_dummy_actions.py
+++ b/napari/_qt/_qapp_model/_tests/test_dummy_actions.py
@@ -16,7 +16,7 @@ def test_menu_viewer_relaunch(make_napari_viewer):
 
     viewer2 = make_napari_viewer()
     # prior to #7106, this would fail
-    assert_empty_keys_in_context(viewer)
+    assert_empty_keys_in_context(viewer2)
     viewer2.close()
 
     # prior to #7106, creating this viewer would error

--- a/napari/_qt/_qapp_model/_tests/test_dummy_actions.py
+++ b/napari/_qt/_qapp_model/_tests/test_dummy_actions.py
@@ -2,7 +2,8 @@ from napari._app_model.constants._menus import MenuId
 from napari._app_model.utils import to_id_key
 
 
-def assert_empty_keys_in_context(context):
+def assert_empty_keys_in_context(viewer):
+    context = viewer.window._qt_viewer._layers.model().sourceModel()._root._ctx
     for menu_id in MenuId.contributables():
         context_key = f'{to_id_key(menu_id)}_empty'
         assert context_key in context
@@ -10,18 +11,12 @@ def assert_empty_keys_in_context(context):
 
 def test_menu_viewer_relaunch(make_napari_viewer):
     viewer = make_napari_viewer()
-    ll_context = (
-        viewer.window._qt_viewer._layers.model().sourceModel()._root._ctx
-    )
-    assert_empty_keys_in_context(ll_context)
+    assert_empty_keys_in_context(viewer)
     viewer.close()
 
     viewer2 = make_napari_viewer()
-    ll_context = (
-        viewer2.window._qt_viewer._layers.model().sourceModel()._root._ctx
-    )
     # prior to #7106, this would fail
-    assert_empty_keys_in_context(ll_context)
+    assert_empty_keys_in_context(viewer)
     viewer2.close()
 
     # prior to #7106, creating this viewer would error

--- a/napari/_qt/_qapp_model/_tests/test_dummy_actions.py
+++ b/napari/_qt/_qapp_model/_tests/test_dummy_actions.py
@@ -1,0 +1,28 @@
+from napari._app_model.constants._menus import MenuId
+from napari._app_model.utils import to_id_key
+
+
+def assert_empty_keys_in_context(context):
+    for menu_id in MenuId.contributables():
+        context_key = f'{to_id_key(menu_id)}_empty'
+        assert context_key in context
+
+
+def test_menu_viewer_relaunch(make_napari_viewer):
+    viewer = make_napari_viewer()
+    ll_context = (
+        viewer.window._qt_viewer._layers.model().sourceModel()._root._ctx
+    )
+    assert_empty_keys_in_context(ll_context)
+    viewer.close()
+
+    viewer2 = make_napari_viewer()
+    ll_context = (
+        viewer2.window._qt_viewer._layers.model().sourceModel()._root._ctx
+    )
+    # prior to #7106, this would fail
+    assert_empty_keys_in_context(ll_context)
+    viewer2.close()
+
+    # prior to #7106, creating this viewer would error
+    make_napari_viewer()

--- a/napari/_qt/_qapp_model/qactions/__init__.py
+++ b/napari/_qt/_qapp_model/qactions/__init__.py
@@ -116,5 +116,8 @@ def add_dummy_actions(context: Context) -> None:
         dummmy_action, context_key = get_dummy_action(menu_id)
         if dummmy_action.id not in app.commands:
             actions.append(dummmy_action)
-            context[context_key] = partial(is_empty_menu, menu_id)
+        # NOTE: even if action is already registered, the `context` instance
+        # may be new e.g. when closing and relaunching a viewer
+        # in a notebook. Context key should be assigned regardless
+        context[context_key] = partial(is_empty_menu, menu_id)
     app.register_actions(actions)


### PR DESCRIPTION
# References and relevant issues
Closes #7105 

# Description
This PR ensures that even if the dummy `Empty` action is registered with the `app`, we still assign its `context_key`. I checked that there's no danger in assigning the context key multiple times (like there is in registering an action multiple times), so this shouldn't have any undesirable side effects... 😬 

Because new viewers in notebooks share the same `app` instance, the `Empty` dummy action is already registered with all launched viewers, but each launched viewer gets its own instance of the `LayerList` and therefore its own new instance of the `context`. This means we **keep** the registered actions, but have to reassign all the context keys. I think this is terrible, but should be fixed in concert with whatever we decide in #7101.


