### PR TITLE
[WIP] Add setting to track `napari-plugin-manager` 3rd party plugins disclaimer message visibility

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_plugins.py
+++ b/napari/_qt/_qapp_model/qactions/_plugins.py
@@ -8,6 +8,7 @@ from app_model.types import Action
 from napari._app_model.constants import MenuGroup, MenuId
 from napari._qt.dialogs.qt_plugin_report import QtPluginErrReporter
 from napari._qt.qt_main_window import Window
+from napari.settings import get_settings
 from napari.utils.translations import trans
 
 logger = getLogger(__name__)
@@ -32,7 +33,9 @@ def _show_plugin_install_dialog(window: Window) -> None:
     # This callback is only used when this package is available, thus we do not check
     from napari_plugin_manager.qt_plugin_dialog import QtPluginDialog
 
-    QtPluginDialog(window._qt_window).exec_()
+    show_disclaimer = get_settings().plugins.manager_disclaimer
+    QtPluginDialog(window._qt_window, show_disclaimer=show_disclaimer).exec_()
+    get_settings().plugins.manager_disclaimer = False
 
 
 def _show_plugin_err_reporter(window: Window) -> None:

--- a/napari/settings/_plugins.py
+++ b/napari/settings/_plugins.py
@@ -53,6 +53,13 @@ class PluginsSettings(EventedSettings):
             'Assign file extensions to specific writer plugins'
         ),
     )
+    manager_disclaimer: bool = Field(
+        True,
+        title=trans._('Plugin manager 3rd party plugins disclaimer'),
+        description=trans._(
+            'Show disclaimer message over plugin manager dialog about 3rd party nature of the plugins available for installation'
+        ),
+    )
 
     class Config:
         use_enum_values = False
@@ -63,4 +70,5 @@ class PluginsSettings(EventedSettings):
             'schema_version',
             'disabled_plugins',
             'extension2writer',
+            # 'manager_disclaimer',
         )


### PR DESCRIPTION
# References and relevant issues

Part of https://github.com/napari/napari-plugin-manager/issues/93

# Description

The changes here are the napari side of things of the work being done at https://github.com/napari/napari-plugin-manager/pull/95 to enable showing a dissclaimer message over the napari-plugin-manager dialog only once per napari/settings installation

A preview of the intereaction that wants to be achieved with a the disclaimer message can be checked at https://github.com/napari/napari-plugin-manager/pull/95#issue-2456363003




# Notes

Need to bump the minimum version on `napari-plugin-manager` to a release version that includes the changes being done at https://github.com/napari/napari-plugin-manager/pull/95