### PR TITLE
[--pre] Update constraints to allow pyOpenGL 3.1.7, but block 3.1.9a1

### DIFF
--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -350,7 +350,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10_docs.txt
+++ b/resources/constraints/constraints_py3.10_docs.txt
@@ -441,7 +441,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.10_pydantic_1.txt
@@ -347,7 +347,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.10_windows.txt
+++ b/resources/constraints/constraints_py3.10_windows.txt
@@ -321,7 +321,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -343,7 +343,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11_docs.txt
+++ b/resources/constraints/constraints_py3.11_docs.txt
@@ -429,7 +429,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r resources/constraints/version_denylist.txt
     #   napari (pyproject.toml)

--- a/resources/constraints/constraints_py3.11_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.11_pydantic_1.txt
@@ -340,7 +340,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.11_windows.txt
+++ b/resources/constraints/constraints_py3.11_windows.txt
@@ -314,7 +314,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -340,7 +340,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.12_pydantic_1.txt
@@ -337,7 +337,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.12_windows.txt
+++ b/resources/constraints/constraints_py3.12_windows.txt
@@ -311,7 +311,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9.txt
+++ b/resources/constraints/constraints_py3.9.txt
@@ -354,7 +354,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_examples.txt
+++ b/resources/constraints/constraints_py3.9_examples.txt
@@ -373,7 +373,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_pydantic_1.txt
+++ b/resources/constraints/constraints_py3.9_pydantic_1.txt
@@ -351,7 +351,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/constraints_py3.9_windows.txt
+++ b/resources/constraints/constraints_py3.9_windows.txt
@@ -325,7 +325,7 @@ pygments==2.18.0
     #   superqt
 pymsgbox==1.0.9
     # via pyautogui
-pyopengl==3.1.6
+pyopengl==3.1.7
     # via
     #   -r napari_repo/resources/constraints/version_denylist.txt
     #   napari (napari_repo/pyproject.toml)

--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -2,7 +2,6 @@ pytest-cov
 PySide6 < 6.3.2 ; python_version < '3.10'
 PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.12'
 pytest-json-report
-pyopengl!=3.1.7
 tensorstore!=0.1.38
 ipykernel!=7.0.0a0
 wrapt!=1.17.0 # problem with macOS intel

--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -1,3 +1,4 @@
+pyopengl!=3.1.9a1
 pytest-cov
 PySide6 < 6.3.2 ; python_version < '3.10'
 PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.12'


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7376

# Description
--pre tests are failing due to import issue of OpenGL.GL in the latest alpha
This PR blocks that alpha.
I opened an upstream issue: https://github.com/mcfletch/pyopengl/issues/133

Additionally, I un-deny version 3.1.7
It's not clear why it was denied--it's not blocked in pyproject.toml, so I've been using it locally.
All tests pass in my fork:
https://github.com/psobolewskiPhD/napari/actions/runs/12572981536/job/35045688821?pr=55


