### PR TITLE
[CI] Update test_vispy_camera.py to skip orientation_2d test on windows

### DIFF
--- a/napari/_vispy/_tests/test_vispy_camera.py
+++ b/napari/_vispy/_tests/test_vispy_camera.py
@@ -143,6 +143,9 @@ def test_camera_model_update_from_vispy_3D(make_napari_viewer):
     np.testing.assert_almost_equal(viewer.camera.zoom, vispy_camera.zoom)
 
 
+@pytest.mark.skipif(
+    sys.platform == 'win32', reason='This new test is flaky on windows'
+)
 def test_camera_orientation_2d(make_napari_viewer, qtbot):
     """Test that flipping orientation of the camera flips displayed image."""
     viewer = make_napari_viewer(show=True)


### PR DESCRIPTION
# References and relevant issues
Despite the previous attempt https://github.com/napari/napari/pull/7709
still getting windows seg faults:
https://github.com/napari/napari/issues/7715

# Description
Skip the other orientation test on windows.
Hopefully this solves it?
🤞 