### PR TITLE
[CI] skip flaky camera_3d test on windows

### DIFF
--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -180,6 +180,7 @@ def test_camera_orientation_2d(make_napari_viewer, qtbot):
     avg_col_intensity_grad2 = np.diff(np.mean(sshot2, axis=0))
     assert np.all(avg_col_intensity_grad2 <= 0)
 
+
 @pytest.mark.skipif(
     sys.platform == 'win32', reason='This new test is flaky on windows'
 )

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -1,3 +1,5 @@
+import sys
+import pytest
 import numpy as np
 
 

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -1,6 +1,7 @@
 import sys
-import pytest
+
 import numpy as np
+import pytest
 
 
 def test_camera(make_napari_viewer):

--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -180,7 +180,9 @@ def test_camera_orientation_2d(make_napari_viewer, qtbot):
     avg_col_intensity_grad2 = np.diff(np.mean(sshot2, axis=0))
     assert np.all(avg_col_intensity_grad2 <= 0)
 
-
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='This new test is flaky on windows'
+)
 def test_camera_orientation_3d(make_napari_viewer, qtbot):
     """Test that flipping camera orientation in 3D flips volume as expected."""
     viewer = make_napari_viewer(show=True)


### PR DESCRIPTION
# References and relevant issues
Part of https://github.com/napari/napari/issues/7705

# Description
I think this is skipping the new-ish test that is flaky on windows.
Please feel free to check me on this!!
(getting tired of chain rerunning CI! 😡 )
