### PR TITLE
Combine two statements in calculate_status

### DIFF
--- a/napari/_qt/threads/status_checker.py
+++ b/napari/_qt/threads/status_checker.py
@@ -97,7 +97,7 @@ class StatusChecker(QThread):
             return
 
         try:
-            res = viewer._calc_status_from_cursor()
+            self.status_and_tooltip_changed.emit(viewer._calc_status_from_cursor())
         except Exception as e:  # pragma: no cover # noqa: BLE001
             # Our codebase is not threadsafe. It is possible that an
             # ViewerModel or Layer state is changed while we are trying to
@@ -108,7 +108,6 @@ class StatusChecker(QThread):
             # We do not want to crash the thread to keep the status updates.
             notification_manager.dispatch(Notification.from_exception(e))
             return
-        self.status_and_tooltip_changed.emit(res)
 
 
 if os.environ.get('ASV') == 'true':

--- a/napari/_qt/threads/status_checker.py
+++ b/napari/_qt/threads/status_checker.py
@@ -97,7 +97,9 @@ class StatusChecker(QThread):
             return
 
         try:
-            self.status_and_tooltip_changed.emit(viewer._calc_status_from_cursor())
+            self.status_and_tooltip_changed.emit(
+                viewer._calc_status_from_cursor()
+            )
         except Exception as e:  # pragma: no cover # noqa: BLE001
             # Our codebase is not threadsafe. It is possible that an
             # ViewerModel or Layer state is changed while we are trying to


### PR DESCRIPTION
# References and relevant issues

Adresses #7363 error of unbound local.

# Description

This PR removes the placeholder variable `res` and combines two statements to remove the placeholder that does not appear to be referenced outside of this block or returned.
