### PR TITLE
Fix double-click-to-zoom for case of only 2D layer in 3D display

### DIFF
--- a/napari/components/_tests/test_viewer_mouse_bindings.py
+++ b/napari/components/_tests/test_viewer_mouse_bindings.py
@@ -73,9 +73,16 @@ def test_paint(modifiers, native, expected_dim):
     assert np.equal(viewer.dims.point, expected_dim[3]).all()
 
 
-def test_double_click_to_zoom():
+@pytest.mark.parametrize(
+    'layer_shape',
+    [
+        (10, 10, 10),
+        (10, 10),
+    ],
+)
+def test_double_click_to_zoom(layer_shape):
     viewer = ViewerModel()
-    data = np.zeros((10, 10, 10))
+    data = np.zeros(layer_shape)
     viewer.add_image(data)
 
     # Ensure `pan_zoom` mode is active

--- a/napari/components/_viewer_mouse_bindings.py
+++ b/napari/components/_viewer_mouse_bindings.py
@@ -27,9 +27,8 @@ def double_click_to_zoom(viewer, event):
         return
     # if Alt held down, zoom out instead
     zoom_factor = 0.5 if 'Alt' in event.modifiers else 2
-
     viewer.camera.zoom *= zoom_factor
-    if viewer.dims.ndisplay == 3:
+    if viewer.dims.ndisplay == 3 and viewer.dims.ndim == 3:
         viewer.camera.center = np.asarray(viewer.camera.center) + (
             np.asarray(event.position)[np.asarray(viewer.dims.displayed)]
             - np.asarray(viewer.camera.center)


### PR DESCRIPTION
# References and relevant issues
Closes: #7577 

# Description
If there is only a 2D layer, then `dims.ndim` is 2, but in 3D mode `len(event.position)` and `dims.displayed` will both still be **2**, which resulted in the bug reported in the issue.
In this PR, I add a test that fails on main, replicating the issue, and then fix by ensuring `dims.ndim` is 3 when using 3D code path.

Note: the behavior for the case of a 2D layer in 3D display, with camera rotated, is still not quite correct due to: https://github.com/napari/napari/issues/7585
