### PR TITLE
Improve docstrings and code flow of `ShapeList.outline` add missed return in thread status

### DIFF
--- a/napari/_qt/threads/status_checker.py
+++ b/napari/_qt/threads/status_checker.py
@@ -107,6 +107,7 @@ class StatusChecker(QThread):
             #
             # We do not want to crash the thread to keep the status updates.
             notification_manager.dispatch(Notification.from_exception(e))
+            return
         self.status_and_tooltip_changed.emit(res)
 
 

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1031,7 +1031,7 @@ class ShapeList:
         ----------
         indices : int | Sequence[int]
             Location in list of the shapes to be outline.
-            If sequence must be a list of int
+            If sequence, all elements should be ints
 
         Returns
         -------

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1029,9 +1029,9 @@ class ShapeList:
 
         Parameters
         ----------
-        indices : int | list
-            Location in list of the shapes to be outline. If list must be a
-            list of int
+        indices : int | Sequence[int]
+            Location in list of the shapes to be outline.
+            If sequence must be a list of int
 
         Returns
         -------
@@ -1042,6 +1042,8 @@ class ShapeList:
         triangles : np.ndarray
             Mx3 array of any indices of vertices for triangles of outline
         """
+        if isinstance(indices, Sequence) and len(indices) == 1:
+            indices = indices[0]
         if not isinstance(indices, Sequence):
             shape = self.shapes[indices]
             return (


### PR DESCRIPTION
# References and relevant issues
Minor fixes spotted during development of #7336

# Description

Fix docstring of `ShapeList.outline`, if provide list of length 1, use code for single selection instead of calling a function that calls concat. 

In `status_checker.py::calculate_status` add missed return to prevent `self.status_and_tooltip_changed.emit(res)` with uninitialized `res`. 