### PR TITLE
[bugfix] make self._symbol in points.py writable

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
@@ -99,3 +99,22 @@ def test_current_size_slider_properly_initialized(qtbot):
     assert slider.minimum() == 1
     assert slider.value() == 10
     assert layer.current_size == 10
+
+
+def test_changing_symbol(qtbot):
+    """Changing the symbol should update the UI"""
+    layer = Points(np.random.rand(2, 2))
+    qtctrl = QtPointsControls(layer)
+    qtbot.addWidget(qtctrl)
+    assert layer.symbol[1].value == 'disc'
+    assert layer.current_symbol.value == 'disc'
+
+    # select a point and change its symbol
+    layer.selected_data = {1}
+    layer.current_symbol = 'square'
+    assert layer.symbol[1].value == 'square'
+    assert qtctrl.symbolComboBox.currentText() == 'square'
+
+    # add a point and check that it has the new symbol
+    layer.add([1, 1])
+    assert layer.symbol[2].value == 'square'

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -961,6 +961,7 @@ class Points(Layer):
         # this will check that it is the correct length.
         coerced_symbols = np.broadcast_to(coerced_symbols, self.data.shape[0])
         self._symbol = coerced_symbols
+        self._symbol.flags.writeable = True
         self.events.symbol()
         self.events.highlight()
 


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7139

# Description
Because of the use of `broadcast_to` the self._symbol/self.symbol array is a readonly view.
This PR makes it writable. The other option would to make a copy?

I also added a test that fails on main, but passes with the change here.