### PR TITLE
fix `iso_gradient_mode` in constructor call

### DIFF
--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -318,6 +318,7 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
     def reset(self, event=None) -> None:
         super().reset()
         self._on_colormap_change()
+        self._on_iso_gradient_mode_change()
 
 
 class LabelLayerNode(ScalarFieldLayerNode):

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -211,6 +211,11 @@ class Labels(ScalarFieldBase):
         with a thickness equal to its value. Must be >= 0.
     brush_size : float
         Size of the paint brush in data coordinates.
+    iso_gradient_mode : str
+        Method for calulating the gradient (used to get the surface normal) in the
+        'iso_categorical' rendering mode. Must be one of {'fast', 'smooth'}.
+        'fast' uses a simple finite difference gradient in x, y, and z. 'smooth' uses an
+        isotropic Sobel gradient, which is smoother but more computationally expensive.
     selected_label : int
         Index of selected label. Can be greater than the current maximum label.
     mode : str
@@ -394,7 +399,7 @@ class Labels(ScalarFieldBase):
         self._contiguous = True
         self._brush_size = 10
 
-        self._iso_gradient_mode = IsoCategoricalGradientMode.FAST
+        self._iso_gradient_mode = IsoCategoricalGradientMode(iso_gradient_mode)
 
         self._selected_label = 1
         self.colormap.selection = self._selected_label

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -446,7 +446,7 @@ class Labels(ScalarFieldBase):
         self.events.rendering()
 
     @property
-    def iso_gradient_mode(self):
+    def iso_gradient_mode(self) -> str:
         """Return current gradient mode for isosurface rendering.
 
         Selects the finite-difference gradient method for the isosurface shader. Options include:
@@ -462,7 +462,7 @@ class Labels(ScalarFieldBase):
         return str(self._iso_gradient_mode)
 
     @iso_gradient_mode.setter
-    def iso_gradient_mode(self, value):
+    def iso_gradient_mode(self, value: Union[IsoCategoricalGradientMode, str]):
         self._iso_gradient_mode = IsoCategoricalGradientMode(value)
         self.events.iso_gradient_mode()
 


### PR DESCRIPTION
# Description

I have spotted that `iso_gradient_mode` value provided to constructor is not used in Labels layer. 

This PR fix it and add missed docstring and type annotation 