### PR TITLE
Add psygnal and pydantic to napari --info

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -118,7 +118,9 @@ def sys_info(as_html: bool = False) -> str:
         ('superqt', 'superqt'),
         ('in_n_out', 'in-n-out'),
         ('app_model', 'app-model'),
+        ('psygnal', 'psygnal'),
         ('npe2', 'npe2'),
+        ('pydantic', 'pydantic'),
     )
 
     loaded = {}


### PR DESCRIPTION
# References and relevant issues

Closes #7229

# Description

Recently when debugging a napari install with a user I noticed that the psygnal
version was not listed in the napari --info output, even though it is often
useful for debugging. I've added that, as well as pydantic, to the packages
listed in the info output.
