### PR TITLE
Turn off 'flash' in `screenshot`/`export_figure` examples

### DIFF
--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -99,8 +99,8 @@ viewer.scale_bar.length = 250
 # are not in the exported figure.
 viewer.theme = "light"
 # Optionally for saving the exported figure: viewer.export_figure(path="export_figure.png")
-export_figure = viewer.export_figure()
-scaled_export_figure = viewer.export_figure(scale_factor=5)
+export_figure = viewer.export_figure(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
+scaled_export_figure = viewer.export_figure(scale_factor=5, flash=False)
 viewer.theme = "dark"
 
 viewer.add_image(export_figure, rgb=True, name='exported_figure')

--- a/examples/screenshot_and_export_figure.py
+++ b/examples/screenshot_and_export_figure.py
@@ -59,8 +59,8 @@ viewer.scale_bar.box = True
 # Take screenshots and export figures in 'light' theme, to show the canvas
 # margins and the extent of the exported figure.
 viewer.theme = 'light'
-screenshot = viewer.screenshot()
-figure = viewer.export_figure()
+screenshot = viewer.screenshot(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
+figure = viewer.export_figure(flash=False)
 # optionally, save the exported figure: viewer.export_figure(path='export_figure.png')
 # or screenshot: viewer.screenshot(path='screenshot.png')
 
@@ -68,15 +68,15 @@ figure = viewer.export_figure()
 # Zoom in and take another screenshot and export figure to show the different
 # extents of the exported figure and screenshot.
 viewer.camera.zoom = 3
-screenshot_zoomed = viewer.screenshot()
-figure_zoomed = viewer.export_figure()
+screenshot_zoomed = viewer.screenshot(flash=False)
+figure_zoomed = viewer.export_figure(flash=False)
 
 
 # Remove the layer that exists outside the image extent and take another
 # figure export to show the extent of the exported figure without the
 # layer that exists outside the camera image extent.
 viewer.layers.remove(layer_outside)
-figure_no_outside_shape = viewer.export_figure()
+figure_no_outside_shape = viewer.export_figure(flash=False)
 
 
 # Display the screenshots and figures in 'dark' theme, and switch to grid mode

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -121,7 +121,7 @@ pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 layer = viewer.add_vectors(pos, edge_width=2)
 
 # take screenshot
-screenshot = viewer.screenshot()
+screenshot = viewer.screenshot(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
 viewer.add_image(screenshot, rgb=True, name='screenshot')
 
 # from skimage.io import imsave


### PR DESCRIPTION
# References and relevant issues

Addresses / Closes? #7425 

# Description

Examples using `screenshot` and `figure_export` were found to have a grayscale canvas in the docs. The grayscale appears to be from the `flash=True` argument, so this PR sets `flash=False` to fix the display of the viewer for the Gallery. The canvas will now properly be color. 

This does not fix the root cause of the grayscale canvas as a result of `flash=True`.

Tested with a local docs build (finally!)

Thank you @psobolewskiPhD for assistance.
