### PR TITLE
Add napari-plugin-manager to optional info list

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -166,6 +166,7 @@ def sys_info(as_html: bool = False) -> str:
     optional_modules = (
         ('numba', 'numba'),
         ('triangle', 'triangle'),
+        ('napari_plugin_manager', 'napari-plugin-manager'),
     )
 
     for module, name in optional_modules:


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7094

# Description
Adds `napari-plugin-manager` to the Optional section of `sys_info`, which is used for `napari --info` and the `About napari` window.
This will help with debugging issues with the spun off plugin manager.

new output:
```
napari: 0.5.1.dev6+g62ef757a5
Platform: macOS-14.5-arm64-arm-64bit
System: MacOS 14.5
Python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:13:44) [Clang 16.0.6 ]
Qt: 6.7.1
PyQt6: 
NumPy: 2.0.0
SciPy: 1.14.0
Dask: 2024.7.1
VisPy: 0.14.3
magicgui: 0.8.3
superqt: 0.6.7
in-n-out: 0.2.1
app-model: 0.2.8
npe2: 0.7.6

OpenGL:
  - GL version:  2.1 Metal - 88.1
  - MAX_TEXTURE_SIZE: 16384
  - GL_MAX_3D_TEXTURE_SIZE: 2048

Screens:
  - screen 1: resolution 1680x1050, scale 2.0

Optional:
  - numba: 0.60.0
  - triangle not installed
  - napari-plugin-manager: 0.1.0a2

Settings path:
  - /Users/piotrsobolewski/Library/Application Support/napari/napari-dev_a1eb8b76ba95fa16ad06e26097b46b8455dfbf0b/settings.yaml
Plugins:
  - napari: 0.5.1.dev6+g62ef757a5 (81 contributions)
  - napari-console: 0.0.9 (0 contributions)
  - napari-svg: 0.2.0 (2 contributions)
  
```
