### PR TITLE
Remove lucyleeow from qt/ codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # submodules
 napari/_vispy/      @brisvag @melonora
-napari/_qt/         @Czaki @lucyleeow @DragaDoncila @psobolewskiPhD
+napari/_qt/         @Czaki @DragaDoncila @psobolewskiPhD
 napari/_app_model/  @lucyleeow @DragaDoncila
 napari/benchmarks/  @Czaki @jni
 napari/plugins/     @Czaki @DragaDoncila @lucyleeow


### PR DESCRIPTION
# Description
I think it was too optimistic to add myself to `qt/`. Happy to be pinged
on app-model/action related Qt stuff though.