### PR TITLE
bug fix: have layerlist consume return, not pass to viewer

### DIFF
--- a/napari/_qt/containers/qt_layer_list.py
+++ b/napari/_qt/containers/qt_layer_list.py
@@ -84,5 +84,9 @@ class QtLayerList(QtListView[Layer]):
             e.ignore()
         elif e.key() != Qt.Key.Key_Space:
             super().keyPressEvent(e)
-        if e.key() not in (Qt.Key.Key_Backspace, Qt.Key.Key_Delete):
+        if e.key() not in (
+            Qt.Key.Key_Backspace,
+            Qt.Key.Key_Delete,
+            Qt.Key.Key_Return,
+        ):
             e.ignore()  # pass key events up to viewer


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7409

# Description
In this PR the `Return` keybind is consumed by the LayerList and not passed up to the viewer. This is the same approach as a previous fix https://github.com/napari/napari/pull/4259 which did the same for Delete/Backspace.
