### PR TITLE
Check changes to prevent a `TypeError` on mainwindow `eventFilter` over CI

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1783,9 +1783,11 @@ class Window:
 
     def _teardown(self):
         """Carry out various teardown tasks such as event disconnection."""
+        qapp = get_qapp()
         self._setup_existing_themes(False)
         _themes.events.added.disconnect(self._add_theme)
         _themes.events.removed.disconnect(self._remove_theme)
+        qapp.removeEventFilter(self._qt_window)
 
     def close(self):
         """Close the viewer window and cleanup sub-widgets."""

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import (
 from napari._qt.utils import combine_widgets
 
 
-def test_add_dock_widget(make_napari_viewer, qtbot):
+def test_add_dock_widget(make_napari_viewer):
     """Test basic add_dock_widget functionality"""
     viewer = make_napari_viewer()
     widg = QPushButton('button')
@@ -42,7 +42,7 @@ def test_add_dock_widget(make_napari_viewer, qtbot):
         )
 
 
-def test_add_dock_widget_from_list(make_napari_viewer, qtbot):
+def test_add_dock_widget_from_list(make_napari_viewer):
     """Test that we can add a list of widgets and they will be combined"""
     viewer = make_napari_viewer()
     widg = QPushButton('button')
@@ -61,7 +61,7 @@ def test_add_dock_widget_from_list(make_napari_viewer, qtbot):
     assert isinstance(dwidg.widget().layout(), QHBoxLayout)
 
 
-def test_add_dock_widget_raises(make_napari_viewer, qtbot):
+def test_add_dock_widget_raises(make_napari_viewer):
     """Test that the widget passed must be a DockWidget."""
     viewer = make_napari_viewer()
     widg = object()
@@ -103,7 +103,7 @@ def test_remove_dock_widget_by_widget_reference(make_napari_viewer, qtbot):
     assert not widg.parent()
 
 
-def test_adding_modified_widget(make_napari_viewer, qtbot):
+def test_adding_modified_widget(make_napari_viewer):
     viewer = make_napari_viewer()
     widg = QWidget()
     # not uncommon to see people shadow the builtin layout()
@@ -113,7 +113,7 @@ def test_adding_modified_widget(make_napari_viewer, qtbot):
     assert dw.widget() is widg
 
 
-def test_adding_stretch(make_napari_viewer, qtbot):
+def test_adding_stretch(make_napari_viewer):
     """Make sure that vertical stretch only gets added when appropriate."""
     viewer = make_napari_viewer()
 

--- a/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import (
 from napari._qt.utils import combine_widgets
 
 
-def test_add_dock_widget(make_napari_viewer):
+def test_add_dock_widget(make_napari_viewer, qtbot):
     """Test basic add_dock_widget functionality"""
     viewer = make_napari_viewer()
     widg = QPushButton('button')
@@ -42,7 +42,7 @@ def test_add_dock_widget(make_napari_viewer):
         )
 
 
-def test_add_dock_widget_from_list(make_napari_viewer):
+def test_add_dock_widget_from_list(make_napari_viewer, qtbot):
     """Test that we can add a list of widgets and they will be combined"""
     viewer = make_napari_viewer()
     widg = QPushButton('button')
@@ -61,7 +61,7 @@ def test_add_dock_widget_from_list(make_napari_viewer):
     assert isinstance(dwidg.widget().layout(), QHBoxLayout)
 
 
-def test_add_dock_widget_raises(make_napari_viewer):
+def test_add_dock_widget_raises(make_napari_viewer, qtbot):
     """Test that the widget passed must be a DockWidget."""
     viewer = make_napari_viewer()
     widg = object()
@@ -103,7 +103,7 @@ def test_remove_dock_widget_by_widget_reference(make_napari_viewer, qtbot):
     assert not widg.parent()
 
 
-def test_adding_modified_widget(make_napari_viewer):
+def test_adding_modified_widget(make_napari_viewer, qtbot):
     viewer = make_napari_viewer()
     widg = QWidget()
     # not uncommon to see people shadow the builtin layout()
@@ -113,7 +113,7 @@ def test_adding_modified_widget(make_napari_viewer):
     assert dw.widget() is widg
 
 
-def test_adding_stretch(make_napari_viewer):
+def test_adding_stretch(make_napari_viewer, qtbot):
     """Make sure that vertical stretch only gets added when appropriate."""
     viewer = make_napari_viewer()
 


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/7360#discussion_r1838246771

# Description

Check and prevent raising a error over test related with event handling via the mainwindow `eventFilter` implementation:

```python-traceback
Traceback (most recent call last):
    File "/home/runner/work/napari/napari/napari/_qt/qt_main_window.py", line 329, in eventFilter
      return super().eventFilter(source, event)
  TypeError: 'PySide6.QtCore.QObject.eventFilter' called with wrong argument types:
    PySide6.QtCore.QObject.eventFilter(QWidgetItem, QEvent)
  Supported signatures:
    PySide6.QtCore.QObject.eventFilter(PySide6.QtCore.QObject, PySide6.QtCore.QEvent)
```


