### PR TITLE
Improving the Fourier transforms gallery example

### DIFF
--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -99,7 +99,6 @@ def update_viewer():
     # keep track of each wave in a dictionary by id, this way we can modify/remove
     # existing waves or add new ones
     wave_args = {}
-    new_params = None
     while True:
         sleep(1 / FPS)
         # see https://napari.org/stable/guides/threading.html#full-two-way-communication

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
     napari.run()
 else:
     # for the gallery, sleep to make sure that the images are captured
-    import time
+    from time import time
     time.sleep(5)
 
 thread.quit()

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -144,6 +144,7 @@ def moving_wave(
 viewer.window.add_dock_widget(moving_wave, area='bottom')
 moving_wave()
 
-napari.run()
+if __name__ == '__main__':
+    napari.run()
 
 thread.quit()

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -148,6 +148,6 @@ if __name__ == '__main__':
 else:
     # for the gallery, sleep to make sure that the images are captured
     import time
-    time.sleep(1)
+    time.sleep(5)
 
 thread.quit()

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -13,7 +13,7 @@ by the changes. Threading is used to smoothly animate the waves.
 from time import sleep, time
 
 import numpy as np
-from magicgui import magic_factory
+from magicgui import magicgui
 from scipy.fft import fft2, fftshift
 
 import napari
@@ -116,7 +116,7 @@ def update_viewer():
 thread = update_viewer()
 
 
-@magic_factory(
+@magicgui(
     auto_call=True,
     frequency={'widget_type': 'FloatSlider', 'min': 0, 'max': 1, 'step': 0.01},
     angle={'widget_type': 'Slider', 'min': 0, 'max': 180},
@@ -140,11 +140,9 @@ def moving_wave(
         thread.send((wave_id, frequency, angle, phase_shift, speed))
 
 
-wdg = moving_wave()
-
 # add the widget to the window and run it once
-viewer.window.add_dock_widget(wdg, area='bottom')
-wdg()
+viewer.window.add_dock_widget(moving_wave, area='bottom')
+moving_wave()
 
 napari.run()
 

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -145,5 +145,9 @@ moving_wave()
 
 if __name__ == '__main__':
     napari.run()
+else:
+    # for the gallery, sleep to make sure that the images are captured
+    import time
+    time.sleep(1)
 
 thread.quit()

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
     napari.run()
 else:
     # for the gallery, sleep to make sure that the images are captured
-    import time
-    time.sleep(5)
+    from time import sleep
+    sleep(5)
 
 thread.quit()

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
     napari.run()
 else:
     # for the gallery, sleep to make sure that the images are captured
-    from time import time
+    import time
     time.sleep(5)
 
 thread.quit()


### PR DESCRIPTION
While looking at the gallery for #7462, I noticed that there's no image at all for @brisvag's amazing Fourier transform playground, which is a tragedy cos it's so friggin cool! So I had a look and made an in-passing improvement but would like to use this PR to make a few more.

- [x] replace magic_factory use with magicgui — it's more appropriate here and makes the code easier to read.
- [x] should napari.run() be under an `if __name__ == '__main__'` clause? (@lucyleeow @melissawm I don't actually understand the gallery embedding process...)
- [ ] the gallery screenshot shows an empty viewer even though the example calls the widget once. I think this is because the processing happens in a separate thread and hasn't had time to execute. Can we add some sort of wait/callback to make sure that the functions have updated at least once?
- [ ] I think we should add at least one more interesting wave so you can immediately see the grid and layer interactions (see example screenshot below). It makes the code a bit more complicated but the image *way* more interesting...
- [ ] I'm thinking of a new gallery tag — "teaching" "learning" "teaching_and_learning", ...? Any suggestions? (The triangulation example I would move from dev and use that tag, too.)

<img width="1896" alt="Screenshot 2024-12-22 at 8 29 30 pm" src="https://github.com/user-attachments/assets/a199cb6c-9011-4a2d-94f8-aec27eb85d51" />
