### PR TITLE
Fix convex polygon detection

### DIFF
--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 from vispy.geometry import PolygonData
@@ -96,7 +98,7 @@ def test_polygon():
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
-    expected_face = (8, 2)
+    expected_face = (6, 2) if 'triangle' in sys.modules else (8, 2)
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == expected_face
 

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -80,7 +80,7 @@ def test_polygon_data_triangle_module():
 
 def test_polygon():
     """Test creating Shape with a random polygon."""
-    # Test a single six vertex polygon
+    # Test a single non convex six vertex polygon
     data = np.array(
         [
             [10.97627008, 14.30378733],
@@ -96,7 +96,7 @@ def test_polygon():
     assert shape.data_displayed.shape == (6, 2)
     assert shape.slice_key.shape == (2, 0)
     # should get few triangles
-    expected_face = (6, 2)
+    expected_face = (8, 2)
     assert shape._edge_vertices.shape == (16, 2)
     assert shape._face_vertices.shape == expected_face
 

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -36,7 +36,7 @@ def _is_convex(poly: npt.NDArray) -> bool:
     fst = poly
     snd = np.roll(poly, -1, axis=0)
     thrd = np.roll(poly, -2, axis=0)
-    return np.unique(orientation(fst, snd, thrd)).size == 1
+    return np.unique(orientation(fst.T, snd.T, thrd.T)).size == 1
 
 
 def _fan_triangulation(poly: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:


### PR DESCRIPTION
In reviewing #6654, I discovered that the `_is_convex` helper function, implemented in #7214, wasn't working correctly, because the coordinate arrays passed to the `orientation` function were transposed relative to what that function expects. (It was a coincidence that earlier examples worked in either order.)

I've transposed the arrays being passed to the function and updated the tests to match.