### PR TITLE
Fix min_req CI failures by bumping typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "tifffile>=2022.4.8",
     "toolz>=0.10.0",
     "tqdm>=4.56.0",
-    "typing_extensions>=4.2.0",
+    "typing_extensions>=4.4.0",
     "vispy>=0.14.1,<0.15",
     "wrapt>=1.11.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "tifffile>=2022.4.8",
     "toolz>=0.10.0",
     "tqdm>=4.56.0",
-    "typing_extensions>=4.4.0",
+    "typing_extensions>=4.6.0",
     "vispy>=0.14.1,<0.15",
     "wrapt>=1.11.1",
 ]


### PR DESCRIPTION
Fixes #7107

A new setuptools release started using
`from typing_extensions import Any`, which is only available in
typing_extensions 4.4 and greater. It seems that setuptools is used
during testing, which causes tests to fail with an ImportError.

**Edit:** After updating to 4.4, there was a new error from
setuptools:

```pytb
    File "/home/runner/work/napari/napari/.tox/py39-linux-pyqt5-cov/lib/python3.9/site-packages/setuptools/_vendor/typeguard/_importhook.py", line 22, in <module>
      from typing_extensions import Buffer
  ImportError: cannot import name 'Buffer' from 'typing_extensions' (/home/runner/work/napari/napari/.tox/py39-linux-pyqt5-cov/lib/python3.9/site-packages/typing_extensions.py)
```

The Buffer type was only added in 4.6, so I've further bumped the
dependency from 4.4 to 4.6.