### PR TITLE
[Maint] Pin back to ubuntu-22.04 to fix CI

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   actionlint:
     name: Action lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Check workflow files

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -54,7 +54,7 @@ jobs:
           - benchmark-name: non-Qt
             asv-command: continuous
             selection-regex: "^benchmark_(?!qt_).*"
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-22.04
 
     steps:
       # We need the full repo to avoid this issue
@@ -180,7 +180,7 @@ jobs:
           path: .asv/results
 
   combine-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: benchmark
     if: always()
     steps:

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   download:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Download artifact"
         uses: actions/github-script@v7

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-and-upload:
     name: Build & Upload Artifact
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone docs repo
         uses: actions/checkout@v4

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -11,7 +11,7 @@ concurrency:
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "github.event.context == 'ci/circleci: build-docs'"
     permissions:
       statuses: write

--- a/.github/workflows/citation_cff_validate.yml
+++ b/.github/workflows/citation_cff_validate.yml
@@ -10,7 +10,7 @@ on:
 name: CITATION.cff
 jobs:
   Validate-CITATION-cff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Validate CITATION.cff
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-napari-docs:
     name: Build docs on napari/docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build1:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check_labels:
     name: Remove html comments
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -16,7 +16,7 @@ jobs:
   check_labels:
     if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge'))
     name: Check ready-to-merge PR has at least one type label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check labels
         uses: docker://agilepathway/pull-request-label-checker:latest
@@ -27,7 +27,7 @@ jobs:
   check_next_milestone:
     name: Check milestone is next release
     if: (github.event_name == 'pull_request' && github.event.pull_request.milestone != null)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check milestone for closest due date
         env:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/labeler@v5
       with:

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       id-token: write
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'napari/napari'
     steps:
       - name: Checkout code

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   remove_label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Remove label
         uses: actions/github-script@v7

--- a/.github/workflows/reusable_build_wheel.yml
+++ b/.github/workflows/reusable_build_wheel.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build_wheel:
     name: Build wheel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   upload_coverage:
     name: Upload coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   test_pip_install:
-    name: ubuntu-latest 3.9 pip install
-    runs-on: ubuntu-latest
+    name: ubuntu-22.04 3.9 pip install
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -9,7 +9,7 @@ on:
       platform:
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-22.04"
       toxenv:
         required: false
         type: string
@@ -117,7 +117,7 @@ jobs:
       # here we pass off control of environment creation and running of tests to tox
       # tox-gh-actions, installed above, helps to convert environment variables into
       # tox "factors" ... limiting the scope of what gets tested on each platform
-      # for instance, on ubuntu-latest with python 3.8, it would be equivalent to this command:
+      # for instance, on ubuntu-22.04 with python 3.8, it would be equivalent to this command:
       # `tox -e py38-linux-pyqt,py38-linux-pyside`
       # see tox.ini for more
 

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   manifest:
     name: Check Manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: "Set up Python 3.11"
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-22.04, windows-latest]
         python: ["3.9", "3.10", "3.11", "3.12"]
         backend: [pyqt5, pyside2]
         include:
@@ -66,11 +66,11 @@ jobs:
             platform: ubuntu-20.04
             backend: headless
           - python: "3.12"
-            platform: ubuntu-latest
+            platform: ubuntu-22.04
             backend: pyqt6
             tox_extras: "testing_extra"
           - python: "3.11"
-            platform: ubuntu-latest
+            platform: ubuntu-22.04
             backend: pyside6
             tox_extras: "testing_extra"
         exclude:
@@ -114,7 +114,7 @@ jobs:
 
   synchronize_bot_repository:
     name: Synchronize bot repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main' && github.repository == 'napari/napari'
     permissions:
       contents: read

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
         python: [3.12]
         backend: [pyqt5, pyqt6]
 

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -18,7 +18,7 @@ jobs:
   import_lint:
     name: Import lint
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
@@ -36,7 +36,7 @@ jobs:
     # make sure all necessary files will be bundled in the release
     name: Check Manifest
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -58,7 +58,7 @@ jobs:
   localization_syntax:
     # make sure all necessary files will be bundled in the release
     name: Check l18n syntax
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4
@@ -85,13 +85,13 @@ jobs:
       matrix:
         include:
           - python: 3.9
-            platform: ubuntu-latest
+            platform: ubuntu-22.04
             backend: pyqt5
             pydantic: "_pydantic_1"
             coverage: no_cov
             min_req: ""
           - python: 3.12
-            platform: ubuntu-latest
+            platform: ubuntu-22.04
             backend: pyqt6
             pydantic: ""
             coverage: no_cov
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ ubuntu-latest ]
+        platform: [ ubuntu-22.04 ]
         python: [ "3.9", "3.11" ]
         backend: [ "pyqt5,pyside6" ]
         coverage: [ cov ]
@@ -152,13 +152,13 @@ jobs:
             backend: headless
             coverage: no_cov
           - python: "3.12"
-            platform: ubuntu-latest
+            platform: ubuntu-22.04
             backend: pyqt6
             coverage: cov
             tox_extras: "testing_extra"
           # pyside2 test
           - python: "3.10"
-            platform: ubuntu-latest
+            platform: ubuntu-22.04
             backend: pyside2
             coverage: no_cov
 
@@ -200,7 +200,7 @@ jobs:
 
   test_benchmarks:
     name: test benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test_initial
     timeout-minutes: 60
     env:

--- a/.github/workflows/test_translations.yml
+++ b/.github/workflows/test_translations.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   translations:
     name: Check missing translations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/test_typing.yml
+++ b/.github/workflows/test_typing.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   mypy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   vendor:
     name: Vendored
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.9

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -62,7 +62,7 @@ jobs:
       issues: write
     name: Upgrade & Open Pull Request
     if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Add eyes reaction
         # show that workflow has started

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ fail_on_no_env = True
 
 # This section turns environment variables from github actions
 # into tox environment factors. This, combined with the [gh-actions]
-# section above would mean that a test running python 3.9 on ubuntu-latest
+# section above would mean that a test running python 3.9 on ubuntu-22.04
 # with an environment variable of BACKEND=pyqt would be converted to a
 # tox env of `py39-linux-pyqt5`
 [gh-actions:env]


### PR DESCRIPTION
# References and relevant issues
CI actions on ubuntu are failing, see: https://github.com/napari/napari/actions/runs/11295380512/job/31417980321?pr=7286

First reported: https://napari.zulipchat.com/#narrow/stream/212875-general/topic/Tests.20failing.20on.20Github.20linux-latest

# Description
This is a work around for: https://github.com/tlambert03/setup-qt-libs/issues/65

ubuntu-latest got updated to 24.04 which is causing an issue with the GL libs.
This PR pins back to 22.04 so CI runs again while we sort out a proper fix, probably in setup-qt-libs


