### PR TITLE
Remove narrow import exception condition (#7259)

### DIFF
--- a/napari/utils/colormaps/_accelerated_cmap.py
+++ b/napari/utils/colormaps/_accelerated_cmap.py
@@ -215,7 +215,7 @@ def _labels_raw_to_texture_direct_inner_loop(
 
 try:
     import numba
-except ModuleNotFoundError:
+except:
     zero_preserving_modulo = zero_preserving_modulo_numpy
     labels_raw_to_texture_direct = _labels_raw_to_texture_direct_numpy
     prange = range


### PR DESCRIPTION
# References and relevant issues

#7259

# Description

It resolves a bug on where, at least on (my) MacM1, a different exception isn't caught when trying to import numba. This made it such that napari would crash when loading layers with a colormap.


- [x] My PR is the minimum possible work for the desired functionality

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] If I included new strings, I have used `trans._("some string")` to make them localizable.
  (For more information see our [translations guide](https://napari.org/stable/developers/contributing/translations.html)).
-->
