### PR TITLE
Add comment to test_export_rois for troubleshooting

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -300,6 +300,12 @@ def test_export_figure(make_napari_viewer, tmp_path):
 
 def test_export_rois(make_napari_viewer, tmp_path):
     # Create an image with a defined shape (100x100) and a square in the middle
+    #
+    # Troubleshooting note: If you see a test failure running on a MacBook, it
+    # may be due to the retina display since every pixel in source data is
+    # rendered as 4 pixels on screen. If disabled using BetterDisplay, the test
+    # should pass.
+    # See: https://napari.zulipchat.com/#narrow/channel/212875-general/topic/Check.20export.20roi.20test/near/500698702
 
     img = np.zeros((100, 100), dtype=np.uint8)
     img[25:75, 25:75] = 255


### PR DESCRIPTION
# References and relevant issues
[Zulip chat](https://napari.zulipchat.com/#narrow/channel/212875-general/topic/.E2.9C.94.20Check.20export.20roi.20test/near/500698702)

# Description
To help future devs:
- Add a comment to describe that the test may fail on a MacBook due to scaling of the retina display
- Add troubleshooting info and links to @Czaki's zulip message.

