### PR TITLE
Update `to_screenshot` and `export_figure` example docstrings

### DIFF
--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -2,9 +2,11 @@
 Export Figure
 =============
 
-Display one shapes layer ontop of one image layer using the ``add_shapes`` and
-``add_image`` APIs. When the window is closed it will print the coordinates of
-your shapes.
+Display a variety of layer types in the napari viewer and export the figure with `viewer.export_figure()`.
+The exported figure is then added back as an image layer.
+
+Exported figures include the extent of all data in 2D view, and does not presently work for 3D views.
+To capture the extent of the canvas, instead of the layers, see `viewer.screenshot()`: `examples/to_screenshot.py` and `examples/screenshot_and_export_figure.py`.
 
 .. tags:: visualization-advanced
 """

--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -6,7 +6,7 @@ Display a variety of layer types in the napari viewer and export the figure with
 The exported figure is then added back as an image layer.
 
 Exported figures include the extent of all data in 2D view, and does not presently work for 3D views.
-To capture the extent of the canvas, instead of the layers, see `viewer.screenshot()`: `examples/to_screenshot.py` and `examples/screenshot_and_export_figure.py`.
+To capture the extent of the canvas, instead of the layers, see `viewer.screenshot()`: :ref:`sphx_glr_gallery_to_screenshot.py` and :ref:`sphx_glr_gallery_screenshot_and_export_figure.py`.
 
 .. tags:: visualization-advanced
 """

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -2,9 +2,14 @@
 To screenshot
 =============
 
-Display one shapes layer ontop of one image layer using the ``add_shapes`` and
-``add_image`` APIs. When the window is closed it will print the coordinates of
-your shapes.
+Display a variety of layer types in the napari viewer and take a screenshot of the viewer canvas with `viewer.screenshot()`.
+The screenshot is then added back as an image layer.
+
+Screenshots include all visible layers, bounded by the extent of the canvas, and is functional for 2D and 3D views.
+To capture the extent of all data in 2D view, see `viewer.export_figure()`: `examples/export_figure.py` and `examples/screenshot_and_export_figure.py`.
+
+This example code demonstrates screenshot shortcuts that do not include the viewer (e.g. `File` -> `Copy Screenshot to Clipboard`).
+To include the napari viewer in the screenshot, use `viewer.screenshot(canvas_only=False)` or e.g. `File` -> `Copy Screenshot with Viewer to Clipboard`).
 
 .. tags:: visualization-advanced
 """

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -6,7 +6,7 @@ Display a variety of layer types in the napari viewer and take a screenshot of t
 The screenshot is then added back as an image layer.
 
 Screenshots include all visible layers, bounded by the extent of the canvas, and is functional for 2D and 3D views.
-To capture the extent of all data in 2D view, see `viewer.export_figure()`: `examples/export_figure.py` and `examples/screenshot_and_export_figure.py`.
+To capture the extent of all data in 2D view, see `viewer.export_figure()`: :ref:`sphx_glr_gallery_export_figure.py` and :ref:`sphx_glr_gallery_screenshot_and_export_figure.py`.
 
 This example code demonstrates screenshot shortcuts that do not include the viewer (e.g. `File` -> `Copy Screenshot to Clipboard`).
 To include the napari viewer in the screenshot, use `viewer.screenshot(canvas_only=False)` or e.g. `File` -> `Copy Screenshot with Viewer to Clipboard`).


### PR DESCRIPTION
# References and relevant issues
Closes #7405 

# Description

Updates docstrings for `screenshot` and `export_figure` examples to be descriptive. Replaces previous incorrect (perhaps placeholder) text. 