### PR TITLE
[Maint] drop unused `n_dimensional` property of Labels

### DIFF
--- a/examples/paint-nd.py
+++ b/examples/paint-nd.py
@@ -28,7 +28,6 @@ labels = viewer.add_labels(np.zeros_like(blobs, dtype=np.int32))
 labels.n_edit_dimensions = 3
 labels.brush_size = 15
 labels.mode = 'paint'
-labels.n_dimensional = True
 
 if __name__ == '__main__':
     napari.run()

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1018,7 +1018,7 @@ def test_world_data_extent():
         'mode',
         'selected_label',
         'preserve_labels',
-        'n_dimensional',
+        'n_edit_dimensions',
     ),
     list(
         itertools.product(
@@ -1026,7 +1026,7 @@ def test_world_data_extent():
             ['fill', 'erase', 'paint'],
             [1, 20, 100],
             [True, False],
-            [True, False],
+            [3, 2],
         )
     ),
 )
@@ -1035,7 +1035,7 @@ def test_undo_redo(
     mode,
     selected_label,
     preserve_labels,
-    n_dimensional,
+    n_edit_dimensions,
 ):
     blobs = sk_data.binary_blobs(length=64, volume_fraction=0.3, n_dim=3)
     layer = Labels(blobs)
@@ -1044,7 +1044,7 @@ def test_undo_redo(
     layer.mode = mode
     layer.selected_label = selected_label
     layer.preserve_labels = preserve_labels
-    layer.n_edit_dimensions = 3 if n_dimensional else 2
+    layer.n_edit_dimensions = n_edit_dimensions
     coord = np.random.random((3,)) * (np.array(blobs.shape) - 1)
     while layer.data[tuple(coord.astype(int))] == 0 and np.any(layer.data):
         coord = np.random.random((3,)) * (np.array(blobs.shape) - 1)


### PR DESCRIPTION
# References and relevant issues
`n_dimensional` was removed in https://github.com/napari/napari/pull/3377

# Description
I came across a reference to `n_dimensional` in the docs and realized it didn't exist.
In this PR I remove it from the test and example.
Here's the docs PR where I also switch to the proper property:
https://github.com/napari/docs/pull/522