### PR TITLE
Add 'Extend with Plugins' and 'Contribute to napari' links to the Help menu.

### DIFF
--- a/napari/_qt/_qapp_model/qactions/_help.py
+++ b/napari/_qt/_qapp_model/qactions/_help.py
@@ -81,7 +81,7 @@ Q_HELP_ACTIONS: list[Action] = [
     ),
     Action(
         id='napari.window.help.plugins',
-        title=trans._('Plugin Usage'),
+        title=trans._('Extend with Plugins'),
         callback=partial(web_open, url=HELP_URLS['plugins']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),

--- a/napari/_qt/_qapp_model/qactions/_help.py
+++ b/napari/_qt/_qapp_model/qactions/_help.py
@@ -26,6 +26,8 @@ HELP_URLS: dict[str, str] = {
     'tutorials': f'https://napari.org/{VERSION}/tutorials/index.html',
     'layers_guide': f'https://napari.org/{VERSION}/howtos/layers/index.html',
     'examples_gallery': f'https://napari.org/{VERSION}/gallery.html',
+    'plugins': f'https://napari.org/{VERSION}/plugins/index.html',
+    'contribute': f'https://napari.org/{VERSION}/developers/index.html',
     'release_notes': f'https://napari.org/{VERSION}/release/release_{VERSION.replace(".", "_")}.html',
     'github_issue': 'https://github.com/napari/napari/issues',
     'homepage': 'https://napari.org',
@@ -78,6 +80,12 @@ Q_HELP_ACTIONS: list[Action] = [
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
+        id='napari.window.help.plugins',
+        title=trans._('Plugin Usage'),
+        callback=partial(web_open, url=HELP_URLS['plugins']),
+        menus=[{'id': MenuId.MENUBAR_HELP}],
+    ),
+    Action(
         id='napari.window.help.release_notes',
         title=trans._('Release Notes'),
         callback=partial(web_open, url=HELP_URLS['release_notes']),
@@ -100,6 +108,12 @@ Q_HELP_ACTIONS: list[Action] = [
                 'group': MenuGroup.NAVIGATION,
             }
         ],
+    ),
+    Action(
+        id='napari.window.help.contribute',
+        title=trans._('Contribute to napari'),
+        callback=partial(web_open, url=HELP_URLS['contribute']),
+        menus=[{'id': MenuId.MENUBAR_HELP, 'group': MenuGroup.NAVIGATION}],
     ),
     Action(
         id='napari.window.help.homepage',


### PR DESCRIPTION
# Description

Adds two new links to the Help Menu. These are opinionated additions for sure.

1. 'Plugin Usage' currently links to the Plugin index, but perhaps it would be nice to link to the hub instead? My thought was by going to plugin usage you would learn, then, how to find the hub, but also look through pip and conda stuff. Also, this links people to the how to make plugin docs ;)
2. 'Contribute to napari' links to the Contributing docs. I think this might be a bit of encouragement for any user to check out and learn more. Keeps this link even when in dev because might be a useful reminder to someone if they are working on contributions, regardless. 