### PR TITLE
Add API to Camera model to flip axes

### DIFF
--- a/examples/xarray-latlon-timeseries.py
+++ b/examples/xarray-latlon-timeseries.py
@@ -1,10 +1,12 @@
 """Displaying xarray data in napari.
 
 This example shows how to view xarray datasets in napari, including scale
-and translation information. Currently, napari cannot display
-irregularly-sampled data, so the code assumes that the data indices are
-regularly spaced. If your indices are irregular, use `xarray.Dataset.interp`
-to create a regularly-spaced version before displaying it in napari.
+and translation information.
+
+Currently, napari cannot display irregularly-sampled data, so the code
+assumes that the data indices are regularly spaced. If your indices are
+irregular, use `xarray.Dataset.interp` to create a regularly-spaced version
+before displaying it in napari.
 
 .. tags:: visualization-advanced, layers, xarray
 """

--- a/examples/xarray-latlon-timeseries.py
+++ b/examples/xarray-latlon-timeseries.py
@@ -1,0 +1,81 @@
+"""Displaying xarray data in napari.
+
+This example shows how to view xarray datasets in napari, including scale
+and translation information. Currently, napari cannot display
+irregularly-sampled data, so the code assumes that the data indices are
+regularly spaced. If your indices are irregular, use `xarray.Dataset.interp`
+to create a regularly-spaced version before displaying it in napari.
+
+.. tags:: visualization-advanced, layers, xarray
+"""
+import numpy as np
+import xarray as xr
+
+import napari
+
+# open the xarray global sea surface temperature (40MB) and North America
+# air temperature (30MB) datasets
+sst = xr.tutorial.open_dataset('ersstv5')
+airtemp = xr.tutorial.open_dataset('air_temperature')
+
+
+def get_scale_translate(dataset, array_name):
+    """Get the translate/offset and scale parameters for an xarray dataset.
+
+    This code assumes that the dataset is regularly spaced. You should
+    interpolate your data if it is sampled at irregular spaces.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        The dataset containing the array to be displayed.
+    array_name : str
+        The name of the xarray DataArray within `dataset` to be displayed in
+        napari.
+
+    Returns
+    -------
+    param_dict : dict[str, list[float]]
+        The scale and translate parameters computed from the xarray dimension
+        indices.
+    """
+    array = getattr(dataset, array_name)
+    if array is None:
+        raise ValueError(f'{dataset} has no array with name {array_name}')
+    dims = [getattr(dataset, dim) for dim in array.dims]
+    translate = [float(d[0]) for d in dims]
+    scale = [float(d[1] - d[0]) for d in dims]
+    return {'scale': scale, 'translate': translate}
+
+
+# Show the raw (not resampled) model data
+viewer, sst_layer = napari.imshow(
+        sst.sst,
+        name='sea surface temp',
+        **get_scale_translate(sst, 'sst'),
+        colormap='magma',
+        )
+viewer.dims.axis_labels = sst.sst.dims
+
+air_layer = viewer.add_image(
+        airtemp.air,
+        name='air temp NA',
+        **get_scale_translate(airtemp, 'air'),
+        colormap='viridis',
+        blending='additive',
+        contrast_limits=(-23 + 273, 32 + 273),  # data are in degrees Kelvin
+        )
+
+# set a time that overlaps both datasets
+viewer.dims.set_point(0, np.datetime64('2013-03-10T18:00:00.000000000'))
+
+# latitude goes from -90 (south, down) to 90 (north, up),
+# so we make sure that the camera vertical axis points up.
+viewer.camera.orientation2d = ('up', 'right')
+
+# fill the frame
+viewer.reset_view(margin=0)
+
+
+if __name__ == '__main__':
+    napari.run()

--- a/examples/xarray-latlon-timeseries.py
+++ b/examples/xarray-latlon-timeseries.py
@@ -1,4 +1,6 @@
-"""Displaying xarray data in napari.
+"""
+Displaying xarray data in napari
+================================
 
 This example shows how to view xarray datasets in napari, including scale
 and translation information.

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -1,9 +1,5 @@
-import os
-import sys
-
 import numpy as np
-import pytest
-from qtpy import PYQT5
+from qtpy.QtWidgets import QApplication
 
 
 def test_camera(make_napari_viewer):
@@ -155,6 +151,7 @@ def test_camera_orientation_2d(make_napari_viewer):
     # screenshot should continually increase as you go down in the image.
     # We take only the first channel in the RGBA array for simplicity, since
     # this is a grayscale image.
+    QApplication.processEvents()  # ensure all viewer attributes updated
     sshot0 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     # check that the values are monotonically increasing down:
     avg_row_intensity_grad0 = np.diff(np.mean(sshot0, axis=1))
@@ -167,6 +164,7 @@ def test_camera_orientation_2d(make_napari_viewer):
     # now we reverse the orientation of the vertical axis, and check that the
     # row gradient has changed direction but not the col gradient
     viewer.camera.orientation2d = ('up', 'right')
+    QApplication.processEvents()  # ensure all viewer attributes updated
     sshot1 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     avg_row_intensity_grad1 = np.diff(np.mean(sshot1, axis=1))
     assert np.all(avg_row_intensity_grad1 <= 0)  # note inverted sign
@@ -176,6 +174,7 @@ def test_camera_orientation_2d(make_napari_viewer):
     # finally, reverse orientation of horizontal axis, check that col gradient
     # has now also changed direction
     viewer.camera.orientation2d = ('up', 'left')
+    QApplication.processEvents()  # ensure all viewer attributes updated
     sshot2 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     avg_row_intensity_grad2 = np.diff(np.mean(sshot2, axis=1))
     assert np.all(avg_row_intensity_grad2 <= 0)  # note inverted sign
@@ -183,15 +182,6 @@ def test_camera_orientation_2d(make_napari_viewer):
     assert np.all(avg_col_intensity_grad2 <= 0)
 
 
-@pytest.mark.xfail(
-    condition=(
-        sys.version_info >= (3, 13)
-        and sys.platform.startswith('darwin')
-        and os.getenv('CI', '0') != '0'
-        and PYQT5
-    ),
-    reason='test fails on this specific CI config for some reason',
-)
 def test_camera_orientation_3d(make_napari_viewer):
     """Test that flipping camera orientation in 3D flips volume as expected."""
     viewer = make_napari_viewer()
@@ -210,8 +200,10 @@ def test_camera_orientation_3d(make_napari_viewer):
 
     viewer.camera.perspective = 60
     viewer.camera.orientation = ('away', 'down', 'right')
+    QApplication.processEvents()  # ensure all viewer attributes updated
     sshot_away = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     viewer.camera.orientation = ('towards', 'down', 'right')
+    QApplication.processEvents()  # ensure all viewer attributes updated
     sshot_towards = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
 
     assert np.mean(sshot_towards) > np.mean(sshot_away)

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -146,33 +146,32 @@ def test_camera_orientation_2d(make_napari_viewer):
     _ = viewer.add_image(data, interpolation2d='linear')
 
     # in the default axis orientation of (down, right), the values in a
-    # screenshot should continually increase as you go down in the shot
-    sshot = viewer.screenshot(canvas_only=True, flash=False)
-    sshot_gray = sshot[..., 0]  # take only first channel in RGBA array
+    # screenshot should continually increase as you go down in the image.
+    # We take only the first channel in the RGBA array for simplicity, since
+    # this is a grayscale image.
+    sshot0 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     # check that the values are monotonically increasing down:
-    avg_row_intensity_grad = np.diff(np.mean(sshot_gray, axis=1))
-    assert np.all(avg_row_intensity_grad >= 0)
+    avg_row_intensity_grad0 = np.diff(np.mean(sshot0, axis=1))
+    assert np.all(avg_row_intensity_grad0 >= 0)
 
     # same but to the right
-    avg_col_intensity_grad = np.diff(np.mean(sshot_gray, axis=0))
-    assert np.all(avg_col_intensity_grad >= 0)
+    avg_col_intensity_grad0 = np.diff(np.mean(sshot0, axis=0))
+    assert np.all(avg_col_intensity_grad0 >= 0)
 
     # now we reverse the orientation of the vertical axis, and check that the
     # row gradient has changed direction but not the col gradient
     viewer.camera.orientation2d = ('up', 'right')
-    sshot = viewer.screenshot(canvas_only=True, flash=False)
-    sshot_gray = sshot[..., 0]
-    avg_row_intensity_grad = np.diff(np.mean(sshot_gray, axis=1))
-    assert np.all(avg_row_intensity_grad <= 0)  # note inverted sign
-    avg_col_intensity_grad = np.diff(np.mean(sshot_gray, axis=0))
-    assert np.all(avg_col_intensity_grad >= 0)
+    sshot1 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
+    avg_row_intensity_grad1 = np.diff(np.mean(sshot1, axis=1))
+    assert np.all(avg_row_intensity_grad1 <= 0)  # note inverted sign
+    avg_col_intensity_grad1 = np.diff(np.mean(sshot1, axis=0))
+    assert np.all(avg_col_intensity_grad1 >= 0)
 
     # finally, reverse orientation of horizontal axis, check that col gradient
     # has now also changed direction
     viewer.camera.orientation2d = ('up', 'left')
-    sshot = viewer.screenshot(canvas_only=True, flash=False)
-    sshot_gray = sshot[..., 0]
-    avg_row_intensity_grad = np.diff(np.mean(sshot_gray, axis=1))
-    assert np.all(avg_row_intensity_grad <= 0)  # note inverted sign
-    avg_col_intensity_grad = np.diff(np.mean(sshot_gray, axis=0))
-    assert np.all(avg_col_intensity_grad <= 0)
+    sshot2 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
+    avg_row_intensity_grad2 = np.diff(np.mean(sshot2, axis=1))
+    assert np.all(avg_row_intensity_grad2 <= 0)  # note inverted sign
+    avg_col_intensity_grad2 = np.diff(np.mean(sshot2, axis=0))
+    assert np.all(avg_col_intensity_grad2 <= 0)

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -190,7 +190,8 @@ def test_camera_orientation_2d(make_napari_viewer):
         and os.getenv('CI', '0') != '0'
         and PYQT5
     ),
-    reason='test fails on this specific CI config for some reason',
+    reason='test sometimes fails on this specific CI config for some reason',
+    strict=False,
 )
 def test_camera_orientation_3d(make_napari_viewer):
     """Test that flipping camera orientation in 3D flips volume as expected."""

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -1,4 +1,9 @@
+import os
+import sys
+
 import numpy as np
+import pytest
+from qtpy import PYQT5
 
 
 def test_camera(make_napari_viewer):
@@ -115,6 +120,15 @@ def test_vispy_camera_update_from_model_3D(make_napari_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
+@pytest.mark.xfail(
+    condition=(
+        sys.version_info >= (3, 13)
+        and sys.platform.startswith('darwin')
+        and os.getenv('CI', '0') != '0'
+        and PYQT5
+    ),
+    reason='test fails on this specific CI config for some reason',
+)
 def test_camera_model_update_from_vispy_3D(make_napari_viewer):
     """Test camera model updates from vispy in 3D."""
     viewer = make_napari_viewer()

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -141,6 +141,7 @@ def test_camera_model_update_from_vispy_3D(make_napari_viewer):
 
 
 def test_camera_orientation_2d(make_napari_viewer):
+    """Test that flipping orientation of the camera flips displayed image."""
     viewer = make_napari_viewer()
     data = np.arange(16).reshape((4, 4))
     _ = viewer.add_image(data, interpolation2d='linear')

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -138,3 +138,41 @@ def test_camera_model_update_from_vispy_3D(make_napari_viewer):
     np.testing.assert_almost_equal(viewer.camera.angles, vispy_camera.angles)
     np.testing.assert_almost_equal(viewer.camera.center, vispy_camera.center)
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
+
+
+def test_camera_orientation_2d(make_napari_viewer):
+    viewer = make_napari_viewer()
+    data = np.arange(16).reshape((4, 4))
+    _ = viewer.add_image(data, interpolation2d='linear')
+
+    # in the default axis orientation of (down, right), the values in a
+    # screenshot should continually increase as you go down in the shot
+    sshot = viewer.screenshot(canvas_only=True, flash=False)
+    sshot_gray = sshot[..., 0]  # take only first channel in RGBA array
+    # check that the values are monotonically increasing down:
+    avg_row_intensity_grad = np.diff(np.mean(sshot_gray, axis=1))
+    assert np.all(avg_row_intensity_grad >= 0)
+
+    # same but to the right
+    avg_col_intensity_grad = np.diff(np.mean(sshot_gray, axis=0))
+    assert np.all(avg_col_intensity_grad >= 0)
+
+    # now we reverse the orientation of the vertical axis, and check that the
+    # row gradient has changed direction but not the col gradient
+    viewer.camera.orientation2d = ('up', 'right')
+    sshot = viewer.screenshot(canvas_only=True, flash=False)
+    sshot_gray = sshot[..., 0]
+    avg_row_intensity_grad = np.diff(np.mean(sshot_gray, axis=1))
+    assert np.all(avg_row_intensity_grad <= 0)  # note inverted sign
+    avg_col_intensity_grad = np.diff(np.mean(sshot_gray, axis=0))
+    assert np.all(avg_col_intensity_grad >= 0)
+
+    # finally, reverse orientation of horizontal axis, check that col gradient
+    # has now also changed direction
+    viewer.camera.orientation2d = ('up', 'left')
+    sshot = viewer.screenshot(canvas_only=True, flash=False)
+    sshot_gray = sshot[..., 0]
+    avg_row_intensity_grad = np.diff(np.mean(sshot_gray, axis=1))
+    assert np.all(avg_row_intensity_grad <= 0)  # note inverted sign
+    avg_col_intensity_grad = np.diff(np.mean(sshot_gray, axis=0))
+    assert np.all(avg_col_intensity_grad <= 0)

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -120,15 +120,6 @@ def test_vispy_camera_update_from_model_3D(make_napari_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
-@pytest.mark.xfail(
-    condition=(
-        sys.version_info >= (3, 13)
-        and sys.platform.startswith('darwin')
-        and os.getenv('CI', '0') != '0'
-        and PYQT5
-    ),
-    reason='test fails on this specific CI config for some reason',
-)
 def test_camera_model_update_from_vispy_3D(make_napari_viewer):
     """Test camera model updates from vispy in 3D."""
     viewer = make_napari_viewer()
@@ -192,6 +183,15 @@ def test_camera_orientation_2d(make_napari_viewer):
     assert np.all(avg_col_intensity_grad2 <= 0)
 
 
+@pytest.mark.xfail(
+    condition=(
+        sys.version_info >= (3, 13)
+        and sys.platform.startswith('darwin')
+        and os.getenv('CI', '0') != '0'
+        and PYQT5
+    ),
+    reason='test fails on this specific CI config for some reason',
+)
 def test_camera_orientation_3d(make_napari_viewer):
     """Test that flipping camera orientation in 3D flips volume as expected."""
     viewer = make_napari_viewer()

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -182,7 +182,12 @@ class VispyCamera:
         self.zoom = self._camera.zoom
 
     def _on_orientation_change(self):
+        # Vispy uses xyz coordinates; napari uses zyx coordinates. We therefore
+        # start by inverting the order of coordinates coming from the napari
+        # camera model:
         orientation_xyz = self._camera.orientation[::-1]
+        # The Vispy camera flip is a tuple of three ints in {0, 1}, indicating
+        # whether they are flipped relative to the Vispy default.
         self._2D_camera.flip = tuple(
             int(ori != default_ori)
             for ori, default_ori in zip(

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -3,8 +3,14 @@ from vispy.scene import ArcballCamera, BaseCamera, PanZoomCamera
 
 from napari._vispy.utils.quaternion import quaternion2euler_degrees
 
-VISPY_DEFAULT_ORIENTATION_2D = ('right', 'up', 'towards')  # xyz, not zyx
-VISPY_DEFAULT_ORIENTATION_3D = ('right', 'down', 'away')  # xyz, not zyx
+# Note: the Vispy axis order is xyz, or horizontal, vertical, depth,
+# while the napari axis order is zyx / plane-row-column, or depth, vertical,
+# horizontal — i.e. it is exactly inverted. This switch happens when data
+# is passed from napari to Vispy, usually with a transposition. In the camera
+# models, this means that the order of these orientations appear in the
+# opposite order to that in napari.components.Camera.
+VISPY_DEFAULT_ORIENTATION_2D = ('right', 'up', 'towards')  # xyz
+VISPY_DEFAULT_ORIENTATION_3D = ('right', 'down', 'away')  # xyz
 
 
 class VispyCamera:

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -35,16 +35,11 @@ class VispyCamera:
 
         # Create 2D camera
         self._2D_camera = MouseToggledPanZoomCamera(aspect=1)
-        # flip y-axis to have correct alignment
-        self._2D_camera.flip = (0, 1, 0)
         self._2D_camera.viewbox_key_event = viewbox_key_event
 
         # Create 3D camera
         self._3D_camera = MouseToggledArcballCamera(fov=0)
         self._3D_camera.viewbox_key_event = viewbox_key_event
-        # flip z-axis to ensure right-handed frame in 3D view
-        # see https://github.com/napari/napari/issues/4633
-        self._3D_camera.flip = (0, 0, 1)
 
         # Set 2D camera by default
         self._view.camera = self._2D_camera

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -9,6 +9,8 @@ from napari._vispy.utils.quaternion import quaternion2euler_degrees
 # is passed from napari to Vispy, usually with a transposition. In the camera
 # models, this means that the order of these orientations appear in the
 # opposite order to that in napari.components.Camera.
+#
+# Note that the default Vispy camera orientations come from Vispy, not from us.
 VISPY_DEFAULT_ORIENTATION_2D = ('right', 'up', 'towards')  # xyz
 VISPY_DEFAULT_ORIENTATION_3D = ('right', 'down', 'away')  # xyz
 

--- a/napari/_vispy/camera.py
+++ b/napari/_vispy/camera.py
@@ -197,13 +197,13 @@ class VispyCamera:
         self._2D_camera.flip = tuple(
             int(ori != default_ori)
             for ori, default_ori in zip(
-                orientation_xyz, VISPY_DEFAULT_ORIENTATION_2D, strict=False
+                orientation_xyz, VISPY_DEFAULT_ORIENTATION_2D, strict=True
             )
         )
         self._3D_camera.flip = tuple(
             int(ori != default_ori)
             for ori, default_ori in zip(
-                orientation_xyz, VISPY_DEFAULT_ORIENTATION_3D, strict=False
+                orientation_xyz, VISPY_DEFAULT_ORIENTATION_3D, strict=True
             )
         )
 

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,4 +1,5 @@
 import warnings
+from enum import auto
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
@@ -6,11 +7,29 @@ from scipy.spatial.transform import Rotation as R
 
 from napari._pydantic_compat import validator
 from napari.utils.events import EventedModel
-from napari.utils.misc import ensure_n_tuple
+from napari.utils.misc import StringEnum, ensure_n_tuple
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     import numpy.typing as npt
+
+
+class VerticalAxisOrientation(StringEnum):
+    UP = auto()
+    DOWN = auto()
+
+
+class HorizontalAxisOrientation(StringEnum):
+    LEFT = auto()
+    RIGHT = auto()
+
+
+class DepthAxisOrientation(StringEnum):
+    AWAY = auto()
+    TOWARDS = auto()
+
+
+DEFAULT_ORIENTATION = ('towards', 'down', 'right')
 
 
 class Camera(EventedModel):
@@ -51,6 +70,11 @@ class Camera(EventedModel):
     perspective: float = 0
     mouse_pan: bool = True
     mouse_zoom: bool = True
+    orientation: tuple[
+        DepthAxisOrientation,
+        VerticalAxisOrientation,
+        HorizontalAxisOrientation,
+    ] = DEFAULT_ORIENTATION
 
     # validators
     @validator('center', 'angles', pre=True, allow_reuse=True)

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -238,6 +238,18 @@ class Camera(EventedModel):
         return up_direction_nd
 
     @property
+    def orientation2d(
+        self,
+    ) -> tuple[VerticalAxisOrientation, HorizontalAxisOrientation]:
+        return self.orientation[1:]
+
+    @orientation2d.setter
+    def orientation2d(
+        self, value: tuple[VerticalAxisOrientation, HorizontalAxisOrientation]
+    ) -> None:
+        self.orientation = (self.orientation[0],) + value
+
+    @property
     def interactive(self) -> bool:
         warnings.warn(
             '`Camera.interactive` is deprecated since 0.5.0 and will be removed in 0.6.0.',

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -18,20 +18,24 @@ class VerticalAxisOrientation(StringEnum):
     UP = auto()
     DOWN = auto()
 
-VerticalAxisOrientationStr = Literal['up'] | Literal['down']
+
+VerticalAxisOrientationStr = Literal['up', 'down']
 
 
 class HorizontalAxisOrientation(StringEnum):
     LEFT = auto()
     RIGHT = auto()
-    
-HorizontalAxisOrientationStr = Literal['left'] | Literal['right']
+
+
+HorizontalAxisOrientationStr = Literal['left', 'right']
+
 
 class DepthAxisOrientation(StringEnum):
     AWAY = auto()
     TOWARDS = auto()
-    
-HorizontalAxisOrientationStr = Literal['away'] | Literal['torwards']
+
+
+HorizontalAxisOrientationStr = Literal['away', 'torwards']
 
 
 DEFAULT_ORIENTATION_TYPED = (
@@ -257,12 +261,17 @@ class Camera(EventedModel):
     def orientation2d(
         self,
         value: tuple[
-            VerticalAxisOrientation | VerticalAxisOrientationStr, HorizontalAxisOrientation | HorizontalAxisOrientationStr
+            VerticalAxisOrientation | VerticalAxisOrientationStr,
+            HorizontalAxisOrientation | HorizontalAxisOrientationStr,
         ],
     ) -> None:
         # we ignore typing because Pydantic + StrEnum can correctly coerce
         # str values to their corresponding StrEnum values in the model
-        self.orientation = (self.orientation[0], VerticalAxisOrientation(value[0]), HorizontalAxisOrientation(value[1]))
+        self.orientation = (
+            self.orientation[0],
+            VerticalAxisOrientation(value[0]),
+            HorizontalAxisOrientation(value[1]),
+        )
 
     @property
     def interactive(self) -> bool:

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -30,6 +30,11 @@ class DepthAxisOrientation(StringEnum):
 
 
 DEFAULT_ORIENTATION = ('towards', 'down', 'right')
+DEFAULT_ORIENTATION_TYPED = (
+    DepthAxisOrientation.TOWARDS,
+    VerticalAxisOrientation.DOWN,
+    HorizontalAxisOrientation.RIGHT,
+)
 
 
 class Camera(EventedModel):
@@ -74,7 +79,7 @@ class Camera(EventedModel):
         DepthAxisOrientation,
         VerticalAxisOrientation,
         HorizontalAxisOrientation,
-    ] = DEFAULT_ORIENTATION
+    ] = DEFAULT_ORIENTATION_TYPED
 
     # validators
     @validator('center', 'angles', pre=True, allow_reuse=True)

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import auto
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R
@@ -18,15 +18,20 @@ class VerticalAxisOrientation(StringEnum):
     UP = auto()
     DOWN = auto()
 
+VerticalAxisOrientationStr = Literal['up'] | Literal['down']
+
 
 class HorizontalAxisOrientation(StringEnum):
     LEFT = auto()
     RIGHT = auto()
-
+    
+HorizontalAxisOrientationStr = Literal['left'] | Literal['right']
 
 class DepthAxisOrientation(StringEnum):
     AWAY = auto()
     TOWARDS = auto()
+    
+HorizontalAxisOrientationStr = Literal['away'] | Literal['torwards']
 
 
 DEFAULT_ORIENTATION_TYPED = (
@@ -252,12 +257,12 @@ class Camera(EventedModel):
     def orientation2d(
         self,
         value: tuple[
-            VerticalAxisOrientation | str, HorizontalAxisOrientation | str
+            VerticalAxisOrientation | VerticalAxisOrientationStr, HorizontalAxisOrientation | HorizontalAxisOrientationStr
         ],
     ) -> None:
         # we ignore typing because Pydantic + StrEnum can correctly coerce
         # str values to their corresponding StrEnum values in the model
-        self.orientation = (self.orientation[0],) + value  # type:ignore[assignment]
+        self.orientation = (self.orientation[0], VerticalAxisOrientation(value[0]), HorizontalAxisOrientation(value[1]))
 
     @property
     def interactive(self) -> bool:

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -250,7 +250,10 @@ class Camera(EventedModel):
 
     @orientation2d.setter
     def orientation2d(
-        self, value: tuple[VerticalAxisOrientation, HorizontalAxisOrientation]
+        self,
+        value: tuple[
+            VerticalAxisOrientation | str, HorizontalAxisOrientation | str
+        ],
     ) -> None:
         self.orientation = (self.orientation[0],) + value
 

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -255,7 +255,9 @@ class Camera(EventedModel):
             VerticalAxisOrientation | str, HorizontalAxisOrientation | str
         ],
     ) -> None:
-        self.orientation = (self.orientation[0],) + value
+        # we ignore typing because Pydantic + StrEnum can correctly coerce
+        # str values to their corresponding StrEnum values in the model
+        self.orientation = (self.orientation[0],) + value  # type:ignore[assignment]
 
     @property
     def interactive(self) -> bool:

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -29,12 +29,12 @@ class DepthAxisOrientation(StringEnum):
     TOWARDS = auto()
 
 
-DEFAULT_ORIENTATION = ('towards', 'down', 'right')
 DEFAULT_ORIENTATION_TYPED = (
     DepthAxisOrientation.TOWARDS,
     VerticalAxisOrientation.DOWN,
     HorizontalAxisOrientation.RIGHT,
 )
+DEFAULT_ORIENTATION = tuple(map(str, DEFAULT_ORIENTATION_TYPED))
 
 
 class Camera(EventedModel):

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -19,15 +19,9 @@ class VerticalAxisOrientation(StringEnum):
     DOWN = auto()
 
 
-VerticalAxisOrientationStr = Literal['up', 'down']
-
-
 class HorizontalAxisOrientation(StringEnum):
     LEFT = auto()
     RIGHT = auto()
-
-
-HorizontalAxisOrientationStr = Literal['left', 'right']
 
 
 class DepthAxisOrientation(StringEnum):
@@ -35,7 +29,9 @@ class DepthAxisOrientation(StringEnum):
     TOWARDS = auto()
 
 
-HorizontalAxisOrientationStr = Literal['away', 'torwards']
+VerticalAxisOrientationStr = Literal['up', 'down']
+HorizontalAxisOrientationStr = Literal['left', 'right']
+DepthAxisOrientationStr = Literal['away', 'torwards']
 
 
 DEFAULT_ORIENTATION_TYPED = (
@@ -265,8 +261,6 @@ class Camera(EventedModel):
             HorizontalAxisOrientation | HorizontalAxisOrientationStr,
         ],
     ) -> None:
-        # we ignore typing because Pydantic + StrEnum can correctly coerce
-        # str values to their corresponding StrEnum values in the model
         self.orientation = (
             self.orientation[0],
             VerticalAxisOrientation(value[0]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ gallery = [
     "pooch",
     "nilearn",
     "xarray",
+    "h5netcdf",
 ]
 # needed to build docs
 docs = [


### PR DESCRIPTION
In #7554 / #7488 we changed the default orientation of axes in 3D mode. This may be undesirable to some users, so this PR adds the ability to flip them.

It also turns out to be handy when displaying data which has specific absolute coordinates as well as a common convention for the display direction, such as geographical data. See the included example which both demonstrates how to use napari with xarray as well as how to use this new camera axis-flip API. Currently I'm pretty happy with the API (see below), but I'm very much open to alternative suggestions!

## API description

This adds an `orientation` attribute to our Camera model. The scene is assumed to have three axes, z, y, and x, which are aligned with the depth, vertical, and horizontal axes of the camera. Each of these axes can then point either:
- away or towards the camera
- down or up
- right or left

I used a StrEnum for each of these values, which makes the API both robust for type checking and easy to use, e.g.:

```python
viewer.camera.orientation = ('away', 'up', 'right')
```

I also added an `orientation2d` property, because it's strange to set three values to flip two axes, even though that is the Vispy model. (camera.flip is a 3-tuple even for 2D cameras in Vispy.) You can see its use in the example. To show latitude (-90 for south, 90 for north), we want the vertical axis to point up, not down like in the napari default. So we do:

```python
viewer.camera.orientation2d = ('up', 'right')
```

and the geographic raster of temperatures is displayed correctly:

![CleanShot 2025-03-03 at 12 42 18@2x](https://github.com/user-attachments/assets/03ee83dd-9272-4991-bf28-524ecd5ff321)

Without this API, the map ends up upside down:

![CleanShot 2025-03-04 at 18 29 50@2x](https://github.com/user-attachments/assets/bb51c197-9fe4-42c8-bd28-687309b46829)
