### PR TITLE
Move focus to main window before close `NapariQtNotification`

### DIFF
--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -203,6 +203,7 @@ class NapariQtNotification(QDialog):
             )
             if len(notifications) > 1 and notifications[-1] == self:
                 notifications[-2].timer_start()
+            self.parent().setFocus()
         super().close()
 
     def close_with_fade(self):


### PR DESCRIPTION
# References and relevant issues
closes #7654 

# Description
Move focus to the main window before destruction to avoid calling of `_focus_changed` during destruction