### PR TITLE
[py313] Update plugins/test_utils.py to account for Windows py313 os.path.isabs change

### DIFF
--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -110,26 +110,49 @@ def test_score_specificity_simple():
 
 
 def test_score_specificity_complex():
-    assert score_specificity('*/my-specific-folder/[nested]/*?.tif') == (
-        True,
-        -3,
-        [
-            MatchFlag.STAR,
-            MatchFlag.NONE,
-            MatchFlag.SET,
-            MatchFlag.STAR | MatchFlag.ANY,
-        ],
-    )
-
-    assert score_specificity('/my-specific-folder/[nested]/*?.tif') == (
-        False,
-        -2,
-        [
-            MatchFlag.NONE,
-            MatchFlag.SET,
-            MatchFlag.STAR | MatchFlag.ANY,
-        ],
-    )
+    # account for py313 change in https://github.com/python/cpython/pull/113829
+    if sys.platform.startswith('win') and sys.version_info >= (3, 13):
+        assert score_specificity(r'*\my-specific-folder\[nested]\*?.tif') == (
+                True,
+                -3,
+                [
+                    MatchFlag.STAR,
+                    MatchFlag.NONE,
+                    MatchFlag.SET,
+                    MatchFlag.STAR | MatchFlag.ANY,
+                ],
+            )
+        
+            assert score_specificity(r'\\my-specific-folder\[nested]\*?.tif') == (
+                False,
+                -2,
+                [
+                    MatchFlag.NONE,
+                    MatchFlag.SET,
+                    MatchFlag.STAR | MatchFlag.ANY,
+                ],
+            )
+    else:
+        assert score_specificity('*/my-specific-folder/[nested]/*?.tif') == (
+            True,
+            -3,
+            [
+                MatchFlag.STAR,
+                MatchFlag.NONE,
+                MatchFlag.SET,
+                MatchFlag.STAR | MatchFlag.ANY,
+            ],
+        )
+    
+        assert score_specificity('/my-specific-folder/[nested]/*?.tif') == (
+            False,
+            -2,
+            [
+                MatchFlag.NONE,
+                MatchFlag.SET,
+                MatchFlag.STAR | MatchFlag.ANY,
+            ],
+        )
 
 
 def test_score_specificity_collapse_star():
@@ -149,7 +172,11 @@ def test_score_specificity_collapse_star():
         -1,
         [MatchFlag.STAR, MatchFlag.STAR],
     )
-    assert score_specificity('/abc*/*.tif') == (False, 0, [MatchFlag.STAR])
+    # account for py313 change in https://github.com/python/cpython/pull/113829
+    if sys.platform.startswith('win') and sys.version_info >= (3, 13):
+        assert score_specificity(r'\\abc*\*.tif') == (False, 0, [MatchFlag.STAR])
+    else:
+        assert score_specificity('/abc*/*.tif') == (False, 0, [MatchFlag.STAR])
 
 
 def test_score_specificity_range():

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -114,16 +114,16 @@ def test_score_specificity_complex():
     # account for py313 change in https://github.com/python/cpython/pull/113829
     if sys.platform.startswith('win') and sys.version_info >= (3, 13):
         assert score_specificity(r'*\my-specific-folder\[nested]\*?.tif') == (
-                True,
-                -3,
-                [
-                    MatchFlag.STAR,
-                    MatchFlag.NONE,
-                    MatchFlag.SET,
-                    MatchFlag.STAR | MatchFlag.ANY,
-                ],
-            )
-        
+            True,
+            -3,
+            [
+                MatchFlag.STAR,
+                MatchFlag.NONE,
+                MatchFlag.SET,
+                MatchFlag.STAR | MatchFlag.ANY,
+            ],
+        )
+
         assert score_specificity(r'\\my-specific-folder\[nested]\*?.tif') == (
             False,
             -2,
@@ -144,7 +144,7 @@ def test_score_specificity_complex():
                 MatchFlag.STAR | MatchFlag.ANY,
             ],
         )
-    
+
         assert score_specificity('/my-specific-folder/[nested]/*?.tif') == (
             False,
             -2,
@@ -175,7 +175,11 @@ def test_score_specificity_collapse_star():
     )
     # account for py313 change in https://github.com/python/cpython/pull/113829
     if sys.platform.startswith('win') and sys.version_info >= (3, 13):
-        assert score_specificity(r'\\abc*\*.tif') == (False, 0, [MatchFlag.STAR])
+        assert score_specificity(r'\\abc*\*.tif') == (
+            False,
+            0,
+            [MatchFlag.STAR],
+        )
     else:
         assert score_specificity('/abc*/*.tif') == (False, 0, [MatchFlag.STAR])
 

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -1,4 +1,5 @@
 import os.path
+import sys
 
 from npe2 import DynamicPlugin
 
@@ -123,15 +124,15 @@ def test_score_specificity_complex():
                 ],
             )
         
-            assert score_specificity(r'\\my-specific-folder\[nested]\*?.tif') == (
-                False,
-                -2,
-                [
-                    MatchFlag.NONE,
-                    MatchFlag.SET,
-                    MatchFlag.STAR | MatchFlag.ANY,
-                ],
-            )
+        assert score_specificity(r'\\my-specific-folder\[nested]\*?.tif') == (
+            False,
+            -2,
+            [
+                MatchFlag.NONE,
+                MatchFlag.SET,
+                MatchFlag.STAR | MatchFlag.ANY,
+            ],
+        )
     else:
         assert score_specificity('*/my-specific-folder/[nested]/*?.tif') == (
             True,

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -113,47 +113,31 @@ def test_score_specificity_simple():
 def test_score_specificity_complex():
     # account for py313 change in https://github.com/python/cpython/pull/113829
     if sys.platform.startswith('win') and sys.version_info >= (3, 13):
-        assert score_specificity(r'*\my-specific-folder\[nested]\*?.tif') == (
-            True,
-            -3,
-            [
-                MatchFlag.STAR,
-                MatchFlag.NONE,
-                MatchFlag.SET,
-                MatchFlag.STAR | MatchFlag.ANY,
-            ],
-        )
-
-        assert score_specificity(r'\\my-specific-folder\[nested]\*?.tif') == (
-            False,
-            -2,
-            [
-                MatchFlag.NONE,
-                MatchFlag.SET,
-                MatchFlag.STAR | MatchFlag.ANY,
-            ],
-        )
+        relative_path = r'*\my-specific-folder\[nested]\*?.tif'
+        absolute_path = r'\\my-specific-folder\[nested]\*?.tif'
     else:
-        assert score_specificity('*/my-specific-folder/[nested]/*?.tif') == (
-            True,
-            -3,
-            [
-                MatchFlag.STAR,
-                MatchFlag.NONE,
-                MatchFlag.SET,
-                MatchFlag.STAR | MatchFlag.ANY,
-            ],
-        )
+        relative_path = '*/my-specific-folder/[nested]/*?.tif'
+        absolute_path = '/my-specific-folder/[nested]/*?.tif'
 
-        assert score_specificity('/my-specific-folder/[nested]/*?.tif') == (
-            False,
-            -2,
-            [
-                MatchFlag.NONE,
-                MatchFlag.SET,
-                MatchFlag.STAR | MatchFlag.ANY,
-            ],
-        )
+    assert score_specificity(relative_path) == (
+        True,
+        -3,
+        [
+            MatchFlag.STAR,
+            MatchFlag.NONE,
+            MatchFlag.SET,
+            MatchFlag.STAR | MatchFlag.ANY,
+        ],
+    )
+    assert score_specificity(absolute_path) == (
+        False,
+        -2,
+        [
+            MatchFlag.NONE,
+            MatchFlag.SET,
+            MatchFlag.STAR | MatchFlag.ANY,
+        ],
+    )
 
 
 def test_score_specificity_collapse_star():

--- a/napari/plugins/_tests/test_utils.py
+++ b/napari/plugins/_tests/test_utils.py
@@ -159,13 +159,11 @@ def test_score_specificity_collapse_star():
     )
     # account for py313 change in https://github.com/python/cpython/pull/113829
     if sys.platform.startswith('win') and sys.version_info >= (3, 13):
-        assert score_specificity(r'\\abc*\*.tif') == (
-            False,
-            0,
-            [MatchFlag.STAR],
-        )
+        absolute_path = r'\\abc*\*.tif'
     else:
-        assert score_specificity('/abc*/*.tif') == (False, 0, [MatchFlag.STAR])
+        absolute_path = '/abc*/*.tif'
+
+    assert score_specificity(absolute_path) == (False, 0, [MatchFlag.STAR])
 
 
 def test_score_specificity_range():


### PR DESCRIPTION
# References and relevant issues
Needed by: https://github.com/napari/napari/pull/7481

# Description
Python 3.13 changed how `os.path.isabs` works on Windows:
https://github.com/python/cpython/pull/113829
Specifically, it will now return False for paths like `/foo/bar` on Windows, while True on POSIX.
For True on Windows the path now needs to be `\\foo\bar`

We have 2 tests that use paths like `/foo/bar` and expect them to be considered absolute. 
In this PR, I add logic to test the proper paths on Windows using `\`.

You can see all tests pass on 3.13 with this fix in my fork: https://github.com/psobolewskiPhD/napari/actions/runs/12574076907/job/35047736273