### PR TITLE
Update scale bar tests to actually test white/magenta

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -1245,7 +1245,7 @@ def test_scale_bar_colored(qt_viewer, qtbot):
     def check_white_scale_bar():
         screenshot = qt_viewer.screenshot(flash=False)
         assert not np.all(screenshot == [0, 0, 0, 255], axis=-1).all()
-        assert np.all(screenshot == [1, 1, 1, 255], axis=-1).any()
+        assert np.all(screenshot == [255, 255, 255, 255], axis=-1).any()
 
     scale_bar.visible = True
     qtbot.waitUntil(check_white_scale_bar)
@@ -1253,8 +1253,8 @@ def test_scale_bar_colored(qt_viewer, qtbot):
     # Check scale bar is colored (canvas has fuchsia `[1, 0, 1, 255]` and not white in it)
     def check_colored_scale_bar():
         screenshot = qt_viewer.screenshot(flash=False)
-        assert not np.all(screenshot == [1, 1, 1, 255], axis=-1).any()
-        assert np.all(screenshot == [1, 0, 1, 255], axis=-1).any()
+        assert not np.all(screenshot == [255, 255, 255, 255], axis=-1).any()
+        assert np.all(screenshot == [255, 0, 255, 255], axis=-1).any()
 
     scale_bar.colored = True
     qtbot.waitUntil(check_colored_scale_bar)
@@ -1262,8 +1262,8 @@ def test_scale_bar_colored(qt_viewer, qtbot):
     # Check scale bar is still visible but not colored (canvas has white again but not fuchsia in it)
     def check_only_white_scale_bar():
         screenshot = qt_viewer.screenshot(flash=False)
-        assert np.all(screenshot == [1, 1, 1, 255], axis=-1).any()
-        assert not np.all(screenshot == [1, 0, 1, 255], axis=-1).any()
+        assert np.all(screenshot == [255, 255, 255, 255], axis=-1).any()
+        assert not np.all(screenshot == [255, 0, 255, 255], axis=-1).any()
 
     scale_bar.colored = False
     qtbot.waitUntil(check_only_white_scale_bar)
@@ -1289,7 +1289,7 @@ def test_scale_bar_ticks(qt_viewer, qtbot):
     def check_white_scale_bar():
         screenshot = qt_viewer.screenshot(flash=False)
         assert not np.all(screenshot == [0, 0, 0, 255], axis=-1).all()
-        assert np.all(screenshot == [1, 1, 1, 255], axis=-1).any()
+        assert np.all(screenshot == [255, 255, 255, 255], axis=-1).any()
 
     scale_bar.visible = True
     qtbot.waitUntil(check_white_scale_bar)
@@ -1301,7 +1301,7 @@ def test_scale_bar_ticks(qt_viewer, qtbot):
     # Check scale bar without ticks (still white present but new screenshot differs from ticks one)
     def check_no_ticks_scale_bar():
         screenshot = qt_viewer.screenshot(flash=False)
-        assert np.all(screenshot == [1, 1, 1, 255], axis=-1).any()
+        assert np.all(screenshot == [255, 255, 255, 255], axis=-1).any()
         npt.assert_raises(
             AssertionError,
             npt.assert_array_equal,
@@ -1315,7 +1315,7 @@ def test_scale_bar_ticks(qt_viewer, qtbot):
     # Check scale bar again has ticks (still white present and new screenshot corresponds with ticks one)
     def check_ticks_scale_bar():
         screenshot = qt_viewer.screenshot(flash=False)
-        assert np.all(screenshot == [1, 1, 1, 255], axis=-1).any()
+        assert np.all(screenshot == [255, 255, 255, 255], axis=-1).any()
         npt.assert_array_equal(screenshot, screenshot_with_ticks)
 
     scale_bar.ticks = True


### PR DESCRIPTION
It turns out that the scale bar tests were not testing for the presence
of white or magenta in the screenshots, but very faint white or magenta.
The tests passed because there is antialiasing of the fonts when text is
being displayed:

![CleanShot 2025-01-28 at 19 45 06@2x](https://github.com/user-attachments/assets/380345ca-15d9-4e6d-b327-fd50160bb0da)

But the antialiasing appears to be dependent on display settings --
screen resolution, OpenGL drivers, etc -- which results in the test
failing in pyapp-kit/superqt#277.

This makes the tests robust by using the true colour of the scale bar.
