### PR TITLE
Style fix: use recommended capitalization for "GitHub" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can see details of [the project roadmap here](https://napari.org/stable/road
 
 ## contributing
 
-Contributions are encouraged! Please read our [contributing guide](https://napari.org/dev/developers/contributing/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in. 
+Contributions are encouraged! Please read our [contributing guide](https://napari.org/dev/developers/contributing/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [GitHub Issues](https://github.com/napari/napari/issues) before jumping in. 
 
 If you want to contribute or edit to our documentation, please go to [napari/docs](https://github.com/napari/docs). 
 
@@ -111,7 +111,7 @@ DOI of that version on our [zenodo page](https://zenodo.org/record/3555620). The
 
 We're a community partner on the [image.sc forum](https://forum.image.sc/tags/napari) and all help and support requests should be posted on the forum with the tag `napari`. We look forward to interacting with you there.
 
-Bug reports should be made on our [github issues](https://github.com/napari/napari/issues/new?template=bug_report.md) using
+Bug reports should be made on our [GitHub issues](https://github.com/napari/napari/issues/new?template=bug_report.md) using
 the bug report template. If you think something isn't working, don't hesitate to reach out - it is probably us and not you!
 
 ## institutional and funding partners


### PR DESCRIPTION


# References and relevant issues

# Description


Github -> GitHub