### PR TITLE
Doc/metadata: add jni's ORCID to the CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,6 +23,7 @@ authors:
 - given-names: Juan
   family-names: Nunez-Iglesias
   affiliation: Monash eResearch Centre, Monash University
+  orcid: https://orcid.org/0000-0002-7239-5828
   alias: jni
 - given-names: Peter
   family-names: Sobolewski


### PR DESCRIPTION
@Czaki reminded me that my ORCID is missing from the CITATION.cff file, for some reason or another. This PR just adds it.
