### PR TITLE
Fix color shuffling for bool labels

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -118,6 +118,20 @@ def test_bool_labels():
     assert all(np.issubdtype(d.dtype, np.integer) for d in layer.data)
 
 
+def test_editing_bool_labels():
+    # make random data, mostly 0s
+    data = np.random.random((10, 10)) > 0.7
+    # create layer, which may convert bool to uint8 *as a view*
+    layer = Labels(data)
+    # paint the whole layer with 1
+    layer.paint_polygon(
+        points=[[-1, -1], [-1, 11], [11, 11], [11, -1]],
+        new_label=1,
+    )
+    # check that the original data has been correspondingly modified
+    assert np.all(data)
+
+
 def test_changing_labels():
     """Test changing Labels data."""
     shape_a = (10, 15)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -664,7 +664,7 @@ class Labels(ScalarFieldBase):
                     )
                 )
             if data_level.dtype == bool:
-                int_data.append(data_level.astype(np.int8))
+                int_data.append(data_level.view(np.uint8))
             else:
                 int_data.append(data_level)
         data = int_data


### PR DESCRIPTION
# References and relevant issues

Does not quite deal with #7277 (but sort of does)

# Description

In investigating #7277 I found that:

- we automatically convert bool volumes to int8
- we do this with a *copy*, not a view, which is bad because then editing the
  Labels layer does not change the input array (which we do for every other
  data type)
- our logic for shuffling colors for signed integers is faulty — we assign
  colors with `arr % n`, where `n` can be larger than the maximum value for the
  dtype, causing an `OverflowError`.

This PR does **not** address the third point, only the first two, by:

- using uint8 instead of int8 in the case of bool labels, since sign is
  meaningless here.
- using `data.view` instead of `data.astype`, which ensures that painting into
  the data also paints into the input array.

I've added a test for that behaviour.

I think it's worth getting this in for 0.5.4, and dealing with the broader
problem of signed ints in subsequent releases, because bool masks are very very
common, while signed int8 and int16 are very *un*common. (And this problem does
not affect larger signed integers.)

As a side note, I was convinced this dated from our scramble to get Labels
overhauled for 0.4.19, but in fact it dates all the way back to #2496! 😂
