### PR TITLE
Add some basic codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@ napari/settings/        @Czaki @jni
 napari/layers/image/    @Czaki @brisvag @andy-sweet
 napari/layers/labels/   @jni @Czaki @brisvag
 napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet
-napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora 
+napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora
 napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
 napari/layers/tracks/   @Czaki @andy-sweet
 napari/layers/vectors/  @brisvag @kevinyamauchi @andy-sweet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ napari/layers/tracks/   @jni @andy-sweet
 napari/layers/vectors/  @brisvag @kevinyamauchi @andy-sweet
 
 # docs
-examples/                            @melissawm @psobolewskiPhD
-.github/workflows/build_docs.yml     @melissawm @psobolewskiPhD
+examples/                            @melissawm @psobolewskiPhD @lucyleeow
+.github/workflows/build_docs.yml     @melissawm @psobolewskiPhD @lucyleeow
 .github/workflows/deploy_docs.yml    @melissawm @psobolewskiPhD
 .github/workflows/circleci.yml       @melissawm @psobolewskiPhD

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # anything with no explicit code owners will be tagged to @core-devs
-*                       @napari/core-devs
+*   @napari/core-devs
 
 # submodules
-napari/_vispy/          @brisvag @melonora
-napari/_qt/             @Czaki @lucyleeow @DragaDoncila
-napari/_app_model/      @lucyleeow @DragaDoncila
-napari/benchmarks/      @Czaki @jni
-napari/plugins/         @Czaki @DragaDoncila @lucyleeow
-napari/qt/              @Czaki @jni
-napari/settings/        @Czaki @jni
+napari/_vispy/      @brisvag @melonora
+napari/_qt/         @Czaki @lucyleeow @DragaDoncila
+napari/_app_model/  @lucyleeow @DragaDoncila
+napari/benchmarks/  @Czaki @jni
+napari/plugins/     @Czaki @DragaDoncila @lucyleeow
+napari/qt/          @Czaki @jni
+napari/settings/    @Czaki @jni
 
 # specific layers
 napari/layers/image/    @Czaki @brisvag @andy-sweet
@@ -16,5 +16,5 @@ napari/layers/labels/   @jni @Czaki @brisvag
 napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet @DragaDoncila
 napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora
 napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
-napari/layers/tracks/   @Czaki @andy-sweet
+napari/layers/tracks/   @jni @andy-sweet
 napari/layers/vectors/  @brisvag @kevinyamauchi @andy-sweet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # submodules
 napari/_vispy/          @brisvag @melonora
 napari/_qt/             @Czaki @lucyleeow @DragaDoncila
-napari/_app_model/      @lucyleeow @DragaDoncila 
+napari/_app_model/      @lucyleeow @DragaDoncila
 napari/benchmarks/      @Czaki @jni
 napari/plugins/         @Czaki @DragaDoncila @lucyleeow
 napari/qt/              @Czaki @jni
@@ -13,7 +13,7 @@ napari/settings/        @Czaki @jni
 # specific layers
 napari/layers/image/    @Czaki @brisvag @andy-sweet
 napari/layers/labels/   @jni @Czaki @brisvag
-napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet @DragaDoncila 
+napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet @DragaDoncila
 napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora
 napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
 napari/layers/tracks/   @Czaki @andy-sweet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# anything with no explicit code owners will be tagged to @core-devs
+*                       @napari/core-devs
+
+# submodules
+napari/_vispy/          @brisvag @melonora
+napari/_qt/             @Czaki @lucyleeow @DragaDoncila
+napari/_app_model/      @lucyleeow
+napari/benchmarks/      @Czaki
+napari/plugins/         @Czaki @DragaDoncila
+napari/qt/              @Czaki
+napari/settings/        @Czaki @jni
+
+# specific layers
+napari/layers/image/    @Czaki @brisvag @andy-sweet
+napari/layers/labels/   @jni @Czaki @brisvag
+napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet
+napari/layers/shapes/   @kevinyamauchi @DragaDoncila
+napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
+napari/layers/tracks/   @Czaki @andy-sweet
+napari/layers/vectors/  @brisvag @kevinyamauchi @andy-sweet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # submodules
 napari/_vispy/      @brisvag @melonora
-napari/_qt/         @Czaki @lucyleeow @DragaDoncila
+napari/_qt/         @Czaki @lucyleeow @DragaDoncila @psobolewskiPhD 
 napari/_app_model/  @lucyleeow @DragaDoncila
 napari/benchmarks/  @Czaki @jni
 napari/plugins/     @Czaki @DragaDoncila @lucyleeow

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # submodules
 napari/_vispy/      @brisvag @melonora
-napari/_qt/         @Czaki @lucyleeow @DragaDoncila @psobolewskiPhD 
+napari/_qt/         @Czaki @lucyleeow @DragaDoncila @psobolewskiPhD
 napari/_app_model/  @lucyleeow @DragaDoncila
 napari/benchmarks/  @Czaki @jni
 napari/plugins/     @Czaki @DragaDoncila @lucyleeow

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,16 +4,16 @@
 # submodules
 napari/_vispy/          @brisvag @melonora
 napari/_qt/             @Czaki @lucyleeow @DragaDoncila
-napari/_app_model/      @lucyleeow
-napari/benchmarks/      @Czaki
+napari/_app_model/      @lucyleeow @DragaDoncila 
+napari/benchmarks/      @Czaki @jni
 napari/plugins/         @Czaki @DragaDoncila @lucyleeow
-napari/qt/              @Czaki
+napari/qt/              @Czaki @jni
 napari/settings/        @Czaki @jni
 
 # specific layers
 napari/layers/image/    @Czaki @brisvag @andy-sweet
 napari/layers/labels/   @jni @Czaki @brisvag
-napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet
+napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet @DragaDoncila 
 napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora
 napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
 napari/layers/tracks/   @Czaki @andy-sweet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@ napari/_vispy/          @brisvag @melonora
 napari/_qt/             @Czaki @lucyleeow @DragaDoncila
 napari/_app_model/      @lucyleeow
 napari/benchmarks/      @Czaki
-napari/plugins/         @Czaki @DragaDoncila
+napari/plugins/         @Czaki @DragaDoncila @lucyleeow
 napari/qt/              @Czaki
 napari/settings/        @Czaki @jni
 
@@ -14,7 +14,7 @@ napari/settings/        @Czaki @jni
 napari/layers/image/    @Czaki @brisvag @andy-sweet
 napari/layers/labels/   @jni @Czaki @brisvag
 napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet
-napari/layers/shapes/   @kevinyamauchi @DragaDoncila
+napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora 
 napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
 napari/layers/tracks/   @Czaki @andy-sweet
 napari/layers/vectors/  @brisvag @kevinyamauchi @andy-sweet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,16 @@ napari/qt/          @Czaki @jni
 napari/settings/    @Czaki @jni
 
 # specific layers
-napari/layers/image/    @Czaki @brisvag @andy-sweet
+napari/layers/image/    @Czaki @brisvag @andy-sweet @kephale
 napari/layers/labels/   @jni @Czaki @brisvag
-napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet @DragaDoncila
+napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet @DragaDoncila @kephale
 napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora
 napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
 napari/layers/tracks/   @jni @andy-sweet
 napari/layers/vectors/  @brisvag @kevinyamauchi @andy-sweet
+
+# docs
+examples/                            @melissawm @psobolewskiPhD
+.github/workflows/build_docs.yml     @melissawm @psobolewskiPhD
+.github/workflows/deploy_docs.yml    @melissawm @psobolewskiPhD
+.github/workflows/circleci.yml       @melissawm @psobolewskiPhD


### PR DESCRIPTION
# References and relevant issues
#5224

# Description
In my infite quest for procrastination, I keep looking at github notifications to find something else to do other than write my thesis... Turns out, I get too many notifications where my help isn't needed/requested, or that I'm not interested in. So I thought to revisit the CODEOWNERS talk we had a while back.

To get a starting rough configuration, I used `git summary --line <path>` (from git-extras) on each submodule to see who of the currenty active core devs is working most on each, and combined it with my personal experience.

This is meant as a starting point: please add/remove yourself from wherever you please.

Things to note:
- I don't think the tool above accounts for review contributions, so that's for sure biased
- too much of poor @czaki :P I'm sure you want to remove yourself from a few of these!
- `layers/tracks` it seems was mostly written by @quantumjot so I'm not sure who among core devs is more on top of it.
- We can go more granular than this
- a few folks are missing, but I'll leave it to them to pick their poison!
