### PR TITLE
Dont exclude benchmarks from MANIFEST.in, need them for sample Balls

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include napari *.pyi
 recursive-include napari *.png *.svg *.qss *.gif *.ico *.icns
 recursive-include napari *.yaml
 recursive-include napari *.py_tmpl
+recursive-include napari *.md
 
 # explicit excludes to keep check-manifest happy and remind us that
 # these things are not being included unless we ask

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,7 +13,6 @@ recursive-include napari *.py_tmpl
 # these things are not being included unless we ask
 recursive-exclude tools *
 recursive-exclude napari *.pyc
-exclude napari/benchmarks/*
 recursive-exclude resources *
 recursive-exclude binder *
 recursive-exclude examples *


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7185

# Description
Balls were added to sample images in https://github.com/napari/napari/pull/6527 but the manifest wasn't updated to not exclude `napari/benchmarks`. This PR updates the manifest so benchmarks is in the wheel.

Hopefully in https://github.com/napari/napari/pull/7186 we can make CI fail with current main and then this PR will fix it.
