### PR TITLE
mark slow local tests

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -367,6 +367,7 @@ def test_points_layer_display_correct_slice_on_scale(make_napari_viewer):
     np.testing.assert_equal(response.indices, [0])
 
 
+@pytest.mark.slow
 @skip_on_win_ci
 def test_qt_viewer_clipboard_with_flash(make_napari_viewer, qtbot):
     viewer = make_napari_viewer()
@@ -1026,6 +1027,7 @@ def test_shortcut_passing(make_napari_viewer):
     assert layer.mode == 'erase'
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('mode', ['direct', 'random'])
 def test_selection_collision(qt_viewer: QtViewer, mode):
     data = np.zeros((10, 10), dtype=np.uint8)
@@ -1107,6 +1109,7 @@ def test_all_supported_dtypes(qt_viewer):
         )
 
 
+@pytest.mark.slow
 def test_more_than_uint16_colors(qt_viewer):
     pytest.importorskip('numba')
     # this test is slow (10s locally)

--- a/napari/_qt/widgets/_tests/test_qt_play.py
+++ b/napari/_qt/widgets/_tests/test_qt_play.py
@@ -70,6 +70,7 @@ CONDITIONS = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     ('nframes', 'fps', 'mode', 'rng', 'result'), CONDITIONS
 )

--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -8,6 +8,7 @@ from imageio.v3 import imread
 from napari.utils.io import imsave
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     'image_file', ['image', 'image.png', 'image.tif', 'image.bmp']
 )
@@ -72,6 +73,7 @@ def test_imsave_float(tmp_path, image_file):
         assert not image_file_path.is_file()
 
 
+@pytest.mark.slow
 def test_imsave_large_file(monkeypatch, tmp_path):
     old_write = tifffile.imwrite
 

--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -73,7 +73,6 @@ def test_imsave_float(tmp_path, image_file):
         assert not image_file_path.is_file()
 
 
-@pytest.mark.slow
 def test_imsave_large_file(monkeypatch, tmp_path):
     old_write = tifffile.imwrite
 

--- a/napari_builtins/_tests/test_reader.py
+++ b/napari_builtins/_tests/test_reader.py
@@ -51,6 +51,7 @@ def test_animated_gif_reader(save_image):
     assert layer_data[0][0].shape == (5, 20, 20, 3)
 
 
+@pytest.mark.slow
 def test_reader_plugin_url():
     layer_data = npe2.read(
         ['https://samples.fiji.sc/FakeTracks.tif'], stack=False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,7 +359,7 @@ filterwarnings = [
   "ignore:There is no current event loop:DeprecationWarning:",
   "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # pandas pyarrow (pandas<3.0),
   # TODO: remove once xarray is updated to avoid this warning
-  # https://github.com/pydata/xarray/blame/b1f3fea467ff9387ed35c221205a70524f4caa18b/pyproject.toml#L333-L334
+  # https://github.com/pydata/xarray/blame/b1f3fea467f9387ed35c221205a70524f4caa18b/pyproject.toml#L333-L334
   # https://github.com/pydata/xarray/pull/8939
   "ignore:__array__ implementation doesn't accept a copy keyword, so passing copy=False failed.",
   "ignore:pkg_resources is deprecated",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,7 +359,7 @@ filterwarnings = [
   "ignore:There is no current event loop:DeprecationWarning:",
   "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",  # pandas pyarrow (pandas<3.0),
   # TODO: remove once xarray is updated to avoid this warning
-  # https://github.com/pydata/xarray/blame/b1f3fea467f9387ed35c221205a70524f4caa18b/pyproject.toml#L333-L334
+  # https://github.com/pydata/xarray/blame/b1f3fea467ff9387ed35c221205a70524f4caa18b/pyproject.toml#L333-L334
   # https://github.com/pydata/xarray/pull/8939
   "ignore:__array__ implementation doesn't accept a copy keyword, so passing copy=False failed.",
   "ignore:pkg_resources is deprecated",
@@ -373,6 +373,7 @@ markers = [
     "disable_qtimer_start: Disable timer start in this Test",
     "disable_qanimation_start: Disable animation start in this Test",
     "enable_console: Don't mock the IPython console (in QtConsole) in this Test",
+    "slow: mark a test as slow",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,6 +373,7 @@ markers = [
     "disable_qtimer_start: Disable timer start in this Test",
     "disable_qanimation_start: Disable animation start in this Test",
     "enable_console: Don't mock the IPython console (in QtConsole) in this Test",
+    # mark slow tests, so they can be skipped using: pytest -m "not slow"
     "slow: mark a test as slow",
 ]
 


### PR DESCRIPTION
# References and relevant issues
Partially addresses #7382

# Description
This PR marks the 10 slowest tests on my local machine. This allows me to include
or exclude when I run tests locally.

This could be an initial proof of concept step that could be used to identify some slow
tests on CI runs and treat them differently than the rest of the test suite. Perhaps exclude on some test matrix runs or parallelize the slow tests.

