### PR TITLE
Remove `post` identifier in fetching release notes

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -44,7 +44,7 @@ jobs:
           VER="${TAG/a*/}"  # remove alpha identifier
           VER="${VER/b*/}"  # remove beta identifier
           VER="${VER/rc*/}"  # remove rc identifier
-          VER="${VER/post*}"  # remove post identifier
+          VER="${VER/post*/}"  # remove post identifier
           RELEASE_NOTES_PATH="docs/docs/release/release_${VER//./_}.md"
 
           echo "tag=${TAG}" >> "$GITHUB_ENV"

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -44,6 +44,7 @@ jobs:
           VER="${TAG/a*/}"  # remove alpha identifier
           VER="${VER/b*/}"  # remove beta identifier
           VER="${VER/rc*/}"  # remove rc identifier
+          VER="${VER/post*}"  # remove post identifier
           RELEASE_NOTES_PATH="docs/docs/release/release_${VER//./_}.md"
 
           echo "tag=${TAG}" >> "$GITHUB_ENV"


### PR DESCRIPTION
# Description

When making a github release, we fetch the docs repo and try to find the release notes file corresponding to the release. This workflow fails when the release number contains a .postX qualifier.

In this PR, the .post identifier is removed when looking for release notes.