### PR TITLE
[py313] Update test_prereleases.yml to add py313

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
           BACKEND: ${{ matrix.backend }}
+          PYTHON: ${{ matrix.python }}
           COVERAGE: "no_cov"
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           PIP_CONSTRAINT: resources/constraints/version_denylist.txt

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python: [3.12]
+        python: [3.12, 3.13]
         backend: [pyqt5, pyqt6]
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@
 # "tox -e py38-macos-pyqt" will test python3.8 with pyqt on macos
 # (even if a combination of factors is not in the default envlist
 # you can run it manually... like py39-linux-pyside2)
-envlist = py{39,310,311,312}-{linux,macos,windows}-{pyqt5,pyside2,pyqt6,pyside6,headless}-{cov,no_cov},mypy
+envlist = py{39,310,311,312,313}-{linux,macos,windows}-{pyqt5,pyside2,pyqt6,pyside6,headless}-{cov,no_cov},mypy
 isolated_build = true
 toxworkdir={env:TOX_WORK_DIR:/tmp/.tox}
 
@@ -25,6 +25,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.12: py313
 fail_on_no_env = True
 
 # This section turns environment variables from github actions

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
-    3.12: py313
+    3.13: py313
 fail_on_no_env = True
 
 # This section turns environment variables from github actions


### PR DESCRIPTION
# References and relevant issues
Prompted by: https://github.com/napari/napari/pull/7479

# Description
This PR adds python 3.13 to our --pre tests.
At present, this branch will fail until the following PR are merged:
- affecting all --pre: 
https://github.com/napari/napari/pull/7480
- affecting all py313: 
https://github.com/napari/napari/pull/7479
- affecting Win/py313: 
https://github.com/napari/napari/pull/7482

You can see all tests pass with the above 3 required changes in my fork:
https://github.com/psobolewskiPhD/napari/actions/runs/12574076907/job/35047736273

- We also have an unrelated zarr 3rc1 fail, which will be fixed by:
https://github.com/napari/napari/pull/7489