### PR TITLE
[UI] Add Command Palette to the welcome screen

### DIFF
--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -69,17 +69,17 @@ class QtWelcomeWidget(QWidget):
             QtShortcutLabel(sc),
             QtShortcutLabel(trans._('Open image(s)')),
         )
-        self._shortcut_label = QtShortcutLabel('')
-        shortcut_layout.addRow(
-            self._shortcut_label,
-            QtShortcutLabel(trans._('Show all key bindings')),
-        )
         sc = QKeySequence('Ctrl+Shift+P', QKeySequence.PortableText).toString(
             QKeySequence.NativeText
         )
         shortcut_layout.addRow(
             QtShortcutLabel(sc),
             QtShortcutLabel(trans._('Show Command Palette')),
+        )
+        self._shortcut_label = QtShortcutLabel('')
+        shortcut_layout.addRow(
+            self._shortcut_label,
+            QtShortcutLabel(trans._('Show all key bindings')),
         )
         shortcut_layout.setSpacing(0)
 

--- a/napari/_qt/widgets/qt_welcome.py
+++ b/napari/_qt/widgets/qt_welcome.py
@@ -67,12 +67,19 @@ class QtWelcomeWidget(QWidget):
         )
         shortcut_layout.addRow(
             QtShortcutLabel(sc),
-            QtShortcutLabel(trans._('open image(s)')),
+            QtShortcutLabel(trans._('Open image(s)')),
         )
         self._shortcut_label = QtShortcutLabel('')
         shortcut_layout.addRow(
             self._shortcut_label,
-            QtShortcutLabel(trans._('show all key bindings')),
+            QtShortcutLabel(trans._('Show all key bindings')),
+        )
+        sc = QKeySequence('Ctrl+Shift+P', QKeySequence.PortableText).toString(
+            QKeySequence.NativeText
+        )
+        shortcut_layout.addRow(
+            QtShortcutLabel(sc),
+            QtShortcutLabel(trans._('Show Command Palette')),
         )
         shortcut_layout.setSpacing(0)
 


### PR DESCRIPTION
# References and relevant issues
Part of: https://github.com/napari/napari/issues/7611

# Description
In this PR I add the Command Palette & keybinding to the welcome screen.
(I also make the capitalization of the listed elements consistent)
This helps make it more discoverable -- but it's also a bit of a commitment to making it a maintained feature!

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/fe2a61ab-b3df-45d6-a0b5-3be3a364997b" />
