### PR TITLE
Stop testing PySide6 on python 3.9

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -114,7 +114,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-latest ]
-        python: [ "3.9", "3.11" ]
+        python: [ "3.10", "3.11" ]
         backend: [ "pyqt5,pyside6" ]
         coverage: [ cov ]
         pydantic: ["_pydantic_1"]
@@ -142,6 +142,11 @@ jobs:
             backend: pyqt5
             MIN_REQ: 1
             coverage: cov
+          # basic test for 3.9
+          - python: "3.9"
+            platform: ubuntu-latest
+            backend: pyqt5
+            coverage: no_cov
           - python: "3.11"
             platform: ubuntu-22.04
             backend: pyqt5
@@ -163,7 +168,6 @@ jobs:
             platform: ubuntu-latest
             backend: pyside2
             coverage: no_cov
-
     with:
       python_version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -142,11 +142,6 @@ jobs:
             backend: pyqt5
             MIN_REQ: 1
             coverage: cov
-          # basic test for 3.9
-          - python: "3.9"
-            platform: ubuntu-latest
-            backend: pyqt5
-            coverage: no_cov
           - python: "3.11"
             platform: ubuntu-22.04
             backend: pyqt5


### PR DESCRIPTION
# References and relevant issues

closes #7366

# Description

As pyside6 on python 3.9 is old, maybe just skip testing it and only test pyqt5 on this old python

