### PR TITLE
Skip vispy bounding box test on windows

### DIFF
--- a/napari/_vispy/_tests/test_vispy_bounding_box_visual.py
+++ b/napari/_vispy/_tests/test_vispy_bounding_box_visual.py
@@ -4,7 +4,7 @@ from itertools import product
 import numpy as np
 import pytest
 
-@pytest.mark.skipif(sys.platform="win32", reason="This new test is flaky on windows")
+@pytest.mark.skipif(sys.platform=="win32", reason="This new test is flaky on windows")
 def test_bounding_box_multiscale_3D(make_napari_viewer, qtbot):
     viewer = make_napari_viewer(show=True)
 

--- a/napari/_vispy/_tests/test_vispy_bounding_box_visual.py
+++ b/napari/_vispy/_tests/test_vispy_bounding_box_visual.py
@@ -4,7 +4,10 @@ from itertools import product
 import numpy as np
 import pytest
 
-@pytest.mark.skipif(sys.platform=="win32", reason="This new test is flaky on windows")
+
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='This new test is flaky on windows'
+)
 def test_bounding_box_multiscale_3D(make_napari_viewer, qtbot):
     viewer = make_napari_viewer(show=True)
 

--- a/napari/_vispy/_tests/test_vispy_bounding_box_visual.py
+++ b/napari/_vispy/_tests/test_vispy_bounding_box_visual.py
@@ -1,8 +1,10 @@
+import sys
 from itertools import product
 
 import numpy as np
+import pytest
 
-
+@pytest.mark.skipif(sys.platform="win32", reason="This new test is flaky on windows")
 def test_bounding_box_multiscale_3D(make_napari_viewer, qtbot):
     viewer = make_napari_viewer(show=True)
 


### PR DESCRIPTION
# Description

This PR skips a flaky test on Windows. The test #7545 was introduced recently and is intermittently failing on Windows.

This should unblock #7686 and #7632 

