### PR TITLE
Add autouse fixture that clears cached property `Action.injected`

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -1,10 +1,12 @@
 import pytest
-from qtpy.QtCore import QPoint
+from qtpy.QtCore import QPoint, Qt
 from qtpy.QtWidgets import QApplication
 
+from napari._app_model._app import get_app
 from napari._qt.dialogs.qt_modal import QtPopup
 from napari._qt.widgets.qt_viewer_buttons import QtViewerButtons
 from napari.components.viewer_model import ViewerModel
+from napari.viewer import Viewer
 
 
 @pytest.fixture
@@ -131,3 +133,20 @@ def test_ndisplay_button_popup(qt_viewer_buttons, qtbot):
         == viewer_buttons.perspective_slider.value()
         == 10
     )
+
+
+def test_toggle_ndisplay(mock_app, qt_viewer_buttons, qtbot):
+    """Check `toggle_ndisplay` works via `mouseClick`."""
+    viewer, viewer_buttons = qt_viewer_buttons
+    assert viewer_buttons.ndisplayButton
+
+    app = get_app()
+
+    assert viewer.dims.ndisplay == 2
+    with app.injection_store.register(
+        providers=[
+            (lambda: viewer, Viewer, 100),
+        ]
+    ):
+        qtbot.mouseClick(viewer_buttons.ndisplayButton, Qt.LeftButton)
+        assert viewer.dims.ndisplay == 3

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -297,7 +297,7 @@ def _clear_cached_action_injection():
     """Automatically clear cached property `Action.injected`.
 
     Allows action manager actions to be injected using current provider/processors
-    and dependencies. See #7219 for details
+    and dependencies. See #7219 for details.
     To be removed after ActionManager deprecation.
     """
     from napari.utils.action_manager import action_manager

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -292,6 +292,17 @@ def tmp_plugin(npe2pm_: TestPluginManager):
         yield plugin
 
 
+@pytest.fixture(autouse=True)
+def _clear_cached_action_injection():
+    # Clear cached property `Action.injected`, see #7219 for details
+    # To be removed after ActionManager deprecation
+    from napari.utils.action_manager import action_manager
+
+    for action in action_manager._actions.values():
+        if 'injected' in action.__dict__:
+            del action.__dict__['injected']
+
+
 def _event_check(instance):
     def _prepare_check(name, no_event_):
         def check(instance, no_event=no_event_):

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -294,8 +294,12 @@ def tmp_plugin(npe2pm_: TestPluginManager):
 
 @pytest.fixture(autouse=True)
 def _clear_cached_action_injection():
-    # Clear cached property `Action.injected`, see #7219 for details
-    # To be removed after ActionManager deprecation
+    """Automatically clear cached property `Action.injected`.
+
+    Allows action manager actions to be injected using current provider/processors
+    and dependencies. See #7219 for details
+    To be removed after ActionManager deprecation.
+    """
     from napari.utils.action_manager import action_manager
 
     for action in action_manager._actions.values():

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -317,14 +317,6 @@ def make_napari_viewer(
 
     yield actual_factory
 
-    # Clear cached property `Action.injected`, see #7219 for details
-    # To be removed after ActionManager deprecation
-    from napari.utils.action_manager import action_manager
-
-    for action in action_manager._actions.values():
-        if 'injected' in action.__dict__:
-            del action.__dict__['injected']
-
     # Some tests might have the viewer closed, so this call will not be able
     # to access the window.
     with suppress(AttributeError):

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -317,6 +317,8 @@ def make_napari_viewer(
 
     yield actual_factory
 
+    # Clear cached property `Action.injected`, see #7219 for details
+    # To be removed after ActionManager deprecation
     from napari.utils.action_manager import action_manager
 
     for action in action_manager._actions.values():

--- a/napari/utils/_testsupport.py
+++ b/napari/utils/_testsupport.py
@@ -317,6 +317,12 @@ def make_napari_viewer(
 
     yield actual_factory
 
+    from napari.utils.action_manager import action_manager
+
+    for action in action_manager._actions.values():
+        if 'injected' in action.__dict__:
+            del action.__dict__['injected']
+
     # Some tests might have the viewer closed, so this call will not be able
     # to access the window.
     with suppress(AttributeError):


### PR DESCRIPTION
# References and relevant issues
Closes #7219 
See https://github.com/napari/napari/pull/7052 for more discussion.

# Description
Clear cached property `ActionManager.injected` in an autoused fixture.

Currently tests share a single `ActionManager` instance and its `Actions` (in `ActionManager._actions`) include a cached property `Action.injected`. This means that when the action is triggered in a test, it will not run `injected` again, which means any changes to the `app` injection `Store` (which keeps all providers and processors) will not take effect. See #7219, https://github.com/napari/napari/pull/7052 for more details.