### PR TITLE
Fix `is_convex` to properly handle shapes with self intersection

### DIFF
--- a/examples/dev/triangle_edge.py
+++ b/examples/dev/triangle_edge.py
@@ -337,6 +337,13 @@ def add_helper_layers(viewer: napari.Viewer, source_layer):
         partial(update_helper_layers, viewer=viewer, source_layer=source_layer)
     )
 
+def pentagram():
+    radius = 10
+    n = 5
+    angles = np.linspace(0, 4 * np.pi, n, endpoint=False)
+    return np.column_stack((radius * np.cos(angles), radius * np.sin(angles)))
+
+
 
 path = np.array([[0,0], [0,1], [1,1], [1,0]]) * 10
 sparkle = np.array([[1, 1], [10, 0], [1, -1], [0, -10],
@@ -344,6 +351,7 @@ sparkle = np.array([[1, 1], [10, 0], [1, -1], [0, -10],
 fork = np.array([[2, 10], [0, -5], [-2, 10], [-2, -10], [2, -10]])
 
 poly_hole = np.array([[0,0], [10, 0], [10, 10], [0, 10], [0, 0], [2, 5], [5, 8], [8, 5], [5, 2], [2, 5]]) *1.5
+
 
 polygons = [
     # square
@@ -368,6 +376,7 @@ polygons = [
               [15.83450076, 10.5778984]],
              ) + np.array([[60, -15]]),
     poly_hole + np.array([[65, 20]]),
+    pentagram() + np.array([[70, 75]]),
     ]
 
 paths = [

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -158,7 +158,7 @@ def test_polygon2():
     shape = Polygon(data, interpolation_order=3)
     # should get many triangles
 
-    expected_face = (249, 2)
+    expected_face = (251, 2)
 
     assert shape._edge_vertices.shape == (500, 2)
     assert shape._face_vertices.shape == expected_face

--- a/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
+++ b/napari/layers/shapes/_shapes_models/_tests/test_shapes_models.py
@@ -158,7 +158,7 @@ def test_polygon2():
     shape = Polygon(data, interpolation_order=3)
     # should get many triangles
 
-    expected_face = (251, 2)
+    expected_face = (249, 2)
 
     assert shape._edge_vertices.shape == (500, 2)
     assert shape._face_vertices.shape == expected_face

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -92,7 +92,7 @@ def _is_simple(poly: npt.NDArray) -> bool:
     angles = angles - angles[0]
     angles[angles < 0] += 2 * np.pi
     # check if angles are increasing
-    return np.all(np.diff(angles) > 0)
+    return bool(np.all(np.diff(angles) > 0))
 
 
 def _is_convex(poly: npt.NDArray) -> bool:

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -88,7 +88,7 @@ def _common_orientation(poly: npt.NDArray) -> int | None:
 
 
 def _is_simple(poly: npt.NDArray, orientation_: int) -> bool:
-    """Check whether a polygon is simple.
+    """Check whether a polygon with same oriented angles between successive edges is simple.
 
     A polygon is considered simple if its edges do not intersect themselves.
     This is determined by checking whether the angles between successive

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -88,15 +88,15 @@ def _same_oriented_angles(poly: npt.NDArray) -> tuple[bool, int]:
 def _is_simple(poly: npt.NDArray, orientation_: int) -> bool:
     if poly.shape[0] < 3:
         return False  # Not enough vertices to form a polygon
+    if orientation_ == 1:
+        poly = poly[::-1]
     centroid = poly.mean(axis=0)
     angles = np.arctan2(poly[:, 1] - centroid[1], poly[:, 0] - centroid[0])
     # orig_angles = angles.copy()
-    angles = angles - angles[0]
-    angles[angles < 0] += 2 * np.pi
+    shifted_angles = angles - angles[0]
+    shifted_angles[shifted_angles < 0] += 2 * np.pi
     # check if angles are increasing
-    if angles[0] < angles[-1]:
-        return bool(np.all(np.diff(angles) > 0))
-    return bool(np.all(np.diff(angles) < 0))
+    return bool(np.all(np.diff(shifted_angles) > 0))
 
 
 def _is_convex(poly: npt.NDArray) -> bool:

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -60,8 +60,8 @@ def find_planar_axis(
     return np.empty((0, 2), dtype=points.dtype), None, None
 
 
-def _is_convex(poly: npt.NDArray) -> bool:
-    """Check whether a polygon is convex.
+def _same_oriented_angles(poly: npt.NDArray) -> bool:
+    """Check whether a polygon has the same orientation for all its angles
 
     Parameters
     ----------
@@ -82,6 +82,31 @@ def _is_convex(poly: npt.NDArray) -> bool:
     return (orn_set[0] == orientation(poly[-2], poly[-1], poly[0])) and (
         orn_set[0] == orientation(poly[-1], poly[0], poly[1])
     )
+
+
+def _is_simple(poly: npt.NDArray) -> bool:
+    if poly.shape[0] < 3:
+        return False  # Not enough vertices to form a polygon
+    centroid = poly.mean(axis=0)
+    angles = np.arctan2(poly[:, 1] - centroid[1], poly[:, 0] - centroid[0])
+    # check if angles are increasing
+    return np.all(np.diff(angles) > 0)
+
+
+def _is_convex(poly: npt.NDArray) -> bool:
+    """Check whether a polygon is convex.
+
+    Parameters
+    ----------
+    poly: numpy array of floats, shape (N, 3)
+        Polygon vertices, in order.
+
+    Returns
+    -------
+    bool
+        True if the given polygon is convex.
+    """
+    return _same_oriented_angles(poly) and _is_simple(poly)
 
 
 def _fan_triangulation(poly: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -89,6 +89,8 @@ def _is_simple(poly: npt.NDArray) -> bool:
         return False  # Not enough vertices to form a polygon
     centroid = poly.mean(axis=0)
     angles = np.arctan2(poly[:, 1] - centroid[1], poly[:, 0] - centroid[0])
+    angles = angles - angles[0]
+    angles[angles < 0] += 2 * np.pi
     # check if angles are increasing
     return np.all(np.diff(angles) > 0)
 

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -89,11 +89,11 @@ def _common_orientation(poly: npt.NDArray) -> int | None:
 
 def _is_simple(poly: npt.NDArray, orientation_: int) -> bool:
     """Check whether a polygon is simple.
-    
-    A polygon is considered simple if its edges do not intersect themselves. 
-    This is determined by checking whether the angles between successive 
-    vertices, measured from the centroid, increase consistently around the 
-    polygon in a counterclockwise (or clockwise) direction. If the angles 
+
+    A polygon is considered simple if its edges do not intersect themselves.
+    This is determined by checking whether the angles between successive
+    vertices, measured from the centroid, increase consistently around the
+    polygon in a counterclockwise (or clockwise) direction. If the angles
     from one vertex to the next increase, the polygon is simple.
 
     Parameters
@@ -101,7 +101,7 @@ def _is_simple(poly: npt.NDArray, orientation_: int) -> bool:
     poly: numpy array of floats, shape (N, 2)
         polygon vertices, in order.
     orientation_: int
-        The orientation of the polygon. A value of `1` indicates clockwise 
+        The orientation of the polygon. A value of `1` indicates clockwise
         and `-1` indicates counterclockwise orientation.
 
     Returns

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -72,7 +72,7 @@ def _common_orientation(poly: npt.NDArray) -> int | None:
     -------
     int or None
         if all angles have same orientation return it, otherwise None.
-        Possible values: -1, 0, 1
+        Possible values: -1 if all angles are counterclockwise, 0 if all angles are collinear, 1 if all angles are clockwise
     """
     fst = poly[:-2]
     snd = poly[1:-1]
@@ -89,14 +89,20 @@ def _common_orientation(poly: npt.NDArray) -> int | None:
 
 def _is_simple(poly: npt.NDArray, orientation_: int) -> bool:
     """Check whether a polygon is simple.
-    check if all polygon points have increasing planar coordinates
+    
+    A polygon is considered simple if its edges do not intersect themselves. 
+    This is determined by checking whether the angles between successive 
+    vertices, measured from the centroid, increase consistently around the 
+    polygon in a counterclockwise (or clockwise) direction. If the angles 
+    from one vertex to the next increase, the polygon is simple.
 
     Parameters
     ----------
     poly: numpy array of floats, shape (N, 2)
         polygon vertices, in order.
     orientation_: int
-        clockwise or counterclockwise orientation of the polygon encded as +-1
+        The orientation of the polygon. A value of `1` indicates clockwise 
+        and `-1` indicates counterclockwise orientation.
 
     Returns
     -------

--- a/napari/layers/shapes/_shapes_utils.py
+++ b/napari/layers/shapes/_shapes_utils.py
@@ -87,7 +87,7 @@ def _common_orientation(poly: npt.NDArray) -> int | None:
     return None
 
 
-def _is_simple(poly: npt.NDArray, orientation_: int) -> bool:
+def _are_polar_angles_monotonic(poly: npt.NDArray, orientation_: int) -> bool:
     """Check whether a polygon with same oriented angles between successive edges is simple.
 
     A polygon is considered simple if its edges do not intersect themselves.
@@ -138,7 +138,7 @@ def _is_convex(poly: npt.NDArray) -> bool:
     orientation_ = _common_orientation(poly)
     if orientation_ is None or orientation_ == 0:
         return False
-    return _is_simple(poly, orientation_)
+    return _are_polar_angles_monotonic(poly, orientation_)
 
 
 def _fan_triangulation(poly: npt.NDArray) -> tuple[npt.NDArray, npt.NDArray]:

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -434,5 +434,14 @@ def pentagram():
     return np.column_stack((radius * np.cos(angles), radius * np.sin(angles)))
 
 
-def test_is_convex():
-    assert not _is_convex(pentagram())
+@pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
+def test_is_convex(angle):
+    p = pentagram()
+    rot = np.array(
+        [
+            [np.cos(np.radians(angle)), -np.sin(np.radians(angle))],
+            [np.sin(np.radians(angle)), np.cos(np.radians(angle))],
+        ]
+    )
+    data = np.dot(p, rot)
+    assert not _is_convex(data)

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -6,6 +6,7 @@ from napari.layers.shapes._accelerated_triangulate_dispatch import (
     generate_2D_edge_meshes_py,
 )
 from napari.layers.shapes._shapes_utils import (
+    _is_convex,
     get_default_shape_type,
     number_of_shapes,
     perpendicular_distance,
@@ -424,3 +425,14 @@ def test_perpendicular_distance(start, end, point):
     distance = perpendicular_distance(point, start, end)
 
     assert distance == 1
+
+
+def pentagram():
+    radius = 10
+    n = 5
+    angles = np.linspace(0, 4 * np.pi, n, endpoint=False)
+    return np.column_stack((radius * np.cos(angles), radius * np.sin(angles)))
+
+
+def test_is_convex():
+    assert not _is_convex(pentagram())

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -434,14 +434,32 @@ def pentagram():
     return np.column_stack((radius * np.cos(angles), radius * np.sin(angles)))
 
 
-@pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
-def test_is_convex(angle):
-    p = pentagram()
-    rot = np.array(
+def generate_regular_polygon(n, radius=1):
+    angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    return np.column_stack((radius * np.cos(angles), radius * np.sin(angles)))
+
+
+def rotation_matrix(angle):
+    return np.array(
         [
             [np.cos(np.radians(angle)), -np.sin(np.radians(angle))],
             [np.sin(np.radians(angle)), np.cos(np.radians(angle))],
         ]
     )
+
+
+@pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
+def test_is_convex_self_intersection(angle):
+    p = pentagram()
+    rot = rotation_matrix(angle)
     data = np.dot(p, rot)
     assert not _is_convex(data)
+
+
+@pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
+@pytest.mark.parametrize('n_vertex', [3, 4, 7, 11, 12, 15, 20])
+def test_is_convex(angle, n_vertex):
+    poly = generate_regular_polygon(n_vertex)
+    rot = rotation_matrix(angle)
+    rotated_poly = np.dot(poly, rot)
+    assert _is_convex(rotated_poly)

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -452,18 +452,21 @@ def rotation_matrix(angle):
     )
 
 
-@pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
+ANGLES = [0, 5, 75, 95, 355]
+
+
+@pytest.mark.parametrize('angle', ANGLES, ids=str)
 @pytest.mark.parametrize('reverse', [False, True])
 def test_is_convex_self_intersection(angle, reverse):
-    p = pentagram()
+    p = pentagram(reverse)
     rot = rotation_matrix(angle)
     data = np.dot(p, rot)
     assert not _is_convex(data)
 
 
-@pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
-@pytest.mark.parametrize('n_vertex', [3, 4, 7, 11, 12, 15, 20])
-@pytest.mark.parametrize('reverse', [True, False])
+@pytest.mark.parametrize('angle', ANGLES, ids=str)
+@pytest.mark.parametrize('n_vertex', [3, 4, 7, 12, 15, 20])
+@pytest.mark.parametrize('reverse', [False, True])
 def test_is_convex(angle, n_vertex, reverse):
     poly = generate_regular_polygon(n_vertex, reverse=reverse)
     rot = rotation_matrix(angle)

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -427,15 +427,19 @@ def test_perpendicular_distance(start, end, point):
     assert distance == 1
 
 
-def pentagram():
+def pentagram(reverse):
     radius = 10
     n = 5
     angles = np.linspace(0, 4 * np.pi, n, endpoint=False)
+    if reverse:
+        angles = angles[::-1]
     return np.column_stack((radius * np.cos(angles), radius * np.sin(angles)))
 
 
-def generate_regular_polygon(n, radius=1):
+def generate_regular_polygon(n, reverse, radius=1):
     angles = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    if reverse:
+        angles = angles[::-1]
     return np.column_stack((radius * np.cos(angles), radius * np.sin(angles)))
 
 
@@ -449,7 +453,8 @@ def rotation_matrix(angle):
 
 
 @pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
-def test_is_convex_self_intersection(angle):
+@pytest.mark.parametrize('reverse', [False, True])
+def test_is_convex_self_intersection(angle, reverse):
     p = pentagram()
     rot = rotation_matrix(angle)
     data = np.dot(p, rot)
@@ -458,8 +463,9 @@ def test_is_convex_self_intersection(angle):
 
 @pytest.mark.parametrize('angle', np.arange(0, 360, 5), ids=str)
 @pytest.mark.parametrize('n_vertex', [3, 4, 7, 11, 12, 15, 20])
-def test_is_convex(angle, n_vertex):
-    poly = generate_regular_polygon(n_vertex)
+@pytest.mark.parametrize('reverse', [True, False])
+def test_is_convex(angle, n_vertex, reverse):
+    poly = generate_regular_polygon(n_vertex, reverse=reverse)
     rot = rotation_matrix(angle)
     rotated_poly = np.dot(poly, rot)
     assert _is_convex(rotated_poly)

--- a/napari/layers/shapes/_tests/test_shapes_utils.py
+++ b/napari/layers/shapes/_tests/test_shapes_utils.py
@@ -467,7 +467,7 @@ def test_is_convex_self_intersection(angle, reverse):
 @pytest.mark.parametrize('angle', ANGLES, ids=str)
 @pytest.mark.parametrize('n_vertex', [3, 4, 7, 12, 15, 20])
 @pytest.mark.parametrize('reverse', [False, True])
-def test_is_convex(angle, n_vertex, reverse):
+def test_is_convex_regular_polygon(angle, n_vertex, reverse):
     poly = generate_regular_polygon(n_vertex, reverse=reverse)
     rot = rotation_matrix(angle)
     rotated_poly = np.dot(poly, rot)


### PR DESCRIPTION
# References and relevant issues

# Description
Current main is wrongly identifying shapes like pentagram as convex. This PR fixes it by checking of order of points when projecting on circle from centroid:

main:
![Zrzut ekranu z 2025-03-10 23-50-57](https://github.com/user-attachments/assets/c7098e2c-e254-4ed1-b120-ae991dba764d)

this PR: 
![Zrzut ekranu z 2025-03-10 23-51-26](https://github.com/user-attachments/assets/9b007cfa-c458-4a93-a0f7-ba2840f20bd5)

For compiled backend, the fix will be applied separately to the compiled backend repository.  