### PR TITLE
Fix using transform mode when having layers with a different number of dimensions

### DIFF
--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -286,6 +286,6 @@ def test_highlight_box_handles(position, dims_displayed, nearby_handle):
 def test_transform_box():
     layer = Image(np.empty((10, 10)))
     event = Mock(position=[0, 3], dims_displayed=[0, 1], modifiers=[None])
-    transform_with_box(layer, event)
+    next(transform_with_box(layer, event))
     # no interaction has been done so affine should be the same as the initial
     assert layer.affine == layer._initial_affine

--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -257,10 +257,14 @@ def test_unselected_layer_mouse_bindings(qtbot, make_napari_viewer):
 @pytest.mark.parametrize(
     ('position', 'dims_displayed', 'nearby_handle'),
     [
+        # Postion inside the transform box space so the inside value should be set as selected
         ([0, 3], [0, 1], InteractionBoxHandle.INSIDE),
         ([0, 3, 3], [1, 2], InteractionBoxHandle.INSIDE),
+        # Postion outside the transform box space so no handle should be set as selected
         ([0, 11], [0, 1], None),
         ([0, 11, 11], [1, 2], None),
+        # When 3 dimensions are being displayed no `highlight_box_handles` logic should be run
+        ([0, 3, 3], [0, 1, 2], None),
     ],
 )
 def test_highlight_box_handles(position, dims_displayed, nearby_handle):

--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -7,7 +7,10 @@ import pytest
 from napari._tests.utils import skip_on_win_ci
 from napari.layers import Image
 from napari.layers.base._base_constants import InteractionBoxHandle
-from napari.layers.base._base_mouse_bindings import highlight_box_handles
+from napari.layers.base._base_mouse_bindings import (
+    highlight_box_handles,
+    transform_with_box,
+)
 
 
 @skip_on_win_ci
@@ -278,3 +281,11 @@ def test_highlight_box_handles(position, dims_displayed, nearby_handle):
     )
     # mouse event should be detected over the expected handle
     assert layer._overlays['transform_box'].selected_handle == nearby_handle
+
+
+def test_transform_box():
+    layer = Image(np.empty((10, 10)))
+    event = Mock(position=[0, 3], dims_displayed=[0, 1], modifiers=[None])
+    transform_with_box(layer, event)
+    # no interaction has been done so affine should be the same as the initial
+    assert layer.affine == layer._initial_affine

--- a/napari/_tests/test_mouse_bindings.py
+++ b/napari/_tests/test_mouse_bindings.py
@@ -2,8 +2,12 @@ import os
 from unittest.mock import Mock
 
 import numpy as np
+import pytest
 
 from napari._tests.utils import skip_on_win_ci
+from napari.layers import Image
+from napari.layers.base._base_constants import InteractionBoxHandle
+from napari.layers.base._base_mouse_bindings import highlight_box_handles
 
 
 @skip_on_win_ci
@@ -248,3 +252,25 @@ def test_unselected_layer_mouse_bindings(qtbot, make_napari_viewer):
     mock_drag.method.assert_not_called()
     mock_release.method.assert_not_called()
     mock_move.method.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ('position', 'dims_displayed', 'nearby_handle'),
+    [
+        ([0, 3], [0, 1], InteractionBoxHandle.INSIDE),
+        ([0, 3, 3], [1, 2], InteractionBoxHandle.INSIDE),
+        ([0, 11], [0, 1], None),
+        ([0, 11, 11], [1, 2], None),
+    ],
+)
+def test_highlight_box_handles(position, dims_displayed, nearby_handle):
+    layer = Image(np.empty((10, 10)))
+    event = Mock(
+        position=position, dims_displayed=dims_displayed, modifiers=[None]
+    )
+    highlight_box_handles(
+        layer,
+        event,
+    )
+    # mouse event should be detected over the expected handle
+    assert layer._overlays['transform_box'].selected_handle == nearby_handle

--- a/napari/layers/base/_base_mouse_bindings.py
+++ b/napari/layers/base/_base_mouse_bindings.py
@@ -28,12 +28,11 @@ def highlight_box_handles(layer: 'Layer', event: Event) -> None:
     # we work in data space so we're axis aligned which simplifies calculation
     # same as Layer.world_to_data
     world_to_data = (
-        layer._transforms[1:].set_slice(event.dims_displayed).inverse
+        layer._transforms[1:].set_slice(layer._slice_input.displayed).inverse
     )
     pos = np.array(world_to_data(event.position))[event.dims_displayed]
-
     handle_coords = generate_transform_box_from_layer(
-        layer, event.dims_displayed
+        layer, layer._slice_input.displayed
     )
     # TODO: dynamically set tolerance based on canvas size so it's not hard to pick small layer
     nearby_handle = get_nearby_handle(pos, handle_coords)
@@ -51,7 +50,9 @@ def _translate_with_box(
 ) -> None:
     offset = mouse_pos - initial_mouse_pos
     new_affine = Affine(translate=offset).compose(initial_affine)
-    layer.affine = layer.affine.replace_slice(event.dims_displayed, new_affine)
+    layer.affine = layer.affine.replace_slice(
+        layer._slice_input.displayed, new_affine
+    )
 
 
 def _rotate_with_box(
@@ -89,7 +90,9 @@ def _rotate_with_box(
         .compose(Affine(translate=-initial_center))
         .compose(initial_affine)
     )
-    layer.affine = layer.affine.replace_slice(event.dims_displayed, new_affine)
+    layer.affine = layer.affine.replace_slice(
+        layer._slice_input.displayed, new_affine
+    )
 
 
 def _scale_with_box(
@@ -163,7 +166,9 @@ def _scale_with_box(
         # compose with the original affine
         .compose(initial_affine)
     )
-    layer.affine = layer.affine.replace_slice(event.dims_displayed, new_affine)
+    layer.affine = layer.affine.replace_slice(
+        layer._slice_input.displayed, new_affine
+    )
 
 
 def transform_with_box(
@@ -178,13 +183,13 @@ def transform_with_box(
     # we work in data space so we're axis aligned which simplifies calculation
     # same as Layer.data_to_world
     simplified = layer._transforms[1:].simplified
-    initial_data_to_world = simplified.set_slice(event.dims_displayed)
+    initial_data_to_world = simplified.set_slice(layer._slice_input.displayed)
     initial_world_to_data = initial_data_to_world.inverse
     initial_mouse_pos = np.array(event.position)[event.dims_displayed]
     initial_mouse_pos_data = initial_world_to_data(initial_mouse_pos)
 
     initial_handle_coords_data = generate_transform_box_from_layer(
-        layer, event.dims_displayed
+        layer, layer._slice_input.displayed
     )
     nearby_handle = get_nearby_handle(
         initial_mouse_pos_data, initial_handle_coords_data
@@ -198,11 +203,11 @@ def transform_with_box(
     initial_handle_coords = initial_data_to_world(initial_handle_coords_data)
 
     # initial layer transform so we can calculate changes later
-    initial_affine = layer.affine.set_slice(event.dims_displayed)
+    initial_affine = layer.affine.set_slice(layer._slice_input.displayed)
 
     # needed for rescaling
     initial_data2physical = layer._transforms['data2physical'].set_slice(
-        event.dims_displayed
+        layer._slice_input.displayed
     )
 
     # needed for resize and rotate

--- a/napari/layers/base/_tests/test_mouse_bindings.py
+++ b/napari/layers/base/_tests/test_mouse_bindings.py
@@ -8,6 +8,7 @@ from napari.utils.transforms import Affine
 
 def test_interaction_box_rotation():
     layer = Mock(affine=Affine())
+    layer._slice_input.displayed = [0, 1]
     initial_affine = Affine()
     initial_mouse_pos = Mock()
     # rotation handle is 8th
@@ -43,6 +44,7 @@ def test_interaction_box_rotation():
 
 def test_interaction_box_fixed_rotation():
     layer = Mock(affine=Affine())
+    layer._slice_input.displayed = [0, 1]
     initial_affine = Affine()
     initial_mouse_pos = Mock()
     # rotation handle is 8th

--- a/napari/layers/base/_tests/test_mouse_bindings.py
+++ b/napari/layers/base/_tests/test_mouse_bindings.py
@@ -2,8 +2,32 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from napari.layers.base._base_mouse_bindings import _rotate_with_box
+from napari.layers.base._base_mouse_bindings import (
+    _rotate_with_box,
+    _translate_with_box,
+)
 from napari.utils.transforms import Affine
+
+
+def test_interaction_box_translation():
+    layer = Mock(affine=Affine())
+    layer._slice_input.displayed = [0, 1]
+    initial_affine = Affine()
+    initial_mouse_pos = np.asarray([3, 3], dtype=np.float32)
+    mouse_pos = np.asarray([6, 5], dtype=np.float32)
+    event = Mock(dims_displayed=[0, 1], modifiers=[None])
+    _translate_with_box(
+        layer,
+        initial_affine,
+        initial_mouse_pos,
+        mouse_pos,
+        event,
+    )
+    # translate should be equal to [3, 2] from doing [6, 5] - [3, 3]
+    assert np.array_equal(
+        layer.affine.translate,
+        Affine(translate=np.asarray([3, 2], dtype=np.float32)).translate,
+    )
 
 
 def test_interaction_box_rotation():

--- a/napari/layers/base/_tests/test_mouse_bindings.py
+++ b/napari/layers/base/_tests/test_mouse_bindings.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import numpy as np
+import pytest
 
 from napari.layers.base._base_mouse_bindings import (
     _rotate_with_box,
@@ -9,13 +10,14 @@ from napari.layers.base._base_mouse_bindings import (
 from napari.utils.transforms import Affine
 
 
-def test_interaction_box_translation():
+@pytest.mark.parametrize('dims_displayed', [[0, 1], [1, 2]])
+def test_interaction_box_translation(dims_displayed):
     layer = Mock(affine=Affine())
     layer._slice_input.displayed = [0, 1]
     initial_affine = Affine()
     initial_mouse_pos = np.asarray([3, 3], dtype=np.float32)
     mouse_pos = np.asarray([6, 5], dtype=np.float32)
-    event = Mock(dims_displayed=[0, 1], modifiers=[None])
+    event = Mock(dims_displayed=dims_displayed, modifiers=[None])
     _translate_with_box(
         layer,
         initial_affine,
@@ -30,7 +32,8 @@ def test_interaction_box_translation():
     )
 
 
-def test_interaction_box_rotation():
+@pytest.mark.parametrize('dims_displayed', [[0, 1], [1, 2]])
+def test_interaction_box_rotation(dims_displayed):
     layer = Mock(affine=Affine())
     layer._slice_input.displayed = [0, 1]
     initial_affine = Affine()
@@ -52,7 +55,7 @@ def test_interaction_box_rotation():
     )
     initial_center = np.asarray([3, 3], dtype=np.float32)
     mouse_pos = np.asarray([6, 5], dtype=np.float32)
-    event = Mock(dims_displayed=[0, 1], modifiers=[None])
+    event = Mock(dims_displayed=dims_displayed, modifiers=[None])
     _rotate_with_box(
         layer,
         initial_affine,
@@ -66,7 +69,8 @@ def test_interaction_box_rotation():
     assert np.allclose(layer.affine.rotate, Affine(rotate=33.69).rotate)
 
 
-def test_interaction_box_fixed_rotation():
+@pytest.mark.parametrize('dims_displayed', [[0, 1], [1, 2]])
+def test_interaction_box_fixed_rotation(dims_displayed):
     layer = Mock(affine=Affine())
     layer._slice_input.displayed = [0, 1]
     initial_affine = Affine()


### PR DESCRIPTION
# References and relevant issues

Closes #7333

# Description

Enable using the to transform mode on 2d layers even when there are >2d layers over the viewer

A preview:

```python
import napari

viewer = napari.Viewer()
_ = viewer.add_points([[0., 0., 0.]], name="3Dlayer")
pt2 = viewer.add_points([[1., 1.]], name="2Dlayer")
pt2.mode = 'transform'

napari.run()
```

![transform_2d_3d_data_working](https://github.com/user-attachments/assets/39173ce4-c060-4ed4-9de5-ecadb0b4dae6)


