### PR TITLE
Use no compression when writing zarr for tensorstore

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1149,6 +1149,7 @@ def test_fill_tensorstore(tmp_path, zarr_version, zarr_driver):
         dtype=np.uint32,
         chunks=(1, 1, 8, 9),
         zarr_version=zarr_version,
+        compressor=None,
     )
     labels_temp[:] = labels
     labels_ts_spec = {


### PR DESCRIPTION
The default compression in zarr changed to Zstd in zarr v3 and uses
compression parameters incompatible with tensorstore reading zarr v2
arrays. Using no compression circumvents the problem.

See zarr-developers/zarr-python#2647, particularly [this comment](https://github.com/zarr-developers/zarr-python/issues/2647#issuecomment-2571658195).

This PR should hopefully mean we are ready for the zarr-python v3 release.
