### PR TITLE
Update README.md to use python 3.10 like napari.org install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We're working on [tutorials](https://napari.org/stable/tutorials/), but you can 
 It is recommended to install napari into a virtual environment, like this:
 
 ```sh
-conda create -y -n napari-env -c conda-forge python=3.9
+conda create -y -n napari-env -c conda-forge python=3.10
 conda activate napari-env
 python -m pip install "napari[all]"
 ```


### PR DESCRIPTION
# References and relevant issues
This came up in an image.sc post:
https://forum.image.sc/t/napari-viewer-does-not-show-loaded-zarr-dataset/108499/7?u=psobolewskiphd

# Description
Updates the conda env instructions in the README to match the current install instructions in the docs (napari.org)