### PR TITLE
Block ipykernel==7.0.0a1

### DIFF
--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -4,7 +4,7 @@ PySide6 < 6.3.2 ; python_version < '3.10'
 PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.12'
 pytest-json-report
 tensorstore!=0.1.38,!=0.1.72
-ipykernel!=7.0.0a0
+ipykernel!=7.0.0a0,!=7.0.0a1
 wrapt!=1.17.0 # problem with macOS intel
 zarr!=3.0.0b3,!=3.0.0b2,!=3.0.0rc1
 pydantic!=2.11.0a2,!=2.11.0a1


### PR DESCRIPTION
# References and relevant issues

Closes #7681

# Description

As ipykernel alpha crashes qt console then block it.