### PR TITLE
[Maint] Remove some pytest skipif for python <3.9

### DIFF
--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -81,9 +81,6 @@ def test_add_layer_data_to_viewer_optional(make_napari_viewer):
     assert len(viewer.layers) == 1
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason='Futures not subscriptable before py3.9'
-)
 @pytest.mark.parametrize(('LayerType', 'data', 'ndim'), test_data)
 def test_magicgui_add_future_data(
     qtbot, make_napari_viewer, LayerType, data, ndim

--- a/napari/utils/_tests/test_theme.py
+++ b/napari/utils/_tests/test_theme.py
@@ -1,6 +1,3 @@
-import os
-import sys
-
 import pytest
 from npe2 import PluginManager, PluginManifest, __version__ as npe2_version
 from npe2.manifest.schema import ContributionPoints
@@ -111,11 +108,6 @@ def test_rebuild_theme_settings():
     settings.appearance.theme = 'another-theme'
 
 
-@pytest.mark.skipif(
-    os.getenv('CI') and sys.version_info < (3, 9),
-    reason='Testing theme on CI is extremely slow ~ 15s per test.'
-    'Skip for now until we find the reason',
-)
 @pytest.mark.parametrize(
     'color',
     [
@@ -132,11 +124,6 @@ def test_theme(color):
     theme.background = color
 
 
-@pytest.mark.skipif(
-    os.getenv('CI') and sys.version_info < (3, 9),
-    reason='Testing theme on CI is extremely slow ~ 15s per test.'
-    'Skip for now until we find the reason',
-)
 def test_theme_font_size():
     theme = get_theme('dark')
     theme.font_size = '15pt'


### PR DESCRIPTION
# References and relevant issues
While looking at https://github.com/napari/napari/issues/3404 I noticed that `test_theme` was skipped for python < 3.9.
Well, we don't support 3.9 anymore and don't run that in our CI matrix.

# Description
This PR removes that and another 3.9 skipif in tests.