### PR TITLE
Use data.dtype for creating slicer

### DIFF
--- a/napari/_app_model/context/_layerlist_context.py
+++ b/napari/_app_model/context/_layerlist_context.py
@@ -150,7 +150,7 @@ def _active_dtype(s: LayerSel) -> DTypeLike:
     dtype = None
     if s.active:
         with contextlib.suppress(AttributeError):
-            dtype = normalize_dtype(s.active.data.dtype).__name__
+            dtype = normalize_dtype(s.active.data.dtype).name
     return dtype
 
 

--- a/napari/layers/_scalar_field/scalar_field.py
+++ b/napari/layers/_scalar_field/scalar_field.py
@@ -289,6 +289,7 @@ class ScalarFieldBase(Layer, ABC):
         self._slice = _ImageSliceResponse.make_empty(
             slice_input=self._slice_input,
             rgb=len(self.data.shape) != self.ndim,
+            dtype=self.dtype,
         )
 
         self._plane = SlicingPlane(thickness=1)

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -88,6 +88,7 @@ class _ImageSliceResponse:
         slice_input: _SliceInput,
         rgb: bool,
         request_id: Optional[int] = None,
+        dtype=np.uint8,
     ) -> '_ImageSliceResponse':
         """Returns an empty image slice response.
 
@@ -108,11 +109,13 @@ class _ImageSliceResponse:
             If None, a new request id will be returned, which guarantees that
             the empty slice never appears as loaded. (Used for layer
             initialisation before attempting data loading.)
+        dtype : np.dtype
+            The dtype of the empty image slice.
         """
         shape = (1,) * slice_input.ndisplay
         if rgb:
             shape = shape + (3,)
-        data = np.zeros(shape, dtype=np.uint8)
+        data = np.zeros(shape, dtype=dtype)
         image = _ImageView.from_view(data)
         ndim = slice_input.ndim
         tile_to_data = Affine(

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -115,7 +115,10 @@ class _ImageSliceResponse:
         shape = (1,) * slice_input.ndisplay
         if rgb:
             shape = shape + (3,)
-        data = np.zeros(shape, dtype=dtype)
+        try:
+            data = np.zeros(shape, dtype=np.dtype(dtype))
+        except TypeError:
+            data = np.zeros(shape, dtype=dtype.numpy_dtype)
         image = _ImageView.from_view(data)
         ndim = slice_input.ndim
         tile_to_data = Affine(

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -311,7 +311,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         # Set contrast limits, colormaps and plane parameters
         if contrast_limits is None:
             if not isinstance(data, np.ndarray):
-                dtype = normalize_dtype(getattr(data, 'dtype', None))
+                dtype = normalize_dtype(getattr(data, 'dtype', np.float32))
                 if np.issubdtype(dtype, np.integer):
                     self.contrast_limits_range = get_dtype_limits(dtype)
                 else:

--- a/napari/utils/_dtype.py
+++ b/napari/utils/_dtype.py
@@ -77,6 +77,8 @@ def normalize_dtype(dtype_spec: 'DTypeLike') -> np.dtype:
         # Handle NumPy dtypes directly, especially big endian types.
         # FIXME: handle big endian types from tensorstore
         return dtype_spec
+    if isinstance(dtype_spec, str):
+        return np.dtype(dtype_spec)
     dtype_str = str(dtype_spec)
     if 'uint' in dtype_str:
         return _normalize_str_by_bit_depth(dtype_str, 'uint')

--- a/napari/utils/_dtype.py
+++ b/napari/utils/_dtype.py
@@ -1,33 +1,36 @@
-from typing import Union
+from typing import TYPE_CHECKING, Final, Union
 
 import numpy as np
 
-_np_uints = {
-    8: np.uint8,
-    16: np.uint16,
-    32: np.uint32,
-    64: np.uint64,
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
+
+_np_uints: Final[dict[int, np.dtype]] = {
+    8: np.dtype(np.uint8),
+    16: np.dtype(np.uint16),
+    32: np.dtype(np.uint32),
+    64: np.dtype(np.uint64),
 }
 
-_np_ints = {
-    8: np.int8,
-    16: np.int16,
-    32: np.int32,
-    64: np.int64,
+_np_ints: Final[dict[int, np.dtype]] = {
+    8: np.dtype(np.int8),
+    16: np.dtype(np.int16),
+    32: np.dtype(np.int32),
+    64: np.dtype(np.int64),
 }
 
-_np_floats = {
-    16: np.float16,
-    32: np.float32,
-    64: np.float64,
+_np_floats: Final[dict[int, np.dtype]] = {
+    16: np.dtype(np.float16),
+    32: np.dtype(np.float32),
+    64: np.dtype(np.float64),
 }
 
-_np_complex = {
-    64: np.complex64,
-    128: np.complex128,
+_np_complex: Final[dict[int, np.dtype]] = {
+    64: np.dtype(np.complex64),
+    128: np.dtype(np.complex128),
 }
 
-_np_kinds = {
+_np_kinds: Final[dict[str, dict[int, np.dtype]]] = {
     'uint': _np_uints,
     'int': _np_ints,
     'float': _np_floats,
@@ -35,9 +38,9 @@ _np_kinds = {
 }
 
 
-def _normalize_str_by_bit_depth(dtype_str, kind):
+def _normalize_str_by_bit_depth(dtype_str: str, kind: str) -> np.dtype:
     if not any(str.isdigit(c) for c in dtype_str):  # Python 'int' or 'float'
-        return np.dtype(kind).type
+        return np.dtype(kind)
     bit_dict = _np_kinds[kind]
     if '128' in dtype_str:
         return bit_dict[128]
@@ -49,10 +52,10 @@ def _normalize_str_by_bit_depth(dtype_str, kind):
         return bit_dict[32]
     if '64' in dtype_str:
         return bit_dict[64]
-    return None
+    raise ValueError(f'Unrecognized bit depth in dtype: {dtype_str}')
 
 
-def normalize_dtype(dtype_spec):
+def normalize_dtype(dtype_spec: 'DTypeLike') -> np.dtype:
     """Return a proper NumPy type given ~any duck array dtype.
 
     Parameters
@@ -70,6 +73,10 @@ def normalize_dtype(dtype_spec):
     -----
     half-precision floats are not supported.
     """
+    if isinstance(dtype_spec, np.dtype):
+        # Handle NumPy dtypes directly, especially big endian types.
+        # FIXME: handle big endian types from tensorstore
+        return dtype_spec
     dtype_str = str(dtype_spec)
     if 'uint' in dtype_str:
         return _normalize_str_by_bit_depth(dtype_str, 'uint')
@@ -80,15 +87,12 @@ def normalize_dtype(dtype_spec):
     if 'complex' in dtype_str:
         return _normalize_str_by_bit_depth(dtype_str, 'complex')
     if 'bool' in dtype_str:
-        return np.bool_
-    # If we don't find one of the named dtypes, return the dtype_spec
-    # unchanged. This allows NumPy big endian types to work. See
-    # https://github.com/napari/napari/issues/3421
+        return np.dtype(np.bool_)
 
-    return dtype_spec
+    raise ValueError(f'Unrecognized dtype: {dtype_spec}')
 
 
-def get_dtype_limits(dtype_spec) -> tuple[float, float]:
+def get_dtype_limits(dtype_spec: 'DTypeLike') -> tuple[float, float]:
     """Return machine limits for numeric types.
 
     Parameters
@@ -110,7 +114,7 @@ def get_dtype_limits(dtype_spec) -> tuple[float, float]:
         info = np.finfo(dtype)
     else:
         raise TypeError(f'Unrecognized or non-numeric dtype: {dtype_spec}')
-    return info.min, info.max
+    return float(info.min), float(info.max)
 
 
 vispy_texture_dtype = np.float32

--- a/napari/utils/_tests/test_dtype.py
+++ b/napari/utils/_tests/test_dtype.py
@@ -28,7 +28,7 @@ def test_normalize_dtype_torch(dtype_str):
     # see https://github.com/pytorch/pytorch/issues/40568
     torch_arr = torch.zeros(5, dtype=getattr(torch, dtype_str))
     np_arr = np.zeros(5, dtype=dtype_str)
-    assert normalize_dtype(torch_arr.dtype) is np_arr.dtype.type
+    assert normalize_dtype(torch_arr.dtype) == np.dtype(np_arr.dtype)
 
 
 @pytest.mark.parametrize(
@@ -37,7 +37,7 @@ def test_normalize_dtype_torch(dtype_str):
 def test_normalize_dtype_tensorstore(dtype_str):
     np_arr = np.zeros(5, dtype=dtype_str)
     ts_arr = ts.array(np_arr)  # inherit ts dtype from np dtype
-    assert normalize_dtype(ts_arr.dtype) is np_arr.dtype.type
+    assert normalize_dtype(ts_arr.dtype) is np.dtype(np_arr.dtype)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# References and relevant issues
closes #7535

# Description

When async mode is on, the async image slicer starts by creating an empty slice. Before this PR, the slice had type np.uint8. For images, this was fine, because when the real slice arrived the dtype got updated correctly. For labels, though, the incorrect dtype caused an incorrect caching of the data dtype -> texture dtype colormap assigned to the layer, which resulted in incorrect colors being displayed.

This PR ensures that the empty slice dtype matches the image dtype.