### PR TITLE
Add information about `numpy<2` problem  on macOS arm

### DIFF
--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from napari.utils._check_numpy_version import PROBLEMATIC_NUMPY_MACOS
 from napari.utils.action_manager import action_manager
 from napari.utils.interactions import Shortcut
 from napari.utils.translations import trans
@@ -58,6 +59,14 @@ class QtWelcomeWidget(QWidget):
         sc = QKeySequence('Ctrl+N', QKeySequence.PortableText).toString(
             QKeySequence.NativeText
         )
+        if PROBLEMATIC_NUMPY_MACOS:
+            shortcut_layout.addRow(
+                QtShortcutLabel(
+                    'We have detected that you are using numpy<2 on macOS arm64 '
+                    'from pypi wheels.\n'
+                    'See https://napari.org/stable/tutorials/fundamentals/installation.html#numpy-problem'
+                )
+            )
         shortcut_layout.addRow(
             QtShortcutLabel(sc),
             QtShortcutLabel(trans._('New Image from Clipboard')),

--- a/napari/utils/__init__.py
+++ b/napari/utils/__init__.py
@@ -1,3 +1,4 @@
+from napari.utils._check_numpy_version import PROBLEMATIC_NUMPY_MACOS
 from napari.utils._dask_utils import resize_dask_cache
 from napari.utils.colormaps.colormap import (
     Colormap,
@@ -23,4 +24,5 @@ __all__ = (
     'progress',
     'resize_dask_cache',
     'sys_info',
+    'PROBLEMATIC_NUMPY_MACOS',
 )

--- a/napari/utils/_check_numpy_version.py
+++ b/napari/utils/_check_numpy_version.py
@@ -13,7 +13,7 @@ if (
 ):  # pragma: no cover
     try:
         PROBLEMATIC_NUMPY_MACOS = (
-            'cibw-run' in np.show_config('dicts')['Python Information']['path']
+            'cibw-run' in np.show_config('dicts')['Python Information']['path']  # type: ignore
         )
     except (KeyError, TypeError):
         PROBLEMATIC_NUMPY_MACOS = False

--- a/napari/utils/_check_numpy_version.py
+++ b/napari/utils/_check_numpy_version.py
@@ -1,0 +1,21 @@
+import platform
+
+import numpy as np
+from packaging.version import parse as parse_version
+
+# if run with numpy<2 on macOS arm64 architecture compiled from pypi wheels,
+# then it will crash with bus error if numpy is used in different thread
+# Issue reported https://github.com/numpy/numpy/issues/21799
+if (
+    parse_version(np.__version__) < parse_version('2')
+    and platform.system() == 'Darwin'
+    and platform.machine() == 'arm64'
+):  # pragma: no cover
+    try:
+        PROBLEMATIC_NUMPY_MACOS = (
+            'cibw-run' in np.show_config('dicts')['Python Information']['path']
+        )
+    except (KeyError, TypeError):
+        PROBLEMATIC_NUMPY_MACOS = False
+else:
+    PROBLEMATIC_NUMPY_MACOS = False


### PR DESCRIPTION
# References and relevant issues
Initially reported here https://github.com/napari/napari/pull/7146#pullrequestreview-2231557186. But may happen for any plugin that uses threads.

requires https://github.com/napari/docs/pull/475 for proper link to documentation

# Description

Add a warning about NumPy macOS problem to the welcome widget to help people who meet segfaults.
