### PR TITLE
FIX `QtViewer._open_files_dialog` handing of `stack`

### DIFF
--- a/napari/_qt/_tests/test_open_file.py
+++ b/napari/_qt/_tests/test_open_file.py
@@ -1,0 +1,18 @@
+from unittest import mock
+
+
+def test_open_files_dialog(make_napari_viewer):
+    """Check `QtViewer._open_files_dialog` correnct when `stack=True`."""
+    viewer = make_napari_viewer()
+    with (
+        mock.patch(
+            'napari._qt.qt_viewer.QtViewer._open_file_dialog_uni'
+        ) as mock_file,
+        mock.patch('napari._qt.qt_viewer.QtViewer._qt_open') as mock_open,
+    ):
+        viewer.window._qt_viewer._open_files_dialog(stack=True)
+    mock_open.assert_called_once_with(
+        mock_file.return_value,
+        choose_plugin=False,
+        stack=True,
+    )

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -914,18 +914,8 @@ class QtViewer(QSplitter):
         """Add files from the menubar."""
         filenames = self._open_file_dialog_uni(trans._('Select file(s)...'))
 
-        if (filenames != []) and (filenames is not None):
-            if stack:
-                self._qt_open(
-                    filenames, choose_plugin=choose_plugin, stack=stack
-                )
-            else:
-                for filename in filenames:
-                    self._qt_open(
-                        [filename],
-                        choose_plugin=choose_plugin,
-                        stack=stack,
-                    )
+        if filenames:
+            self._qt_open(filenames, choose_plugin=choose_plugin, stack=stack)
             update_open_history(filenames[0])
 
     def _open_files_dialog_as_stack_dialog(self, choose_plugin=False):

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -915,12 +915,17 @@ class QtViewer(QSplitter):
         filenames = self._open_file_dialog_uni(trans._('Select file(s)...'))
 
         if (filenames != []) and (filenames is not None):
-            for filename in filenames:
+            if stack:
                 self._qt_open(
-                    [filename],
-                    choose_plugin=choose_plugin,
-                    stack=stack,
+                    filenames, choose_plugin=choose_plugin, stack=stack
                 )
+            else:
+                for filename in filenames:
+                    self._qt_open(
+                        [filename],
+                        choose_plugin=choose_plugin,
+                        stack=stack,
+                    )
             update_open_history(filenames[0])
 
     def _open_files_dialog_as_stack_dialog(self, choose_plugin=False):


### PR DESCRIPTION
# References and relevant issues
closes #7165

# Description
Correctly handles `stack` parameter in `_open_files_dialog`. This was due to a bad refactor in https://github.com/napari/napari/pull/4865

I noticed that we don't test any of the `QtViewer` `open_files...` or `open_folder...` methods. (Some are tested with the file menu but none of these seem to be tested in isolation?)
I've added a new test file for these but only added a test for this instance. Maybe additional tests can be added in a follow up PR, in order to get this fix in quicker?