### PR TITLE
Extend reading with plugins to allow Layer objects

### DIFF
--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -50,6 +50,27 @@ def test_add_layers_with_plugins_full_layers(layer_data_and_types):
             assert v.layers[0].source.reader_plugin == 'testimpl'
 
 
+def test_add_layers_with_plugins_layer_mix(layer_data_and_types):
+    """Test add_layers_with_plugins handles mixed Layer and LayerDataTuple."""
+    layers, _, layer_types, layer_fnames = layer_data_and_types
+    for layer, layer_type, layer_fname in zip(
+        layers, layer_types, layer_fnames
+    ):
+        layer_tuple = (layer.data, {}, layer_type)
+        with patch(
+            'napari.plugins.io.read_data_with_plugins',
+            # return one instantiated layer and one layer tuple
+            MagicMock(return_value=([layer, layer_tuple], _testimpl)),
+        ):
+            v = ViewerModel()
+            v._add_layers_with_plugins([layer_fname], stack=False)
+            # both were added
+            assert len(v.layers) == 2
+            for lyr in v.layers:
+                assert lyr.source.path == layer_fname
+                assert lyr.source.reader_plugin == 'testimpl'
+
+
 @patch(
     'napari.plugins.io.read_data_with_plugins',
     MagicMock(return_value=([], _testimpl)),

--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -35,40 +35,34 @@ def test_add_layers_with_plugins(layer_datum):
         assert all(lay.source == expected_source for lay in v.layers)
 
 
-def test_add_layers_with_plugins_full_layers(layer_data_and_types):
+def test_add_layers_with_plugins_full_layers(layer):
     """Test that add_layers_with_plugins works for full Layer objects."""
-    layers, _, _, layer_fnames = layer_data_and_types
-    for layer, layer_fname in zip(layers, layer_fnames):
-        with patch(
-            'napari.plugins.io.read_data_with_plugins',
-            MagicMock(return_value=([layer], _testimpl)),
-        ):
-            v = ViewerModel()
-            v._add_layers_with_plugins([layer_fname], stack=False)
-            assert len(v.layers) == 1
-            assert v.layers[0].source.path == layer_fname
-            assert v.layers[0].source.reader_plugin == 'testimpl'
-
-
-def test_add_layers_with_plugins_layer_mix(layer_data_and_types):
-    """Test add_layers_with_plugins handles mixed Layer and LayerDataTuple."""
-    layers, _, layer_types, layer_fnames = layer_data_and_types
-    for layer, layer_type, layer_fname in zip(
-        layers, layer_types, layer_fnames
+    with patch(
+        'napari.plugins.io.read_data_with_plugins',
+        MagicMock(return_value=([layer], _testimpl)),
     ):
-        layer_tuple = (layer.data, {}, layer_type)
-        with patch(
-            'napari.plugins.io.read_data_with_plugins',
-            # return one instantiated layer and one layer tuple
-            MagicMock(return_value=([layer, layer_tuple], _testimpl)),
-        ):
-            v = ViewerModel()
-            v._add_layers_with_plugins([layer_fname], stack=False)
-            # both were added
-            assert len(v.layers) == 2
-            for lyr in v.layers:
-                assert lyr.source.path == layer_fname
-                assert lyr.source.reader_plugin == 'testimpl'
+        v = ViewerModel()
+        v._add_layers_with_plugins(['mock_path'], stack=False)
+        assert len(v.layers) == 1
+        assert v.layers[0].source.path == 'mock_path'
+        assert v.layers[0].source.reader_plugin == 'testimpl'
+
+
+def test_add_layers_with_plugins_layer_mix(layer):
+    """Test add_layers_with_plugins handles mixed Layer and LayerDataTuple."""
+    layer_tuple = layer.as_layer_data_tuple()
+    with patch(
+        'napari.plugins.io.read_data_with_plugins',
+        # return one instantiated layer and one layer tuple
+        MagicMock(return_value=([layer, layer_tuple], _testimpl)),
+    ):
+        v = ViewerModel()
+        v._add_layers_with_plugins(['mock_path'], stack=False)
+        # both were added
+        assert len(v.layers) == 2
+        for lyr in v.layers:
+            assert lyr.source.path == 'mock_path'
+            assert lyr.source.reader_plugin == 'testimpl'
 
 
 @patch(

--- a/napari/components/_tests/test_add_layers.py
+++ b/napari/components/_tests/test_add_layers.py
@@ -35,6 +35,21 @@ def test_add_layers_with_plugins(layer_datum):
         assert all(lay.source == expected_source for lay in v.layers)
 
 
+def test_add_layers_with_plugins_full_layers(layer_data_and_types):
+    """Test that add_layers_with_plugins works for full Layer objects."""
+    layers, _, _, layer_fnames = layer_data_and_types
+    for layer, layer_fname in zip(layers, layer_fnames):
+        with patch(
+            'napari.plugins.io.read_data_with_plugins',
+            MagicMock(return_value=([layer], _testimpl)),
+        ):
+            v = ViewerModel()
+            v._add_layers_with_plugins([layer_fname], stack=False)
+            assert len(v.layers) == 1
+            assert v.layers[0].source.path == layer_fname
+            assert v.layers[0].source.reader_plugin == 'testimpl'
+
+
 @patch(
     'napari.plugins.io.read_data_with_plugins',
     MagicMock(return_value=([], _testimpl)),

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1450,11 +1450,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             basename, _ext = os.path.splitext(os.path.basename(filename))
             # actually add the layer
             if isinstance(data, Layer):
-                if (
-                    data.source.path is None
-                    and data.source.reader_plugin is None
-                ):
-                    data._source = Source(path=filename, reader_plugin=plugin)
+                data._set_source(Source(path=filename, reader_plugin=plugin))
                 lyr = self.add_layer(data)
                 current_added = [lyr]
             else:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -4,7 +4,7 @@ import inspect
 import itertools
 import os
 import warnings
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
 from functools import lru_cache
 from pathlib import Path
 from typing import (
@@ -1581,10 +1581,10 @@ def _normalize_layer_data(data: LayerData) -> FullLayerData:
 
     _data = list(data)
     if len(_data) > 1:
-        if not isinstance(_data[1], dict):
+        if not isinstance(_data[1], MutableMapping):
             raise ValueError(
                 trans._(
-                    'The second item in a LayerData tuple must be a dict',
+                    'The second item in a LayerData tuple must be a dict or other MutableMapping.',
                     deferred=True,
                 )
             )

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1450,12 +1450,12 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             basename, _ext = os.path.splitext(os.path.basename(filename))
             # actually add the layer
             if isinstance(data, Layer):
-                lyr = self.add_layer(data)
                 if (
-                    lyr.source.path is None
-                    and lyr.source.reader_plugin is None
+                    data.source.path is None
+                    and data.source.reader_plugin is None
                 ):
-                    lyr.source = Source(path=filename, reader_plugin=plugin)
+                    data.source = Source(path=filename, reader_plugin=plugin)
+                lyr = self.add_layer(data)
                 current_added = [lyr]
             else:
                 _data = _unify_data_and_user_kwargs(

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1454,7 +1454,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                     data.source.path is None
                     and data.source.reader_plugin is None
                 ):
-                    data.source = Source(path=filename, reader_plugin=plugin)
+                    data._source = Source(path=filename, reader_plugin=plugin)
                 lyr = self.add_layer(data)
                 current_added = [lyr]
             else:

--- a/napari/layers/_tests/test_source.py
+++ b/napari/layers/_tests/test_source.py
@@ -13,6 +13,17 @@ def test_layer_source():
     assert points.source == Source(path='some_path', reader_plugin='napari')
 
 
+def test_cant_overwrite_source():
+    """Test that we can't overwrite the source of a layer."""
+    with layer_source(path='some_path', reader_plugin='napari'):
+        points = Points()
+    assert points.source == Source(path='some_path', reader_plugin='napari')
+    with pytest.raises(ValueError, match='Tried to set source on layer'):
+        points._set_source(
+            Source(path='other_path', reader_plugin='other_plugin')
+        )
+
+
 def test_source_context():
     """Test nested contexts, overrides, and resets."""
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -678,6 +678,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     def source(self) -> Source:
         return self._source
 
+    @source.setter
+    def source(self, source: Source) -> None:
+        self._source = source
+
     @property
     def loaded(self) -> bool:
         """True if this layer is fully loaded in memory, False otherwise.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -679,7 +679,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         return self._source
 
     @source.setter
-    def source(self, source: Source) -> None:
+    def _source(self, source: Source) -> None:
         self._source = source
 
     @property

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -678,8 +678,20 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     def source(self) -> Source:
         return self._source
 
-    @source.setter
-    def _source(self, source: Source) -> None:
+    def _set_source(self, source: Source) -> None:
+        if any(
+            getattr(self._source, attr)
+            for attr in [
+                'path',
+                'reader_plugin',
+                'sample',
+                'widget',
+                'parent',
+            ]
+        ):
+            raise ValueError(
+                f'Tried to set source on layer {self.name} when source is already set to {self._source}'
+            )
         self._source = source
 
     @property


### PR DESCRIPTION
# References and relevant issues
Addresses issue reported in this [zulip comment](https://napari.zulipchat.com/#narrow/channel/309872-plugins/topic/Reader.20plugin.20with.20connected.20event/near/485161161)

# Description
Extends `add_layers_with_plugins` to handle instantiated `Layer` objects returned from `reader` plugins, not just `LayerDataTuple`s. 

This allows plugin developers to instantiate layers and connect callbacks to them (if desired) before returning from the reader.

Note: this plugin sets the source on the returned `Layer` if and only if the plugin developer has left both `path` and `reader_plugin` of the Layer's source blank. We may want to **always** override the source of the layer, if we judge this is likely to lead to better UI. In order to set the source of an already created layer, I had to add a `source` setter, which is currently public. We may want to guard it, so that users/plugin developers can't override a `Layer'`s source and it's entirely within our control?


