### PR TITLE
[bugfix] use mean instead of norm for fixed aspect scaling in transform mode

### DIFF
--- a/napari/layers/base/_base_mouse_bindings.py
+++ b/napari/layers/base/_base_mouse_bindings.py
@@ -137,7 +137,6 @@ def _scale_with_box(
         initial_handle_coords_data[nearby_handle] - scaling_center
     )
     center_to_mouse = initial_world_to_data(mouse_pos) - scaling_center
-
     # get per-dimension scale values
     with warnings.catch_warnings():
         # a "divide by zero" warning is raised here when resizing along only one axis
@@ -149,7 +148,7 @@ def _scale_with_box(
         scale = np.nan_to_num(scale, posinf=1, neginf=1)
 
     if locked_aspect_ratio:
-        scale_factor = np.linalg.norm(scale)
+        scale_factor = np.mean(scale)
         scale = [scale_factor, scale_factor]
 
     new_affine = (

--- a/napari/layers/base/_tests/test_mouse_bindings.py
+++ b/napari/layers/base/_tests/test_mouse_bindings.py
@@ -3,8 +3,10 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 
+from napari.layers.base._base_constants import InteractionBoxHandle
 from napari.layers.base._base_mouse_bindings import (
     _rotate_with_box,
+    _scale_with_box,
     _translate_with_box,
 )
 from napari.utils.transforms import Affine
@@ -105,3 +107,46 @@ def test_interaction_box_fixed_rotation(dims_displayed):
     )
     # should be 45 degrees
     assert np.allclose(layer.affine.rotate, Affine(rotate=45).rotate)
+
+
+@pytest.mark.parametrize('dims_displayed', [[0, 1], [1, 2]])
+def test_interaction_box_scale(dims_displayed):
+    layer = Mock(affine=Affine())
+    layer._slice_input.displayed = [0, 1]
+    initial_handle_coords_data = np.asarray(
+        [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [3, 3],
+            [4, 4],
+            [5, 5],
+            [6, 6],
+            [7, 7],
+            [6, 3],
+        ],
+        dtype=np.float32,
+    )
+    initial_affine = Affine()
+    initial_world_to_data = Affine()
+    initial_data2physical = Affine()
+    nearby_handle = InteractionBoxHandle.TOP_LEFT
+    initial_center = np.asarray([3, 3], dtype=np.float32)
+    mouse_pos = np.asarray([0, 0], dtype=np.float32)
+    event = Mock(dims_displayed=dims_displayed, modifiers=['Shift'])
+    _scale_with_box(
+        layer,
+        initial_affine,
+        initial_world_to_data,
+        initial_data2physical,
+        nearby_handle,
+        initial_center,
+        initial_handle_coords_data,
+        mouse_pos,
+        event,
+    )
+    # when clicking on handle, scale should be 1
+    assert np.array_equal(
+        layer.affine.scale,
+        Affine(scale=np.asarray([1, 1], dtype=np.float32)).scale,
+    )

--- a/napari/layers/base/_tests/test_mouse_bindings.py
+++ b/napari/layers/base/_tests/test_mouse_bindings.py
@@ -110,7 +110,7 @@ def test_interaction_box_fixed_rotation(dims_displayed):
 
 
 @pytest.mark.parametrize('dims_displayed', [[0, 1], [1, 2]])
-def test_interaction_box_scale(dims_displayed):
+def test_interaction_box_scale_with_fixed_aspect(dims_displayed):
     layer = Mock(affine=Affine())
     layer._slice_input.displayed = [0, 1]
     initial_handle_coords_data = np.asarray(
@@ -146,7 +146,7 @@ def test_interaction_box_scale(dims_displayed):
         event,
     )
     # when clicking on handle, scale should be 1
-    assert np.array_equal(
+    assert np.allclose(
         layer.affine.scale,
         Affine(scale=np.asarray([1, 1], dtype=np.float32)).scale,
     )


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7453

# Description
On live, when scaling a layer with fixed aspect, the code does :
`scale_factor = np.linalg.norm(scale)`
This is the magnitude of a vector, so when the user grabs the handle and scale is (1, 1), or close to it, this will return sqrt(2), which is incorrect.
In this PR instead I use np.mean, which feels pretty natural when pulling a handle diagonally or more up or more to the side.
I also add a test that fails on main, but passes with this fix.