### PR TITLE
Fix layout issue in image/surface controls

### DIFF
--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -185,8 +185,7 @@ class QtImageControls(QtBaseImageControls):
             self.colorbarLabel.setVisible(False)
         else:
             colormap_layout.addWidget(self.colorbarLabel)
-            colormap_layout.addWidget(self.colormapComboBox)
-        colormap_layout.addStretch(1)
+            colormap_layout.addWidget(self.colormapComboBox, stretch=1)
 
         self.layout().addRow(self.button_grid)
         self.layout().addRow(self.opacityLabel, self.opacitySlider)

--- a/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/napari/_qt/layer_controls/qt_surface_controls.py
@@ -52,8 +52,7 @@ class QtSurfaceControls(QtBaseImageControls):
 
         colormap_layout = QHBoxLayout()
         colormap_layout.addWidget(self.colorbarLabel)
-        colormap_layout.addWidget(self.colormapComboBox)
-        colormap_layout.addStretch(1)
+        colormap_layout.addWidget(self.colormapComboBox, stretch=1)
 
         shading_comboBox = QComboBox(self)
         for display_name, shading in SHADING_TRANSLATION.items():


### PR DESCRIPTION
This fixes a minor layout issue for the image/surface layer controls (which use. the colormapComboBox.

I noticed that if the width of the layer controls is changed, the 'colormap' combobox doesn't get resized (because there was a stretch after the control). 

I should have noticed in #7600 but clearly missed it.

before
![image](https://github.com/user-attachments/assets/a5644564-274b-4ba6-b522-c2639a22fed4)

after
![image](https://github.com/user-attachments/assets/7ec326c8-3441-4be2-9dbb-3c4e293fef78)

# References and relevant issues

# Description


