### PR TITLE
fix: change highlight only on zoom and mouse press

### DIFF
--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from napari._tests.utils import skip_local_popups, skip_on_win_ci
+from napari.layers import Shapes
 from napari.utils._test_utils import read_only_mouse_event
 from napari.utils.interactions import (
     mouse_move_callbacks,
@@ -566,7 +567,9 @@ def test_active_layer_highlight_visibility(qt_viewer):
 
     # add shapes layer setting edge and face color to `black` (so shapes aren't
     # visible unless they're selected), create a rectangle and select the created shape
-    shapes_layer = viewer.add_shapes(edge_color='black', face_color='black')
+    shapes_layer: Shapes = viewer.add_shapes(
+        edge_color='black', face_color='black'
+    )
     shapes_layer.add_rectangles([[0, 0], [1, 1]])
     shapes_layer.selected_data = {0}
 

--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -871,3 +871,8 @@ def _move_active_element_under_cursor(
             shapes = layer.selected_data
             layer._selected_box = layer.interaction_box(shapes)
             layer.refresh()
+
+
+def _set_highlight(layer: Shapes, event: MouseEvent) -> None:
+    if event.type in {'mouse_press', 'mouse_wheel'}:
+        layer._set_highlight()

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -30,6 +30,7 @@ from napari.layers.shapes._shapes_constants import (
     shape_classes,
 )
 from napari.layers.shapes._shapes_mouse_bindings import (
+    _set_highlight,
     add_ellipse,
     add_line,
     add_path_polygon,
@@ -612,6 +613,8 @@ class Shapes(Layer):
         )
 
         # Trigger generation of view slice and thumbnail
+        self.mouse_wheel_callbacks.append(_set_highlight)
+        self.mouse_drag_callbacks.append(_set_highlight)
         self.refresh()
 
     def _initialize_current_color_for_empty_layer(
@@ -2789,16 +2792,6 @@ class Shapes(Layer):
             cur_len = np.linalg.norm(handle_vec)
             box[Box.HANDLE] = box[Box.TOP_CENTER] + r * handle_vec / cur_len
         self._selected_box = box + center
-
-    def _update_draw(
-        self, scale_factor, corner_pixels_displayed, shape_threshold
-    ):
-        prev_scale = self.scale_factor
-        super()._update_draw(
-            scale_factor, corner_pixels_displayed, shape_threshold
-        )
-        # update highlight only if scale has changed, otherwise causes a cycle
-        self._set_highlight(force=(prev_scale != self.scale_factor))
 
     def _get_value(self, position):
         """Value of the data at a position in data coordinates.

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1292,6 +1292,8 @@ class Shapes(Layer):
                 with self.block_update_properties():
                     self.current_properties = unique_properties
 
+        self._set_highlight()
+
     @property
     def _is_moving(self) -> bool:
         return self._private_is_moving


### PR DESCRIPTION
# References and relevant issues
Closes: #7074

# Description

Instead of updating the highlight on every draw, just do it when the mouse moves or press. 