### PR TITLE
Update example annotate_segmentation_with_text.py to add link to the tutorial

### DIFF
--- a/examples/annotate_segmentation_with_text.py
+++ b/examples/annotate_segmentation_with_text.py
@@ -3,7 +3,7 @@ Annotate segmentation with text
 ===============================
 
 Perform a segmentation and annotate the results with
-bounding boxes and text.  
+bounding boxes and text.
 This example is fully explained in the following tutorial:
 https://napari.org/stable/tutorials/segmentation/annotate_segmentation.html
 

--- a/examples/annotate_segmentation_with_text.py
+++ b/examples/annotate_segmentation_with_text.py
@@ -3,7 +3,9 @@ Annotate segmentation with text
 ===============================
 
 Perform a segmentation and annotate the results with
-bounding boxes and text
+bounding boxes and text.  
+This example is fully explained in the following tutorial:
+https://napari.org/stable/tutorials/segmentation/annotate_segmentation.html
 
 .. tags:: analysis
 """


### PR DESCRIPTION
# Description
In this PR I add a link in the annotate_segmentation_with_text.py example to the fully worked tutorial in the docs. 