### PR TITLE
[Enhancement] Modify attenuation slider aspect: attenuation value is displayed

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -169,9 +169,10 @@ class QtImageControls(QtBaseImageControls):
         sld = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)
         sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(0)
-        sld.setMaximum(100)
-        sld.setSingleStep(1)
-        sld.setValue(int(self.layer.attenuation * 200))
+        sld.setMaximum(0.5)
+        sld.setSingleStep(0.001)
+        sld.setValue(self.layer.attenuation)
+        sld.setDecimals(3)
         sld.valueChanged.connect(self.changeAttenuation)
         self.attenuationSlider = sld
         self.attenuationLabel = QLabel(trans._('attenuation:'))
@@ -289,12 +290,12 @@ class QtImageControls(QtBaseImageControls):
             Attenuation rate for attenuated maximum intensity projection.
         """
         with self.layer.events.blocker(self._on_attenuation_change):
-            self.layer.attenuation = value / 200
+            self.layer.attenuation = value
 
     def _on_attenuation_change(self):
         """Receive layer model attenuation change event and update the slider."""
         with self.layer.events.attenuation.blocker():
-            self.attenuationSlider.setValue(int(self.layer.attenuation * 200))
+            self.attenuationSlider.setValue(self.layer.attenuation)
 
     def _on_interpolation_change(self, event):
         """Receive layer interpolation change event and update dropdown menu.

--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -6,7 +6,6 @@ from qtpy.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QPushButton,
-    QSlider,
     QWidget,
 )
 from superqt import QLabeledDoubleSlider
@@ -167,7 +166,7 @@ class QtImageControls(QtBaseImageControls):
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel(trans._('iso threshold:'))
 
-        sld = QSlider(Qt.Orientation.Horizontal, parent=self)
+        sld = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)
         sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(100)

--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -166,7 +166,7 @@ class QtImageControls(QtBaseImageControls):
         self.isoThresholdSlider = sld
         self.isoThresholdLabel = QLabel(trans._('iso threshold:'))
 
-        sld = QDoubleSlider(Qt.Orientation.Horizontal, parent=self)
+        sld = QLabeledDoubleSlider(Qt.Orientation.Horizontal, parent=self)
         sld.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         sld.setMinimum(0)
         sld.setMaximum(0.5)


### PR DESCRIPTION
# References and relevant issues
Issue #7521 

# Description
- The attenuation value is now displayed beside the slider
- Before PR, the real attenuation was multiplied by 200 so that the range of the slider (invisible) value was 0-100
- The multiplication factor is now removed, so that the displayed value reflects the real value - the range of the slider value is now 0-0.5
- Before PR, the number of decimals was 2, which is the default value
- The number of decimals is now set to 3, so that it allows precise control, with step 0.001

<img width="269" alt="image" src="https://github.com/user-attachments/assets/12b6554a-3f21-4940-8608-457f02096c53" />
