### PR TITLE
stop using ubuntu 20.04 runners in actions

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -58,12 +58,12 @@ jobs:
             backend: pyqt5
           # test with minimum specified requirements
           - python: "3.9"
-            platform: ubuntu-20.04
+            platform: ubuntu-22.04
             backend: pyqt5
             MIN_REQ: 1
           # test without any Qt backends
           - python: "3.9"
-            platform: ubuntu-20.04
+            platform: ubuntu-22.04
             backend: headless
           - python: "3.12"
             platform: ubuntu-latest

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -134,7 +134,7 @@ jobs:
             coverage: no_cov
           # minimum specified requirements
           - python: "3.9"
-            platform: ubuntu-20.04
+            platform: ubuntu-22.04
             backend: pyqt5
             MIN_REQ: 1
             coverage: cov
@@ -145,7 +145,7 @@ jobs:
             tox_extras: "optional"
           # test without any Qt backends
           - python: "3.10"
-            platform: ubuntu-20.04
+            platform: ubuntu-22.04
             backend: headless
             coverage: no_cov
           - python: "3.12"


### PR DESCRIPTION
# References and relevant issues

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/


# Description
As Ubuntu 20.04 runners are scheduled to retire on April 1, 2025, this PR changes it to Ubuntu 22.04 
