### PR TITLE
Add an image to the get_current_viewer example

### DIFF
--- a/examples/get_current_viewer.py
+++ b/examples/get_current_viewer.py
@@ -9,6 +9,7 @@ viewer when the viewer is out of scope.
 
 .. tags:: gui
 """
+import numpy as np
 
 import napari
 
@@ -20,3 +21,14 @@ viewer = 'oops no viewer here'
 
 # get that reference again
 viewer = napari.current_viewer()
+
+# work with the viewer
+x = np.arange(256)
+y = np.arange(256).reshape((256, 1))
+# from: https://botsin.space/@bitartbot/113553754823363986
+image = (-(~((y - x) ^ (y + x)))) % 11
+layer = viewer.add_image(image)
+layer.contrast_limits = (8.5, 10)
+
+if __name__ == '__main__':
+    napari.run()


### PR DESCRIPTION
I'll admit that this was inspiration first, motivation second 😂 — I saw this [toot](https://botsin.space/@bitartbot/113553754823363986) from the bitart bot and I found the pattern really impressive, so I thought we could replace an np.random image in our gallery. But, most are gone, it turns out! So I looked for examples that have an empty viewer, and came upon this one, which I thought wasn't that great anyway because it didn't demonstrate that the call had actually succeeded. By adding an image after getting the viewer reference back, this "proves" that the current_viewer call worked. And it's pretty! 😊 

<img width="1896" alt="Screenshot 2024-12-22 at 7 50 15 pm" src="https://github.com/user-attachments/assets/f2011bff-1ed3-45ee-bd4c-d4205741164d" />
