### PR TITLE
Add metadata event to Layer class

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -456,6 +456,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             source=self,
             axis_labels=Event,
             data=Event,
+            metadata=Event,
             affine=Event,
             blending=Event,
             cursor=Event,
@@ -670,6 +671,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     def metadata(self, value: dict) -> None:
         self._metadata.clear()
         self._metadata.update(value)
+        self.events.metadata()
 
     @property
     def source(self) -> Source:


### PR DESCRIPTION
# References and relevant issues
Closes #7415 

# Description
Add metadata event in Layer EmitterGroup

### Example

```python
from skimage import data

import napari

# create the viewer with an image
viewer = napari.view_image(data.astronaut(), rgb=True)

def observer(event):
    print(event.source.metadata)

viewer.layers[0].events.metadata.connect(observer)

viewer.layers[0].metadata = {'name': 'astronaut'} # prints {'name': 'astronaut'}
viewer.layers[0].metadata['name'] = 'astro' # does not print anything

if __name__ == '__main__':
    napari.run()
```

Note that the setter is not triggered when you manipulate directly the underlying dictionary object. I don't know if this is something we want?