### PR TITLE
Add reminder about version added directive in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,7 @@ a screenshot or a screen capture: "An image is worth a thousand words!" -->
 - I have added tests that prove my fix is effective or that my feature works
 - If I included new strings, I have used `trans._("some string")` to make them localizable.
   (For more information see our [translations guide](https://napari.org/stable/developers/contributing/translations.html)).
+- If an API has been modified, I have added a `.. versionadded::` or `.. versionchanged::`
+  directive to the appropriate docstring (For more information see
+  [the Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions)).
 -->


### PR DESCRIPTION
# References and relevant issues
Addresses #7192. Will have a corresponding PR to the code-dev guide.

# Description
Adds a reminder about the versionadded/versionchanged directive in the PR template. 