### PR TITLE
Remove skip conditions for PySide2/6 over plugins menu tests and bump `napari-plugin-manager` minimum version (>=0.1.3)

### DIFF
--- a/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
@@ -2,7 +2,6 @@ import importlib
 from unittest import mock
 
 import pytest
-import qtpy
 from app_model.types import MenuItem, SubmenuItem
 from npe2 import DynamicPlugin
 from qtpy.QtWidgets import QWidget
@@ -22,10 +21,6 @@ class DummyWidget(QWidget):
 @pytest.mark.skipif(
     not _plugins._plugin_manager_dialog_avail(),
     reason='`napari_plugin_manager` not available',
-)
-@pytest.mark.skipif(
-    qtpy.PYSIDE2 or getattr(qtpy, 'PYSIDE6', False),
-    reason='Test segfaults with PySide2/6',
 )
 def test_plugin_manager_action(make_napari_viewer):
     """
@@ -244,7 +239,6 @@ def test_plugin_widget_checked(
     assert widget_action.isChecked()
 
 
-@pytest.mark.skipif(qtpy.PYSIDE2, reason='Test segfaults with PySide2')
 def test_import_plugin_manager():
     from napari_plugin_manager.qt_plugin_dialog import QtPluginDialog
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ qt = [
 ]
 all = [
     "napari[pyqt,optional]",
-    "napari-plugin-manager >=0.1.0a1, <0.2.0",
+    "napari-plugin-manager >=0.1.2, <0.2.0",
 ]
 optional = [
     "triangle ; platform_machine != 'arm64'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ qt = [
 ]
 all = [
     "napari[pyqt,optional]",
-    "napari-plugin-manager >=0.1.2, <0.2.0",
+    "napari-plugin-manager >=0.1.3, <0.2.0",
 ]
 optional = [
     "triangle ; platform_machine != 'arm64'",

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -184,7 +184,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -184,7 +184,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10_docs.txt
+++ b/resources/constraints/constraints_py3.10_docs.txt
@@ -242,7 +242,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-sphinx-theme==0.5.0
     # via -r docs/requirements.txt

--- a/resources/constraints/constraints_py3.10_docs.txt
+++ b/resources/constraints/constraints_py3.10_docs.txt
@@ -242,7 +242,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-sphinx-theme==0.5.0
     # via -r docs/requirements.txt

--- a/resources/constraints/constraints_py3.10_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.10_pydantic_1.txt
@@ -182,7 +182,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.10_pydantic_1.txt
@@ -182,7 +182,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10_windows.txt
+++ b/resources/constraints/constraints_py3.10_windows.txt
@@ -193,7 +193,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10_windows.txt
+++ b/resources/constraints/constraints_py3.10_windows.txt
@@ -193,7 +193,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -177,7 +177,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -177,7 +177,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.11_pydantic_1.txt
@@ -175,7 +175,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.11_pydantic_1.txt
@@ -175,7 +175,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11_windows.txt
+++ b/resources/constraints/constraints_py3.11_windows.txt
@@ -186,7 +186,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11_windows.txt
+++ b/resources/constraints/constraints_py3.11_windows.txt
@@ -186,7 +186,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -175,7 +175,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -175,7 +175,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.12_pydantic_1.txt
@@ -173,7 +173,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.12_pydantic_1.txt
@@ -173,7 +173,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12_windows.txt
+++ b/resources/constraints/constraints_py3.12_windows.txt
@@ -184,7 +184,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12_windows.txt
+++ b/resources/constraints/constraints_py3.12_windows.txt
@@ -184,7 +184,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9.txt
+++ b/resources/constraints/constraints_py3.9.txt
@@ -188,7 +188,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9.txt
+++ b/resources/constraints/constraints_py3.9.txt
@@ -188,7 +188,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_examples.txt
+++ b/resources/constraints/constraints_py3.9_examples.txt
@@ -193,7 +193,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_examples.txt
+++ b/resources/constraints/constraints_py3.9_examples.txt
@@ -193,7 +193,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.9_pydantic_1.txt
@@ -186,7 +186,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.9_pydantic_1.txt
@@ -186,7 +186,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_windows.txt
+++ b/resources/constraints/constraints_py3.9_windows.txt
@@ -197,7 +197,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.2
+napari-plugin-manager==0.1.3
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_windows.txt
+++ b/resources/constraints/constraints_py3.9_windows.txt
@@ -197,7 +197,7 @@ napari-console==0.0.9
     # via napari (napari_repo/pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (napari_repo/pyproject.toml)
-napari-plugin-manager==0.1.1
+napari-plugin-manager==0.1.2
     # via napari (napari_repo/pyproject.toml)
 napari-svg==0.2.0
     # via napari (napari_repo/pyproject.toml)


### PR DESCRIPTION
# References and relevant issues

Part of https://github.com/napari/napari-plugin-manager/issues/94
Follow up for https://github.com/napari/napari/pull/7138

# Description

* Remove skip conditions related with `napari-plugin-manager` and PySide issues
* Bump minimum `napari-plugin-manager` version constraint to >=0.1.2 (need for a new `napari-plugin-manager` release)
* Following the discovery of still having issues related with PySide2 compatibility that need to be addressed over napari-plugin-manager (https://github.com/napari/napari-plugin-manager/issues/106) update requirement to 0.1.3 release and update the constraints