### PR TITLE
Remove obsolete self from layout argument

### DIFF
--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -122,7 +122,7 @@ class QtLayerControls(QFrame):
         self.transform_button.installEventFilter(self)
         self._on_editable_or_visible_change()
 
-        self.button_grid = QGridLayout(self)
+        self.button_grid = QGridLayout()
         self.button_grid.addWidget(self.panzoom_button, 0, 6)
         self.button_grid.addWidget(self.transform_button, 0, 7)
         self.button_grid.setContentsMargins(5, 0, 0, 5)


### PR DESCRIPTION
# References and relevant issues
close  #7290

# Description

This PR removes obsolete self from layout constructor. 

This was, an artifact left after trying to clean some leaking widgets, but after rethink and check it looks obsolete. 

Thanks, @dalthviz, for find.  