### PR TITLE
Conditionally call IPython 9+ with a theme_name instead of color_scheme

### DIFF
--- a/napari/utils/_tracebacks.py
+++ b/napari/utils/_tracebacks.py
@@ -25,6 +25,7 @@ def get_tb_formatter() -> Callable[[ExcInfo, bool, str], str]:
         or plain text.
     """
     try:
+        import IPython
         import IPython.core.ultratb
 
         def format_exc_info(
@@ -32,7 +33,12 @@ def get_tb_formatter() -> Callable[[ExcInfo, bool, str], str]:
         ) -> str:
             # avoid verbose printing of the array data
             with np.printoptions(precision=5, threshold=10, edgeitems=2):
-                vbtb = IPython.core.ultratb.VerboseTB(color_scheme=color)
+                if IPython.version_info > (9, 0):
+                    vbtb = IPython.core.ultratb.VerboseTB(
+                        theme_name=color.lower()
+                    )
+                else:
+                    vbtb = IPython.core.ultratb.VerboseTB(color_scheme=color)
                 if as_html:
                     ansi_string = vbtb.text(*info).replace(' ', '&nbsp;')
                     html = ''.join(ansi2html(ansi_string))

--- a/napari/utils/_tracebacks.py
+++ b/napari/utils/_tracebacks.py
@@ -33,7 +33,7 @@ def get_tb_formatter() -> Callable[[ExcInfo, bool, str], str]:
         ) -> str:
             # avoid verbose printing of the array data
             with np.printoptions(precision=5, threshold=10, edgeitems=2):
-                if IPython.version_info > (9, 0):
+                if IPython.version_info >= (9, 0):
                     vbtb = IPython.core.ultratb.VerboseTB(
                         theme_name=color.lower()
                     )


### PR DESCRIPTION
I prefer a version check than a try/except as this makes it easy to know in a few years which branch of the code you can drop.

Note that there are a few differences between themes and color_scheme, in particular themes use pygments, and can change some symbols (like the current frame/line arrow), while colorscheme can only change ansicolors.

I also want to note that themes are yielding a sequence of token which are formatted using pygments, so _in theory_ the formatter could emit html (instead of ansi) and so now you could try to plug an HtmlFormatter instead of an Terminal256 Formatter and get rid of your ansi2html, and this will give you more freedom on style by changing font, using strikethrough, and a few other that Ansi does not support.

That might requires a few more updates on the IPython side, and maybe downstream to stack data), and in the end you might be able to just provide a Napari theme.


--- 


Prompted by #7649

