### PR TITLE
Fix selection of nD-sliced shapes

### DIFF
--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -255,6 +255,7 @@ class ShapeList:
         slice_key = list(slice_key)
         if not np.array_equal(self._slice_key, slice_key):
             self._slice_key = slice_key
+            self._clear_cache()
             self._update_displayed()
 
     def _update_displayed(self) -> None:
@@ -1106,8 +1107,19 @@ class ShapeList:
         return shapes
 
     @cached_property
+    def _visible_shapes(self):
+        slice_key = self.slice_key
+        return [
+            (i, s)
+            for i, s in enumerate(self.shapes)
+            if s.slice_key[0] <= slice_key <= s.slice_key[1]
+        ]
+
+    @cached_property
     def _bounding_boxes(self):
-        data = np.array([s.bounding_box for s in self.shapes])
+        data = np.array([s[1].bounding_box for s in self._visible_shapes])
+        if data.size == 0:
+            return np.empty((0, self.ndisplay)), np.empty((0, self.ndisplay))
         return data[:, 0], data[:, 1]
 
     def inside(self, coord):
@@ -1136,17 +1148,24 @@ class ShapeList:
         if inside_indices.size == 0:
             return None
         try:
-            z_index = [self.shapes[i].z_index for i in inside_indices]
+            z_index = [
+                self._visible_shapes[i][1].z_index for i in inside_indices
+            ]
             pos = np.argsort(z_index)
-            return next(
-                inside_indices[p]
-                for p in pos[::-1]
-                if np.any(
-                    inside_triangles(
-                        self.shapes[inside_indices[p]]._all_triangles() - coord
+            return self._visible_shapes[
+                next(
+                    inside_indices[p]
+                    for p in pos[::-1]
+                    if np.any(
+                        inside_triangles(
+                            self._visible_shapes[inside_indices[p]][
+                                1
+                            ]._all_triangles()
+                            - coord
+                        )
                     )
                 )
-            )
+            ][0]
         except StopIteration:
             return None
 
@@ -1363,3 +1382,4 @@ class ShapeList:
 
     def _clear_cache(self):
         self.__dict__.pop('_bounding_boxes', None)
+        self.__dict__.pop('_visible_shapes', None)

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1109,11 +1109,13 @@ class ShapeList:
     @cached_property
     def _visible_shapes(self):
         slice_key = self.slice_key
-        return [
-            (i, s)
-            for i, s in enumerate(self.shapes)
-            if s.slice_key[0] <= slice_key <= s.slice_key[1]
-        ]
+        if len(slice_key):
+            return [
+                (i, s)
+                for i, s in enumerate(self.shapes)
+                if s.slice_key[0] <= slice_key <= s.slice_key[1]
+            ]
+        return list(enumerate(self.shapes))
 
     @cached_property
     def _bounding_boxes(self):

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -129,7 +128,7 @@ class Shape(ABC):
     ) -> None:
         self._dims_order = dims_order or list(range(2))
         self._ndisplay = ndisplay
-        self.slice_key: Optional[npt.NDArray] = None
+        self.slice_key: npt.NDArray
 
         self._face_vertices = np.empty((0, self.ndisplay))
         self._face_triangles = np.empty((0, 3), dtype=np.uint32)

--- a/napari/layers/shapes/_tests/test_shape_list.py
+++ b/napari/layers/shapes/_tests/test_shape_list.py
@@ -150,3 +150,14 @@ def test_bad_color_array(attribute):
     bad_color_array = np.array([[0, 0, 0, 1], [1, 1, 1, 1]])
     with pytest.raises(ValueError, match='must have shape'):
         setattr(shape_list, f'{attribute}_color', bad_color_array)
+
+
+def test_inside():
+    shape1 = Polygon(np.array([[0, 0, 0], [0, 1, 0], [0, 1, 1], [0, 0, 1]]))
+    shape2 = Polygon(np.array([[1, 0, 0], [1, 1, 0], [1, 1, 1], [1, 0, 1]]))
+    shape3 = Polygon(np.array([[2, 0, 0], [2, 1, 0], [2, 1, 1], [2, 0, 1]]))
+
+    shape_list = ShapeList()
+    shape_list.add([shape1, shape2, shape3])
+    shape_list.slice_key = (1,)
+    assert shape_list.inside((0.5, 0.5)) == 1


### PR DESCRIPTION
# References and relevant issues

closes #7458  

# Description

This PR closes bug with selecting shapes only from current slice, introduced in #7144.

The source of the bug is not filtering out-of-slice shapes when searching for intersecting triangles.