### PR TITLE
stop/start notification timer on window focus change

### DIFF
--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, cast
 
 from qtpy.QtCore import (
     QEasingCurve,
@@ -158,14 +158,34 @@ class NapariQtNotification(QDialog):
         self.slide_in()
         if self.parent() is not None and not self.parent().isActiveWindow():
             return
+        if self.parent() is not None:
+            notifications = cast(
+                list[NapariQtNotification],
+                self.parent().findChildren(NapariQtNotification),
+            )
+            for notification in notifications:
+                notification.timer_stop()
         if self.DISMISS_AFTER > 0:
             self.timer.setInterval(self.DISMISS_AFTER)
             self.timer.setSingleShot(True)
             self.timer.timeout.connect(self.close_with_fade)
             self.timer.start()
 
-    def mouseMoveEvent(self, event):
+    def enterEvent(self, event):
         """On hover, stop the self-destruct timer"""
+        self.timer_stop()
+
+    def leaveEvent(self, event):
+        """On hover exit, restart the self-destruct timer"""
+        self.timer_start()
+
+    def timer_start(self):
+        """Start the self-destruct timer"""
+        if self.DISMISS_AFTER > 0:
+            self.timer.start()
+
+    def timer_stop(self):
+        """Stop the self-destruct timer"""
         self.timer.stop()
 
     def mouseDoubleClickEvent(self, event):
@@ -173,9 +193,16 @@ class NapariQtNotification(QDialog):
         self.toggle_expansion()
 
     def close(self):
-        self.timer.stop()
+        self.timer_stop()
         self.opacity_anim.stop()
         self.geom_anim.stop()
+        if self.parent() is not None:
+            notifications = cast(
+                list[NapariQtNotification],
+                self.parent().findChildren(NapariQtNotification),
+            )
+            if len(notifications) > 1 and notifications[-1] == self:
+                notifications[-2].timer_start()
         super().close()
 
     def close_with_fade(self):

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -72,6 +72,11 @@ def _focus_changed(old: Optional[QWidget], new: Optional[QWidget]):
     else:
         start_timer = False
         window = old.window()
+
+    from napari._qt.qt_main_window import _QtMainWindow
+
+    if not isinstance(window, _QtMainWindow):
+        return
     notifications = cast(
         list[NapariQtNotification], window.findChildren(NapariQtNotification)
     )

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -6,11 +6,10 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Optional, cast
 from warnings import warn
 
-from PyQt6.QtWidgets import QWidget
 from qtpy import PYQT5, PYSIDE2
 from qtpy.QtCore import QDir, Qt
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QWidget
 
 from napari import Viewer, __version__
 from napari._qt.dialogs.qt_notification import NapariQtNotification


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari/pull/7220#issuecomment-2477654620

# Description

This PR stops the notification timer if windows lost focus, and starts the timer for the top one most after gaining focus again. 

If a new notification shows, then the previous one timer is stopped and started again if it is closed. 

The notification timer is restarted after the mouse leaves the dialog area. 

I do not handle the case of hundreds of notifications. Maybe someone will have an idea how to do this properly. 
