### PR TITLE
Activate "Save selected layer" when viewer only contains one layer.

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_file.py
+++ b/napari/_qt/_qapp_model/qactions/_file.py
@@ -203,7 +203,7 @@ Q_FILE_ACTIONS: list[Action] = [
         callback=_save_selected_layers,
         menus=[{'id': MenuId.MENUBAR_FILE, 'group': MenuGroup.SAVE}],
         keybindings=[StandardKeyBinding.Save],
-        enablement=(LLSCK.num_selected_layers > 0),
+        enablement=(LLCK.num_layers == 1 or LLSCK.num_selected_layers > 0),
     ),
     Action(
         id='napari.window.file.save_layers_dialog',

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -747,6 +747,8 @@ class QtViewer(QSplitter):
         msg = ''
         if not len(self.viewer.layers):
             msg = trans._('There are no layers in the viewer to save')
+        elif len(self.viewer.layers) == 1:
+            self.viewer.layers.selection.active = self.viewer.layers[0]
         elif selected and not len(self.viewer.layers.selection):
             msg = trans._(
                 'Please select one or more layers to save,'


### PR DESCRIPTION
# References and relevant issues
Partially addresses #7387

# Description
This PR activates the "Save selected layer(s)" action in the menu and via keybinding when only a single layer is present in the viewer, even if that layer is not selected.

Note that currently we actually select the layer before opening the dialog. I kinda like it because it makes the selection more explicit, but happy to turn that off.

If we want to grey out the menu item but keep the keybinding, that's going to be significantly more effort. 


