### PR TITLE
Fix highlighting artifacts when selecting multiple shapes

### DIFF
--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1077,7 +1077,12 @@ class ShapeList:
         shapes_list = [self.shapes[i] for i in indices]
         offsets = np.vstack([s._edge_offsets for s in shapes_list])
         centers = np.vstack([s._edge_vertices for s in shapes_list])
-        triangles = np.vstack([s._edge_triangles for s in shapes_list])
+        vert_count = np.cumsum(
+            [0] + [len(s._edge_vertices) for s in shapes_list]
+        )
+        triangles = np.vstack(
+            [s._edge_triangles + c for s, c in zip(shapes_list, vert_count)]
+        )
 
         return centers, offsets, triangles
 

--- a/napari/layers/shapes/_tests/test_shape_list.py
+++ b/napari/layers/shapes/_tests/test_shape_list.py
@@ -110,6 +110,18 @@ def test_shape_list_outline():
         assert np.array_equal(value_by_idx, value_by_idx_np)
 
 
+def test_shape_list_outline_two_shapes():
+    shape1 = Polygon([[0, 0], [0, 10], [10, 10], [10, 0]])
+    shape2 = Polygon([[20, 20], [20, 30], [30, 30], [30, 20]])
+    shape_list = ShapeList()
+    shape_list.add([shape1, shape2])
+
+    # check if the outline contains triangle with vertex of number 16
+
+    triangles = shape_list.outline([0, 1])[2]
+    assert np.any(triangles == 16)
+
+
 def test_nD_shapes():
     """Test adding shapes to ShapeList."""
     np.random.seed(0)


### PR DESCRIPTION
# References and relevant issues

closes #7244

# Description

This PR fixes highlighting by updating triangle indices when stacking all shape triangles together.

Fixes the bug first introduced in #7223