### PR TITLE
[Maint] Update dockerfile for xpra source change

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -59,7 +59,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y wget gnupg2 apt-transport-https \
     software-properties-common ca-certificates && \
     wget -O "/usr/share/keyrings/xpra.asc" https://xpra.org/xpra.asc && \
-    wget -O "/etc/apt/sources.list.d/xpra.sources" https://xpra.org/repos/jammy/xpra.sources
+    wget -O "/etc/apt/sources.list.d/xpra.sources" https://raw.githubusercontent.com/Xpra-org/xpra/master/packaging/repos/jammy/xpra.sources
 
 
 RUN apt-get update && \


### PR DESCRIPTION
# References and relevant issues
xpra container is failing due to a change in the location of the source file
https://github.com/napari/napari/actions/runs/10009964035/job/27670042263
BTW There are actually folks using this!

# Description
Update the link based on latest xpra docs:
https://github.com/Xpra-org/xpra/wiki/Download#-for-debian-based-distributions

You can check that:
Fails: https://xpra.org/repos/jammy/xpra.sources
Works: https://raw.githubusercontent.com/Xpra-org/xpra/master/packaging/repos/jammy/xpra.sources

