### PR TITLE
Remove andy-sweet from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,13 +11,13 @@ napari/qt/          @Czaki @jni
 napari/settings/    @Czaki @jni
 
 # specific layers
-napari/layers/image/    @Czaki @brisvag @andy-sweet @kephale
+napari/layers/image/    @Czaki @brisvag @kephale
 napari/layers/labels/   @jni @Czaki @brisvag
-napari/layers/points/   @brisvag @kevinyamauchi @andy-sweet @DragaDoncila @kephale
+napari/layers/points/   @brisvag @kevinyamauchi @DragaDoncila @kephale
 napari/layers/shapes/   @kevinyamauchi @DragaDoncila @melonora
 napari/layers/surface/  @brisvag @kevinyamauchi @Czaki
-napari/layers/tracks/   @jni @andy-sweet
-napari/layers/vectors/  @brisvag @kevinyamauchi @andy-sweet
+napari/layers/tracks/   @jni
+napari/layers/vectors/  @brisvag @kevinyamauchi
 
 # docs
 examples/                            @melissawm @psobolewskiPhD @lucyleeow


### PR DESCRIPTION
# Description
I am no longer a core-dev and do not have much time to fix a lot of issues. But I do want to be mentioned in occasional issues and PRs where I can help because I can probably find some time in those cases.

The best mechanism for me to do this is through GitHub notifications, but being in CODEOWNERS means that I get so many notifications via subscription that I may miss those mentions.

This change allows me to easily see the notifications where I could do something and better reflects reality.