### PR TITLE
Move parallel setting for coverage calculation to tox.ini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -762,7 +762,6 @@ exclude_lines = [
 ]
 
 [tool.coverage.run]
-parallel = true
 omit = [
     "*/_vendor/*",
     "*/_version.py",

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ indexserver =
     extra = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 commands =
     echo "COVERAGE: {env:COVERAGE:}"
-    cov: coverage run \
+    cov: coverage run --parallel-mode \
     !cov: python \
         -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \
         --ignore tools --maxfail=5 --json-report \
@@ -116,7 +116,7 @@ commands_pre =
     pip uninstall -y pyautogui pytest-qt pyqt5 pyside2 pyside6 pyqt6
 
 commands =
-    cov: coverage run \
+    cov: coverage run --parallel-mode \
     !cov: python \
         -m pytest -v --color=yes --basetemp={envtmpdir} --ignore napari/_vispy \
         --ignore napari/_qt --ignore napari/_tests --ignore tools \
@@ -131,7 +131,7 @@ deps =
     numpy < 1.24
     packaging
 commands =
-    cov: coverage run \
+    cov: coverage run --parallel-mode \
     !cov: python \
         -m pytest napari/_tests/test_examples.py -v --color=yes --basetemp={envtmpdir} {posargs}
 


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari/pull/7146#discussion_r1711207999

# Description

During development of #7146 I found that using `parallel` mode by default (configured in pyproject.toml) breaks PyCharm codecov integration.

Also, manual running coverage process leads to creation of `.coverage.something` files that needs to perform additional `python -m coverage combine coverage` call before call `coverage html` or `coverage xml` that could be loaded and used for coverage visualization. 

So before this PR running coverage from PyCharm was not working and manual running required:

```bash 
coverage run -m pytest ... 
coverage combine
coverage html
```

After this PR, PyCharm works, and manual running is simpler: 

```bash
coverage run -m pytest ...
coverage html
```
