### PR TITLE
[tests] add tests for Layer._world_to_displayed_data_normal

### DIFF
--- a/napari/layers/base/_tests/test_base.py
+++ b/napari/layers/base/_tests/test_base.py
@@ -115,3 +115,33 @@ def test_non_visible_mode():
     assert layer.mode == 'pan_zoom'
     layer.visible = True
     assert layer.mode == 'transform'
+
+
+def test_world_to_displayed_data_normal_3D():
+    layer = SampleLayer(np.empty((10, 10, 10)))
+    layer.scale = (1, 3, 2)
+
+    normal_vector = [0, 1, 1]
+
+    expected_transformed_vector = [0, 3 * (13**0.5) / 13, 2 * (13**0.5) / 13]
+
+    transformed_vector = layer._world_to_displayed_data_normal(
+        normal_vector, dims_displayed=[0, 1, 2]
+    )
+
+    assert np.allclose(transformed_vector, expected_transformed_vector)
+
+
+def test_world_to_displayed_data_normal_4D():
+    layer = SampleLayer(np.empty((10, 10, 10, 10)))
+    layer.scale = (1, 3, 2, 1)
+
+    normal_vector = [0, 1, 1]
+
+    expected_transformed_vector = [0, 3 * (13**0.5) / 13, 2 * (13**0.5) / 13]
+
+    transformed_vector = layer._world_to_displayed_data_normal(
+        normal_vector, dims_displayed=[0, 1, 2]
+    )
+
+    assert np.allclose(transformed_vector, expected_transformed_vector)


### PR DESCRIPTION
# References and relevant issues
Closes : https://github.com/napari/napari/issues/7434

# Description
Juan merged https://github.com/napari/napari/pull/7422 while I was working on it!
This PR adds a simple 3D and 4D test of layers with non-uniform scale (transform) and computing the normal using displayed dims. These tests failed before #7422 (using ray not normal transform) but should pass now with the new method.
