### PR TITLE
Refactor setting face meshes in Shapes to support other planar axes

### DIFF
--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -353,17 +353,12 @@ class Shape(ABC):
             self._edge_triangles = np.empty((0, 3), dtype=np.uint32)
 
         if face:
-            idx = np.concatenate(
-                [[True], ~np.all(data[1:] == data[:-1], axis=-1)]
-            )
-            clean_data = data[idx].copy()
-
-            if not is_collinear(clean_data[:, -2:]):
-                if clean_data.shape[1] == 2:
-                    vertices, triangles = triangulate_face(clean_data)
-                elif len(np.unique(clean_data[:, 0])) == 1:
-                    val = np.unique(clean_data[:, 0])
-                    vertices, triangles = triangulate_face(clean_data[:, -2:])
+            if not is_collinear(data[:, -2:]):
+                if data.shape[1] == 2:
+                    vertices, triangles = triangulate_face(data)
+                elif len(np.unique(data[:, 0])) == 1:
+                    val = np.unique(data[:, 0])
+                    vertices, triangles = triangulate_face(data[:, -2:])
                     exp = np.expand_dims(np.repeat(val, len(vertices)), axis=1)
                     vertices = np.concatenate([exp, vertices], axis=1)
                 else:

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -369,7 +369,8 @@ class Shape(ABC):
         if face and not is_collinear(data2d):
             vertices, triangles = triangulate_face(data2d)
             if ndim == 3:
-                vertices = np.insert(vertices, axis, value, axis=1)
+                # axis and value can be None, but not if ndim == 3, so ignore
+                vertices = np.insert(vertices, axis, value, axis=1)  # type:ignore[arg-type]
             if len(triangles) > 0:
                 self._face_vertices = vertices
                 self._face_triangles = triangles

--- a/napari/layers/shapes/_shapes_models/shape.py
+++ b/napari/layers/shapes/_shapes_models/shape.py
@@ -368,9 +368,12 @@ class Shape(ABC):
 
         if face and not is_collinear(data2d):
             vertices, triangles = triangulate_face(data2d)
-            if ndim == 3:
-                # axis and value can be None, but not if ndim == 3, so ignore
-                vertices = np.insert(vertices, axis, value, axis=1)  # type:ignore[arg-type]
+            if ndim == 3 and axis is not None and value is not None:
+                # axis and value can be None if data 3D but not limited to an
+                # axis-aligned plane. However in that situation data2d will be
+                # empty, is_collinear is True, and we will never get here. But
+                # we check anyway for mypy's sake
+                vertices = np.insert(vertices, axis, value, axis=1)
             if len(triangles) > 0:
                 self._face_vertices = vertices
                 self._face_triangles = triangles

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -31,6 +31,43 @@ except ImportError:
     acc_create_box_from_bounding = None
 
 
+def find_planar_axis(
+    points: npt.NDArray,
+) -> tuple[npt.NDArray, int | None, float | None]:
+    """Find an axis along which the input points are planar.
+
+    If points are 2D, they are returned unchanged.
+
+    If there is a planar axis, return the corresponding 2D points, the axis
+    position, and the coordinate of the plane.
+
+    If there is *no* planar axis, return an empty dataset.
+
+    Parameters
+    ----------
+    points : array, shape (npoints, ndim)
+        An array of point coordinates. ``ndim`` must be 2 or 3.
+
+    Returns
+    -------
+    points2d : array, shape (npoints | 0, 2)
+        Array of 2D points. May be empty if input points are not planar along
+        any axis.
+    axis_idx : int | None
+        The axis along which points are planar.
+    value : float | None
+        The coordinate of the points along ``axis``.
+    """
+    ndim = points.shape[1]
+    if ndim == 2:
+        return points, None, None
+    for axis_idx in range(ndim):
+        values = np.unique(points[:, axis_idx])
+        if len(values) == 1:
+            return np.delete(points, axis_idx, axis=1), axis_idx, values[0]
+    return np.empty((0, 2), dtype=points.dtype), None, None
+
+
 def _is_convex(poly: npt.NDArray) -> bool:
     """Check whether a polygon is convex.
 


### PR DESCRIPTION
Closes #7621

This also simplifies the many nested if/else clauses within the
`Shape._set_meshes_py` code, which will be handy for #6654.
