### PR TITLE
Fix overflow error in shuffle colormap for signed integer labels

### DIFF
--- a/napari/_vispy/_tests/test_vispy_labels_layer.py
+++ b/napari/_vispy/_tests/test_vispy_labels_layer.py
@@ -126,3 +126,13 @@ def test_labels_iso_gradient_modes(qtbot, qt_viewer):
     QCoreApplication.instance().processEvents()
     assert layer.iso_gradient_mode == 'fast'
     assert visual.node.iso_gradient_mode == 'fast'
+
+
+def test_int8_labels_color(qtbot, qt_viewer):
+    """Check that int8 labels colors can be shuffled without overflow.
+
+    See https://github.com/napari/napari/issues/7277.
+    """
+    data = np.arange(-128, 128, dtype=np.int8).reshape((16, 16))
+    layer = qt_viewer.viewer.add_labels(data)
+    layer.new_colormap(seed=0)

--- a/napari/_vispy/_tests/test_vispy_labels_layer.py
+++ b/napari/_vispy/_tests/test_vispy_labels_layer.py
@@ -126,13 +126,3 @@ def test_labels_iso_gradient_modes(qtbot, qt_viewer):
     QCoreApplication.instance().processEvents()
     assert layer.iso_gradient_mode == 'fast'
     assert visual.node.iso_gradient_mode == 'fast'
-
-
-def test_int8_labels_color(qtbot, qt_viewer):
-    """Check that int8 labels colors can be shuffled without overflow.
-
-    See https://github.com/napari/napari/issues/7277.
-    """
-    data = np.arange(-128, 128, dtype=np.int8).reshape((16, 16))
-    layer = qt_viewer.viewer.add_labels(data)
-    layer.new_colormap(seed=0)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1752,3 +1752,13 @@ class TestLabels:
 def test_docstring():
     validate_all_params_in_docstring(Labels)
     validate_kwargs_sorted(Labels)
+
+
+def test_new_colormap_int8():
+    """Check that int8 labels colors can be shuffled without overflow.
+
+    See https://github.com/napari/napari/issues/7277.
+    """
+    data = np.arange(-128, 128, dtype=np.int8).reshape((16, 16))
+    layer = Labels(data)
+    layer.new_colormap(seed=0)

--- a/napari/utils/colormaps/_accelerated_cmap.py
+++ b/napari/utils/colormaps/_accelerated_cmap.py
@@ -74,12 +74,11 @@ def zero_preserving_modulo_numpy(
         The result: 0 for the ``to_zero`` value, ``values % n + 1``
         everywhere else.
     """
-    dtype_info = np.iinfo(dtype)
-    if n > dtype_info.max:
-        # we have signed integer data that are in to small dtype
-        for dtype_ in (np.int16, np.int32, np.int64):
-            if n <= np.iinfo(dtype_).max:
-                values = values.astype(dtype_)
+    if n > np.iinfo(dtype).max:
+        # n is to big, modulo will be pointless
+        res = values.astype(dtype)
+        res[values == to_zero] = 0
+        return res
     res = ((values - 1) % n + 1).astype(dtype)
     res[values == to_zero] = 0
     return res

--- a/napari/utils/colormaps/_accelerated_cmap.py
+++ b/napari/utils/colormaps/_accelerated_cmap.py
@@ -74,6 +74,12 @@ def zero_preserving_modulo_numpy(
         The result: 0 for the ``to_zero`` value, ``values % n + 1``
         everywhere else.
     """
+    dtype_info = np.iinfo(dtype)
+    if n > dtype_info.max:
+        # we have signed integer data that are in to small dtype
+        for dtype_ in (np.int16, np.int32, np.int64):
+            if n <= np.iinfo(dtype_).max:
+                values = values.astype(dtype_)
     res = ((values - 1) % n + 1).astype(dtype)
     res[values == to_zero] = 0
     return res


### PR DESCRIPTION
# References and relevant issues

closes #7277

# Description

Fix `zero_preserving_modulo_numpy` by not performing modulo operation when `n` is bigger than dtype of `values` 