### PR TITLE
ENH: adjust layer coordinates in status by _translate_grid

### DIFF
--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -2225,7 +2225,8 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
                 # position may be higher-dimensional due to other
                 # layers in the viewer, but self._translate_grid already
                 # has the correct dimensionality
-                position[-self.ndim :] - self._translate_grid, value
+                position[-self.ndim :] - self._translate_grid,
+                value,
             )
         else:
             source_info['coordinates'] = generate_layer_coords_status(

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -2219,13 +2219,14 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             value = None
 
         source_info = self._get_source_info()
+        # use self._translate_grid to adjust layer origin in grid mode
         if position is not None:
             source_info['coordinates'] = generate_layer_coords_status(
-                position[-self.ndim :], value
+                position[-self.ndim :] - self._translate_grid, value
             )
         else:
             source_info['coordinates'] = generate_layer_coords_status(
-                position, value
+                position - self._translate_grid, value
             )
         return source_info
 

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -2222,6 +2222,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         # use self._translate_grid to adjust layer origin in grid mode
         if position is not None:
             source_info['coordinates'] = generate_layer_coords_status(
+                # position may be higher-dimensional due to other
+                # layers in the viewer, but self._translate_grid already
+                # has the correct dimensionality
                 position[-self.ndim :] - self._translate_grid, value
             )
         else:


### PR DESCRIPTION
# References and relevant issues
Closes #7581 

# Description

This PR adjusts the coordinates displayed in the status bar for the offset used in grid mode.
By subtracting the offset, the coordinates shown for each layer are of the layer data.
