### PR TITLE
Emit highlight event only if selection changed

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1996,6 +1996,7 @@ class Points(Layer):
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
+        prev_stored = self._selected_data_stored
         self._selected_data_stored = Selection(self.selected_data)
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
@@ -2042,7 +2043,8 @@ class Points(Layer):
             pos = None
 
         self._highlight_box = pos
-        self.events.highlight()
+        if prev_stored != self._selected_data_stored:
+            self.events.highlight()
 
     def _update_thumbnail(self) -> None:
         """Update thumbnail with current points and colors."""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2589,10 +2589,12 @@ class Shapes(Layer):
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
+        prev_selected = self._selected_data_stored
         self._selected_data_stored = copy(self.selected_data)
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
-        self.events.highlight()
+        if prev_selected != self._selected_data_stored:
+            self.events.highlight()
 
     def _finish_drawing(self, event=None) -> None:
         """Reset properties used in shape drawing."""


### PR DESCRIPTION
# References and relevant issues
closes #7071


# Description

Currently, on main, we omit a highlight event every time when `_set_highlight` method is called. However, it is called every time the zoom or canvas size is changed to fix some problems with highlights (see #6425)

I think that it should be emitted only if selection is changed. 