### PR TITLE
Cleanup _image_key_bindings

### DIFF
--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -94,6 +94,10 @@ class ShortcutEditor(QWidget):
                     all_actions.pop(name)
             self.key_bindings_strs[f'{layer.__name__} layer'] = actions
 
+        # Don't include actions without keymapproviders
+        for action_name in all_actions.copy():
+            if all_actions[action_name].keymapprovider is None:
+                all_actions.pop(action_name)
         # Left over actions can go here.
         self.key_bindings_strs[self.VIEWER_KEYBINDINGS] = all_actions
 

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -45,7 +45,11 @@ def orient_plane_normal_along_x(layer: Image) -> None:
     orient_plane_normal_around_cursor(layer, plane_normal=(0, 0, 1))
 
 
-@register_image_action(trans._('Orient plane normal along view direction'))
+@register_image_action(
+    trans._(
+        'Orient plane normal along view direction\nHold down to have plane follow camera'
+    )
+)
 def orient_plane_normal_along_view_direction(
     layer: Image,
 ) -> Union[None, Generator[None, None, None]]:

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 from collections.abc import Generator
 from typing import Callable, Union
 
-from app_model.types import KeyCode
-
 import napari
 from napari.layers.base._base_constants import Mode
 from napari.layers.image.image import Image
 from napari.layers.utils.interactivity_utils import (
     orient_plane_normal_around_cursor,
 )
-from napari.layers.utils.layer_utils import register_layer_action
+from napari.layers.utils.layer_utils import (
+    register_layer_action,
+    register_layer_attr_action,
+)
+from napari.utils.action_manager import action_manager
 from napari.utils.events import Event
 from napari.utils.translations import trans
 
@@ -22,26 +24,28 @@ def register_image_action(
     return register_layer_action(Image, description, repeatable)
 
 
-@Image.bind_key(KeyCode.KeyZ, overwrite=True)
+def register_image_mode_action(
+    description: str,
+) -> Callable[[Callable], Callable]:
+    return register_layer_attr_action(Image, description, 'mode')
+
+
 @register_image_action(trans._('Orient plane normal along z-axis'))
 def orient_plane_normal_along_z(layer: Image) -> None:
     orient_plane_normal_around_cursor(layer, plane_normal=(1, 0, 0))
 
 
-@Image.bind_key(KeyCode.KeyY, overwrite=True)
-@register_image_action(trans._('orient plane normal along y-axis'))
+@register_image_action(trans._('Orient plane normal along y-axis'))
 def orient_plane_normal_along_y(layer: Image) -> None:
     orient_plane_normal_around_cursor(layer, plane_normal=(0, 1, 0))
 
 
-@Image.bind_key(KeyCode.KeyX, overwrite=True)
-@register_image_action(trans._('orient plane normal along x-axis'))
+@register_image_action(trans._('Orient plane normal along x-axis'))
 def orient_plane_normal_along_x(layer: Image) -> None:
     orient_plane_normal_around_cursor(layer, plane_normal=(0, 0, 1))
 
 
-@Image.bind_key(KeyCode.KeyO, overwrite=True)
-@register_image_action(trans._('orient plane normal along view direction'))
+@register_image_action(trans._('Orient plane normal along view direction'))
 def orient_plane_normal_along_view_direction(
     layer: Image,
 ) -> Union[None, Generator[None, None, None]]:
@@ -68,7 +72,8 @@ def orient_plane_normal_along_view_direction(
     return None
 
 
-@register_image_action(trans._('orient plane normal along view direction'))
+# The generator function above can't be bound to a button, so here
+# is a non-generator version of the function
 def orient_plane_normal_along_view_direction_no_gen(layer: Image) -> None:
     viewer = napari.viewer.current_viewer()
     if viewer is None or viewer.dims.ndisplay != 3:
@@ -78,12 +83,22 @@ def orient_plane_normal_along_view_direction_no_gen(layer: Image) -> None:
     )
 
 
-@register_image_action(trans._('Transform'))
+# register the non-generator without a keybinding
+# this way the generator version owns the keybinding
+action_manager.register_action(
+    name='napari:orient_plane_normal_along_view_direction_no_gen',
+    command=orient_plane_normal_along_view_direction_no_gen,
+    description=trans._('Orient plane normal along view direction button'),
+    keymapprovider=None,
+)
+
+
+@register_image_mode_action(trans._('Transform'))
 def activate_image_transform_mode(layer: Image) -> None:
     layer.mode = str(Mode.TRANSFORM)
 
 
-@register_image_action(trans._('Pan/zoom'))
+@register_image_mode_action(trans._('Pan/zoom'))
 def activate_image_pan_zoom_mode(layer: Image) -> None:
     layer.mode = str(Mode.PAN_ZOOM)
 

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -161,7 +161,8 @@ class ActionManager:
         self._actions[name] = Action(
             command, description, keymapprovider, repeatable
         )
-        self._update_shortcut_bindings(name)
+        if keymapprovider:
+            self._update_shortcut_bindings(name)
 
     def _update_shortcut_bindings(self, name: str):
         """
@@ -173,7 +174,7 @@ class ActionManager:
         if name not in self._shortcuts:
             return
         action = self._actions[name]
-        km_provider: KeymapProvider = action.keymapprovider
+        km_provider = action.keymapprovider
         if hasattr(km_provider, 'bind_key'):
             for shortcut in self._shortcuts[name]:
                 # NOTE: it would be better if we could bind `self.trigger` here

--- a/napari/utils/action_manager.py
+++ b/napari/utils/action_manager.py
@@ -104,7 +104,7 @@ class ActionManager:
         name: str,
         command: Callable,
         description: str,
-        keymapprovider: KeymapProvider,
+        keymapprovider: Optional[KeymapProvider],
         repeatable: bool = False,
     ):
         """

--- a/napari/utils/shortcuts.py
+++ b/napari/utils/shortcuts.py
@@ -84,6 +84,10 @@ _default_shortcuts = {
     ],
     'napari:finish_drawing_shape': [KeyCode.Escape],
     # image
+    'napari:orient_plane_normal_along_x': [KeyCode.KeyX],
+    'napari:orient_plane_normal_along_y': [KeyCode.KeyY],
+    'napari:orient_plane_normal_along_z': [KeyCode.KeyZ],
+    'napari:orient_plane_normal_along_view_direction': [KeyCode.KeyO],
     'napari:activate_image_pan_zoom_mode': [KeyCode.Digit1],
     'napari:activate_image_transform_mode': [KeyCode.Digit2],
     # vectors


### PR DESCRIPTION
# References and relevant issues
I had test_viewer.py tests failing `test_all_layer_actions_are_accessible_via_shortcut` for Image, see https://napari.zulipchat.com/#narrow/stream/212875-general/topic/test.20fails.20locally.20related.20to.20shortcuts.3F

Turns out there was an action being registered (`orient_plane_normal_along_view_direction_no_gen`) that didn't have a keybinding, because it was just for the layer controls button (`oblique`) -- the actual keybinding is "richer" because it allows you to move the plane while held down!! (I didn't know this!!)

# Description
In this PR I make some small cleanups:
1. Don't register the `orient_plane_normal_along_view_direction_no_gen` action with a keymap_provider -- I leave it in the same location/file, because it makes more sense to be with the keybinding action. This fixes the test failure.
2. If the keycap_provider is None, don't put it int he Shortcuts widget (without this anything not explicitly on a layer goes to Viewer by default)
3. The z, y, x, o keybindings are moved to shortcuts.py rather than being hard coded in _image_key_bindings. This makes them discoverable in the Settings -- hard coded bindings aren't shown there.
4. Have the Image layer mode bindings work the same as other layers, using `register_layer_attr_action` -- this makes them press-and-hold like the other layers.
5. Clarify the `O` keybinding label in the settings, to make folks more aware of the press-and-hold behavior. 
