### PR TITLE
Enforce minimum side length when guessing if image is RGB

### DIFF
--- a/napari/components/_tests/test_multichannel.py
+++ b/napari/components/_tests/test_multichannel.py
@@ -37,7 +37,7 @@ multi_channel_test_data = [
     # split single RGB image
     ((15, 10, 3), {'colormap': ['red', 'green', 'blue']}),
     # multiple RGB images
-    ((15, 10, 5, 3), {'channel_axis': 2, 'rgb': True}),
+    ((45, 40, 5, 3), {'channel_axis': 2, 'rgb': True}),
     # Test adding multichannel image with custom names.
     ((), {'name': ['multi ' + str(i + 3) for i in range(5)]}),
     # Test adding multichannel image with custom contrast limits.

--- a/napari/layers/_tests/test_layer_actions.py
+++ b/napari/layers/_tests/test_layer_actions.py
@@ -39,7 +39,7 @@ def test_split_stack():
 
 def test_split_rgb():
     layer_list = LayerList()
-    layer_list.append(Image(np.random.random((8, 8, 3))))
+    layer_list.append(Image(np.random.random((48, 48, 3))))
     assert len(layer_list) == 1
     assert layer_list[0].rgb is True
 
@@ -48,7 +48,7 @@ def test_split_rgb():
     assert len(layer_list) == 3
 
     for idx in range(3):
-        assert layer_list[idx].data.shape == (8, 8)
+        assert layer_list[idx].data.shape == (48, 48)
 
 
 def test_merge_stack():

--- a/napari/layers/image/_image_utils.py
+++ b/napari/layers/image/_image_utils.py
@@ -12,10 +12,11 @@ from napari.layers.image._image_constants import ImageProjectionMode
 from napari.utils.translations import trans
 
 
-def guess_rgb(shape: tuple[int, ...]) -> bool:
+def guess_rgb(shape: tuple[int, ...], min_side_len: int = 30) -> bool:
     """Guess if the passed shape comes from rgb data.
 
-    If last dim is 3 or 4 assume the data is rgb, including rgba.
+    If last dim is 3 or 4 and other dims are larger (>30), assume the data is
+    rgb, including rgba.
 
     Parameters
     ----------
@@ -29,8 +30,13 @@ def guess_rgb(shape: tuple[int, ...]) -> bool:
     """
     ndim = len(shape)
     last_dim = shape[-1]
+    viewed_dims = shape[-3:-1]
 
-    return ndim > 2 and last_dim in (3, 4)
+    return (
+        ndim > 2
+        and last_dim in (3, 4)
+        and all(d > min_side_len for d in viewed_dims)
+    )
 
 
 def guess_multiscale(

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -145,7 +145,7 @@ def test_5D_image_shape_1():
 
 def test_rgb_image():
     """Test instantiating Image layer with RGB data."""
-    shape = (10, 15, 3)
+    shape = (40, 45, 3)
     np.random.seed(0)
     data = np.random.random(shape)
     layer = Image(data)
@@ -160,7 +160,7 @@ def test_rgb_image():
 
 def test_rgba_image():
     """Test instantiating Image layer with RGBA data."""
-    shape = (10, 15, 4)
+    shape = (40, 45, 4)
     np.random.seed(0)
     data = np.random.random(shape)
     layer = Image(data)
@@ -175,7 +175,7 @@ def test_rgba_image():
 
 def test_negative_rgba_image():
     """Test instantiating Image layer with negative RGBA data."""
-    shape = (10, 15, 4)
+    shape = (40, 45, 4)
     np.random.seed(0)
     # Data between -1.0 and 1.0
     data = 2 * np.random.random(shape) - 1

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -123,7 +123,7 @@ def test_non_uniform_3D_multiscale():
 
 def test_rgb_multiscale():
     """Test instantiating Image layer with RGB data."""
-    shapes = [(40, 20, 3), (20, 10, 3), (10, 5, 3)]
+    shapes = [(40, 32, 3), (20, 16, 3), (10, 8, 3)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
@@ -138,7 +138,7 @@ def test_rgb_multiscale():
 
 def test_3D_rgb_multiscale():
     """Test instantiating Image layer with 3D RGB data."""
-    shapes = [(8, 40, 20, 3), (4, 20, 10, 3), (2, 10, 5, 3)]
+    shapes = [(8, 40, 32, 3), (4, 20, 16, 3), (2, 10, 8, 3)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
@@ -153,7 +153,7 @@ def test_3D_rgb_multiscale():
 
 def test_non_rgb_image():
     """Test forcing Image layer to be 3D and not rgb."""
-    shapes = [(40, 20, 3), (20, 10, 3), (10, 5, 3)]
+    shapes = [(40, 32, 3), (20, 16, 3), (10, 8, 3)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True, rgb=False)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -263,15 +263,14 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
     ):
         # Determine if rgb
         data_shape = data.shape if hasattr(data, 'shape') else data[0].shape
-        rgb_guess = guess_rgb(data_shape)
-        if rgb and not rgb_guess:
+        if rgb and not guess_rgb(data_shape, min_side_len=0):
             raise ValueError(
                 trans._(
                     "'rgb' was set to True but data does not have suitable dimensions."
                 )
             )
         if rgb is None:
-            rgb = rgb_guess
+            rgb = guess_rgb(data_shape)
 
         self.rgb = rgb
         super().__init__(


### PR DESCRIPTION
# References and relevant issues

Closes #7261

# Description

For the vast majority of user RGB images, the side length would be larger than 30 pixels. (For reference, our layer thumbnails are 32x32.) Therefore, we can reduce or avoid issues like #7261 by enforcing a minimum side length before we use the final dim as an RGB dim.

I've implemented this as a parameter on the guess_rgb function, which allows us
to turn this into a preference in the future.
