### PR TITLE
Fix double reporting of leaked widgets

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -979,9 +979,11 @@ def _find_dangling_widgets(request, qtbot):
             f'Widget: {widget} of type {type(widget)} with name {widget.objectName()}'
             for widget in problematic_widgets
         )
+
+        for widget in problematic_widgets:
+            widget.setObjectName('handled_widget')
+
         raise RuntimeError(f'Found dangling widgets:\n{text}')
-    for widget in problematic_widgets:
-        widget.setObjectName('handled_widget')
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
# Description

As in the current code, we raise an exception before calling `widget.setObjectName` on leaked widgets, the setting name never happens. That may lead to double reporting of the same widget.

Found during update of https://czaki.github.io/blog/2024/09/16/preventing-segfaults-in-test-suite-that-has-qt-tests/

