### PR TITLE
Add Image Border / Bounding Box Gallery Examples for both 2D and 3D

### DIFF
--- a/examples/image_border.py
+++ b/examples/image_border.py
@@ -1,0 +1,56 @@
+"""
+Border Overlay / Bounding Box
+=============================
+
+Display a 3D, 2 layer image in napari and add a border overlay (i.e. `bounding_box`).
+Creates two viewers to show functionality in both 2D and 3D display mode.
+
+The 2D viewer is utilized to demonstrate visualization of many border overlay properties,
+including line color, line thickness, point size, opacity.
+In addition, this viewer shows how layer overlays interact when draw on top of each other.
+Use `viewer.layers[0].bounding_box` to view all modifiable attributes of the border overlay.
+
+The 3D viewer shows default `bounding_box` properties (changing only color), use in grid mode, and extent of 3D bounding box.
+
+.. tags:: visualization-advanced, visualization-nD
+"""
+
+from skimage import data
+
+import napari
+
+# Create a napari viewer with a 3D, 2 channel image, with the `view_image` convenience function.
+viewer_2d = napari.view_image(
+    data.cells3d(), channel_axis=1, name=['membrane', 'nuclei']
+)
+viewer_2d.grid.enabled = True
+
+# Add a border overlay to each layer, and modify properties of the border overlay.
+viewer_2d.layers[0].bounding_box.visible = True
+viewer_2d.layers[0].bounding_box.line_color = 'cyan' # default: 'red'
+viewer_2d.layers[0].bounding_box.line_thickness = 5 # default: 1, max: 5
+viewer_2d.layers[0].bounding_box.point_size = 10 # default: 5
+viewer_2d.layers[0].bounding_box.point_color = 'yellow' # default: 'blue'
+
+viewer_2d.layers[1].bounding_box.visible = True
+viewer_2d.layers[1].bounding_box.line_color = 'orange'
+viewer_2d.layers[1].bounding_box.line_thickness = 2
+viewer_2d.layers[1].bounding_box.opacity = 0.8 # default: 1
+# viewer_2d.layers[1].bounding_box.blending = 'additive' # default: 'translucent'
+
+
+# An equivalent alternative to creating the 2D napari viewer, this viewer is
+# created with 3D display and the `open_sample` convenience function
+viewer_3d = napari.view_image(
+    data.cells3d(), channel_axis=1, name=['membrane', 'nuclei']
+)
+viewer_3d.grid.enabled = True
+viewer_3d.dims.ndisplay = 3
+viewer_3d.camera.angles = (5, 25, 130)
+
+viewer_3d.layers[0].bounding_box.visible = True
+viewer_3d.layers[1].bounding_box.visible = True
+viewer_3d.layers[1].bounding_box.line_color = 'cyan'
+
+if __name__ == '__main__':
+    napari.run()

--- a/examples/image_border.py
+++ b/examples/image_border.py
@@ -1,13 +1,14 @@
 """
-Layer Border Overlay
+Layer Bounding Box (Border) Overlay
 ====================
 
-Display an image in napari and add a border overlay (i.e. `bounding_box`).
+Display an image in napari and add a bounding box overlay (a border) at the edges of the layer.
 
-Demonstrates visualization of many border overlay properties,
+The bounding box overlay is a visual representation of the extents of a layer.
+This example demonstrates visualization of many bounding box overlay properties,
 including line color, line thickness, point size, opacity.
 In addition, this viewer shows how layer overlays interact when draw on top of each other (at the intersection of the grid).
-Use `viewer.layers[0].bounding_box` to view all modifiable attributes of the border overlay.
+Use `viewer.layers[0].bounding_box` to view all modifiable attributes of the overlay.
 
 For an example showing how bounding box extents are visualized, see
 :ref:`sphx_glr_gallery_layer_bounding_box.py`.
@@ -28,7 +29,7 @@ viewer.grid.enabled = True
 # Add a border overlay to each layer, and modify properties of the border overlay.
 viewer.layers[0].bounding_box.visible = True
 viewer.layers[0].bounding_box.line_color = 'cyan' # default: 'red'
-viewer.layers[0].bounding_box.line_thickness = 5 # default: 1, apparent max: 5; GPU-dependent, see: https://vispy.org/api/vispy.scene.visuals.html#vispy.scene.visuals.Line
+viewer.layers[0].bounding_box.line_thickness = 5 # default: 1, maximum is GPU-dependent, see: https://vispy.org/api/vispy.scene.visuals.html#vispy.scene.visuals.Line
 viewer.layers[0].bounding_box.point_size = 10 # default: 5
 viewer.layers[0].bounding_box.point_color = 'yellow' # default: 'blue'
 

--- a/examples/image_border.py
+++ b/examples/image_border.py
@@ -28,7 +28,7 @@ viewer.grid.enabled = True
 # Add a border overlay to each layer, and modify properties of the border overlay.
 viewer.layers[0].bounding_box.visible = True
 viewer.layers[0].bounding_box.line_color = 'cyan' # default: 'red'
-viewer.layers[0].bounding_box.line_thickness = 5 # default: 1, max: 5
+viewer.layers[0].bounding_box.line_thickness = 5 # default: 1, apparent max: 5; GPU-dependent, see: https://vispy.org/api/vispy.scene.visuals.html#vispy.scene.visuals.Line
 viewer.layers[0].bounding_box.point_size = 10 # default: 5
 viewer.layers[0].bounding_box.point_color = 'yellow' # default: 'blue'
 

--- a/examples/image_border.py
+++ b/examples/image_border.py
@@ -1,18 +1,18 @@
 """
-Border Overlay / Bounding Box
-=============================
+Layer Border Overlay
+====================
 
-Display a 3D, 2 layer image in napari and add a border overlay (i.e. `bounding_box`).
-Creates two viewers to show functionality in both 2D and 3D display mode.
+Display an image in napari and add a border overlay (i.e. `bounding_box`).
 
-The 2D viewer is utilized to demonstrate visualization of many border overlay properties,
+Demonstrates visualization of many border overlay properties,
 including line color, line thickness, point size, opacity.
-In addition, this viewer shows how layer overlays interact when draw on top of each other.
+In addition, this viewer shows how layer overlays interact when draw on top of each other (at the intersection of the grid).
 Use `viewer.layers[0].bounding_box` to view all modifiable attributes of the border overlay.
 
-The 3D viewer shows default `bounding_box` properties (changing only color), use in grid mode, and extent of 3D bounding box.
+For an example showing how bounding box extents are visualized, see
+:ref:`sphx_glr_gallery_layer_bounding_box.py`.
 
-.. tags:: visualization-advanced, visualization-nD
+.. tags:: visualization-advanced
 """
 
 from skimage import data
@@ -20,37 +20,23 @@ from skimage import data
 import napari
 
 # Create a napari viewer with a 3D, 2 channel image, with the `view_image` convenience function.
-viewer_2d = napari.view_image(
+viewer = napari.view_image(
     data.cells3d(), channel_axis=1, name=['membrane', 'nuclei']
 )
-viewer_2d.grid.enabled = True
+viewer.grid.enabled = True
 
 # Add a border overlay to each layer, and modify properties of the border overlay.
-viewer_2d.layers[0].bounding_box.visible = True
-viewer_2d.layers[0].bounding_box.line_color = 'cyan' # default: 'red'
-viewer_2d.layers[0].bounding_box.line_thickness = 5 # default: 1, max: 5
-viewer_2d.layers[0].bounding_box.point_size = 10 # default: 5
-viewer_2d.layers[0].bounding_box.point_color = 'yellow' # default: 'blue'
+viewer.layers[0].bounding_box.visible = True
+viewer.layers[0].bounding_box.line_color = 'cyan' # default: 'red'
+viewer.layers[0].bounding_box.line_thickness = 5 # default: 1, max: 5
+viewer.layers[0].bounding_box.point_size = 10 # default: 5
+viewer.layers[0].bounding_box.point_color = 'yellow' # default: 'blue'
 
-viewer_2d.layers[1].bounding_box.visible = True
-viewer_2d.layers[1].bounding_box.line_color = 'orange'
-viewer_2d.layers[1].bounding_box.line_thickness = 2
-viewer_2d.layers[1].bounding_box.opacity = 0.8 # default: 1
+viewer.layers[1].bounding_box.visible = True
+viewer.layers[1].bounding_box.line_color = 'orange'
+viewer.layers[1].bounding_box.line_thickness = 2
+viewer.layers[1].bounding_box.opacity = 0.8 # default: 1
 # viewer_2d.layers[1].bounding_box.blending = 'additive' # default: 'translucent'
-
-
-# An equivalent alternative to creating the 2D napari viewer, this viewer is
-# created with 3D display and the `open_sample` convenience function
-viewer_3d = napari.view_image(
-    data.cells3d(), channel_axis=1, name=['membrane', 'nuclei']
-)
-viewer_3d.grid.enabled = True
-viewer_3d.dims.ndisplay = 3
-viewer_3d.camera.angles = (5, 25, 130)
-
-viewer_3d.layers[0].bounding_box.visible = True
-viewer_3d.layers[1].bounding_box.visible = True
-viewer_3d.layers[1].bounding_box.line_color = 'cyan'
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/image_border.py
+++ b/examples/image_border.py
@@ -1,6 +1,6 @@
 """
 Layer Bounding Box (Border) Overlay
-====================
+===================================
 
 Display an image in napari and add a bounding box overlay (a border) at the edges of the layer.
 

--- a/examples/layer_bounding_box.py
+++ b/examples/layer_bounding_box.py
@@ -1,0 +1,63 @@
+"""
+3D Layer Bounding Box Overlay
+=============================
+
+Display multiple layer types in 3D and add a bounding box overlay to each layer.
+
+The bounding box overlay is a visual representation of the extents of each layer.
+Image and label layers have data extents that are the same as the image data.
+Shapes and points layers have data extents that represent the convex hull of the data.
+
+For an example showing how to modify the properties of the bounding box overlay,
+see :ref:`sphx_glr_gallery_image_border.py`.
+
+.. tags:: visualization-advanced, visualization-nD
+"""
+
+import numpy as np
+from skimage import data, feature, filters, morphology
+
+import napari
+
+# get sample 3D image data, threshold, and find maxima
+cells3d = data.cells3d()
+nuclei = cells3d[:, 1]
+
+nuclei_smoothed = filters.gaussian(nuclei, sigma=5)
+nuclei_thresholded = nuclei_smoothed > filters.threshold_otsu(nuclei_smoothed)
+nuclei_labels = morphology.label(nuclei_thresholded)
+nuclei_points = feature.peak_local_max(nuclei_smoothed, min_distance=20)
+
+# create an arbitrary path for display
+path = np.array([
+    [0, 10, 10],
+    [20, 5, 15],
+    [56, 70, 21],
+    [127, 127, 127]
+])
+
+# create the viewer and display the different layer types
+viewer = napari.Viewer()
+viewer.add_image(nuclei, name='nuclei', contrast_limits = (10000, 65355))
+viewer.add_labels(nuclei_labels, name='nuclei labels')
+viewer.add_points(
+    nuclei_points, name='nuclei maxima', blending='additive', opacity=0.5
+)
+viewer.add_shapes(
+    path, name='path', shape_type='path', blending='additive', edge_color='yellow'
+)
+
+# add a bounding box overlay to each layer, then change the color
+for layer in viewer.layers:
+    layer.bounding_box.visible = True
+
+viewer.layers['nuclei labels'].bounding_box.line_color = 'cyan'
+viewer.layers['nuclei maxima'].bounding_box.line_color = 'orange'
+viewer.layers['path'].bounding_box.line_color = 'magenta'
+
+# set the view to 3D and rotate camera
+viewer.dims.ndisplay = 3
+viewer.camera.angles = (2, 15, 150)
+
+if __name__ == '__main__':
+    napari.run()


### PR DESCRIPTION
# References and relevant issues
Addresses part of #298

# Description
Adds two gallery examples to show functionality of `viewer.layers[n].bounding_box`. 

`image_border.py` Shows how attributes of the bounding box can be changed. This part of the example shows the simple goal of #298. Also shows how overlays could overlap even in grid mode, due to the middle line.

`layer_bounding_box.py` Creates a 3D viewer to show default bounding box behavior of various layer types, showing the data extent. 

![image](https://github.com/user-attachments/assets/fee810bf-dc5f-45e5-afa9-3ae97b115580)


# Alternatives

1. Split two examples back into a single example (or create 2 PRs)





