### PR TITLE
Replace duck-typing check with isinstance check for QRangeSlider

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -18,6 +18,7 @@ from qtpy.QtWidgets import (
     QPushButton,
     QRadioButton,
 )
+from superqt.sliders import QRangeSlider
 
 from napari._qt.layer_controls.qt_image_controls import QtImageControls
 from napari._qt.layer_controls.qt_labels_controls import QtLabelsControls
@@ -333,7 +334,7 @@ def test_create_layer_controls_qslider(
     # check QAbstractSlider by changing value with `setValue` from minimum value to maximum
     for qslider in ctrl.findChildren(QAbstractSlider):
         if isinstance(qslider.minimum(), float):
-            if getattr(qslider, '_valuesChanged', None):
+            if isinstance(qslider, QRangeSlider):
                 # create a list of tuples in the case the slider is ranged
                 # from (minimum, minimum) to (maximum, maximum) +
                 # from (minimum, maximum) to (minimum, minimum)
@@ -355,7 +356,7 @@ def test_create_layer_controls_qslider(
             else:
                 value_range = np.linspace(qslider.minimum(), qslider.maximum())
         else:
-            if getattr(qslider, '_valuesChanged', None):
+            if isinstance(qslider, QRangeSlider):
                 # create a list of tuples in the case the slider is ranged
                 # from (minimum, minimum) to (maximum, maximum) +
                 # from (minimum, maximum) to (minimum, minimum)


### PR DESCRIPTION
In #5757, we added a test for sliders in layer controls that checked for ranged
sliders by checking for the presence of a private attribute `_valuesChanged`.
It's bad practice to check for private attributes in outside libraries. This
instead checks for the correct class in superqt.

See also: https://github.com/pyapp-kit/superqt/pull/283
