### PR TITLE
[Maint] Update version_denylist.txt to block zarr rc1 in --pre tests

### DIFF
--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -6,4 +6,4 @@ pytest-json-report
 tensorstore!=0.1.38
 ipykernel!=7.0.0a0
 wrapt!=1.17.0 # problem with macOS intel
-zarr!=3.0.0b3,!=3.0.0b2
+zarr!=3.0.0b3,!=3.0.0b2,!=3.0.0rc1


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7484

# Description
The latest --pre fail is due to recent changes in zarr released in 3.0.0rc1:
https://github.com/zarr-developers/zarr-python/pull/2463

JNI already has an issue and PR to fix upstream, so lets just block this rc.
