### PR TITLE
Speedup `_is_convex` by avoid calling `np.roll`

### DIFF
--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -39,9 +39,9 @@ def _is_convex(poly: npt.NDArray) -> bool:
     orn_set = np.unique(orientation(fst.T, snd.T, thrd.T))
     if orn_set.size != 1:
         return False
-    return orn_set[0] == orientation(poly[-2], poly[-1], poly[0]) and orn_set[
-        0
-    ] == orientation(poly[-1], poly[0], poly[1])
+    return (orn_set[0] == orientation(poly[-2], poly[-1], poly[0])) and (
+        orn_set[0] == orientation(poly[-1], poly[0], poly[1])
+    )
 
 
 def _fan_triangulation(poly: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -33,10 +33,15 @@ def _is_convex(poly: npt.NDArray) -> bool:
     bool
         True if the given polygon is convex.
     """
-    fst = poly
-    snd = np.roll(poly, -1, axis=0)
-    thrd = np.roll(poly, -2, axis=0)
-    return np.unique(orientation(fst.T, snd.T, thrd.T)).size == 1
+    fst = poly[:-2]
+    snd = poly[1:-1]
+    thrd = poly[2:]
+    orn_set = np.unique(orientation(fst.T, snd.T, thrd.T))
+    if orn_set.size != 1:
+        return False
+    return orn_set[0] == orientation(poly[-2], poly[-1], poly[0]) and orn_set[
+        0
+    ] == orientation(poly[-1], poly[0], poly[1])
 
 
 def _fan_triangulation(poly: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:


### PR DESCRIPTION
# Description

In #7214 I have introduced `_is_convex` helper functions that speedup shapes triangulation. However, I found that calling `np.roll` is expensive. 

![obraz](https://github.com/user-attachments/assets/c4b5633b-3013-4bc4-a3d6-697c91150220)

This PR reimplements `_is_convex` to not use `np.roll` 

![obraz](https://github.com/user-attachments/assets/03cce330-a4d1-45cc-8660-113ff6cec041)


Tested different sizes and speedup was always observable. 
