### PR TITLE
Update layerlist.py docstring to stop doc build warnings

### DIFF
--- a/napari/components/layerlist.py
+++ b/napari/components/layerlist.py
@@ -35,7 +35,7 @@ class LayerList(SelectableEventedList[Layer]):
         Iterable of napari.layer.Layer
 
     Events
-    ------
+    ~~~~~~
     inserting : (index: int)
         emitted before an item is inserted at ``index``
     inserted : (index: int, value: T)


### PR DESCRIPTION
# References and relevant issues
Trying ro reduce warnings in docs CI

# Description
This PR checks if changing the heading level for events will stop the warning error about the LayerList for every CI run.

