### PR TITLE
Fix test_export_rois to work on HiDPI screens

### DIFF
--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -298,7 +298,7 @@ def test_export_figure(make_napari_viewer, tmp_path):
     assert img.shape == (250, 250, 4)
 
 
-def test_export_rois(make_napari_viewer, tmp_path, qapp):
+def test_export_rois(make_napari_viewer, tmp_path):
     # Create an image with a defined shape (100x100) and a square in the middle
 
     img = np.zeros((100, 100), dtype=np.uint8)

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -335,9 +335,9 @@ def test_export_rois(make_napari_viewer, tmp_path):
         for i in range(len(roi_shapes_data))
     )
 
-    # we get scaling to adjust the expected size of ROI images
+    # This test uses scaling to adjust the expected size of ROI images
     # and number of white pixels in the ROI screenshots
-    # it may not work for screens with fractional scaling
+    # The assertion may fail if the test is run on screens with fractional scaling.
     scaling = viewer.window._qt_window.screen().devicePixelRatio()
 
     assert all(

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -298,7 +298,7 @@ def test_export_figure(make_napari_viewer, tmp_path):
     assert img.shape == (250, 250, 4)
 
 
-def test_export_rois(make_napari_viewer, tmp_path):
+def test_export_rois(make_napari_viewer, tmp_path, qapp):
     # Create an image with a defined shape (100x100) and a square in the middle
 
     img = np.zeros((100, 100), dtype=np.uint8)
@@ -334,7 +334,11 @@ def test_export_rois(make_napari_viewer, tmp_path):
         (tmp_path / f'roi_{i}.png').exists()
         for i in range(len(roi_shapes_data))
     )
-    assert all(roi.shape == (20, 20, 4) for roi in test_roi)
+    scaling = viewer.window._qt_window.screen().devicePixelRatio()
+
+    assert all(
+        roi.shape == (20 * scaling, 20 * scaling, 4) for roi in test_roi
+    )
     assert viewer.camera.center == camera_center
     assert viewer.camera.zoom == camera_zoom
 
@@ -347,9 +351,9 @@ def test_export_rois(make_napari_viewer, tmp_path):
     expected_values = [0, 100, 100, 100, 100, 400]
     for index, roi_img in enumerate(test_roi):
         gray_img = roi_img[..., 0]
-        assert np.count_nonzero(gray_img) == expected_values[index], (
-            f'Wrong number of white pixels in the ROI {index}'
-        )
+        assert (
+            np.count_nonzero(gray_img) == expected_values[index] * scaling**2
+        ), f'Wrong number of white pixels in the ROI {index}'
 
     # Not testing the exact content of the screenshot. It seems not to work within the test, but manual testing does.
     viewer.close()

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -334,6 +334,10 @@ def test_export_rois(make_napari_viewer, tmp_path):
         (tmp_path / f'roi_{i}.png').exists()
         for i in range(len(roi_shapes_data))
     )
+
+    # we get scaling to adjust the expected size of ROI images
+    # and number of white pixels in the ROI screenshots
+    # it may not work for screens with fractional scaling
     scaling = viewer.window._qt_window.screen().devicePixelRatio()
 
     assert all(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ Documentation = "https://napari.org"
 
 [project.optional-dependencies]
 pyside2 = [
-    "PySide2>=5.13.2,!=5.15.0 ; python_version < '3.11' and platform_machine != 'arm64'",
+    "PySide2>=5.15.1 ; python_version < '3.11' and platform_machine != 'arm64'",
 ]
 pyside6_experimental = [
     "PySide6 < 6.5 ; python_version < '3.12'"
@@ -105,7 +105,7 @@ pyside = [
     "napari[pyside2]"
 ]
 pyqt5 = [
-    "PyQt5>=5.13.2,!=5.15.0",
+    "PyQt5>=5.15.8"
 ]
 pyqt = [
     "napari[pyqt5]"


### PR DESCRIPTION
# References and relevant issues

alternative to #7624 

Zulip discussion: https://napari.zulipchat.com/#narrow/channel/212875-general/topic/.E2.9C.94.20Check.20export.20roi.20test/near/500695247

# Description

test_export_rois makes assertion about screen capture sizes when running the export_roi function. However, these tests may fail if the screen uses scaling. (For example, macOS retina screens use 2x scaling by default.) This PR accounts for scaling in the test. (Note: it has only been tested with 2x scaling. Fractional scaling could still fail the test.)
