### PR TITLE
Isolate keybinding tests using pytest.mark

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -453,6 +453,7 @@ def test_qt_viewer_clipboard_without_flash(make_napari_viewer):
     assert not hasattr(viewer.window._qt_window, '_flash_animation')
 
 
+@pytest.mark.key_bindings
 def test_active_keybindings(make_napari_viewer):
     """Test instantiating viewer."""
     viewer = make_napari_viewer()

--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -226,6 +226,7 @@ def test_preferences_dialog_escape(qtbot, pref):
     assert get_settings().appearance.theme == 'light'
 
 
+@pytest.mark.key_bindings
 def test_preferences_dialog_cancel(qtbot, pref):
     with qtbot.waitSignal(pref.finished):
         pref._button_cancel.click()
@@ -235,6 +236,7 @@ def test_preferences_dialog_cancel(qtbot, pref):
     ] == [KeyBinding.from_str('Ctrl')]
 
 
+@pytest.mark.key_bindings
 def test_preferences_dialog_restore(qtbot, pref, monkeypatch):
     theme_widget = pref._stack.widget(1).widget().widget.widgets['theme']
     highlight_widget = (

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -48,6 +48,7 @@ def test_shortcut_editor_defaults(
     shortcut_editor_widget()
 
 
+@pytest.mark.key_bindings
 def test_potentially_conflicting_actions(shortcut_editor_widget):
     widget = shortcut_editor_widget()
     assert widget.layer_combo_box.currentText() == widget.VIEWER_KEYBINDINGS
@@ -75,6 +76,7 @@ def test_potentially_conflicting_actions(shortcut_editor_widget):
     assert actions2 == expected_actions2
 
 
+@pytest.mark.key_bindings
 def test_mark_conflicts(shortcut_editor_widget, qtbot):
     widget = shortcut_editor_widget()
     ctrl_keybinding = KeyBinding.from_str('Ctrl')
@@ -133,6 +135,7 @@ def test_restore_defaults(shortcut_editor_widget):
     assert shortcut == KEY_SYMBOLS['Ctrl']
 
 
+@pytest.mark.key_bindings
 @skip_local_focus
 @pytest.mark.parametrize(
     ('key', 'modifier', 'key_symbols'),

--- a/napari/_tests/test_key_bindings.py
+++ b/napari/_tests/test_key_bindings.py
@@ -1,9 +1,11 @@
 from unittest.mock import Mock
 
 import numpy as np
+import pytest
 from vispy import keys
 
 
+@pytest.mark.key_bindings
 def test_viewer_key_bindings(make_napari_viewer):
     """Test adding key bindings to the viewer"""
     np.random.seed(0)
@@ -76,6 +78,7 @@ def test_viewer_key_bindings(make_napari_viewer):
     mock_shift_release.reset_mock()
 
 
+@pytest.mark.key_bindings
 def test_layer_key_bindings(make_napari_viewer):
     """Test adding key bindings to a layer"""
     np.random.seed(0)

--- a/napari/components/_tests/test_viewer_keybindings.py
+++ b/napari/components/_tests/test_viewer_keybindings.py
@@ -20,6 +20,7 @@ from napari.settings import get_settings
 from napari.utils.theme import available_themes, get_system_theme
 
 
+@pytest.mark.key_bindings
 def test_theme_toggle_keybinding():
     viewer = ViewerModel()
     assert viewer.theme == get_settings().appearance.theme

--- a/napari/layers/points/_tests/test_points_key_bindings.py
+++ b/napari/layers/points/_tests/test_points_key_bindings.py
@@ -1,6 +1,9 @@
+import pytest
+
 from napari.layers.points import Points, _points_key_bindings as key_bindings
 
 
+@pytest.mark.key_bindings
 def test_modes(layer):
     data = [[1, 3], [8, 4], [10, 10], [15, 4]]
     layer = Points(data, size=1)
@@ -13,6 +16,7 @@ def test_modes(layer):
     assert layer.mode == 'pan_zoom'
 
 
+@pytest.mark.key_bindings
 def test_copy_paste(layer):
     data = [[1, 3], [8, 4], [10, 10], [15, 4]]
     layer = Points(data, size=1)
@@ -31,6 +35,7 @@ def test_copy_paste(layer):
     assert len(layer._clipboard) > 0
 
 
+@pytest.mark.key_bindings
 def test_select_all_in_slice(layer):
     data = [[1, 3], [8, 4], [10, 10], [15, 4]]
     layer = Points(data, size=1)
@@ -47,6 +52,7 @@ def test_select_all_in_slice(layer):
     assert len(layer.selected_data) == 0
 
 
+@pytest.mark.key_bindings
 def test_select_all_in_slice_3d_data(layer):
     data = [[0, 1, 3], [0, 8, 4], [0, 10, 10], [1, 15, 4]]
     layer = Points(data, size=1)
@@ -63,6 +69,7 @@ def test_select_all_in_slice_3d_data(layer):
     assert len(layer.selected_data) == 0
 
 
+@pytest.mark.key_bindings
 def test_select_all_data(layer):
     data = [[1, 3], [8, 4], [10, 10], [15, 4]]
     layer = Points(data, size=1)
@@ -79,6 +86,7 @@ def test_select_all_data(layer):
     assert len(layer.selected_data) == 0
 
 
+@pytest.mark.key_bindings
 def test_select_all_data_3d_data(layer):
     data = [[0, 1, 3], [0, 8, 4], [0, 10, 10], [1, 15, 4]]
     layer = Points(data, size=1)

--- a/napari/utils/_tests/test_key_bindings.py
+++ b/napari/utils/_tests/test_key_bindings.py
@@ -17,6 +17,7 @@ from napari.utils.key_bindings import (
 )
 
 
+@pytest.mark.key_bindings
 def test_bind_key():
     kb = {}
 
@@ -61,6 +62,7 @@ def test_bind_key():
     assert key == KeyBinding.from_str('Shift-A')
 
 
+@pytest.mark.key_bindings
 def test_bind_key_decorator():
     kb = {}
 
@@ -70,6 +72,7 @@ def test_bind_key_decorator():
     assert kb == {KeyBinding.from_str('A'): foo}
 
 
+@pytest.mark.key_bindings
 def test_keymap_provider():
     class Foo(KeymapProvider): ...
 
@@ -89,6 +92,7 @@ def test_keymap_provider():
     assert Baz.class_keymap == {KeyBinding.from_str('A'): ...}
 
 
+@pytest.mark.key_bindings
 def test_bind_keymap():
     class Foo: ...
 
@@ -133,6 +137,7 @@ class Baz(Bar):
     class_keymap = {'F': lambda x: setattr(x, 'F', 16)}
 
 
+@pytest.mark.key_bindings
 def test_handle_single_keymap_provider():
     foo = Foo()
 
@@ -185,6 +190,7 @@ def test_handle_single_keymap_provider():
     assert not hasattr(foo, 'C')
 
 
+@pytest.mark.key_bindings
 @patch('napari.utils.key_bindings.USER_KEYMAP', new_callable=dict)
 def test_bind_user_key(keymap_mock):
     foo = Foo()
@@ -217,6 +223,7 @@ def test_bind_user_key(keymap_mock):
     assert x == 42
 
 
+@pytest.mark.key_bindings
 def test_handle_multiple_keymap_providers():
     foo = Foo()
     bar = Bar()
@@ -281,6 +288,7 @@ def test_handle_multiple_keymap_providers():
     assert not hasattr(foo, 'B')
 
 
+@pytest.mark.key_bindings
 def test_inherited_keymap():
     baz = Baz()
     handler = KeymapHandler()
@@ -302,6 +310,7 @@ def test_inherited_keymap():
     }
 
 
+@pytest.mark.key_bindings
 def test_handle_on_release_bindings():
     def make_42(x):
         # on press
@@ -348,6 +357,7 @@ def test_handle_on_release_bindings():
     assert baz.aliiiens == 0
 
 
+@pytest.mark.key_bindings
 def test_bind_key_method():
     class Foo2(KeymapProvider): ...
 
@@ -365,6 +375,7 @@ def test_bind_key_method():
     assert Foo2.class_keymap[KeyBinding.from_str('B')] is bar
 
 
+@pytest.mark.key_bindings
 def test_bind_key_doc():
     doc = inspect.getdoc(bind_key)
     doc = doc.split('Notes\n-----\n')[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,6 @@ pyside2 = [
 pyside6_experimental = [
     "PySide6 < 6.5 ; python_version < '3.12'"
 ]
-pyside6_latest = [
-    "PySide6; python_version>='3.12'"
-]
 pyqt6 = [
     "PyQt6 > 6.5",
     "PyQt6 != 6.6.1 ; platform_system == 'Darwin'"
@@ -132,7 +129,7 @@ testing = [
     "hypothesis>=6.8.0",
     "lxml[html_clean]>5",
     "matplotlib >= 3.6.1",
-    #"numba>=0.57.1",
+    "numba>=0.57.1",
     "pooch>=1.6.0",
     "coverage>7",
     "docstring_parser>=0.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ pyside2 = [
 pyside6_experimental = [
     "PySide6 < 6.5 ; python_version < '3.12'"
 ]
+pyside6_latest = [
+    "PySide6; python_version>='3.12'"
+]
 pyqt6 = [
     "PyQt6 > 6.5",
     "PyQt6 != 6.6.1 ; platform_system == 'Darwin'"
@@ -129,7 +132,7 @@ testing = [
     "hypothesis>=6.8.0",
     "lxml[html_clean]>5",
     "matplotlib >= 3.6.1",
-    "numba>=0.57.1",
+    #"numba>=0.57.1",
     "pooch>=1.6.0",
     "coverage>7",
     "docstring_parser>=0.15",
@@ -373,6 +376,7 @@ markers = [
     "disable_qtimer_start: Disable timer start in this Test",
     "disable_qanimation_start: Disable animation start in this Test",
     "enable_console: Don't mock the IPython console (in QtConsole) in this Test",
+    "key_bindings: Test of keybindings",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
# References and relevant issues
Refactoring keybindings.

# Description
This PR uses the pytest mark functionality to identify tests that are related to keybindings. As things
with keybindings are refactored, this would speed up local testing of keybinding functionality.

To run the keybinding tests, enter:
```sh
pytest -v -m key_bindings
```

cc/ @lucyleeow You may find this useful. If so, I will take this out of draft.


