### PR TITLE
remove xfail from test_add_many_zarr_1d_array_is_ignored

### DIFF
--- a/napari_builtins/_tests/test_io.py
+++ b/napari_builtins/_tests/test_io.py
@@ -1,6 +1,5 @@
 import csv
 import os
-from importlib.metadata import version
 from pathlib import Path
 from typing import NamedTuple
 from uuid import uuid4
@@ -12,7 +11,6 @@ import numpy as np
 import pytest
 import tifffile
 import zarr
-from packaging.version import parse as parse_version
 
 from napari_builtins.io._read import (
     _guess_layer_type_from_column_names,
@@ -321,12 +319,6 @@ def test_add_zarr_1d_array_is_ignored(tmp_path):
     assert npe2.read([image_path], stack=False) == [(None,)]
 
 
-@pytest.mark.xfail(
-    parse_version(version('zarr')) >= parse_version('3.0.0a0')
-    and os.name == 'nt',
-    reason='zarr 3 return incorrect key in windows',
-    strict=True,
-)
 def test_add_many_zarr_1d_array_is_ignored(tmp_path):
     # For more details: https://github.com/napari/napari/issues/1471
     zarr_dir = str(tmp_path / 'data.zarr')


### PR DESCRIPTION
# References and relevant issues

closes #7499

# Description

As zarr fixed the handling path on Windows, we may remove this xfail.


