### PR TITLE
Revert #7488 "Flip z axis on 3D camera to default to right-handed frame"

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -508,7 +508,7 @@ def test_process_mouse_event(make_napari_viewer):
 
     @labels.mouse_drag_callbacks.append
     def on_click(layer, event):
-        np.testing.assert_almost_equal(event.view_direction, [0, -1, 0, 0])
+        np.testing.assert_almost_equal(event.view_direction, [0, 1, 0, 0])
         np.testing.assert_array_equal(event.dims_displayed, [1, 2, 3])
         assert event.dims_point[0] == data.shape[0] // 2
 

--- a/napari/_tests/test_with_screenshot.py
+++ b/napari/_tests/test_with_screenshot.py
@@ -329,7 +329,7 @@ def test_grid_mode(make_napari_viewer):
 def test_changing_image_attenuation(make_napari_viewer):
     """Test changing attenuation value changes rendering."""
     data = np.zeros((100, 10, 10))
-    data[0] = 1
+    data[-1] = 1
 
     viewer = make_napari_viewer(show=True)
     viewer.dims.ndisplay = 3

--- a/napari/_vispy/_tests/test_utils.py
+++ b/napari/_vispy/_tests/test_utils.py
@@ -50,7 +50,7 @@ def test_get_view_direction_in_scene_coordinates(make_napari_viewer):
     view_dir = get_view_direction_in_scene_coordinates(
         view_box, viewer.dims.ndim, viewer.dims.displayed
     )
-    np.testing.assert_allclose(view_dir, [-1, 0, 0], atol=1e-8)
+    np.testing.assert_allclose(view_dir, [1, 0, 0], atol=1e-8)
 
 
 def test_get_view_direction_in_scene_coordinates_2d(make_napari_viewer):

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -31,9 +31,6 @@ class VispyCamera:
         # Create 3D camera
         self._3D_camera = MouseToggledArcballCamera(fov=0)
         self._3D_camera.viewbox_key_event = viewbox_key_event
-        # flip z-axis to ensure right-handed frame in 3D view
-        # see https://github.com/napari/napari/issues/4633
-        self._3D_camera.flip = (0, 0, 1)
 
         # Set 2D camera by default
         self._view.camera = self._2D_camera

--- a/napari/_vispy/layers/surface.py
+++ b/napari/_vispy/layers/surface.py
@@ -18,7 +18,7 @@ class VispySurfaceLayer(VispyBaseLayer):
     def __init__(self, layer) -> None:
         node = SurfaceVisual()
         self._texture_filter = None
-        self._light_direction = (1, 1, 1)
+        self._light_direction = (-1, 1, 1)
         self._meshdata = None
         super().__init__(layer, node)
 
@@ -200,7 +200,7 @@ class VispySurfaceLayer(VispyBaseLayer):
             up = np.array(camera.up_direction)[::-1]
             view = np.array(camera.view_direction)[::-1]
             # combine to get light behind the camera on the top right
-            self._light_direction = up - view - np.cross(up, view)
+            self._light_direction = view - up + np.cross(up, view)
         if (
             self.node.shading_filter is not None
             and self._meshdata._vertices is not None

--- a/napari/components/_tests/test_camera.py
+++ b/napari/components/_tests/test_camera.py
@@ -55,12 +55,7 @@ def test_calculate_up_direction_3d():
 
     # more complex case with order dependent Euler angles
     camera = Camera(center=(0, 0, 0), angles=(10, 20, 30), zoom=1)
-    assert np.allclose(camera.up_direction, (-0.88, -0.44, 0.16), atol=0.01)
-
-
-def _normalize_angle(degrees):
-    """Normalize angle to be in (-180, 180]."""
-    return -((180 - np.asarray(degrees)) % 360) + 180
+    assert np.allclose(camera.up_direction, (0.88, -0.44, 0.16), atol=0.01)
 
 
 def test_set_view_direction_3d():
@@ -69,16 +64,14 @@ def test_set_view_direction_3d():
     camera = Camera(center=(0, 0, 0), angles=(0, 0, 0), zoom=1)
     camera.set_view_direction(view_direction=(1, 0, 0))
     assert np.allclose(camera.view_direction, (1, 0, 0))
-    assert np.allclose(_normalize_angle(camera.angles), (180, 0, -90))
+    assert np.allclose(camera.angles, (0, 0, 90))
 
     # case with ordering and up direction setting
     view_direction = np.array([1, 2, 3], dtype=float)
     view_direction /= np.linalg.norm(view_direction)
     camera.set_view_direction(view_direction=view_direction)
     assert np.allclose(camera.view_direction, view_direction)
-    assert np.allclose(
-        _normalize_angle(camera.angles), (121.9, -53.3, -26.6), atol=0.1
-    )
+    assert np.allclose(camera.angles, (58.1, -53.3, 26.6), atol=0.1)
 
 
 def test_calculate_view_direction_nd():

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -64,9 +64,7 @@ class Camera(EventedModel):
         """
         ang = np.deg2rad(self.angles)
         view_direction = (
-            # z has a negative sign for the right-handed reference frame
-            # flip (#7488)
-            -np.sin(ang[2]) * np.cos(ang[1]),
+            np.sin(ang[2]) * np.cos(ang[1]),
             np.cos(ang[2]) * np.cos(ang[1]),
             -np.sin(ang[1]),
         )
@@ -84,9 +82,7 @@ class Camera(EventedModel):
             seq='yzx', angles=self.angles, degrees=True
         ).as_matrix()
         return (
-            # z has a negative sign for the right-handed reference frame
-            # flip (#7488)
-            -rotation_matrix[2, 2],
+            rotation_matrix[2, 2],
             rotation_matrix[1, 2],
             rotation_matrix[0, 2],
         )
@@ -127,22 +123,14 @@ class Camera(EventedModel):
             0,
         )
         if view_direction_along_y_axis and up_direction_along_y_axis:
-            up_direction = (1, 0, 0)  # align up direction along z axis
+            up_direction = (-1, 0, 0)  # align up direction along z axis
 
-        # xyz ordering for vispy
-        view_vector = np.array(view_direction, dtype=float, copy=True)[::-1]
-        # flip z axis for right-handed frame
-        view_vector *= [1, 1, -1]
-        # normalise vector for rotation matrix
+        # xyz ordering for vispy, normalise vectors for rotation matrix
+        view_vector = np.asarray(view_direction, dtype=float)[::-1]
         view_vector /= np.linalg.norm(view_vector)
 
-        # xyz ordering for vispy
-        up_vector = np.array(up_direction, dtype=float, copy=True)[::-1]
-        # flip z axis for right-handed frame
-        up_vector *= [1, 1, -1]
-        # ??? why a cross product here?
+        up_vector = np.asarray(up_direction, dtype=float)[::-1]
         up_vector = np.cross(view_vector, up_vector)
-        # normalise vector for rotation matrix
         up_vector /= np.linalg.norm(up_vector)
 
         # explicit check for parallel view direction and up direction


### PR DESCRIPTION
This reverts commit ca4ca5179db3d4cd68904ec84e03091641a8482b.

In the core devs chat, we discussed making a few major compatibility
changes to the release after 0.5.6 and calling it 0.6.0. #7488 fits
better in that release, so this PR temporarily reverts it so we can
release 0.5.6, then we can re-add it after release.
