### PR TITLE
Set pytest configuration file for test run using pip

### DIFF
--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -50,8 +50,8 @@ jobs:
         uses: aganders3/headless-gui@v2
         with:
           run: |
-            python -m pytest --pyargs napari --color=yes --basetemp=.pytest_tmp
-            python -m pytest --pyargs napari_builtins --color=yes --basetemp=.pytest_tmp
+            python -m pytest --pyargs napari --color=yes --basetemp=.pytest_tmp --config-file=napari-from-github/pyproject.toml
+            python -m pytest --pyargs napari_builtins --color=yes --basetemp=.pytest_tmp --config-file=napari-from-github/pyproject.toml
 
       - name: Upload test artifacts
         if: failure()


### PR DESCRIPTION
# Description

When opening the log for pip tests, we could see a bunch of warnings like:  

<img width="1002" alt="Screenshot 2024-12-29 at 17 33 51" src="https://github.com/user-attachments/assets/60d8ad8d-49c2-4923-8ada-fd9fe3cb5a5e" />

This PR set explicitly config file (as pytest looks for config files in the current directory and its parents).
