### PR TITLE
Update build_docs.yml to match napari/docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,5 +1,5 @@
 # As much as possible, this file should be kept in sync with
-# https://github.com/napari/docs/blob/main/.github/workflows/build_docs.yml
+# https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy_docs.yml
 name: Build PR Docs
 
 on:
@@ -38,15 +38,13 @@ jobs:
           python-version: "3.10"
           cache-dependency-path: |
             napari/pyproject.toml
-            docs/requirements.txt
 
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari/[all]"
-          python -m pip install -r docs/requirements.txt
+          python -m pip install "napari/[pyqt5, docs]"
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
 
@@ -62,7 +60,7 @@ jobs:
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
-          run:  make -C docs docs
+          run:  make -C docs html
           # skipping setup stops the action from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time and it was causing
           # problems with screenshots (https://github.com/napari/docs/issues/285)
@@ -73,4 +71,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs
-          path: docs/docs/_build
+          path: docs/docs/_build/html


### PR DESCRIPTION
# References and relevant issues
Part of: https://github.com/napari/docs/issues/589
Depends on: https://github.com/napari/docs/pull/591

# Description
This PR updates the build_docs.yml action to match napari/docs.
It's somewhat unneeded, because it ~fires off merge to main~ fires off of `v*` tag push, while we build/deploy docs from napari/docs, but it can be manually triggered, so it should be correct.