### PR TITLE
Elide layer name in the middle instead of the end

### DIFF
--- a/napari/_qt/containers/_layer_delegate.py
+++ b/napari/_qt/containers/_layer_delegate.py
@@ -94,7 +94,7 @@ class LayerDelegate(QStyledItemDelegate):
     ):
         """Paint the item in the model at `index`."""
         # update the icon based on layer type
-
+        option.textElideMode = Qt.TextElideMode.ElideMiddle
         self.get_layer_icon(option, index)
         # paint the standard itemView (includes name, icon, and vis. checkbox)
         super().paint(painter, option, index)


### PR DESCRIPTION
# References and relevant issues

closes #7460

# Description

Layer names can often be long, and the distinguishing characteristic is as often at the end of the layer name as at the start. When a layer name is too long to display, we should therefore put the ellipsis in the middle of the layer name, rather than at the end.