### PR TITLE
Add `napari.benchmarks.util` to sdist and wheel to fix balls example data

### DIFF
--- a/.github/workflows/reusable_build_wheel.yml
+++ b/.github/workflows/reusable_build_wheel.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build wheel
         run: |
-          python -m build --wheel --outdir dist/
+          python -m build --outdir dist/
 
       - name: Upload wheel
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -22,10 +22,23 @@ jobs:
 
       - uses: tlambert03/setup-qt-libs@v1
 
-      - name: Install this commit
+      - name: Build wheel
         run: |
-          pip install --upgrade pip
-          pip install "./napari-from-github[pyqt,testing]"
+          pip install --upgrade pip build
+          python -m build "./napari-from-github"
+          # there is a bug in build/setuptools that build only wheel will ignore manifest content.
+          # so we need to build sdist first and then build wheel
+
+      - name: get wheel path
+        run: |
+          WHEEL_PATH=$(ls napari-from-github/dist/*.whl)
+          echo "WHEEL_PATH=$WHEEL_PATH" >> "$GITHUB_ENV"
+
+      - name: Install napari from wheel
+        run: |
+          pip install "${{ env.WHEEL_PATH }}[pyqt,testing]"
+        shell:
+            bash
         env:
           PIP_CONSTRAINT: napari-from-github/resources/constraints/constraints_py3.9.txt
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,7 @@ recursive-include napari *.py_tmpl
 recursive-exclude tools *
 recursive-exclude napari *.pyc
 exclude napari/benchmarks/*
+include napari/benchmarks/utils.py
 recursive-exclude resources *
 recursive-exclude binder *
 recursive-exclude examples *


### PR DESCRIPTION
# References and relevant issues
closes #7185
closes #7189

# Description

Ensure that `napari.benchmarks.utils` is added to wheel and sdist, because it is used in a sample menu item. 
Fix testing workflow to fail if some additional file is missing in the future. 
