### PR TITLE
Normalize path when searching for a plugin to open file

### DIFF
--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -1,3 +1,5 @@
+import os.path
+
 from npe2 import DynamicPlugin
 
 from napari.plugins.utils import (
@@ -79,7 +81,7 @@ def test_get_preferred_reader_more_nested():
 def test_get_preferred_reader_abs_path():
     get_settings().plugins.extension2reader = {
         # abs path so highest specificity
-        '/asdf/*.tif': 'most-specific-plugin',
+        os.path.realpath('/asdf/*.tif'): 'most-specific-plugin',
         # less nested so less specificity
         '*.tif': 'generic-tif-plugin',
         # more nested so higher specificity

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -171,6 +171,17 @@ def test_get_preferred_reader_no_extension():
     assert get_preferred_reader('my_file') is None
 
 
+def test_get_preferred_reader_full_path(tmp_path, monkeypatch):
+    (tmp_path / 'my_file.zarr').mkdir()
+    zarr_path = str(tmp_path / 'my_file.zarr')
+
+    assert get_preferred_reader(zarr_path) is None
+    get_settings().plugins.extension2reader[f'{zarr_path}/'] = 'fake-plugin'
+    assert get_preferred_reader(zarr_path) == 'fake-plugin'
+    monkeypatch.chdir(tmp_path)
+    assert get_preferred_reader('./my_file.zarr') == 'fake-plugin'
+
+
 def test_get_potential_readers_gives_napari(
     builtins, tmp_plugin: DynamicPlugin
 ):

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -84,7 +84,7 @@ def _get_preferred_readers(path: PathLike) -> list[tuple[str, str]]:
     filtered_preferences : List[Tuple[str, str]]
         Filtered patterns and their corresponding readers.
     """
-    path = str(path)
+    path = os.path.realpath(str(path))
 
     if osp.isdir(path) and not path.endswith(os.sep):
         path = path + os.sep


### PR DESCRIPTION
# References and relevant issues

followup of #7112

# Description

I was happy after the merge of #7112 and started again working with zarr files. 

Then decide not to drag and drop file but open napari form command line. I type 

```
napari ../spatialdata-sandbox/xenium_2.0.0_io/data.zarr
```

And dialog with plugin selection popup again :(. 

Short digging into codebase shows that `../spatialdata-sandbox/xenium_2.0.0_io/data.zarr` is used to determine the reader, instead of full file path. But the full file path is always used to save information in settings. This PR adds normalization of path, and proper test to ensure that the solution works.

I think that the whole mechanism may require additional tests on Windows where there is problem with path separator. 