### PR TITLE
Fix cursor dimensionality race condition

### DIFF
--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -434,3 +434,13 @@ def test_running_status_thread(make_napari_viewer, qtbot, monkeypatch):
     start_mock.assert_not_called()
     settings.appearance.update_status_based_on_layer = True
     start_mock.assert_called_once()
+
+
+def test_negative_translate(make_napari_viewer, qtbot):
+    """Check that negative translation behaves as expected.
+
+    See https://github.com/napari/napari/issues/7248
+    """
+    data = np.random.random((1, 3, 10, 12, 12))
+    viewer = make_napari_viewer()
+    _ = viewer.add_image(data, translate=(-1, 0, 0))

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -444,3 +444,4 @@ def test_negative_translate(make_napari_viewer, qtbot):
     data = np.random.random((1, 3, 10, 12, 12))
     viewer = make_napari_viewer()
     _ = viewer.add_image(data, translate=(-1, 0, 0))
+    assert viewer.dims.range[2].start == -1

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -474,6 +474,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         # shown with this position may be incorrect. See the discussion for more details:
         # https://github.com/napari/napari/pull/5377#discussion_r1036280855
         position = list(self.cursor.position)
+        if len(position) < self.dims.ndim:
+            # cursor dimensionality is outdated — reset to correct dimension
+            position = [0.0] * self.dims.ndim
         for ind in self.dims.order[: -self.dims.ndisplay]:
             position[ind] = self.dims.point[ind]
         self.cursor.position = tuple(position)


### PR DESCRIPTION
# References and relevant issues

Closes #7248

# Description

The cursor is supposed to have the same dimensionality as the full dims model.
However, #7248 exposed one of those situations where we want to simultaneously
update many objects, and the order winds up mattering: we try to update the
*position* of the cursor before the *dimensionality* of the cursor has been
updated, causing an IndexError.

In this PR, I simply check for the right dimensionality, and use a clear (all
zeros) position of the correct dimensionality if the cursor dimensionality is
out of date for the current slice request.

There's probably a better way to do this, but this fixes a rather severe bug
so I'd like to get this fix out quickly, and maybe refactor later.

The PR includes a new test to avoid a regression.
