### PR TITLE
[maint] Update pyproject.toml to move plugin manager to optional and let triangle work on arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,11 +115,11 @@ qt = [
     "napari[pyqt]"
 ]
 all = [
-    "napari[pyqt,optional]",
-    "napari-plugin-manager >=0.1.3, <0.2.0",
+    "napari[pyqt,optional]"
 ]
 optional = [
-    "triangle ; platform_machine != 'arm64'",
+    "napari-plugin-manager >=0.1.3, <0.2.0",
+    "triangle",
     "PartSegCore-compiled-backend>=0.15.8",
     "numba>=0.57.1",
     "zarr>=2.12.0", # needed by `builtins` (dask.array.from_zarr) to open zarr


### PR DESCRIPTION
Currently the only way to install napari with the plugin-manager is via `all` which is `pyqt5`.
This PR moves the plugin-manager to `optional`, so that you can at least use `pip install "[pyqt6, optional]"` to get a functional napari and the plugin manager.
For those using `[all]` nothing will change, because `[all]` includes `optional`.

Alternately, it could go in the base requirements along side `napari-svg`...

While doing this, I noticed the exclusion flag of arm64 for triangle.
A recent release has wheels now for just about everything:
https://pypi.org/project/triangle/#files
so this flag can be removed.
