### PR TITLE
CI benchmark run comment will now include results table

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -168,6 +168,9 @@ jobs:
           "[CI logs and artifacts](||BENCHMARK_CI_LOGS_URL||) for further details." \
           > .asv/results/message_${{ matrix.benchmark-name }}.txt
 
+          awk  '/Benchmark.*Parameter/,/SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY/' asv_continuous.log \
+          >> .asv/results/message_${{ matrix.benchmark-name }}.txt
+
           fi
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

The current comment about benchmark results looks like:
![obraz](https://github.com/user-attachments/assets/54b74fb8-4488-46b4-8bc5-313965b622d9)

So when we need to check what changed, we need to open log and scroll down. I have found that we could use awk to extract this information from log and add them to comment. 

Here sample output of run command in terminal:

![obraz](https://github.com/user-attachments/assets/97e25f46-0a2b-4ec6-9bf4-6339a19c5e7e)
