### PR TITLE
Limit setuptools vesion for minimum requirements test

### DIFF
--- a/resources/constraints/constraints_py3.9_min_req.txt
+++ b/resources/constraints/constraints_py3.9_min_req.txt
@@ -1,0 +1,1 @@
+setuptools<70


### PR DESCRIPTION
# References and relevant issues

closes #7107

# Description

Try workaround problem described in #7107 by limit setuptools version. 