### PR TITLE
Specify dtype when using zarr.Group.create_array

### DIFF
--- a/napari_builtins/_tests/test_io.py
+++ b/napari_builtins/_tests/test_io.py
@@ -114,7 +114,7 @@ def test_zarr_multiscale(tmp_path):
     root = zarr.open_group(fout, mode='a')
     for i in range(len(multiscale)):
         shape = 20 // 2**i
-        z = root.create_dataset(str(i), shape=(shape,) * 2)
+        z = root.create_dataset(str(i), shape=(shape,) * 2, dtype=np.float64)
         z[:] = multiscale[i]
     multiscale_in = magic_imread([fout])
     assert len(multiscale) == len(multiscale_in)


### PR DESCRIPTION
Closes #7496

It looks like create_array used to have a default dtype in zarr-python 2.x but
now the dtype is mandatory. I'll make a corresponding issue in the zarr-python
repo but in the meantime fix the issue locally by specifying the dtype — I kind
of agree that it should be a required argument anyway.
