### PR TITLE
Bugfix: Check if Layer._loaded before returning status

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -569,7 +569,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         if not self.mouse_over_canvas:
             return None
         active = self.layers.selection.active
-        if active is not None:
+        if active is not None and active._loaded:
             status = active.get_status(
                 self.cursor.position,
                 view_direction=self.cursor._view_direction,


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7407

# Description

Ensures a layer is fully loaded before returning values/properties/etc.
This is based on the comments from Juan and Andy in the issue.

