### PR TITLE
Alow to call benchmark that do not have params

### DIFF
--- a/napari/benchmarks/utils.py
+++ b/napari/benchmarks/utils.py
@@ -244,6 +244,15 @@ def run_benchmark_from_module(
             except NotImplementedError:
                 continue
             getattr(obj, method_name)(*param)
+            getattr(obj, 'teardown', lambda: None)()
+    else:
+        obj = klass()
+        try:
+            obj.setup()
+        except NotImplementedError:
+            return
+        getattr(obj, method_name)()
+        getattr(obj, 'teardown', lambda: None)()
 
 
 def run_benchmark():


### PR DESCRIPTION
# Description
In #7145 I have implemented option to call benchmarks without using asv (for debug purpose).

However, I have forgotten about the case of benchmarks without any parameters. I also forgot about the call of teardown method. This PR is fixing this.
