### PR TITLE
Clean selected data in Shapes layer when setting data

### DIFF
--- a/napari/layers/shapes/_tests/test_shapes.py
+++ b/napari/layers/shapes/_tests/test_shapes.py
@@ -2395,6 +2395,14 @@ def test_shapes_add_delete_only_emit_two_events():
     assert emitted_events.call_count == 4
 
 
+def test_clean_selection_on_set_data():
+    data = [[[0, 0], (10, 10)], [[0, 15], [10, 25]]]
+    layer = Shapes(data)
+    layer.selected_data = {0}
+    layer.data = [[[0, 0], (10, 10)]]
+    assert layer.selected_data == set()
+
+
 def test_docstring():
     validate_all_params_in_docstring(Shapes)
     validate_kwargs_sorted(Shapes)

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -667,6 +667,7 @@ class Shapes(Layer):
     @data.setter
     def data(self, data):
         self._finish_drawing()
+        self.selected_data = set()
         prior_data = len(self.data) > 0
         data, shape_type = extract_shape_type(data)
         n_new_shapes = number_of_shapes(data)


### PR DESCRIPTION
# References and relevant issues

closes  #7335

# Description

This PR add missed cleaning of selection of shapes layer data after calling setter. Bug was introduced as side effect of #6640 