### PR TITLE
fix: remove "openblas_set_num_threads not found" warning by add missed break

### DIFF
--- a/napari/_check_numpy_version.py
+++ b/napari/_check_numpy_version.py
@@ -85,5 +85,6 @@ def limit_numpy1x_threads_on_macos_arm() -> (
         )
         if openblas_set_num_threads is not None:
             openblas_set_num_threads(1)
+            break
     else:
         logging.warning('openblas_set_num_threads not found')


### PR DESCRIPTION
# Description

When start napari on macOS that uses `numpy<2` its emit warning "openblas_set_num_threads not found" even if it was found, and number of threads is set properly.

This is because of a missed break, so for loop always do all loops and ends in `else` clause. This PR fixes it. 
