### PR TITLE
Update menu sorting tests still using `mock_app` and `get_app` instead of `mock_app_model` and `get_app_model`

### DIFF
--- a/napari/_qt/_qapp_model/_tests/test_file_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_file_menu.py
@@ -142,10 +142,10 @@ def test_sample_menu_single_data(
 
 def test_sample_menu_sorted(
     mock_pm,  # noqa: F811
-    mock_app,
+    mock_app_model,
     tmp_plugin: DynamicPlugin,
 ):
-    from napari._app_model import get_app
+    from napari._app_model import get_app_model
     from napari.plugins import _initialize_plugins
 
     # we make sure 'plugin-b' is registered first
@@ -165,7 +165,7 @@ def test_sample_menu_sorted(
     def sample2_2(): ...
 
     _initialize_plugins()
-    samples_menu = list(get_app().menus.get_menu('napari/file/samples'))
+    samples_menu = list(get_app_model().menus.get_menu('napari/file/samples'))
     submenus = [item for item in samples_menu if isinstance(item, SubmenuItem)]
     assert len(submenus) == 3
     # mock_pm registers a sample_manifest with two sample data contributions

--- a/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
@@ -284,10 +284,10 @@ def test_no_plugin_manager(monkeypatch, make_napari_viewer):
 
 def test_plugins_menu_sorted(
     mock_pm,  # noqa: F811
-    mock_app,
+    mock_app_model,
     tmp_plugin: DynamicPlugin,
 ):
-    from napari._app_model import get_app
+    from napari._app_model import get_app_model
     from napari.plugins import _initialize_plugins
 
     # we make sure 'plugin-b' is registered first
@@ -311,7 +311,7 @@ def test_plugins_menu_sorted(
     def widget2_2(): ...
 
     _initialize_plugins()
-    plugins_menu = list(get_app().menus.get_menu('napari/plugins'))
+    plugins_menu = list(get_app_model().menus.get_menu('napari/plugins'))
     submenus = [item for item in plugins_menu if isinstance(item, SubmenuItem)]
     assert len(submenus) == 2
     assert submenus[0].title == 'plugin-a'


### PR DESCRIPTION
# References and relevant issues

CI over main is failing due to the issue this PR fixes

# Description

Since PR #7269 and PR #7266 where being worked on in parallel merging both caused some tests to fail (due to their usage of `mock_app` and `get_app`)


