### PR TITLE
Handle tifffile deprecation warning for compressionargs

### DIFF
--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -3,9 +3,9 @@ import struct
 import warnings
 
 import numpy as np
+from packaging.version import parse
 
 from napari._version import __version__
-from napari.settings._fields import parse
 from napari.utils.notifications import show_warning
 from napari.utils.translations import trans
 

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 
 from napari._version import __version__
+from napari/settings/_fields.py import parse
 from napari.utils.notifications import show_warning
 from napari.utils.translations import trans
 

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 
 from napari._version import __version__
-from napari/settings/_fields import parse
+from napari.settings._fields import parse
 from napari.utils.notifications import show_warning
 from napari.utils.translations import trans
 

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -114,7 +114,7 @@ def imsave_tiff(filename, data):
             else:
                 tifffile.imwrite(filename, data, compression=('zlib', 1))
         except struct.error:  # compressed data >4GB
-            if tifffile.__version__ >= '2022.7.28':
+            if parse(version('tifffile')) >= parse('2022.7.28'):
                 tifffile.imwrite(
                     filename, data, compressionargs={'zlib': 1}, bigtiff=True
                 )

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -107,9 +107,9 @@ def imsave_tiff(filename, data):
         # Deprecation warning for tuple instead of 'compressionargs' in 2022.7.28 version
         try:
             from importlib.metadata import version
-            from packaging.version import parse as parse_version 
-            
-            if parse(version("tifffile")) >= parse('2022.7.28'):
+
+
+            if parse(version('tifffile')) >= parse('2022.7.28'):
                 tifffile.imwrite(filename, data, compressionargs={'zlib': 1})
             else:
                 tifffile.imwrite(filename, data, compression=('zlib', 1))

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -106,7 +106,10 @@ def imsave_tiff(filename, data):
         # https://forum.image.sc/t/problem-saving-generated-labels-in-cellpose-napari/54892/8
         # Deprecation warning for tuple instead of 'compressionargs' in 2022.7.28 version
         try:
-            if tifffile.__version__ >= '2022.7.28':
+            from importlib.metadata import version
+            from packaging.version import parse as parse_version 
+            
+            if parse(version("tifffile")) >= parse('2022.7.28'):
                 tifffile.imwrite(filename, data, compressionargs={'zlib': 1})
             else:
                 tifffile.imwrite(filename, data, compression=('zlib', 1))

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 
 from napari._version import __version__
-from napari/settings/_fields.py import parse
+from napari/settings/_fields import parse
 from napari.utils.notifications import show_warning
 from napari.utils.translations import trans
 

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -104,15 +104,24 @@ def imsave_tiff(filename, data):
         # 'compression' kwarg since 2021.6.6; we depend on more recent versions
         # now. See:
         # https://forum.image.sc/t/problem-saving-generated-labels-in-cellpose-napari/54892/8
+        # Deprecation warning for tuple instead of 'compressionargs' in 2022.7.28 version
         try:
-            tifffile.imwrite(filename, data, compression=('zlib', 1))
+            if tifffile.__version__ >= '2022.7.28':
+                tifffile.imwrite(filename, data, compressionargs={'zlib': 1})
+            else:
+                tifffile.imwrite(filename, data, compression=('zlib', 1))
         except struct.error:  # compressed data >4GB
-            tifffile.imwrite(
-                filename,
-                data,
-                compression=('zlib', 1),
-                bigtiff=True,
-            )
+            if tifffile.__version__ >= '2022.7.28':
+                tifffile.imwrite(
+                    filename, data, compressionargs={'zlib': 1}, bigtiff=True
+                )
+            else:
+                tifffile.imwrite(
+                    filename,
+                    data,
+                    compression=('zlib', 1),
+                    bigtiff=True,
+                )
 
 
 def __getattr__(name: str):

--- a/napari/utils/io.py
+++ b/napari/utils/io.py
@@ -108,7 +108,6 @@ def imsave_tiff(filename, data):
         try:
             from importlib.metadata import version
 
-
             if parse(version('tifffile')) >= parse('2022.7.28'):
                 tifffile.imwrite(filename, data, compressionargs={'zlib': 1})
             else:


### PR DESCRIPTION
# References and relevant issues

Related to #6765

From tifffile 2022.7.28 on, a deprecation warning is emitted if a tuple is used
instead of `compressionargs`. This deprecation warning is emitted in some of our
tests.

# Description
This PR checks whether a new version is used and provides the correct function
parameters or passes along the old format with the tuple for older versions.

