### PR TITLE
Trigger docs deployment on tagged commit

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "v*x"
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      - "v*x"
+    tags:
+      - "v*"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
# References and relevant issues

Followup to https://github.com/napari/docs/pull/463

# Description

It looks like the condition from https://github.com/napari/docs/pull/463 was never triggered, as base workflow in repository was triggered only by push to main branch, not on tag. 