### PR TITLE
Handle case where `link_layers` receives a single attribute as a tuple

### DIFF
--- a/napari/layers/utils/_link_layers.py
+++ b/napari/layers/utils/_link_layers.py
@@ -100,7 +100,7 @@ def link_layers(
     valid_attrs = _get_common_evented_attributes(layers)
 
     # now, ensure that the attributes requested are valid
-    attr_set = set(attributes)
+    attr_set = set([attributes])
     if attributes:
         extra = attr_set - valid_attrs
         if extra:


### PR DESCRIPTION
# Description
When a tuple with a single attribute is passed to [link_layers](https://github.com/napari/napari/blob/4c3001844e87b2ed36e83f1abacbbfbe96cec126/napari/layers/utils/_link_layers.py#L54) it results in an error.  See example below.  I believe this is related to how `set` handles an iterable on [line 103](https://github.com/napari/napari/blob/4c3001844e87b2ed36e83f1abacbbfbe96cec126/napari/layers/utils/_link_layers.py#L103).

Code snippet
```python
from napari.experimental import link_layers
link_layers(viewer.layers, ('plane'))
```

Error message
```python
ValueError: Cannot link attributes that are not shared by all layers: {'e', 'n', 'a', 'l', 'p'}. 
Allowable attrs include: {'plane', 'axis_labels', 'refresh', 'mouse_pan', 'iso_threshold', 'units', 'interpolation2d', 'interpolation3d', 'blending', 'shear', 'scale', 'contrast_limits_range', 'cursor_size', 'translate', 'attenuation', 'depiction', 'rendering', 'gamma', 'mouse_zoom', 'cursor', 'custom_interpolation_kernel_2d', 'rotate', 'opacity', 'colormap', 'editable', 'contrast_limits', 'affine', 'visible', 'help', 'projection_mode'}
```

Thank you
