### PR TITLE
Update the docstrings and comments for status checker thread

### DIFF
--- a/napari/_qt/threads/status_checker.py
+++ b/napari/_qt/threads/status_checker.py
@@ -1,3 +1,5 @@
+"""A performant, dedicated thread to compute cursor status and signal updates to a viewer."""
+
 from __future__ import annotations
 
 import os
@@ -14,19 +16,19 @@ if TYPE_CHECKING:
 
 
 class StatusChecker(QThread):
-    """Separate thread dedicated to updating the status bar.
+    """A dedicated thread for performant updating of the status bar.
+
+    This class offloads the job of computing the cursor status into a separate thread,
+    Qt Signals are used to update the main viewer with the status string.
 
     Prior to https://github.com/napari/napari/pull/7146, status bar updates
     happened on the main thread in the viewer model, which could be
     expensive in some layers and resulted in bad performance when some
     layers were selected.
 
-    This class puts the job of computing the status into a separate thread,
-    which then uses Qt Signals to update the main viewer with the status
-    string.
-
     Because the thread runs a single infinite while loop, the updates are
-    naturally throttled to as fast as they can be computed, but no faster.
+    naturally throttled since they can only be sent at the rate which updates
+    can be computed, but no faster.
 
     Attributes
     ----------
@@ -35,16 +37,21 @@ class StatusChecker(QThread):
         for keeping track of when the status needs updating
         (because the cursor has moved).
     _terminate : bool
-        Whether the thread needs to be terminated. Set by the QtViewer
-        when it is being closed. No more status updates will take place if
-        _terminate is set.
+        If set to True, the status checker thread needs to be terminated.
+        When the QtViewer is being closed, it sets this flag to terminate
+        the status checker thread.
+        After _terminate is set to True, no more status updates are sent.
+        Default: False.
     viewer_ref : weakref.ref[napari.viewer.ViewerModel]
-        A weak reference to the viewer providing the status updates. We
-        don't want this thread to prevent the viewer from being garbage
-        collected, so we keep only a weak reference, and check it when
-        we need to compute a new status update.
+        A weak reference to the viewer which is providing status updates.
+        We keep a weak reference to the viewer so the status checker thread
+        will not prevent the viewer from being garbage collected.
+        We proactively check the viewer to determine if a new status update
+        needs to be computed and emitted.
     """
 
+    # Create a Signal to establish a lightweight communication mechanism between the
+    # viewer and the status checker thread for cursor events and related status
     status_and_tooltip_changed = Signal(object)
 
     def __init__(self, viewer: ViewerModel, parent: QObject | None = None):
@@ -57,15 +64,16 @@ class StatusChecker(QThread):
     def trigger_status_update(self) -> None:
         """Trigger a status update computation.
 
-        The viewer should call this when the cursor moves.
+        When the cursor moves, the viewer will call this to instruct
+        the status checker to update the viewer with the present status.
         """
         self._need_status_update.set()
 
     def terminate(self) -> None:
-        """Terminate the thread.
+        """Terminate the status checker thread.
 
-        It's important that _terminate is set to True before
-        _needs_status_update.set is called.
+        For proper cleanup,it's important to set _terminate to True before
+        calling _needs_status_update.set.
         """
         self._terminate = True
         self._need_status_update.set()
@@ -73,6 +81,10 @@ class StatusChecker(QThread):
     def start(
         self, priority: QThread.Priority = QThread.Priority.InheritPriority
     ) -> None:
+        """Start the status checker thread.
+
+        Make sure to set the _terminate attribute to False prior to start.
+        """
         self._terminate = False
         super().start(priority)
 
@@ -90,24 +102,26 @@ class StatusChecker(QThread):
     def calculate_status(self) -> None:
         """Calculate the status and emit the signal.
 
-        If the viewer is not available, do nothing.
+        If the viewer is not available, do nothing. Otherwise,
+        emit the signal that the status has changed.
         """
         viewer = self.viewer_ref()
         if viewer is None:
             return
 
         try:
+            # Calculate the status change from cursor's movement
             res = viewer._calc_status_from_cursor()
         except Exception as e:  # pragma: no cover # noqa: BLE001
             # Our codebase is not threadsafe. It is possible that an
             # ViewerModel or Layer state is changed while we are trying to
-            # calculate the status, which may lead to an exception.
-            # We catch all exceptions here to prevent the thread from
-            # crashing. The error is logged and a notification is shown.
-            #
-            # We do not want to crash the thread to keep the status updates.
+            # calculate the status, which may cause an exception.
+            # All exceptions are caught and handled to keep updates
+            # from crashing the thread. The exception is logged
+            # and a notification is sent.
             notification_manager.dispatch(Notification.from_exception(e))
             return
+        # Emit the signal with the updated status
         self.status_and_tooltip_changed.emit(res)
 
 


### PR DESCRIPTION
# References and relevant issues
Addresses #7363 

# Description
This PR updates the docstrings and comments to help clarify behavior
of the dedicated status checker thread and its relationship with
the viewer. Add a bit more context about the signal between the viewer
and the thread.
