### PR TITLE
Disconnect all dims events when closing viewer

### DIFF
--- a/napari/_qt/_tests/test_async_slicing.py
+++ b/napari/_qt/_tests/test_async_slicing.py
@@ -226,6 +226,19 @@ def test_async_slice_vectors_on_current_step_change(make_napari_viewer, qtbot):
     )
 
 
+@pytest.mark.usefixtures('_enable_async')
+def test_async_slice_two_layers_shutdown(make_napari_viewer):
+    """See https://github.com/napari/napari/issues/6685"""
+    viewer = make_napari_viewer()
+    # To reproduce the issue, we need two points layers where the second has
+    # some non-zero coordinates.
+    viewer.add_points()
+    points = viewer.add_points()
+    points.add([[1, 2]])
+
+    viewer.close()
+
+
 def setup_viewer_for_async_slicing(
     viewer: Viewer,
     layer: Layer,

--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -258,13 +258,7 @@ class _LayerSlicer:
         This should only be called from the main thread.
         """
         logger.debug('_LayerSlicer.shutdown')
-        # Replace with cancel_futures=True in shutdown when we drop support
-        # for Python 3.8
-        with self._lock_layers_to_task:
-            tasks = tuple(self._layers_to_task.values())
-        for task in tasks:
-            task.cancel()
-        self._executor.shutdown(wait=True)
+        self._executor.shutdown(wait=True, cancel_futures=True)
         self.events.disconnect()
         self.events.ready.disconnect()
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -268,7 +268,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         #        the source of truth, and is now defined in world space. This exposed an existing
         #        bug where if a field in Dims is modified by the root_validator, events won't
         #        be fired for it. This won't happen for properties because we have dependency
-        #        checks. To fix this, we need dep checks for fileds (psygnal!) and then we
+        #        checks. To fix this, we need dep checks for fields (psygnal!) and then we
         #        can remove the following line. Note that because of this we fire double events,
         #        but this should be ok because we have early returns when slices are unchanged.
         self.dims.events.current_step.connect(self._update_layers)

--- a/napari/layers/points/_slice.py
+++ b/napari/layers/points/_slice.py
@@ -69,7 +69,7 @@ class _PointSliceRequest:
         # Return early if no data
         if len(self.data) == 0:
             return _PointSliceResponse(
-                indices=np.array([]),
+                indices=np.array([], dtype=int),
                 scale=np.empty(0),
                 slice_input=self.slice_input,
                 request_id=self.id,

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from napari.components.viewer_model import ViewerModel
 from napari.utils import _magicgui
+from napari.utils.events.event_utils import disconnect_events
 
 if TYPE_CHECKING:
     # helpful for IDE support
@@ -194,6 +195,9 @@ class Viewer(ViewerModel):
         """Close the viewer window."""
         # Shutdown the slicer first to avoid processing any more tasks.
         self._layer_slicer.shutdown()
+        # Disconnect changes to dims before removing layers one-by-one
+        # to avoid any unnecessary slicing.
+        disconnect_events(self.dims.events, self)
         # Remove all the layers from the viewer
         self.layers.clear()
         # Close the main window
@@ -204,7 +208,7 @@ class Viewer(ViewerModel):
     @classmethod
     def close_all(cls) -> int:
         """
-        Class metod, Close all existing viewer instances.
+        Class method, Close all existing viewer instances.
 
         This is mostly exposed to avoid leaking of viewers when running tests.
         As having many non-closed viewer can adversely affect performances.


### PR DESCRIPTION
# References and relevant issues
Closes #6685 

# Description
This disconnects all the `Dims` events from `Viewer` methods when calling `Viewer.close`. This prevents the `Viewer` from responding to changes to `Dims` as layers are removed one-by-one.

It also fixes another related TODO and some typos.

After some consideration (documented by the comments in #6685) I decided that this approach is justified because `Viewer.close` has lots of side-effects that make `Viewer` and things it owns mostly unusable. Compare to other simpler apporaches, this also avoids unnecessary work when closing the viewer.

I wonder if we should disconnect even more events when calling `Viewer.close`, but I'll leave that for future work.
