### PR TITLE
Add beanli161514 to citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -170,6 +170,11 @@ authors:
   affiliation: Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland
   orcid: https://orcid.org/0000-0002-3656-2449
   alias: jeylau
+- given-names: Rubin
+  family-names: Zhao
+  affiliation: Chinese Academy of Sciences - SIAT, Shenzhen, China
+  orcid: https://orcid.org/0009-0005-8264-5682
+  alias: BeanLi
 - given-names: Gregor
   family-names: Lichtner
   affiliation: Universitätsmedizin Greifswald

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -170,11 +170,6 @@ authors:
   affiliation: Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland
   orcid: https://orcid.org/0000-0002-3656-2449
   alias: jeylau
-- given-names: Rubin
-  family-names: Zhao
-  affiliation: Chinese Academy of Sciences - SIAT, Shenzhen, China
-  orcid: https://orcid.org/0009-0005-8264-5682
-  alias: BeanLi
 - given-names: Gregor
   family-names: Lichtner
   affiliation: Universitätsmedizin Greifswald
@@ -329,5 +324,10 @@ authors:
   family-names: Winston
   affiliation: Tobeva Software
   alias: pwinston
+- given-names: Rubin
+  family-names: Zhao
+  affiliation: Chinese Academy of Sciences - SIAT, Shenzhen, China
+  orcid: https://orcid.org/0009-0005-8264-5682
+  alias: BeanLi
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause


### PR DESCRIPTION
Add @beanli161514 to CITATION.cff
```
- given-names: Rubin
  family-names: Zhao
  affiliation: Chinese Academy of Sciences - SIAT, Shenzhen, China
  orcid: https://orcid.org/0009-0005-8264-5682
  alias: BeanLi
```
Thanks for @jni, @brisvag and @Czaki 's help to get https://github.com/napari/napari/pull/7090 merged. I'd like to contribute more about 3D interactivity for this project. 
