### PR TITLE
Change naming of 'pan/zoom' mode to 'Move camera' to clarify functionality differences in 2D and 3D

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -49,9 +49,9 @@ class QtImageControls(QtBaseImageControls):
     button_grid : qtpy.QtWidgets.QGridLayout
         GridLayout for the layer mode buttons
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to pan/zoom shapes layer.
+        Button to activate move camera mode.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to transform shapes layer.
+        Button to transform layer.
     attenuationSlider : qtpy.QtWidgets.QSlider
         Slider controlling attenuation rate for `attenuated_mip` mode.
     attenuationLabel : qtpy.QtWidgets.QLabel

--- a/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -70,9 +70,9 @@ class QtBaseImageControls(QtLayerControls):
     button_grid : qtpy.QtWidgets.QGridLayout
         GridLayout for the layer mode buttons
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to pan/zoom shapes layer.
+        Button to activate move camera mode for layer.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to transform shapes layer.
+        Button to transform image layer.
     clim_popup : napari._qt.qt_range_slider_popup.QRangeSliderPopup
         Popup widget launching the contrast range slider.
     colorbarLabel : qtpy.QtWidgets.QLabel

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -62,9 +62,9 @@ class QtLayerControls(QFrame):
     button_grid : qtpy.QtWidgets.QGridLayout
         GridLayout for the layer mode buttons
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to pan/zoom shapes layer.
+        Button to activate move camera mode for layer.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to transform shapes layer.
+        Button to transform layer.
     blendComboBox : qtpy.QtWidgets.QComboBox
         Dropdown widget to select blending mode of layer.
     layer : napari.layers.Layer
@@ -106,7 +106,9 @@ class QtLayerControls(QFrame):
             self.MODE.PAN_ZOOM,
             False,
             self.PAN_ZOOM_ACTION_NAME,
-            extra_tooltip_text=trans._('(or hold Space)'),
+            extra_tooltip_text=trans._(
+                '\n(or hold Space [2D]\nor Shift+Space [3D])'
+            ),
             checked=True,
         )
         self.transform_button = self._radio_button(

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -107,7 +107,7 @@ class QtLayerControls(QFrame):
             False,
             self.PAN_ZOOM_ACTION_NAME,
             extra_tooltip_text=trans._(
-                '\n(or hold Space\n[+Shift to pan in 3D])'
+                '\n(or hold Space)\n(hold Shift to pan in 3D)'
             ),
             checked=True,
         )

--- a/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -107,7 +107,7 @@ class QtLayerControls(QFrame):
             False,
             self.PAN_ZOOM_ACTION_NAME,
             extra_tooltip_text=trans._(
-                '\n(or hold Space [2D]\nor Shift+Space [3D])'
+                '\n(or hold Space\n[+Shift to pan in 3D])'
             ),
             checked=True,
         )

--- a/napari/_qt/layer_controls/qt_points_controls.py
+++ b/napari/_qt/layer_controls/qt_points_controls.py
@@ -57,7 +57,7 @@ class QtPointsControls(QtLayerControls):
     outOfSliceCheckBox : qtpy.QtWidgets.QCheckBox
         Checkbox to indicate whether to render out of slice.
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button for pan/zoom mode.
+        Button to activate move camera mode for layer.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
         Button to select transform mode.
     select_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton

--- a/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -62,7 +62,7 @@ class QtShapesControls(QtLayerControls):
     move_front_button : qtpy.QtWidgets.QtModePushButton
         Button to move shape(s) to the front.
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to pan/zoom shapes layer.
+        Button to activate move camera mode for layer.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
         Button to transform shapes layer.
     path_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton

--- a/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/napari/_qt/layer_controls/qt_surface_controls.py
@@ -35,7 +35,7 @@ class QtSurfaceControls(QtBaseImageControls):
     button_grid : qtpy.QtWidgets.QGridLayout
         GridLayout for the layer mode buttons
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button to pan/zoom shapes layer.
+        Button to activate move camera mode for layer.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
         Button to transform shapes layer.
 

--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -32,7 +32,7 @@ class QtTracksControls(QtLayerControls):
     button_group : qtpy.QtWidgets.QButtonGroup
         Button group of points layer modes (ADD, PAN_ZOOM, SELECT).
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button for pan/zoom mode.
+        Button for activate move camera mode for layer.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
         Button to select transform mode.
 

--- a/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -42,7 +42,7 @@ class QtVectorsControls(QtLayerControls):
     button_group : qtpy.QtWidgets.QButtonGroup
         Button group of points layer modes (ADD, PAN_ZOOM, SELECT).
     panzoom_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
-        Button for pan/zoom mode.
+        Button for activate move camera mode for layer.
     transform_button : napari._qt.widgets.qt_mode_button.QtModeRadioButton
         Button to select transform mode.
     edge_color_label : qtpy.QtWidgets.QLabel

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -218,7 +218,7 @@ def toggle_console_visibility(viewer: Viewer):
     viewer.window._qt_viewer.toggle_console_visibility()
 
 
-@register_viewer_action(trans._('Press and hold for pan/zoom mode'))
+@register_viewer_action(trans._('Press and hold for move camera mode'))
 def hold_for_pan_zoom(viewer: ViewerModel):
     selected_layer = viewer.layers.selection.active
     if selected_layer is None:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -578,7 +578,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
 
         if mode == TRANSFORM:
             self.help = trans._(
-                'hold <space> to pan/zoom, hold <shift> to preserve aspect ratio and rotate in 45° increments'
+                'hold <space> to move camera, hold <shift> to preserve aspect ratio and rotate in 45° increments'
             )
         elif mode == PAN_ZOOM:
             self.help = ''

--- a/napari/layers/image/_image_key_bindings.py
+++ b/napari/layers/image/_image_key_bindings.py
@@ -102,7 +102,7 @@ def activate_image_transform_mode(layer: Image) -> None:
     layer.mode = str(Mode.TRANSFORM)
 
 
-@register_image_mode_action(trans._('Pan/zoom'))
+@register_image_mode_action(trans._('Move camera'))
 def activate_image_pan_zoom_mode(layer: Image) -> None:
     layer.mode = str(Mode.PAN_ZOOM)
 

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -28,7 +28,7 @@ def activate_labels_transform_mode(layer: Labels):
     layer.mode = Mode.TRANSFORM
 
 
-@register_label_mode_action(trans._('Pan/zoom'))
+@register_label_mode_action(trans._('Move camera'))
 def activate_labels_pan_zoom_mode(layer: Labels):
     layer.mode = Mode.PAN_ZOOM
 

--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -31,7 +31,7 @@ def activate_points_transform_mode(layer: Points) -> None:
     layer.mode = Mode.TRANSFORM
 
 
-@register_points_mode_action(trans._('Pan/zoom'))
+@register_points_mode_action(trans._('Move camera'))
 def activate_points_pan_zoom_mode(layer: Points) -> None:
     layer.mode = Mode.PAN_ZOOM
 

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -57,7 +57,7 @@ def activate_shapes_transform_mode(layer: Shapes) -> None:
     layer.mode = Mode.TRANSFORM
 
 
-@register_shapes_mode_action(trans._('Pan/zoom'))
+@register_shapes_mode_action(trans._('Move camera'))
 def activate_shapes_pan_zoom_mode(layer: Shapes) -> None:
     layer.mode = Mode.PAN_ZOOM
 

--- a/napari/layers/surface/_surface_key_bindings.py
+++ b/napari/layers/surface/_surface_key_bindings.py
@@ -26,7 +26,7 @@ def activate_surface_transform_mode(layer: Surface) -> None:
     layer.mode = str(Mode.TRANSFORM)
 
 
-@register_surface_mode_action(trans._('Pan/zoom'))
+@register_surface_mode_action(trans._('Move camera'))
 def activate_surface_pan_zoom_mode(layer: Surface) -> None:
     layer.mode = str(Mode.PAN_ZOOM)
 

--- a/napari/layers/tracks/_tracks_key_bindings.py
+++ b/napari/layers/tracks/_tracks_key_bindings.py
@@ -26,7 +26,7 @@ def activate_tracks_transform_mode(layer: Tracks) -> None:
     layer.mode = str(Mode.TRANSFORM)
 
 
-@register_tracks_mode_action(trans._('Pan/zoom'))
+@register_tracks_mode_action(trans._('Move camera'))
 def activate_tracks_pan_zoom_mode(layer: Tracks) -> None:
     layer.mode = str(Mode.PAN_ZOOM)
 

--- a/napari/layers/vectors/_vectors_key_bindings.py
+++ b/napari/layers/vectors/_vectors_key_bindings.py
@@ -26,7 +26,7 @@ def activate_vectors_transform_mode(layer: Vectors) -> None:
     layer.mode = str(Mode.TRANSFORM)
 
 
-@register_vectors_mode_action(trans._('Pan/zoom'))
+@register_vectors_mode_action(trans._('Move camera'))
 def activate_vectors_pan_zoom_mode(layer: Vectors) -> None:
     layer.mode = str(Mode.PAN_ZOOM)
 


### PR DESCRIPTION
# References and relevant issues
Closes #7467 by clearing up confusion about how to activate and move camera/layer in various circumstances including 2D vs 3D and labels layers. Thank you in particular for additional information @psobolewskiPhD and @brisvag (and for the 'Move camera' suggestion, for which I could not think of anything more appropriate).

I will open a PR to update the name used in the docs if this PR ends up being merged. 

![image](https://github.com/user-attachments/assets/09eb8bdd-6706-4bb1-98fb-39851d847e1c)

# Description
1. Updates name of qt button from 'Pan/zoom' to 'Move camera'. Corresponding keybindings auto update
2. Changes extra tooltip to clarify 2D vs 3D behavior of moving the camera, especially for temporary mode. Updates keybinding tooltip for temp mode.
3. Minorly updates docstrings for things like panzoom_button to call reflect change to camera move mode. Does not change any attribute/method names. 

## Alternatives
1. Only change extra tooltip in `qt_layer_controls_base.py` to clarify 2D vs 3D usage

