### PR TITLE
Update CIrcleCI config.yml to use docs dependency group and pyqt5 (match napari/docs)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[pyside,dev]"
+            python -m pip install -e "napari/[pyqt5,docs]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:
@@ -40,7 +40,7 @@ jobs:
           command: |
             . venv/bin/activate
             cd docs
-            xvfb-run --auto-servernum make docs
+            xvfb-run --auto-servernum make html
           environment:
             PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
       - store_artifacts:


### PR DESCRIPTION
# References and relevant issues
This PR matches napari/docs PR: https://github.com/napari/docs/pull/590

# Description
Updates the CircleCI action to use the new `docs` dependency group and also switches to using PyQt5 to reduce flakiness.
Note: our main build and deploy workflow has always been using pyqt5, so now CircleCI matches what is deployed.