### PR TITLE
If a shape is convex, use faster fan triangulation

### DIFF
--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import pytest
 from vispy.geometry import PolygonData
@@ -98,7 +96,7 @@ def test_polygon():
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
-    expected_face = (6, 2) if 'triangle' in sys.modules else (8, 2)
+    expected_face = (6, 2)
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == expected_face
 
@@ -108,7 +106,7 @@ def test_polygon2():
     shape = Polygon(data, interpolation_order=3)
     # should get many triangles
 
-    expected_face = (249, 2) if 'triangle' in sys.modules else (251, 2)
+    expected_face = (249, 2)
 
     assert shape._edge_vertices.shape == (500, 2)
     assert shape._face_vertices.shape == expected_face

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -57,7 +57,7 @@ def _fan_triangulation(poly: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:
         The triangles of the triangulation, as triplets of indices into the
         vertices array.
     """
-    vertices = poly
+    vertices = np.copy(poly)
     triangles = np.zeros((len(poly) - 2, 3), dtype=np.uint32)
     triangles[:, 1] = np.arange(1, len(poly) - 1)
     triangles[:, 2] = np.arange(2, len(poly))

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
     triangulate = None
 
 
-def _is_convex(poly: npt.Array) -> bool:
+def _is_convex(poly: npt.NDArray) -> bool:
     """Check whether a polygon is convex.
 
     Parameters
@@ -39,7 +39,7 @@ def _is_convex(poly: npt.Array) -> bool:
     return np.unique(orientation(fst, snd, thrd)).size == 1
 
 
-def _fan_triangulation(poly: npt.Array) -> tuple[npt.Array, npt.Array]:
+def _fan_triangulation(poly: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:
     """Return a fan triangulation of a given polygon.
 
     https://en.wikipedia.org/wiki/Fan_triangulation

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -567,7 +567,17 @@ def triangulate_face(data: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:
         res = triangulate({'vertices': data, 'segments': edges}, 'p')
         vertices, triangles = res['vertices'], res['triangles']
     else:
-        vertices, triangles = PolygonData(vertices=data).triangulate()
+        fst = data
+        snd = np.roll(data, -1, axis=0)
+        thrd = np.roll(data, -2, axis=0)
+        is_convex = np.unique(orientation(fst, snd, thrd)).size == 1
+        if is_convex:
+            vertices = data
+            triangles = np.zeros((len(data) - 2, 3), dtype=np.uint32)
+            triangles[:, 1] = np.arange(1, len(data) - 1)
+            triangles[:, 2] = np.arange(2, len(data))
+        else:
+            vertices, triangles = PolygonData(vertices=data).triangulate()
 
     triangles = triangles.astype(np.uint32)
 


### PR DESCRIPTION
# References and relevant issues

This PR is part of work done in https://github.com/4DNucleome/PartSegCore-compiled-backend/pull/36 from where I extract idea for checking if polygon is convex 

# Description

For a convex polygon, the triangulation is a trivial problem that could be done in linear time. However, the current approach is performing heavy computations even for such cases. 

This PR adds an additional check that increases time for non-convex polygons, but drastically reduces for convex one. 

On sample data (of thousands of quadrangles) it reduces the time to triangulate face from, 20456ms (56% of running time) to 1461ms (8,8%) of running time. 

Example:

```python
from napari.layers import Shapes
import numpy as np

DATA_SIZE = 18000
PER_LINE = int(DATA_SIZE ** (1/2))

array = np.array([(0.2, 0.1), (0.1, 0.9), (0.9, 0.9), (0.9, 0.2)]) * 10

data = []
for i in range(DATA_SIZE // PER_LINE):
    for j in range(PER_LINE):
        data.append(array + (i*10, j*10))

s = Shapes(data, shape_type='polygon')
```

I may prepare more complex examples to validate this approach if you think that it is a good idea. 