### PR TITLE
Fix typo observable in Preferences -> Appearance

### DIFF
--- a/napari/settings/_appearance.py
+++ b/napari/settings/_appearance.py
@@ -56,7 +56,7 @@ class AppearanceSettings(EventedModel):
         True,
         title=trans._('Update status based on layer'),
         description=trans._(
-            'Calculate status bar based on current active layer and mose position.'
+            'Calculate status bar based on current active layer and mouse position.'
         ),
     )
 


### PR DESCRIPTION
# References and relevant issues

Typo

# Description

`mose` -> `mouse`

Please let me know if this is too silly of a PR... or if noting these sorts of things is helpful. 
