### PR TITLE
Bugfix: Revert "Emit highlight event only if selection changed (#7162)"

### DIFF
--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2005,7 +2005,6 @@ class Points(Layer):
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
-        prev_stored = self._selected_data_stored
         self._selected_data_stored = Selection(self.selected_data)
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
@@ -2052,8 +2051,7 @@ class Points(Layer):
             pos = None
 
         self._highlight_box = pos
-        if prev_stored != self._selected_data_stored:
-            self.events.highlight()
+        self.events.highlight()
 
     def _update_thumbnail(self) -> None:
         """Update thumbnail with current points and colors."""

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2592,12 +2592,10 @@ class Shapes(Layer):
             and np.array_equal(self._drag_box, self._drag_box_stored)
         ) and not force:
             return
-        prev_selected = self._selected_data_stored
         self._selected_data_stored = copy(self.selected_data)
         self._value_stored = copy(self._value)
         self._drag_box_stored = copy(self._drag_box)
-        if prev_selected != self._selected_data_stored:
-            self.events.highlight()
+        self.events.highlight()
 
     def _finish_drawing(self, event=None) -> None:
         """Reset properties used in shape drawing."""


### PR DESCRIPTION
# References and relevant issues
This reverts commit b7a8d00decfde0ee255d768ad195e2c18dd89902.
Closes: https://github.com/napari/napari/issues/7187
Re-opens: https://github.com/napari/napari/issues/7071
Alternative to https://github.com/napari/napari/pull/7188

# Description
https://github.com/napari/napari/pull/7162 resulted in major un-intended (lack of tests 😬) consequences to:
1. selecting points and shapes with the selection tool
2. drawing shapes
3. editing shapes using the vertex selection tool
4. moving shapes using the selection tool

I had made https://github.com/napari/napari/pull/7188 as a naive fix to the first symptoms: points selection, but the issue is more far reaching and requires more thought. See also some discussion here: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/highlight

My suggestion here is to just revert #7162 because the unintended consequences are far more severe than the original issue. Then we can return to the drawing board to disentangle highlights from selection and try to address the original event related issue more precisely.
