### PR TITLE
Fix missed cache invalidation in transform shape

### DIFF
--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -410,7 +410,7 @@ class Shape(ABC):
             self._data[:, self.dims_displayed] @ transform.T
         )
         self._face_vertices = self._face_vertices @ transform.T
-
+        self.__dict__.pop('data_displayed', None)  # clear cache
         points = self.data_displayed
         points = remove_path_duplicates(points, closed=self._closed)
         centers, offsets, triangles = triangulate_edge(


### PR DESCRIPTION
# References and relevant issues

close #7527

# Description

This PR add missed cache invalidation in transform of shape (used for drawing of figures). 
