### PR TITLE
Fix bug preventing from change symbol for points initialized with single value

### DIFF
--- a/napari/layers/points/_points_utils.py
+++ b/napari/layers/points/_points_utils.py
@@ -297,7 +297,7 @@ def coerce_symbols(
     # if a symbol is a unique string or Symbol instance, convert it to a
     # proper Symbol instance
     if isinstance(symbol, (str, Symbol)):
-        return np.array(symbol_conversion(symbol), dtype=object)
+        return np.array([symbol_conversion(symbol)], dtype=object)
 
     if not isinstance(symbol, np.ndarray):
         symbol = np.array(symbol)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2657,6 +2657,22 @@ def test_events_callback(old_name, new_name, value):
     old_name_callback.assert_called_once()
 
 
+def test_changing_symbol():
+    """Changing the symbol should update the UI"""
+    layer = Points(np.random.rand(2, 2))
+
+    assert layer.symbol[1].value == 'disc'
+    assert layer.current_symbol.value == 'disc'
+
+    # select a point and change its symbol
+    layer.selected_data = {1}
+    layer.current_symbol = 'square'
+    assert layer.symbol[1].value == 'square'
+    # add a point and check that it has the new symbol
+    layer.add([1, 1])
+    assert layer.symbol[2].value == 'square'
+
+
 def test_docstring():
     validate_all_params_in_docstring(Points)
     validate_kwargs_sorted(Points)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2671,6 +2671,7 @@ def test_changing_symbol():
     # add a point and check that it has the new symbol
     layer.add([1, 1])
     assert layer.symbol[2].value == 'square'
+    assert layer.symbol[0].value == 'disc'
 
 
 def test_docstring():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -680,6 +680,11 @@ def test_symbol():
     layer.symbol = symbol
     assert np.array_equal(layer.symbol, expected)
 
+    with pytest.raises(
+        ValueError, match='Symbol array must be the same length as data'
+    ):
+        layer.symbol = symbol[1:5]
+
     layer = Points(data, symbol='star')
     assert np.array_equiv(layer.symbol, 'star')
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -959,7 +959,16 @@ class Points(Layer):
         # If a single symbol has been converted, this will broadcast it to
         # the number of points in the data. If symbols is already an array,
         # this will check that it is the correct length.
-        coerced_symbols = np.broadcast_to(coerced_symbols, self.data.shape[0])
+        if coerced_symbols.size == 1:
+            coerced_symbols = np.full(
+                self.data.shape[0], coerced_symbols[0], dtype=object
+            )
+        else:
+            coerced_symbols = np.array(coerced_symbols)
+            if coerced_symbols.size != self.data.shape[0]:
+                raise ValueError(
+                    'Symbol array must be the same length as data.'
+                )
         self._symbol = coerced_symbols
         self.events.symbol()
         self.events.highlight()


### PR DESCRIPTION
# References and relevant issues

Alternative to #7141

# Description

Instead of using broadcast, this PR directly allocates full array to
symbols. As allocation is after call of `coerce_symbols` then
performance should not be significantly impacted.

I confirmed this with a benchmarks run here:
https://github.com/napari/napari/pull/7184#issuecomment-2287249143