### PR TITLE
Add setting Windows resolution step for prereleases testing workflow and some tests fixes

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -47,6 +47,11 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v2
         continue-on-error: true
 
+      - name: Set Windows resolution
+        if: runner.os == 'Windows'
+        run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
+        shell: powershell
+
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |

--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -26,6 +26,19 @@ def check_windows_style(viewer):
     assert window_style & win32con.WS_BORDER == win32con.WS_BORDER
 
 
+def check_view_menu_visibility(viewer, qtbot):
+    if viewer.window._qt_window.menuBar().isNativeMenuBar():
+        return
+
+    assert not viewer.window.view_menu.isVisible()
+    qtbot.keyClick(
+        viewer.window._qt_window.menuBar(), Qt.Key_V, modifier=Qt.AltModifier
+    )
+    qtbot.waitUntil(viewer.window.view_menu.isVisible)
+    viewer.window.view_menu.close()
+    assert not viewer.window.view_menu.isVisible()
+
+
 @pytest.mark.parametrize(
     ('action_id', 'action_title', 'viewer_attr', 'sub_attr'),
     toggle_action_details,
@@ -80,47 +93,29 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
     assert not viewer.window._qt_window.isFullScreen()
 
     # Check `View` menu can be seen in normal window state
-    assert not viewer.window.view_menu.isVisible()
-    qtbot.keyClick(
-        viewer.window._qt_window.menuBar(), Qt.Key_V, modifier=Qt.AltModifier
-    )
-    qtbot.waitUntil(viewer.window.view_menu.isVisible)
-    viewer.window.view_menu.close()
-    assert not viewer.window.view_menu.isVisible()
+    check_view_menu_visibility(viewer, qtbot)
 
     # Check fullscreen state change
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
         qtbot.wait(250)
-    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
+    assert viewer.window._qt_window.isFullScreen()
     check_windows_style(viewer)
 
     # Check `View` menu can be seen in fullscreen window state
-    assert not viewer.window.view_menu.isVisible()
-    qtbot.keyClick(
-        viewer.window._qt_window.menuBar(), Qt.Key_V, modifier=Qt.AltModifier
-    )
-    qtbot.waitUntil(viewer.window.view_menu.isVisible)
-    viewer.window.view_menu.close()
-    assert not viewer.window.view_menu.isVisible()
+    check_view_menu_visibility(viewer, qtbot)
 
     # Check return to non fullscreen state
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
         qtbot.wait(250)
-    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
+    assert not viewer.window._qt_window.isFullScreen()
     check_windows_style(viewer)
 
     # Check `View` still menu can be seen in non fullscreen window state
-    assert not viewer.window.view_menu.isVisible()
-    qtbot.keyClick(
-        viewer.window._qt_window.menuBar(), Qt.Key_V, modifier=Qt.AltModifier
-    )
-    qtbot.waitUntil(viewer.window.view_menu.isVisible)
-    viewer.window.view_menu.close()
-    assert not viewer.window.view_menu.isVisible()
+    check_view_menu_visibility(viewer, qtbot)
 
 
 @skip_local_popups
@@ -142,46 +137,28 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
     viewer.window._qt_window.showMaximized()
 
     # Check `View` menu can be seen in maximized window state
-    assert not viewer.window.view_menu.isVisible()
-    qtbot.keyClick(
-        viewer.window._qt_window.menuBar(), Qt.Key_V, modifier=Qt.AltModifier
-    )
-    qtbot.waitUntil(viewer.window.view_menu.isVisible)
-    viewer.window.view_menu.close()
-    assert not viewer.window.view_menu.isVisible()
+    check_view_menu_visibility(viewer, qtbot)
 
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
         qtbot.wait(250)
-    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
+    assert viewer.window._qt_window.isFullScreen()
     check_windows_style(viewer)
 
     # Check `View` menu can be seen in fullscreen window state coming from maximized state
-    assert not viewer.window.view_menu.isVisible()
-    qtbot.keyClick(
-        viewer.window._qt_window.menuBar(), Qt.Key_V, modifier=Qt.AltModifier
-    )
-    qtbot.waitUntil(viewer.window.view_menu.isVisible)
-    viewer.window.view_menu.close()
-    assert not viewer.window.view_menu.isVisible()
+    check_view_menu_visibility(viewer, qtbot)
 
     # Check return to non fullscreen state
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
-        qtbot.wait(250)
-    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
+        qtbot.wait(350)
+    assert not viewer.window._qt_window.isFullScreen()
     check_windows_style(viewer)
 
     # Check `View` still menu can be seen in non fullscreen window state
-    assert not viewer.window.view_menu.isVisible()
-    qtbot.keyClick(
-        viewer.window._qt_window.menuBar(), Qt.Key_V, modifier=Qt.AltModifier
-    )
-    qtbot.waitUntil(viewer.window.view_menu.isVisible)
-    viewer.window.view_menu.close()
-    assert not viewer.window.view_menu.isVisible()
+    check_view_menu_visibility(viewer, qtbot)
 
 
 @skip_local_focus

--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -154,8 +154,12 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
-        qtbot.wait(500)
-    assert not viewer.window._qt_window.isFullScreen()
+        qtbot.wait(250)
+
+    def check_not_fullscreen():
+        assert not viewer.window._qt_window.isFullScreen()
+
+    qtbot.waitUntil(check_not_fullscreen)
     check_windows_style(viewer)
 
     # Check `View` still menu can be seen in non fullscreen window state

--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -170,7 +170,7 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
-        qtbot.wait(250)
+        qtbot.wait(350)
     assert not viewer.window._qt_window.isFullScreen()
     check_windows_style(viewer)
 

--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -90,10 +90,7 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
 
     # Check fullscreen state change
     app.commands.execute_command(action_id)
-    if sys.platform == 'darwin':
-        # On macOS, wait for the animation to complete
-        qtbot.wait(250)
-    assert viewer.window._qt_window.isFullScreen()
+    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 
     # Check `View` menu can be seen in fullscreen window state
@@ -107,10 +104,7 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
 
     # Check return to non fullscreen state
     app.commands.execute_command(action_id)
-    if sys.platform == 'darwin':
-        # On macOS, wait for the animation to complete
-        qtbot.wait(250)
-    assert not viewer.window._qt_window.isFullScreen()
+    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 
     # Check `View` still menu can be seen in non fullscreen window state
@@ -151,10 +145,7 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
     assert not viewer.window.view_menu.isVisible()
 
     app.commands.execute_command(action_id)
-    if sys.platform == 'darwin':
-        # On macOS, wait for the animation to complete
-        qtbot.wait(250)
-    assert viewer.window._qt_window.isFullScreen()
+    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 
     # Check `View` menu can be seen in fullscreen window state coming from maximized state
@@ -168,10 +159,7 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
 
     # Check return to non fullscreen state
     app.commands.execute_command(action_id)
-    if sys.platform == 'darwin':
-        # On macOS, wait for the animation to complete
-        qtbot.wait(350)
-    assert not viewer.window._qt_window.isFullScreen()
+    qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 
     # Check `View` still menu can be seen in non fullscreen window state

--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -139,6 +139,7 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
     # Check `View` menu can be seen in maximized window state
     check_view_menu_visibility(viewer, qtbot)
 
+    # Check fullscreen state change
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
@@ -153,7 +154,7 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
     app.commands.execute_command(action_id)
     if sys.platform == 'darwin':
         # On macOS, wait for the animation to complete
-        qtbot.wait(350)
+        qtbot.wait(500)
     assert not viewer.window._qt_window.isFullScreen()
     check_windows_style(viewer)
 

--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -90,6 +90,9 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
 
     # Check fullscreen state change
     app.commands.execute_command(action_id)
+    if sys.platform == 'darwin':
+        # On macOS, wait for the animation to complete
+        qtbot.wait(250)
     qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 
@@ -104,6 +107,9 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
 
     # Check return to non fullscreen state
     app.commands.execute_command(action_id)
+    if sys.platform == 'darwin':
+        # On macOS, wait for the animation to complete
+        qtbot.wait(250)
     qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 
@@ -145,6 +151,9 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
     assert not viewer.window.view_menu.isVisible()
 
     app.commands.execute_command(action_id)
+    if sys.platform == 'darwin':
+        # On macOS, wait for the animation to complete
+        qtbot.wait(250)
     qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 
@@ -159,6 +168,9 @@ def test_toggle_fullscreen_from_maximized(make_napari_viewer, qtbot):
 
     # Check return to non fullscreen state
     app.commands.execute_command(action_id)
+    if sys.platform == 'darwin':
+        # On macOS, wait for the animation to complete
+        qtbot.wait(250)
     qtbot.waitUntil(viewer.window._qt_window.isFullScreen)
     check_windows_style(viewer)
 

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -326,7 +326,7 @@ class _QtMainWindow(QMainWindow):
                         self.menuBar().hide()
             elif event.type() == QEvent.Type.Leave and source is self:
                 self.menuBar().hide()
-        return False
+        return super().eventFilter(source, event)
 
     def _load_window_settings(self):
         """

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -326,7 +326,7 @@ class _QtMainWindow(QMainWindow):
                         self.menuBar().hide()
             elif event.type() == QEvent.Type.Leave and source is self:
                 self.menuBar().hide()
-        return super().eventFilter(source, event)
+        return False
 
     def _load_window_settings(self):
         """


### PR DESCRIPTION
# References and relevant issues

Closes #7357

# Description

* Missing workflow step on the prereleases testing workflow to prevent generating warnings when testing fullscreen toggle on Windows
* Use `qtbot.waitUntil` and `qtbot.wait` for delay of macOS animation when changing from/to fullscreen window state over the maximized window state test
* Don't check for menu visibility if native menu bar is being used (macOS for example)


