### PR TITLE
Allow easy call single benchmark

### DIFF
--- a/napari/benchmarks/README.md
+++ b/napari/benchmarks/README.md
@@ -21,3 +21,22 @@ To run a single benchmark (Vectors3DSuite.time_refresh) with the environment you
 To compare benchmarks across branches, run using conda environments (instead of virtualenv), and limit to the `Labels2DSuite` benchmarks:
 
 `asv continuous main fix_benchmark_ci -q --environment conda --bench Labels2DSuite`
+
+
+## Debugging
+
+To simplify debugging we can run the benchmarks in the current environment as simple python functions script.
+
+You could do this by running the following command:
+
+```bash
+python -m napari.benchmarks benchmark_shapes_layer.Shapes3DSuite.time_get_value
+```
+
+or
+
+```bash
+python napari/benchmarks/benchmark_shapes_layer.py Shapes3DSuite.time_get_value
+```
+
+Passing the proper benchmark identifier as argument.

--- a/napari/benchmarks/__main__.py
+++ b/napari/benchmarks/__main__.py
@@ -1,0 +1,41 @@
+import argparse
+import importlib
+from typing import NamedTuple
+
+from .utils import run_benchmark_from_module
+
+
+class BenchmarkIdentifier(NamedTuple):
+    module: str
+    klass: str
+    method: str
+
+
+def split_identifier(value: str) -> BenchmarkIdentifier:
+    """Split a string into a module and class identifier."""
+    parts = value.split('.')
+    if len(parts) != 3:
+        raise argparse.ArgumentError(
+            "Benchmark identifier should be in the form 'module.class.benchmark'"
+        )
+    return BenchmarkIdentifier(*parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Run selected napari benchmarks for debugging.'
+    )
+    parser.add_argument(
+        'benchmark', type=split_identifier, help='Benchmark to run.'
+    )
+    args = parser.parse_args()
+    module = importlib.import_module(
+        f'.{args.benchmark.module}', package='napari.benchmarks'
+    )
+    run_benchmark_from_module(
+        module, args.benchmark.klass, args.benchmark.method
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/napari/benchmarks/benchmark_evented_model.py
+++ b/napari/benchmarks/benchmark_evented_model.py
@@ -57,3 +57,9 @@ class EventedModelSuite:
         self.model.events.e.connect(long_connection)
 
         self.model.d = 15
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_image_layer.py
+++ b/napari/benchmarks/benchmark_image_layer.py
@@ -103,3 +103,9 @@ class Image3DSuite:
     def mem_data(self, n):
         """Memory used by raw data."""
         return self.data
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_import.py
+++ b/napari/benchmarks/benchmark_import.py
@@ -6,3 +6,9 @@ class ImportTimeSuite:
     def time_import(self):
         cmd = [sys.executable, '-c', 'import napari']
         subprocess.run(cmd, stderr=subprocess.PIPE)
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_labels_layer.py
+++ b/napari/benchmarks/benchmark_labels_layer.py
@@ -215,3 +215,9 @@ class Labels3DSuite:
     def mem_data(self, *_):
         """Memory used by raw data."""
         return self.data
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_points_layer.py
+++ b/napari/benchmarks/benchmark_points_layer.py
@@ -153,3 +153,9 @@ class PointsToMaskSuite:
 
     def time_to_mask(self, num_points, mask_shape, point_size):
         self.layer.to_mask(shape=mask_shape)
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_python_layer.py
+++ b/napari/benchmarks/benchmark_python_layer.py
@@ -14,3 +14,9 @@ class CoerceSymbolsSuite:
 
     def time_coerce_symbols2(self):
         coerce_symbols(self.symbols2)
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_qt_slicing.py
+++ b/napari/benchmarks/benchmark_qt_slicing.py
@@ -186,3 +186,9 @@ class QtViewerAsyncPointsAndImage2DSuite:
 
     def teardown(self, *args):
         self.viewer.window.close()
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_qt_viewer.py
+++ b/napari/benchmarks/benchmark_qt_viewer.py
@@ -17,3 +17,9 @@ class QtViewerSuite:
     def time_create_viewer(self):
         """Time to create the viewer."""
         self.viewer = napari.Viewer()
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_qt_viewer_image.py
+++ b/napari/benchmarks/benchmark_qt_viewer_image.py
@@ -276,3 +276,9 @@ class QtVolumeRenderingSuite:
         self.viewer.layers[0].gamma = 0.5
         self.viewer.layers[0].gamma = 0.8
         self.viewer.layers[0].gamma = 1.3
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_qt_viewer_labels.py
+++ b/napari/benchmarks/benchmark_qt_viewer_labels.py
@@ -219,3 +219,9 @@ class LabelRenderingSuite3D(LabelRendering):
 
     def time_zoom_change(self, *args):
         self._time_zoom_change(*args)
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_qt_viewer_vectors.py
+++ b/napari/benchmarks/benchmark_qt_viewer_vectors.py
@@ -48,3 +48,9 @@ class QtViewerViewVectorSuite:
         self.viewer.layers[0].refresh()
         self.viewer.layers[0].refresh()
         self.viewer.layers[0].refresh()
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_shapes_layer.py
+++ b/napari/benchmarks/benchmark_shapes_layer.py
@@ -209,3 +209,9 @@ class ShapesInteractionSuite:
         mouse_release_callbacks(self.layer, release_event)
 
     time_select_shape.param_names = ['n_shapes']
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_surface_layer.py
+++ b/napari/benchmarks/benchmark_surface_layer.py
@@ -91,3 +91,9 @@ class Surface3DSuite:
     def mem_data(self, n):
         """Memory used by raw data."""
         return self.data
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_text_manager.py
+++ b/napari/benchmarks/benchmark_text_manager.py
@@ -68,3 +68,9 @@ class TextManagerSuite:
     time_remove_as_batch.warmup_time = 0
     # See https://asv.readthedocs.io/en/stable/benchmarks.html#timing-benchmarks
     # for more details
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_tracks_layer.py
+++ b/napari/benchmarks/benchmark_tracks_layer.py
@@ -45,3 +45,9 @@ class TracksSuite:
 
     def time_update_layer(self, *_) -> None:
         self.layer.data = self.data
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()

--- a/napari/benchmarks/benchmark_vectors_layer.py
+++ b/napari/benchmarks/benchmark_vectors_layer.py
@@ -99,3 +99,9 @@ class Vectors3DSuite:
     def mem_data(self, n):
         """Memory used by raw data."""
         return self.data
+
+
+if __name__ == '__main__':
+    from utils import run_benchmark
+
+    run_benchmark()


### PR DESCRIPTION
# References and relevant issues

extracted from #7144


# Description

This PR allows calling a single benchmark method without whole setup asv. It simplifies debugging. 

It is a simple change and may not support all asv options (for example, it does not allow running functional benchmark)

Example call `python napari/benchmarks/benchmark_shapes_layer.py Shapes3DSuite.time_get_value`