### PR TITLE
Ensure that fps overlay is visible on gallery screenshot in overlay example

### DIFF
--- a/examples/viewer_fps_label.py
+++ b/examples/viewer_fps_label.py
@@ -23,5 +23,6 @@ viewer.text_overlay.visible = True
 # without warning in future versions!
 viewer.window._qt_viewer.canvas._scene_canvas.measure_fps(callback=update_fps)
 
+update_fps(60)
 if __name__ == '__main__':
     napari.run()

--- a/examples/viewer_fps_label.py
+++ b/examples/viewer_fps_label.py
@@ -23,6 +23,8 @@ viewer.text_overlay.visible = True
 # without warning in future versions!
 viewer.window._qt_viewer.canvas._scene_canvas.measure_fps(callback=update_fps)
 
+# call update_fps function once to have it show before
+# mouse interaction with the canvas
 update_fps(60)
 if __name__ == '__main__':
     napari.run()


### PR DESCRIPTION
# References and relevant issues

Closes #7547

# Description

Put placeholder text before first interaction with canvas in overlay example.

