### PR TITLE
Ensure `tpying.List[LayerDataTuple]` callback is registered with magicgui

### DIFF
--- a/napari/types.py
+++ b/napari/types.py
@@ -152,12 +152,13 @@ def image_reader_to_layerdata_reader(
 def _register_types_with_magicgui():
     """Register ``napari.types`` objects with magicgui."""
     from concurrent.futures import Future
+    from typing import List  # noqa: UP035
 
     from magicgui import register_type
 
     from napari.utils import _magicgui as _mgui
 
-    for type_ in (LayerDataTuple, list[LayerDataTuple]):
+    for type_ in (LayerDataTuple, list[LayerDataTuple], List[LayerDataTuple]):  # noqa: UP006
         register_type(
             type_,
             return_callback=_mgui.add_layer_data_tuples_to_viewer,


### PR DESCRIPTION
# References and relevant issues
Closes #7129 

# Description
As per #7129, this PR adds back an explicit `typing.List[LayerDataTuple]` type registration with magicgui, so that anyone using the original type annotation still gets their layers processed. 

I looked through the rest of the file and didn't see any other types that might have been affected by the changes in #6738.


