### PR TITLE
[Bugfix] Don't exit Preferences widget when using Return/Enter to confirm a shortcut

### DIFF
--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -312,6 +312,7 @@ def test_preferences_dialog_not_dismissed_by_keybind_confirm(
     )
     pref._stack.setCurrentIndex(3)
     # ensure the dialog is showing
+    pref.show()
     qtbot.waitExposed(pref)
     assert pref.isVisible()
 

--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -312,7 +312,7 @@ def test_preferences_dialog_not_dismissed_by_keybind_confirm(
     )
     pref._stack.setCurrentIndex(3)
     # ensure the dialog is showing
-    qtbot.waitUntil(pref.show())
+    qtbot.waitExposed(pref)
     assert pref.isVisible()
 
     shortcut = shortcut_widget._table.item(

--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -290,7 +290,7 @@ def test_preferences_dialog_restore(qtbot, pref, monkeypatch):
 @pytest.mark.key_bindings
 @pytest.mark.parametrize(
     'confirm_key',
-    ['enter', 'return', 'capslock'],
+    ['enter', 'return', 'tab', 'capslock'],
 )
 def test_preferences_dialog_not_dismissed_by_keybind_confirm(
     qtbot, pref, confirm_key

--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -290,7 +290,7 @@ def test_preferences_dialog_restore(qtbot, pref, monkeypatch):
 @pytest.mark.key_bindings
 @pytest.mark.parametrize(
     'confirm_key',
-    ['enter', 'return', 'tab', 'capslock'],
+    ['enter', 'return', 'tab'],
 )
 def test_preferences_dialog_not_dismissed_by_keybind_confirm(
     qtbot, pref, confirm_key
@@ -312,7 +312,7 @@ def test_preferences_dialog_not_dismissed_by_keybind_confirm(
     )
     pref._stack.setCurrentIndex(3)
     # ensure the dialog is showing
-    pref.show()
+    qtbot.waitUntil(pref.show())
     assert pref.isVisible()
 
     shortcut = shortcut_widget._table.item(

--- a/napari/_qt/dialogs/_tests/test_preferences_dialog.py
+++ b/napari/_qt/dialogs/_tests/test_preferences_dialog.py
@@ -1,14 +1,17 @@
 import sys
 
 import numpy.testing as npt
+import pyautogui
 import pytest
-from qtpy.QtCore import Qt
+from qtpy.QtCore import QPoint, Qt
+from qtpy.QtWidgets import QApplication
 
 from napari._pydantic_compat import BaseModel
 from napari._qt.dialogs.preferences_dialog import (
     PreferencesDialog,
     QMessageBox,
 )
+from napari._tests.utils import skip_local_focus, skip_on_mac_ci
 from napari._vendor.qt_json_builder.qt_jsonschema_form.widgets import (
     EnumSchemaWidget,
     FontSizeSchemaWidget,
@@ -280,3 +283,70 @@ def test_preferences_dialog_restore(qtbot, pref, monkeypatch):
             ).text()
         )
     ) == KeyBinding.from_str('Ctrl')
+
+
+@skip_local_focus
+@skip_on_mac_ci
+@pytest.mark.key_bindings
+@pytest.mark.parametrize(
+    'confirm_key',
+    ['enter', 'return', 'capslock'],
+)
+def test_preferences_dialog_not_dismissed_by_keybind_confirm(
+    qtbot, pref, confirm_key
+):
+    """This test ensures that when confirming a keybinding change, the dialog is not dismissed.
+
+    Notes:
+        * Skipped on macOS CI due to accessibility permissions not being
+          settable on macOS GitHub Actions runners.
+        * For this test to pass locally, you need to give the Terminal/iTerm/VSCode
+          application accessibility permissions:
+              `System Settings > Privacy & Security > Accessibility`
+
+        See https://github.com/asweigart/pyautogui/issues/247 and
+        https://github.com/asweigart/pyautogui/issues/247#issuecomment-437668855
+    """
+    shortcut_widget = (
+        pref._stack.widget(3).widget().widget.widgets['shortcuts']
+    )
+    pref._stack.setCurrentIndex(3)
+    # ensure the dialog is showing
+    pref.show()
+    assert pref.isVisible()
+
+    shortcut = shortcut_widget._table.item(
+        0, shortcut_widget._shortcut_col
+    ).text()
+    assert shortcut == 'U'
+
+    x = shortcut_widget._table.columnViewportPosition(
+        shortcut_widget._shortcut_col
+    )
+    y = shortcut_widget._table.rowViewportPosition(0)
+
+    item_pos = QPoint(x, y)
+    qtbot.mouseClick(
+        shortcut_widget._table.viewport(),
+        Qt.MouseButton.LeftButton,
+        pos=item_pos,
+    )
+    qtbot.mouseDClick(
+        shortcut_widget._table.viewport(),
+        Qt.MouseButton.LeftButton,
+        pos=item_pos,
+    )
+    qtbot.waitUntil(lambda: QApplication.focusWidget() is not None)
+    pyautogui.press('delete')
+    qtbot.wait(100)
+    pyautogui.press(confirm_key)
+    qtbot.wait(100)
+
+    # ensure the dialog is still open
+    assert pref.isVisible()
+
+    # verify that the keybind is changed
+    shortcut = shortcut_widget._table.item(
+        0, shortcut_widget._shortcut_col
+    ).text()
+    assert shortcut == ''

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -256,7 +256,7 @@ def test_keybinding_with_only_modifiers(
 )
 @pytest.mark.parametrize(
     'confirm_key',
-    [Qt.Key.Key_Enter, Qt.Key.Key_Return, Qt.Key.Key_CapsLock],
+    [Qt.Key.Key_Enter, Qt.Key.Key_Return, Qt.Key.Key_Tab, Qt.Key.Key_CapsLock],
 )
 def test_remove_shortcut(
     shortcut_editor_widget, qtbot, removal_trigger_key, confirm_key

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -254,7 +254,13 @@ def test_keybinding_with_only_modifiers(
         Qt.Key.Key_Backspace,
     ],
 )
-def test_remove_shortcut(shortcut_editor_widget, qtbot, removal_trigger_key):
+@pytest.mark.parametrize(
+    'confirm_key',
+    [Qt.Key.Key_Enter, Qt.Key.Key_Return, Qt.Key.Key_CapsLock],
+)
+def test_remove_shortcut(
+    shortcut_editor_widget, qtbot, removal_trigger_key, confirm_key
+):
     widget = shortcut_editor_widget()
     shortcut = widget._table.item(0, widget._shortcut_col).text()
     assert shortcut == KEY_SYMBOLS['Ctrl']
@@ -268,7 +274,7 @@ def test_remove_shortcut(shortcut_editor_widget, qtbot, removal_trigger_key):
     qtbot.waitUntil(lambda: widget._table.focusWidget() is not None)
     editor = widget._table.focusWidget()
     qtbot.keyClick(editor, removal_trigger_key)
-    qtbot.keyClick(editor, Qt.Key.Key_Enter)
+    qtbot.keyClick(editor, confirm_key)
     widget._table.commitData(editor)
     widget._table.closeEditor(editor, QAbstractItemDelegate.NoHint)
 

--- a/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
+++ b/napari/_qt/widgets/_tests/test_shortcut_editor_widget.py
@@ -256,7 +256,7 @@ def test_keybinding_with_only_modifiers(
 )
 @pytest.mark.parametrize(
     'confirm_key',
-    [Qt.Key.Key_Enter, Qt.Key.Key_Return, Qt.Key.Key_Tab, Qt.Key.Key_CapsLock],
+    [Qt.Key.Key_Enter, Qt.Key.Key_Return, Qt.Key.Key_Tab],
 )
 def test_remove_shortcut(
     shortcut_editor_widget, qtbot, removal_trigger_key, confirm_key

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -728,7 +728,8 @@ class EditorWidget(QLineEdit):
         }:
             # Do not allow user to set these keys as shortcut.
             # Use them as a save trigger for modifier only shortcuts.
-            self.clearFocus()
+            if event_key == Qt.Key.Key_CapsLock:
+                self.clearFocus()
             return
 
         # Translate key value to key string.

--- a/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/napari/_qt/widgets/qt_keyboard_settings.py
@@ -723,13 +723,10 @@ class EditorWidget(QLineEdit):
         if event_key in {
             Qt.Key.Key_Return,
             Qt.Key.Key_Tab,
-            Qt.Key.Key_CapsLock,
             Qt.Key.Key_Enter,
         }:
             # Do not allow user to set these keys as shortcut.
             # Use them as a save trigger for modifier only shortcuts.
-            if event_key == Qt.Key.Key_CapsLock:
-                self.clearFocus()
             return
 
         # Translate key value to key string.


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7412

# Description

As noted in the issue, Return, Enter, Tab already exit a LineEdit.
Meanwhile, the `clearFocus` was dropping focus on the dialog `OK` button and activating it, because by default when focus is placed using Return/Enter it will activate the button.
In this PR, only Capslock will trigger `clearFocus` because it doesn't do that, keeping the existing (albeit strange) behavior for that key.
