### PR TITLE
[bugfix] update Point size slider on selection (current_size event)

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
@@ -99,3 +99,22 @@ def test_current_size_slider_properly_initialized(qtbot):
     assert slider.minimum() == 1
     assert slider.value() == 10
     assert layer.current_size == 10
+
+
+def test_size_slider_represents_current_size(qtbot):
+    """Changing the current_size attribute should update the slider"""
+    layer = Points(np.random.rand(10, 2))
+    qtctrl = QtPointsControls(layer)
+    qtbot.addWidget(qtctrl)
+    slider = qtctrl.sizeSlider
+    slider.setValue(10)
+
+    # Initial value
+    assert slider.value() == 10
+    assert layer.current_size == 10
+
+    # Size event needs to be triggered manually, because no points are selected.
+    layer.current_size = 5
+    layer.events.current_size()
+    assert slider.value() == 5
+    assert layer.current_size == 5

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -87,6 +87,7 @@ class QtPointsControls(QtLayerControls):
         )
         self.layer.events.symbol.connect(self._on_current_symbol_change)
         self.layer.events.size.connect(self._on_current_size_change)
+        self.layer.events.current_size.connect(self._on_current_size_change)
         self.layer.events.current_border_color.connect(
             self._on_current_border_color_change
         )


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/6115

# Description
In this PR i add a connection to the `current_size` event, so that the slider is updated for the current size of a selected point.
I also add a test for this case. 
