### PR TITLE
Add link to napari weather report dashboard in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ You can see details of [the project roadmap here](https://napari.org/stable/road
 
 Contributions are encouraged! Please read our [contributing guide](https://napari.org/dev/developers/contributing/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [GitHub Issues](https://github.com/napari/napari/issues) before jumping in. 
 
-If you want to contribute or edit to our documentation, please go to [napari/docs](https://github.com/napari/docs). 
+If you want to contribute to or edit our documentation, please go to [napari/docs](https://github.com/napari/docs).
+
+Visit our [project weather report dashboard](https://napari.org/weather-report/) to see metrics and how development is progressing.
 
 ## code of conduct
 


### PR DESCRIPTION
# References and relevant issues

# Description
Adds a link in the README doc under the contributing section to the [napari weather report dashboard](https://napari.org/weather-report/)



