### PR TITLE
Fix bounding box to not contain only shape interior but also edges

### DIFF
--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -757,6 +757,7 @@ class ShapeList:
             indices = self._index == index
             self._vertices[indices] = shape.data_displayed
             self._update_displayed()
+        self._clear_cache()
 
     @_batch_dec
     def _update_z_order(self):

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -722,6 +722,7 @@ class ShapeList:
                 self._mesh.vertices_index[indices, 0] - 1
             )
             self._update_z_order()
+        self._clear_cache()
 
     @_batch_dec
     def _update_mesh_vertices(self, index, edge=False, face=False):

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -33,6 +33,19 @@ def test_rectangle():
     assert shape.slice_key.shape == (2, 0)
 
 
+def test_rectangle_bounding_box():
+    """Test that the bounding box is correctly updated based on edge width."""
+    data = [[10, 10], [20, 20]]
+    shape = Rectangle(data)
+    npt.assert_array_equal(
+        shape.bounding_box, np.array([[9.5, 9.5], [20.5, 20.5]])
+    )
+    shape.edge_width = 2
+    npt.assert_array_equal(shape.bounding_box, np.array([[9, 9], [21, 21]]))
+    shape.edge_width = 4
+    npt.assert_array_equal(shape.bounding_box, np.array([[8, 8], [22, 22]]))
+
+
 def test_rectangle_shift():
     shape = Rectangle(np.array([[0, 0], [1, 0], [1, 1], [0, 1]]))
     npt.assert_array_equal(

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -35,24 +35,30 @@ def test_rectangle():
 
 def test_rectangle_shift():
     shape = Rectangle(np.array([[0, 0], [1, 0], [1, 1], [0, 1]]))
-    npt.assert_array_equal(shape.bounding_box, np.array([[0, 0], [1, 1]]))
+    npt.assert_array_equal(
+        shape.bounding_box, np.array([[-0.5, -0.5], [1.5, 1.5]])
+    )
 
     shape.shift((1, 1))
     npt.assert_array_equal(
         shape.data, np.array([[1, 1], [2, 1], [2, 2], [1, 2]])
     )
-    npt.assert_array_equal(shape.bounding_box, np.array([[1, 1], [2, 2]]))
+    npt.assert_array_equal(
+        shape.bounding_box, np.array([[0.5, 0.5], [2.5, 2.5]])
+    )
 
 
 def test_rectangle_rotate():
     shape = Rectangle(np.array([[1, 2], [-1, 2], [-1, -2], [1, -2]]))
-    npt.assert_array_equal(shape.bounding_box, np.array([[-1, -2], [1, 2]]))
+    npt.assert_array_equal(
+        shape.bounding_box, np.array([[-1.5, -2.5], [1.5, 2.5]])
+    )
     shape.rotate(-90)
     npt.assert_array_almost_equal(
         shape.data, np.array([[-2, 1], [-2, -1], [2, -1], [2, 1]])
     )
     npt.assert_array_almost_equal(
-        shape.bounding_box, np.array([[-2, -1], [2, 1]])
+        shape.bounding_box, np.array([[-2.5, -1.5], [2.5, 1.5]])
     )
 
 
@@ -247,22 +253,28 @@ def test_nD_ellipse():
 
 def test_ellipse_shift():
     shape = Ellipse(np.array([[0, 0], [1, 0], [1, 1], [0, 1]]))
-    npt.assert_array_equal(shape.bounding_box, np.array([[0, 0], [1, 1]]))
+    npt.assert_array_equal(
+        shape.bounding_box, np.array([[-0.5, -0.5], [1.5, 1.5]])
+    )
 
     shape.shift((1, 1))
     npt.assert_array_equal(
         shape.data, np.array([[1, 1], [2, 1], [2, 2], [1, 2]])
     )
-    npt.assert_array_equal(shape.bounding_box, np.array([[1, 1], [2, 2]]))
+    npt.assert_array_equal(
+        shape.bounding_box, np.array([[0.5, 0.5], [2.5, 2.5]])
+    )
 
 
 def test_ellipse_rotate():
     shape = Ellipse(np.array([[1, 2], [-1, 2], [-1, -2], [1, -2]]))
-    npt.assert_array_equal(shape.bounding_box, np.array([[-1, -2], [1, 2]]))
+    npt.assert_array_equal(
+        shape.bounding_box, np.array([[-1.5, -2.5], [1.5, 2.5]])
+    )
     shape.rotate(-90)
     npt.assert_array_almost_equal(
         shape.data, np.array([[-2, 1], [-2, -1], [2, -1], [2, 1]])
     )
     npt.assert_array_almost_equal(
-        shape.bounding_box, np.array([[-2, -1], [2, 1]])
+        shape.bounding_box, np.array([[-2.5, -1.5], [2.5, 1.5]])
     )

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -345,6 +345,7 @@ class Shape(ABC):
         if center is None:
             self.transform(transform)
         else:
+            center = np.array(center)
             self.shift(-center)
             self.transform(transform)
             self.shift(center)
@@ -366,6 +367,7 @@ class Shape(ABC):
         if center is None:
             self.transform(transform)
         else:
+            center = np.array(center)
             self.shift(-center)
             self.transform(transform)
             self.shift(center)

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -169,7 +169,10 @@ class Shape(ABC):
     def bounding_box(self) -> np.ndarray:
         """(2, N) array, bounding box of the object."""
         # We add +-0.5 to handle edge width
-        return self._bounding_box[:, self.dims_displayed] + [[-0.5], [0.5]]
+        return self._bounding_box[:, self.dims_displayed] + [
+            [-0.5 * self.edge_width],
+            [0.5 * self.edge_width],
+        ]
 
     @property
     def dims_not_displayed(self):

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -168,7 +168,8 @@ class Shape(ABC):
     @property
     def bounding_box(self) -> np.ndarray:
         """(2, N) array, bounding box of the object."""
-        return self._bounding_box[:, self.dims_displayed]
+        # We add +-0.5 to handle edge width
+        return self._bounding_box[:, self.dims_displayed] + [[-0.5], [0.5]]
 
     @property
     def dims_not_displayed(self):

--- a/napari/layers/shapes/_tests/test_shape_list.py
+++ b/napari/layers/shapes/_tests/test_shape_list.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.testing as npt
 import pytest
 
 from napari.layers.shapes._shape_list import ShapeList
@@ -21,6 +22,57 @@ def test_adding_to_shape_list():
     shape_list.add(shape)
     assert len(shape_list.shapes) == 1
     assert shape_list.shapes[0] == shape
+
+
+def test_reset_bounding_box_rotation():
+    """Test if move or rotate resets bounding box."""
+    shape = Rectangle(np.array([[0, 0], [10, 10]]))
+    shape_list = ShapeList()
+    shape_list.add(shape)
+    npt.assert_array_almost_equal(
+        shape_list._bounding_boxes, np.array([[[-0.5, -0.5]], [[10.5, 10.5]]])
+    )
+    shape_list.rotate(0, 45, (5, 5))
+    p = 5 * np.sqrt(2) + 0.5
+    npt.assert_array_almost_equal(
+        shape.bounding_box, np.array([[5 - p, 5 - p], [5 + p, 5 + p]])
+    )
+    npt.assert_array_almost_equal(
+        shape_list._bounding_boxes, shape.bounding_box[:, np.newaxis, :]
+    )
+
+
+def test_reset_bounding_box_shift():
+    """Test if move or rotate resets bounding box."""
+    shape = Rectangle(np.array([[0, 0], [10, 10]]))
+    shape_list = ShapeList()
+    shape_list.add(shape)
+    npt.assert_array_almost_equal(
+        shape_list._bounding_boxes, shape.bounding_box[:, np.newaxis, :]
+    )
+    shape_list.shift(0, np.array([5, 5]))
+    npt.assert_array_almost_equal(
+        shape.bounding_box, np.array([[4.5, 4.5], [15.5, 15.5]])
+    )
+    npt.assert_array_almost_equal(
+        shape_list._bounding_boxes, shape.bounding_box[:, np.newaxis, :]
+    )
+
+
+def test_reset_bounding_box_scale():
+    shape = Rectangle(np.array([[0, 0], [10, 10]]))
+    shape_list = ShapeList()
+    shape_list.add(shape)
+    npt.assert_array_almost_equal(
+        shape_list._bounding_boxes, shape.bounding_box[:, np.newaxis, :]
+    )
+    shape_list.scale(0, 2, (5, 5))
+    npt.assert_array_almost_equal(
+        shape.bounding_box, np.array([[-5.5, -5.5], [15.5, 15.5]])
+    )
+    npt.assert_array_almost_equal(
+        shape_list._bounding_boxes, shape.bounding_box[:, np.newaxis, :]
+    )
 
 
 def test_shape_list_outline():

--- a/napari/layers/shapes/_tests/test_shape_list.py
+++ b/napari/layers/shapes/_tests/test_shape_list.py
@@ -25,7 +25,7 @@ def test_adding_to_shape_list():
 
 
 def test_reset_bounding_box_rotation():
-    """Test if move or rotate resets bounding box."""
+    """Test if rotating shape resets bounding box."""
     shape = Rectangle(np.array([[0, 0], [10, 10]]))
     shape_list = ShapeList()
     shape_list.add(shape)
@@ -43,7 +43,7 @@ def test_reset_bounding_box_rotation():
 
 
 def test_reset_bounding_box_shift():
-    """Test if move or rotate resets bounding box."""
+    """Test if shifting shape resets bounding box."""
     shape = Rectangle(np.array([[0, 0], [10, 10]]))
     shape_list = ShapeList()
     shape_list.add(shape)
@@ -60,6 +60,7 @@ def test_reset_bounding_box_shift():
 
 
 def test_reset_bounding_box_scale():
+    """Test if scaling shape resets the bounding box."""
     shape = Rectangle(np.array([[0, 0], [10, 10]]))
     shape_list = ShapeList()
     shape_list.add(shape)


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/stream/212875-general/topic/Issue.20grabbing.20lines.20in.20shape.20layer/near/477001240

# Description

In #7144 we attempted to speed up mouse click testing in shapes by using shapes bounding boxes. However, there were two bugs in that implementation:

- it did not account for edge width around shapes, so one could only click on the interior of a shape — which is hard for edge-only shapes like paths 😅 
- it did not account for certain classes of shapes data changes, so that the bounding box data was out of date when shapes were transformed, and clicking on the shape became impossible 🫣

This PR fixes both issues by:
- supplementing the bounding box by 0.5 times the edge width.
- Add missing cache clears.

It also adds tests for these missed elements.
