### PR TITLE
Use `viewer.layers` instead of  `_layers.model().sourceModel()._root` for dummy context creation

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -684,10 +684,7 @@ class Window:
         # **and** the layerlist context key are available when we update
         # menus. We need a single context to contain all keys required for
         # menu update, so we add them to the layerlist context for now.
-        if self._qt_viewer._layers is not None:
-            add_dummy_actions(
-                self._qt_viewer._layers.model().sourceModel()._root._ctx
-            )
+        add_dummy_actions(self._qt_viewer.viewer.layers._ctx)
         self._update_theme()
         self._update_theme_font_size()
         get_settings().appearance.events.theme.connect(self._update_theme)
@@ -830,7 +827,7 @@ class Window:
 
     def _update_menu_state(self, menu: MenuStr):
         """Update enabled/visible state of menu item with context."""
-        layerlist = self._qt_viewer._layers.model().sourceModel()._root
+        layerlist = self._qt_viewer.viewer.layers
         menu_model = getattr(self, menu)
         menu_model.update_from_context(get_context(layerlist))
 


### PR DESCRIPTION
# References and relevant issues

# Description

Prior to this PR we were retrieving the `LayerList` using a private attribute, but there is an equivalent public attribute, and it's unclear what the original motivation was behind using the private version. This PR simply updates the two locations where `_qt_viewer._layers.model().sourceModel()._root` was used to instead use `_qt_viewer.viewer.layers`. This should be less fragile.