### PR TITLE
start/stop status thread on show/hide main window

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -22,7 +22,6 @@ from typing import (
 from weakref import WeakValueDictionary
 
 import numpy as np
-from PyQt5.QtGui import QHideEvent, QShowEvent
 from qtpy.QtCore import (
     QEvent,
     QEventLoop,
@@ -33,7 +32,7 @@ from qtpy.QtCore import (
     Qt,
     Slot,
 )
-from qtpy.QtGui import QIcon
+from qtpy.QtGui import QHideEvent, QIcon, QShowEvent
 from qtpy.QtWidgets import (
     QApplication,
     QDialog,

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -22,6 +22,7 @@ from typing import (
 from weakref import WeakValueDictionary
 
 import numpy as np
+from PyQt5.QtGui import QHideEvent, QShowEvent
 from qtpy.QtCore import (
     QEvent,
     QEventLoop,
@@ -205,8 +206,6 @@ class _QtMainWindow(QMainWindow):
         self.status_thread.status_and_tooltip_changed.connect(
             self.set_status_and_tooltip
         )
-        if settings.appearance.update_status_based_on_layer:
-            self.status_thread.start()
         viewer.cursor.events.position.connect(
             self.status_thread.trigger_status_update
         )
@@ -219,6 +218,17 @@ class _QtMainWindow(QMainWindow):
             self.status_thread.start()
         else:
             self.status_thread.terminate()
+
+    def showEvent(self, event: QShowEvent):
+        """Override to handle window state changes."""
+        settings = get_settings()
+        if settings.appearance.update_status_based_on_layer:
+            self.status_thread.start()
+        super().showEvent(event)
+
+    def hideEvent(self, event: QHideEvent):
+        self.status_thread.terminate()
+        super().hideEvent(event)
 
     def set_status_and_tooltip(
         self, status_and_tooltip: Optional[tuple[Union[str, dict], str]]

--- a/napari/_qt/threads/status_checker.py
+++ b/napari/_qt/threads/status_checker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from threading import Event
 from typing import TYPE_CHECKING
 from weakref import ref
@@ -69,6 +70,12 @@ class StatusChecker(QThread):
         self._terminate = True
         self._need_status_update.set()
 
+    def start(
+        self, priority: QThread.Priority = QThread.Priority.InheritPriority
+    ) -> None:
+        self._terminate = False
+        super().start(priority)
+
     def run(self) -> None:
         while not self._terminate:
             if self.viewer_ref() is None:
@@ -101,3 +108,11 @@ class StatusChecker(QThread):
             # We do not want to crash the thread to keep the status updates.
             notification_manager.dispatch(Notification.from_exception(e))
         self.status_and_tooltip_changed.emit(res)
+
+
+if os.environ.get('ASV') == 'true':
+    # This is a hack to make sure that the StatusChecker thread is not
+    # running when the benchmark is running. This is because the
+    # StatusChecker thread may introduce some noise in the benchmark
+    # results from waiting on its termination.
+    StatusChecker.start = lambda self: None

--- a/napari/_qt/threads/status_checker.py
+++ b/napari/_qt/threads/status_checker.py
@@ -115,4 +115,4 @@ if os.environ.get('ASV') == 'true':
     # running when the benchmark is running. This is because the
     # StatusChecker thread may introduce some noise in the benchmark
     # results from waiting on its termination.
-    StatusChecker.start = lambda self: None
+    StatusChecker.start = lambda self, priority: None  # type: ignore[assignment,misc]

--- a/napari/_qt/threads/status_checker.py
+++ b/napari/_qt/threads/status_checker.py
@@ -115,4 +115,4 @@ if os.environ.get('ASV') == 'true':
     # running when the benchmark is running. This is because the
     # StatusChecker thread may introduce some noise in the benchmark
     # results from waiting on its termination.
-    StatusChecker.start = lambda self, priority: None  # type: ignore[assignment,misc]
+    StatusChecker.start = lambda self, priority=0: None  # type: ignore[assignment]


### PR DESCRIPTION
# References and relevant issues

hopefully closes #7236 

Environment variables https://github.com/airspeed-velocity/asv/blob/b0ae9d456362169068dab3ea2628f2f9af6c1402/docs/source/env_vars.rst

# Description

This PR implements various fixes related to `StatusChecker`:

1. Delay start of `StatusChecker` thread to show of window, and terminate it immediately after hide Window (hide, not lost of focus)
2. fix bug that prevents from restart of thread when toggling `settings.appearance.update_status_based_on_layer`
3. Disable running thread when using viewer in ASV benchmarks as it may impact benchmark results, because of waiting on thread termination. 
