### PR TITLE
Fix example by connect missing event

### DIFF
--- a/examples/multiple_viewer_widget.py
+++ b/examples/multiple_viewer_widget.py
@@ -359,12 +359,20 @@ class MultipleViewerWidget(QSplitter):
 
         if isinstance(event.value, Labels):
             event.value.events.set_data.connect(self._set_data_refresh)
+            event.value.events.labels_update.connect(self._set_data_refresh)
             self.viewer_model1.layers[
                 event.value.name
             ].events.set_data.connect(self._set_data_refresh)
             self.viewer_model2.layers[
                 event.value.name
             ].events.set_data.connect(self._set_data_refresh)
+            event.value.events.labels_update.connect(self._set_data_refresh)
+            self.viewer_model1.layers[
+                event.value.name
+            ].events.labels_update.connect(self._set_data_refresh)
+            self.viewer_model2.layers[
+                event.value.name
+            ].events.labels_update.connect(self._set_data_refresh)
         if event.value.name != '.cross':
             self.viewer_model1.layers[event.value.name].events.data.connect(
                 self._sync_data


### PR DESCRIPTION
# References and relevant issues


# Description

When in #5732 there was introduced a mechanism for efficient drawing, the `examples/multiple_viewer_widget.py` was broken by lack of refreshing view on paint. 

This PR restores it by connecting to an event introduced in #5732. 