### PR TITLE
Show viewer before trigger screenshot in the camera tests

### DIFF
--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -151,7 +151,7 @@ def test_camera_orientation_2d(make_napari_viewer, qtbot):
     # We take only the first channel in the RGBA array for simplicity, since
     # this is a grayscale image.
     qtbot.wait(50)
-    sshot0 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
+    sshot0 = viewer.window.export_figure(scale=10, flash=False)[..., 0]
     # check that the values are monotonically increasing down:
     avg_row_intensity_grad0 = np.diff(np.mean(sshot0, axis=1))
     assert np.all(avg_row_intensity_grad0 >= 0)
@@ -164,7 +164,7 @@ def test_camera_orientation_2d(make_napari_viewer, qtbot):
     # row gradient has changed direction but not the col gradient
     viewer.camera.orientation2d = ('up', 'right')
     qtbot.wait(50)
-    sshot1 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
+    sshot1 = viewer.window.export_figure(scale=10, flash=False)[..., 0]
     avg_row_intensity_grad1 = np.diff(np.mean(sshot1, axis=1))
     assert np.all(avg_row_intensity_grad1 <= 0)  # note inverted sign
     avg_col_intensity_grad1 = np.diff(np.mean(sshot1, axis=0))
@@ -174,7 +174,7 @@ def test_camera_orientation_2d(make_napari_viewer, qtbot):
     # has now also changed direction
     viewer.camera.orientation2d = ('up', 'left')
     qtbot.wait(50)
-    sshot2 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
+    sshot2 = viewer.window.export_figure(scale=10, flash=False)[..., 0]
     avg_row_intensity_grad2 = np.diff(np.mean(sshot2, axis=1))
     assert np.all(avg_row_intensity_grad2 <= 0)  # note inverted sign
     avg_col_intensity_grad2 = np.diff(np.mean(sshot2, axis=0))

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -180,7 +180,7 @@ def test_camera_orientation_2d(make_napari_viewer):
 
 def test_camera_orientation_3d(make_napari_viewer, qtbot):
     """Test that flipping camera orientation in 3D flips volume as expected."""
-    viewer = make_napari_viewer()
+    viewer = make_napari_viewer(show=True)
     viewer.dims.ndisplay = 3
     gradient_z = np.arange(16).reshape((16, 1, 1))
     image = np.ones((16, 16))

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -142,7 +142,7 @@ def test_camera_model_update_from_vispy_3D(make_napari_viewer):
 
 def test_camera_orientation_2d(make_napari_viewer):
     """Test that flipping orientation of the camera flips displayed image."""
-    viewer = make_napari_viewer()
+    viewer = make_napari_viewer(show=True)
     data = np.arange(16).reshape((4, 4))
     _ = viewer.add_image(data, interpolation2d='linear')
 

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -140,7 +140,7 @@ def test_camera_model_update_from_vispy_3D(make_napari_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
-def test_camera_orientation_2d(make_napari_viewer):
+def test_camera_orientation_2d(make_napari_viewer, qtbot):
     """Test that flipping orientation of the camera flips displayed image."""
     viewer = make_napari_viewer(show=True)
     data = np.arange(16).reshape((4, 4))
@@ -150,6 +150,7 @@ def test_camera_orientation_2d(make_napari_viewer):
     # screenshot should continually increase as you go down in the image.
     # We take only the first channel in the RGBA array for simplicity, since
     # this is a grayscale image.
+    qtbot.wait(50)
     sshot0 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     # check that the values are monotonically increasing down:
     avg_row_intensity_grad0 = np.diff(np.mean(sshot0, axis=1))
@@ -162,6 +163,7 @@ def test_camera_orientation_2d(make_napari_viewer):
     # now we reverse the orientation of the vertical axis, and check that the
     # row gradient has changed direction but not the col gradient
     viewer.camera.orientation2d = ('up', 'right')
+    qtbot.wait(50)
     sshot1 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     avg_row_intensity_grad1 = np.diff(np.mean(sshot1, axis=1))
     assert np.all(avg_row_intensity_grad1 <= 0)  # note inverted sign
@@ -171,6 +173,7 @@ def test_camera_orientation_2d(make_napari_viewer):
     # finally, reverse orientation of horizontal axis, check that col gradient
     # has now also changed direction
     viewer.camera.orientation2d = ('up', 'left')
+    qtbot.wait(50)
     sshot2 = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     avg_row_intensity_grad2 = np.diff(np.mean(sshot2, axis=1))
     assert np.all(avg_row_intensity_grad2 <= 0)  # note inverted sign

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -1,9 +1,4 @@
-import os
-import sys
-
 import numpy as np
-import pytest
-from qtpy import PYQT5
 
 
 def test_camera(make_napari_viewer):
@@ -183,17 +178,7 @@ def test_camera_orientation_2d(make_napari_viewer):
     assert np.all(avg_col_intensity_grad2 <= 0)
 
 
-@pytest.mark.xfail(
-    condition=(
-        sys.version_info >= (3, 13)
-        and sys.platform.startswith('darwin')
-        and os.getenv('CI', '0') != '0'
-        and PYQT5
-    ),
-    reason='test sometimes fails on this specific CI config for some reason',
-    strict=False,
-)
-def test_camera_orientation_3d(make_napari_viewer):
+def test_camera_orientation_3d(make_napari_viewer, qtbot):
     """Test that flipping camera orientation in 3D flips volume as expected."""
     viewer = make_napari_viewer()
     viewer.dims.ndisplay = 3
@@ -211,8 +196,10 @@ def test_camera_orientation_3d(make_napari_viewer):
 
     viewer.camera.perspective = 60
     viewer.camera.orientation = ('away', 'down', 'right')
+    qtbot.wait(50)
     sshot_away = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
     viewer.camera.orientation = ('towards', 'down', 'right')
+    qtbot.wait(50)
     sshot_towards = viewer.screenshot(canvas_only=True, flash=False)[..., 0]
 
     assert np.mean(sshot_towards) > np.mean(sshot_away)


### PR DESCRIPTION
# References and relevant issues

closes #7678

# Description

Show viewer to have working screenshots and fix 2d tests. 

For 2D test, the code was not prepared for margins on screenshot, so it is changed to `export_figure` now. 