### PR TITLE
Use `delete` instead of `get`method for delete `ready to merge` label

### DIFF
--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -171,7 +171,7 @@ def update_own_pr(pr_number: int, access_token: str, base_branch: str, repo):
     # if it is present, then remove it to point that PR was changed
     for label in response.json():
         if label['name'] == 'ready to merge':
-            response = requests.get(remove_label_url, headers=headers)
+            response = requests.delete(remove_label_url, headers=headers)
             response.raise_for_status()
             break
 


### PR DESCRIPTION
# References and relevant issues

closes:  #7159

documentation: https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue 

# Description


