### PR TITLE
[Bugfix] Only import darkdetect when needed

### DIFF
--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -11,7 +11,6 @@ from typing import Any, Literal, Optional, Union, overload
 import npe2
 
 from napari._pydantic_compat import Color, validator
-from napari._vendor import darkdetect
 from napari.resources._icons import (
     PLUGIN_FILE_NAME,
     _theme_path,
@@ -223,6 +222,10 @@ def template(css: str, **theme):
 
 def get_system_theme() -> str:
     """Return the system default theme, either 'dark', or 'light'."""
+    try:
+        from napari._vendor import darkdetect
+    except ImportError:
+        return 'dark'
     try:
         id_ = darkdetect.theme().lower()
     except AttributeError:


### PR DESCRIPTION
# References and relevant issues
This came up during the SciPy tutorial (slow to dig into it 😬):
A user couldn't launch napari from the notebooks due to an import error from *within* `darkdetect`:
![image](https://github.com/user-attachments/assets/67b95969-3844-457d-b22a-8e40123033d0)
(Sorry that's what I got from the user by email!)

They were on a pretty old version of macOS (11.10.7), but in theory still supported by `darkdetect`, so I don't understand why the import was failing nor do I have the ability to debug it. However they were not using a dynamic system theme and were not using the napari `system` theme--just default `dark` from a fresh install--so there is no reason that napari shouldn't launch!

I've tested locally, even with the default napari `dark` theme, the `darkdetect` import happens twice when I launch napari from the terminal and once when using `napari.Viewer()`. 

# Description
In this PR I move the `darkdetect` import to the `get_system_theme` function in a `try` statement.
I've tested locally and if I delete `darkdetect` napari will launch with this PR and remains functional.
