### PR TITLE
Change `Layer.create` type annotation to accept any Mapping

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -9,7 +9,7 @@ import uuid
 import warnings
 from abc import ABC, ABCMeta, abstractmethod
 from collections import defaultdict
-from collections.abc import Generator, Hashable, Sequence
+from collections.abc import Generator, Hashable, Mapping, Sequence
 from contextlib import contextmanager
 from functools import cached_property
 from typing import (
@@ -2241,7 +2241,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     def create(
         cls,
         data: Any,
-        meta: Optional[dict] = None,
+        meta: Optional[Mapping] = None,
         layer_type: Optional[str] = None,
     ) -> Layer:
         """Create layer from `data` of type `layer_type`.


### PR DESCRIPTION
# Description

We should accept any mapping as metadata in `Layer.create`. 

# Related issues and PRs

This is part of a general cleanup of our type annotations that use dict when in fact any mapping would work — and failing to use a more general type has caused bugs in the past. See for example:

#7249
#7250
#7257