### PR TITLE
[bugfix] implement proper world to data normal transformation

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1690,6 +1690,46 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         vector_data_ndisplay /= np.linalg.norm(vector_data_ndisplay)
         return vector_data_ndisplay
 
+    def _world_to_displayed_data_normal(
+        self, vector_world: npt.ArrayLike, dims_displayed: list[int]
+    ) -> np.ndarray:
+        """Convert a normal vector defining an orientation from world coordinates to data coordinates.
+
+        Parameters
+        ----------
+        vector_world : tuple, list, 1D array
+            A vector in world coordinates.
+
+        Returns
+        -------
+        np.ndarray
+            Transformed normal vector (unit vector) in data coordinates.
+
+        Notes
+        -----
+        This method is adapted from napari-threedee under BSD-3-Clause License.
+        For more information see also:
+        https://www.scratchapixel.com/lessons/mathematics-physics-for-computer-graphics/geometry/transforming-normals.html
+        """
+        unit_vector = np.asarray(vector_world) / np.linalg.norm(vector_world)
+
+        # the napari transform is from layer -> world.
+        # We want the inverse of the world ->  layer, so we just take the napari transform
+        inverse_transform = self._transforms[1:].simplified.linear_matrix
+        transpose_inverse_transform = inverse_transform.T
+
+        # transform the vector
+        transformed_vector = np.matmul(
+            transpose_inverse_transform, unit_vector
+        )
+
+        transformed_vector_displayed = transformed_vector[dims_displayed]
+        transformed_vector_displayed /= np.linalg.norm(
+            transformed_vector_displayed
+        )
+
+        return transformed_vector_displayed
+
     def _world_to_layer_dims(
         self, *, world_dims: npt.NDArray, ndim_world: int
     ) -> np.ndarray:

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -61,7 +61,7 @@ def orient_plane_normal_along_view_direction(
         event: Union[None, Event] = None,
     ) -> None:
         """Plane normal syncronisation mouse callback."""
-        layer.plane.normal = layer._world_to_displayed_data_ray(
+        layer.plane.normal = layer._world_to_displayed_data_normal(
             viewer.camera.view_direction, [-3, -2, -1]
         )
 
@@ -82,7 +82,7 @@ def orient_plane_normal_along_view_direction_no_gen(layer: Image) -> None:
     viewer = napari.viewer.current_viewer()
     if viewer is None or viewer.dims.ndisplay != 3:
         return
-    layer.plane.normal = layer._world_to_displayed_data_ray(
+    layer.plane.normal = layer._world_to_displayed_data_normal(
         viewer.camera.view_direction, [-3, -2, -1]
     )
 

--- a/napari/layers/utils/interactivity_utils.py
+++ b/napari/layers/utils/interactivity_utils.py
@@ -149,7 +149,7 @@ def orient_plane_normal_around_cursor(
         layer.plane.position = intersection
 
     # update plane normal
-    layer.plane.normal = layer._world_to_displayed_data_ray(
+    layer.plane.normal = layer._world_to_displayed_data_normal(
         np.asarray(plane_normal), dims_displayed=layer._slice_input.displayed
     )
 


### PR DESCRIPTION
# References and relevant issues
Closes #7008 

# Description
This implements a world to data transformation for normals, which is needed by the render plane implementation.
It's an adaptation of code from napari-threedee to nD by extracting a submatrix from the layer transform matrix and using that. The OP of #7008 has extra details. 
