### PR TITLE
TracksFilter head_length property bug

### DIFF
--- a/napari/_vispy/filters/tracks.py
+++ b/napari/_vispy/filters/tracks.py
@@ -138,7 +138,7 @@ class TracksFilter(Filter):
 
     @property
     def head_length(self) -> float:
-        return self._tail_length
+        return self._head_length
 
     @head_length.setter
     def head_length(self, head_length: float):


### PR DESCRIPTION
# References and relevant issues
I couldn't find an issue for this; it's a silly bug I created myself 3 years ago when adding `head_length` to tracks'

# Description

`TracksFilter.head_length` property returns `_tail_length`
