### PR TITLE
Add maintainer and contributor documentation about workflow automation near the configuration

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,10 @@
 
 *Created: 2024-11-11; Updated:*
 
-See the napari website for more detailed contributor information.
+See the napari website for more detailed contributor information:
+- [deployment](https://napari.org/stable/developers/contributing/documentation/docs_deployment.html)
+- [contributing guide](https://napari.org/stable/developers/contributing/index.html)
+- [core developer guide](https://napari.org/stable/developers/coredev/core_dev_guide.html)
 
 ## Workflows and actions
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,14 +1,21 @@
 # Contributing to GitHub workflows and actions
 
-Created: 2024-11-11; Updated:
+*Created: 2024-11-11; Updated:*
 
-See the napari website for more detailed information.
+See the napari website for more detailed contributor information.
 
 ## Workflows and actions
 
 There are over 20 GitHub workflows found in `.github/workflows`.
 The team creates a workflow to automate manual actions and steps.
-This results in improved accuracy and quality.
+This results in improved accuracy and quality. Some key workflows:
+- `actionlint.yml` does static testing of GitHub action workflows
+- benchmarks
+- `reusable_run_tox_test.yml` uses our constraint files to install the
+  compatible dependencies for each test environment which may differ
+  by OS and qt versions.
+- `upgrade_test_constraints.yml` automates upgrading dependencies for
+  our test environments
 
 If adding a workflow, please take a moment to explain its purpose at the
 top of its file.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,8 @@ This results in improved accuracy and quality. Some key workflows:
   compatible dependencies for each test environment which may differ
   by OS and qt versions.
 - `upgrade_test_constraints.yml` automates upgrading dependencies for
-  our test environments
+  our test environments. It also has extensive commenting on what the
+  upgrade process entails.
 
 If adding a workflow, please take a moment to explain its purpose at the
 top of its file.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to GitHub workflows and actions
+
+Created: 2024-11-11; Updated:
+
+See the napari website for more detailed information.
+
+## Workflows and actions
+
+There are over 20 GitHub workflows found in `.github/workflows`.
+The team creates a workflow to automate manual actions and steps.
+This results in improved accuracy and quality.
+
+If adding a workflow, please take a moment to explain its purpose at the
+top of its file.
+
+## Templates
+
+Used to provide a consistent user experience when submitting an issue or PR.
+napari uses the following:
+- `PULL_REQUEST_TEMPLATE.md`
+- `ISSUE_TEMPLATE` directory containing:
+   - `config.yml` to add the menu selector when "New Issue" button is pressed
+   - `design_related.md`
+   - `documentation.md`
+   - `feature_request.md`
+   - `bug_report.yml` config file to provide text areas for users to complete for bug reports.
+- `FUNDING.yml`: redirect GitHub to napari NumFOCUS account
+- Testing and bots
+   - `missing_translations.md`: used if an action detects a missing language translation
+   - `dependabot.yml`: opens a PR to notify maintainers of updates to dependencies
+   - `labeler.yml` is a labels config file for labeler action
+   - `BOT_REPO_UPDATE_FAIL_TEMPLATE.md` is an bot failure notification template
+   - `TEST_FAIL_TEMPLATE.md` is a test failure notification template
+
+## CODEOWNERS
+
+This `CODEOWNERS` file identifies which individuals are notified if a
+particular file or directory is found in a PR. Core team members can
+update if desired.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This results in improved accuracy and quality. Some key workflows:
 - benchmarks
 - `reusable_run_tox_test.yml` uses our constraint files to install the
   compatible dependencies for each test environment which may differ
-  by OS and qt versions.
+  by OS and qt versions. It is called from `test_pull_request.yml` and `test_comprehensive.yml`, not directly. 
 - `upgrade_test_constraints.yml` automates upgrading dependencies for
   our test environments. It also has extensive commenting on what the
   upgrade process entails.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,7 @@
-# See: .github/workflows/labeler.yml and https://github.com/marketplace/actions/labeler
+# This config file maps code base files to GitHub labels.
+# We use `.github/workflow/labeler.yml` action and use this file to apply labels to PRs.
+# Repo: https://github.com/actions/labeler
+# Marketplace Action docs: https://github.com/marketplace/actions/labeler
 design:
   - changed-files:
     - any-glob-to-any-file: 'napari/_qt/qt_resources/**/*'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,5 @@
 name: Actionlint
+# https://github.com/rhysd/actionlint
 
 on:
   pull_request:


### PR DESCRIPTION
Closes #7364 

# Description

This PR adds a CONTRIBUTING.md to the `.github` directory. The purpose is to quickly
orient a maintainer or contributor about our testing actions, constraints workflows, and
general automation of labels and issues.

