### PR TITLE
Breakout gray and gray_r from mpl_colormaps and ensure they work with `ensure_colormap`

### DIFF
--- a/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/napari/utils/colormaps/_tests/test_colormaps.py
@@ -257,6 +257,20 @@ def test_ensure_colormap_with_recognized_hex_color_string(color):
     assert cmap.name == 'magenta'
 
 
+@pytest.mark.parametrize('color', ['white', '#FFFFFF', '#ffffff', '#ffFFffFF'])
+def test_ensure_colormap_handles_grayscale(color):
+    cmap = ensure_colormap(color)
+    assert isinstance(cmap, Colormap)
+    assert cmap.name == 'gray'
+
+
+@pytest.mark.parametrize('color', ['black', '#000000', '#000000FF'])
+def test_ensure_colormap_handles_black(color):
+    cmap = ensure_colormap(color)
+    assert isinstance(cmap, Colormap)
+    assert cmap.name == 'gray_r'
+
+
 def test_ensure_colormap_error_with_invalid_hex_color_string():
     """
     Test that ensure_colormap errors when using an invalid hex color string

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -51,8 +51,6 @@ matplotlib_colormaps = _MATPLOTLIB_COLORMAP_NAMES = OrderedDict(
     magma=trans._p('colormap', 'magma'),
     inferno=trans._p('colormap', 'inferno'),
     plasma=trans._p('colormap', 'plasma'),
-    gray=trans._p('colormap', 'gray'),
-    gray_r=trans._p('colormap', 'gray r'),
     hsv=trans._p('colormap', 'hsv'),
     turbo=trans._p('colormap', 'turbo'),
     twilight=trans._p('colormap', 'twilight'),
@@ -111,6 +109,16 @@ SIMPLE_COLORMAPS = {
     for name, (display_name, color) in _PRIMARY_COLORS.items()
 }
 
+# add conventional grayscale colormap as a simple one
+SIMPLE_COLORMAPS.update(
+    {
+        'gray': Colormap(
+            name='gray',
+            display_name='gray',
+            colors=[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        )
+    }
+)
 
 # dictionary for bop colormap objects
 BOP_COLORMAPS = {
@@ -122,6 +130,17 @@ INVERSE_COLORMAPS = {
     name: Colormap(value, name=name, display_name=display_name)
     for name, (display_name, value) in inverse_cmaps.items()
 }
+
+# Add the reversed grayscale colormap (white to black) to inverse colormaps
+INVERSE_COLORMAPS.update(
+    {
+        'gray_r': Colormap(
+            name='gray_r',
+            display_name='gray r',
+            colors=[[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]],
+        ),
+    }
+)
 
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
 _MAX_VISPY_SUPPORTED_VALUE = _FLOAT32_MAX / 8
@@ -751,6 +770,11 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
     """
     with AVAILABLE_COLORMAPS_LOCK:
         if isinstance(colormap, str):
+            # when black given as end color, want reversed grayscale colormap
+            # from white to black, named gray_r
+            if colormap == '#000000' or colormap.lower() == 'black':
+                colormap = 'gray_r'
+
             # Is a colormap with this name already available?
             custom_cmap = AVAILABLE_COLORMAPS.get(colormap)
             if custom_cmap is None:

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -772,7 +772,7 @@ def ensure_colormap(colormap: ValidColormapArg) -> Colormap:
         if isinstance(colormap, str):
             # when black given as end color, want reversed grayscale colormap
             # from white to black, named gray_r
-            if colormap == '#000000' or colormap.lower() == 'black':
+            if colormap.startswith('#000000') or colormap.lower() == 'black':
                 colormap = 'gray_r'
 
             # Is a colormap with this name already available?


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7504

# Description
This PR pulls out `gray` and `gray_r` colormaps from the matplotlib colormaps and instead adds `gray` to SIMPLE_COLORMAPS and `gray_r` to INVERSE_COLORMAPS. This way they can be recognized as napari colormaps when `black` or `white` are passed as strings or hex codes.
Additionally, I add a short-cut to `ensure_colormaps` for the case of `black`, such that it doesn't return a black->black colormap, but instead uses white->black (`gray_r`), because by default when given a single color our colormaps go from black->color.
Finally, I add tests for `black`, `#000000`, `white`, `#FFFFFF` etc. to confirm that the proper napari colormap is used.