### PR TITLE
Update event connection order

### DIFF
--- a/napari/_vispy/layers/scalar_field.py
+++ b/napari/_vispy/layers/scalar_field.py
@@ -103,8 +103,8 @@ class VispyScalarFieldBaseLayer(VispyBaseLayer[ScalarFieldBase]):
             ndisplay, getattr(data, 'dtype', None)
         )
 
-        if ndisplay == 3 and self.layer.ndim == 2:
-            data = np.expand_dims(data, axis=0)
+        if ndisplay > data.ndim:
+            data = data.reshape((1,) * (ndisplay - data.ndim) + data.shape)
 
         # Check if data exceeds MAX_TEXTURE_SIZE and downsample
         if self.MAX_TEXTURE_SIZE_2D is not None and ndisplay == 2:

--- a/napari/utils/events/_tests/test_event_emitter.py
+++ b/napari/utils/events/_tests/test_event_emitter.py
@@ -182,19 +182,19 @@ def test_event_order_func():
     res_li = []
     e.connect(fun3)
     e()
-    assert res_li == [3, 1, 2]
+    assert res_li == [1, 3, 2]
     res_li = []
     e.connect(fun4)
     e()
-    assert res_li == [3, 1, 4, 2]
+    assert res_li == [1, 3, 2, 4]
     res_li = []
-    e.connect(partial(fun5, val=5), position='last')
+    e.connect(partial(fun5, val=5), position='first')
     e()
-    assert res_li == [3, 1, 5, 4, 2]
+    assert res_li == [5, 1, 3, 2, 4]
     res_li = []
-    e.connect(partial(fun6, val=6), position='last')
+    e.connect(partial(fun6, val=6), position='first')
     e()
-    assert res_li == [3, 1, 5, 4, 2, 6]
+    assert res_li == [5, 1, 3, 6, 2, 4]
 
 
 def test_event_order_methods():
@@ -228,7 +228,7 @@ def test_event_order_methods():
     e.connect(t1.fun2)
     e.connect(t2.fun4)
     e()
-    assert res_li == [2, 1, 4, 3]
+    assert res_li == [1, 2, 3, 4]
 
 
 def test_no_event_arg():

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -410,7 +410,7 @@ class EventEmitter:
         self,
         callback: Union[Callback, CallbackRef, CallbackStr, 'EventEmitter'],
         ref: Union[bool, str] = False,
-        position: Literal['first', 'last'] = 'first',
+        position: Literal['first', 'last'] = 'last',
         before: Union[str, Callback, list[Union[str, Callback]], None] = None,
         after: Union[str, Callback, list[Union[str, Callback]], None] = None,
         until: Optional['EventEmitter'] = None,


### PR DESCRIPTION
# References and relevant issues

In PartSeg I got multiple such reports:

```python
ValueError: Volume visual needs a 3D array.
  File "PartSeg\common_gui\napari_image_view.py", line 682, in _add_image
  File "PartSeg\common_gui\napari_image_view.py", line 645, in _add_layer_util
  File "napari\components\viewer_model.py", line 742, in add_layer
  File "_collections_abc.py", line 1128, in append
  File "napari\components\layerlist.py", line 188, in insert
  File "napari\utils\events\containers\_selectable_list.py", line 68, in insert
  File "napari\utils\events\containers\_evented_list.py", line 202, in insert
  File "napari\utils\events\event.py", line 764, in __call__
  File "napari\utils\events\event.py", line 802, in _invoke_callback
  File "napari\utils\events\event.py", line 789, in _invoke_callback
  File "napari\_qt\qt_viewer.py", line 658, in _on_add_layer_change
  File "napari\_qt\qt_viewer.py", line 668, in _add_layer
  File "napari\_vispy\utils\visual.py", line 88, in create_vispy_layer
  File "napari\_vispy\layers\image.py", line 89, in __init__
  File "napari\_vispy\layers\scalar_field.py", line 71, in __init__
  File "napari\_vispy\layers\scalar_field.py", line 123, in _on_data_change
  File "vispy\visuals\volume.py", line 852, in set_data
  ```

# Description

When try to debug the above error, I have found that the callback order looks incorrect 

![obraz](https://github.com/user-attachments/assets/20ff8bb1-e246-40a1-a379-f58f8b3845d6)

so `QtViewer._on_add_layer_change` is called before `Viewer._on_add_layer` when the `Viewer._on_add_layer` is triggering data slicer, so  data slice value may be incorrect. 

I think that after #4480 we should keep events in connection order. So Qt updates will be triggered after core models updates 

This PR also updates the code for fixing data shape  to work good with data of `ndim=1`


This PR is a workaround problem that is reported to me as it happens on Windows, on long living sessions. 