### PR TITLE
Bugfix: ensure highlight event works with selection box

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2043,7 +2043,7 @@ class Points(Layer):
             pos = None
 
         self._highlight_box = pos
-        if prev_stored != self._selected_data_stored:
+        if prev_stored != self._selected_data_stored or self._is_selecting:
             self.events.highlight()
 
     def _update_thumbnail(self) -> None:

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1996,7 +1996,6 @@ class Points(Layer):
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
-        prev_stored = self._selected_data_stored
         self._selected_data_stored = Selection(self.selected_data)
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
@@ -2043,7 +2042,7 @@ class Points(Layer):
             pos = None
 
         self._highlight_box = pos
-        if prev_stored != self._selected_data_stored or self._is_selecting:
+        if not force:
             self.events.highlight()
 
     def _update_thumbnail(self) -> None:

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2589,11 +2589,10 @@ class Shapes(Layer):
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
-        prev_selected = self._selected_data_stored
         self._selected_data_stored = copy(self.selected_data)
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
-        if prev_selected != self._selected_data_stored:
+        if not force:
             self.events.highlight()
 
     def _finish_drawing(self, event=None) -> None:


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7187

# Description
In https://github.com/napari/napari/pull/7162 the highlight event was gated on selection changing, but this excluded the selection box, which is also a highlight, as well as shapes drawing highlights.
This PR is an alternative solution for #7071 where the event is only emitted when `force` is not used--force is used for scale. This way the other highlights are preserved.
