### PR TITLE
Change default flash behavior for `viewer` screenshot-like methods (GUI functionality remains the same)

### DIFF
--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -109,8 +109,5 @@ viewer.add_image(export_figure, rgb=True, name='exported_figure')
 viewer.add_image(scaled_export_figure, rgb=True, name='scaled_exported_figure')
 viewer.reset_view()
 
-# from skimage.io import imsave
-# imsave('screenshot.png', screenshot)
-
 if __name__ == '__main__':
     napari.run()

--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -101,8 +101,8 @@ viewer.scale_bar.length = 250
 # are not in the exported figure.
 viewer.theme = "light"
 # Optionally for saving the exported figure: viewer.export_figure(path="export_figure.png")
-export_figure = viewer.export_figure(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
-scaled_export_figure = viewer.export_figure(scale_factor=5, flash=False)
+export_figure = viewer.export_figure()
+scaled_export_figure = viewer.export_figure(scale_factor=5)
 viewer.theme = "dark"
 
 viewer.add_image(export_figure, rgb=True, name='exported_figure')

--- a/examples/screenshot_and_export_figure.py
+++ b/examples/screenshot_and_export_figure.py
@@ -59,8 +59,8 @@ viewer.scale_bar.box = True
 # Take screenshots and export figures in 'light' theme, to show the canvas
 # margins and the extent of the exported figure.
 viewer.theme = 'light'
-screenshot = viewer.screenshot(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
-figure = viewer.export_figure(flash=False)
+screenshot = viewer.screenshot()
+figure = viewer.export_figure()
 # optionally, save the exported figure: viewer.export_figure(path='export_figure.png')
 # or screenshot: viewer.screenshot(path='screenshot.png')
 
@@ -68,15 +68,15 @@ figure = viewer.export_figure(flash=False)
 # Zoom in and take another screenshot and export figure to show the different
 # extents of the exported figure and screenshot.
 viewer.camera.zoom = 3
-screenshot_zoomed = viewer.screenshot(flash=False)
-figure_zoomed = viewer.export_figure(flash=False)
+screenshot_zoomed = viewer.screenshot()
+figure_zoomed = viewer.export_figure()
 
 
 # Remove the layer that exists outside the image extent and take another
 # figure export to show the extent of the exported figure without the
 # layer that exists outside the camera image extent.
 viewer.layers.remove(layer_outside)
-figure_no_outside_shape = viewer.export_figure(flash=False)
+figure_no_outside_shape = viewer.export_figure()
 
 
 # Display the screenshots and figures in 'dark' theme, and switch to grid mode

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -127,10 +127,8 @@ layer = viewer.add_vectors(pos, edge_width=2)
 
 # take screenshot
 screenshot = viewer.screenshot()
+# optionally for saving the exported screenshot: viewer.screenshot(path="screenshot.png")
 viewer.add_image(screenshot, rgb=True, name='screenshot')
-
-# from skimage.io import imsave
-# imsave('screenshot.png', screenshot)
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/to_screenshot.py
+++ b/examples/to_screenshot.py
@@ -126,7 +126,7 @@ pos[:, 1, 1] = 2 * radius_space * np.sin(phi_space)
 layer = viewer.add_vectors(pos, edge_width=2)
 
 # take screenshot
-screenshot = viewer.screenshot(flash=False) # bug: default flash=True causes the canvas to be grayscale in docs
+screenshot = viewer.screenshot()
 viewer.add_image(screenshot, rgb=True, name='screenshot')
 
 # from skimage.io import imsave

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -174,18 +174,30 @@ def test_screenshot(make_napari_viewer, qtbot):
     viewer.add_shapes(data)
 
     # Take screenshot of the image canvas only
-    screenshot = viewer.screenshot(canvas_only=True, flash=False)
+    # Test that flash animation does not occur
+    screenshot = viewer.screenshot(canvas_only=True)
+    assert not hasattr(
+        viewer.window._qt_viewer._welcome_widget, '_flash_animation'
+    )
     assert screenshot.ndim == 3
 
     # Take screenshot with the viewer included
-    screenshot = viewer.screenshot(canvas_only=False, flash=False)
+    screenshot = viewer.screenshot(canvas_only=False)
     assert screenshot.ndim == 3
 
     # test size argument (and ensure it coerces to int)
     screenshot = viewer.screenshot(canvas_only=True, size=(20, 20.0))
     assert screenshot.shape == (20, 20, 4)
-    # Here we wait until the flash animation will be over. We cannot wait on finished
-    # signal as _flash_animation may be already removed when calling wait.
+
+    # test flash animation works
+    screenshot = viewer.screenshot(canvas_only=True, flash=True)
+    assert hasattr(
+        viewer.window._qt_viewer._welcome_widget, '_flash_animation'
+    )
+
+    # Here we wait until the flash animation will be over for teardown.
+    # We cannot wait on finished signal as _flash_animation may be already
+    # removed when calling wait.
     qtbot.waitUntil(
         lambda: not hasattr(
             viewer.window._qt_viewer._welcome_widget, '_flash_animation'

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -95,7 +95,7 @@ class Viewer(ViewerModel):
         path: Optional[str] = None,
         *,
         scale_factor: float = 1,
-        flash: bool = True,
+        flash: bool = False,
     ) -> np.ndarray:
         """Export an image of the full extent of the displayed layer data.
 
@@ -129,7 +129,7 @@ class Viewer(ViewerModel):
             each layer.
         flash : bool
             Flag to indicate whether flash animation should be shown after
-            the screenshot was captured. By default, True.
+            the screenshot was captured. By default, False.
 
         Returns
         -------
@@ -150,7 +150,7 @@ class Viewer(ViewerModel):
         size: Optional[tuple[str, str]] = None,
         scale: Optional[float] = None,
         canvas_only: bool = True,
-        flash: bool = True,
+        flash: bool = False,
     ):
         """Take currently displayed screen and convert to an image array.
 
@@ -171,7 +171,7 @@ class Viewer(ViewerModel):
         flash : bool
             Flag to indicate whether flash animation should be shown after
             the screenshot was captured.
-            By default, True.
+            By default, False.
 
         Returns
         -------


### PR DESCRIPTION
# References and relevant issues

- Addresses one task in #7433, by changing defualt flash behavior in `viewer` methods. This was discussed in #7427.
- Effectively reverts changes in #7427, because they are no longer required to prevent issues brought up in #7425

# Description

- Changes default from `flash=True` to `flash=False` in `viewer.screenshot()` and `viewer.export_figure()` methods. 
- Adds test to assert that `viewer.screenshot()` does not flash by default, and that flashing argument does trigger successfully. This appears to work, but the '_flash_animation' attribute is only temporary. Is there a test environment where this theoretically wouldn't work? The flash animation appears to be slow (i.e. probably the root of the problem in #7425). 
- Maintains current GUI functionality because non-`viewer` methods are used. Flash animation continues when triggered via GUI methods and shortcuts
- Reverts `flash=False` additions in #7427 in relevant examples because it is no longer required with this change. 

This PR changes the default flash animation behavior for `viewer` screenshot-like methods because this is the presented way for users to take screenshots via scripting. By changing flash animation to default, this PR prevents naively triggering rapid flashing from scripting or a plugin that uses `viewer` methods to save a view of the viewer/canvas. This is a somewhat opinionated change (because a user could already access and change this argument), but 1) increases accessibility for naive users by not triggering a flash and 2) scripting explicitly calls the viewer methods, so users do not need the flash animation for feedback [where, in the GUI, this is helpful, and remains].

This PR does not change the default flash behavior in `qt_viewer.py:QtViewer` and `qt_main_window.py:Window` because `viewer` methods are built on top. Should these other methods be changed? They look to be public API in one sense (i.e. `viewer.window.export_figure`) but also considered private API according to the architecture since they are in `_qt/`. If these other methods are changed, then `_qt/_qapp_model/_file.py` would also need updated for Action callbacks. 

ps. Despite this being a small PR, it took me a while to navigate and tease apart these systems, so I'm grateful to have learned more about the bones of napari! If anyone cares to answer, why are there these 'layers' to the framework? It could be structured differently so that there would not be so much repetitive code across different files, and non-'identical' methods to call the same functionality. What is the advantage of this layer of the API? Does it make certain things possible that otherwise wouldn't be?


