### PR TITLE
Remove deprecated items scheduled to be removed in 0.6.0

### DIFF
--- a/examples/without_gui_qt.py
+++ b/examples/without_gui_qt.py
@@ -7,6 +7,8 @@ Alternative to using napari.gui_qt() context manager.
 This is here for historical purposes, to the transition away from
 the "gui_qt()" context manager.
 
+"gui_qt()" was removed in 0.6.0
+
 .. tags:: historical
 """
 

--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -29,7 +29,7 @@ _proto_all_ = [
 ]
 
 _submod_attrs = {
-    '_event_loop': ['gui_qt', 'run'],
+    '_event_loop': ['run'],
     'plugins.io': ['save_layers'],
     'utils': ['sys_info'],
     'utils.notifications': ['notification_manager'],

--- a/napari/__init__.pyi
+++ b/napari/__init__.pyi
@@ -1,5 +1,5 @@
 import napari.utils.notifications
-from napari._qt.qt_event_loop import gui_qt, run
+from napari._qt.qt_event_loop import run
 from napari.plugins.io import save_layers
 from napari.view_layers import (
     view_image,
@@ -21,7 +21,6 @@ __all__ = (
     'Viewer',
     '__version__',
     'current_viewer',
-    'gui_qt',
     'notification_manager',
     'run',
     'save_layers',

--- a/napari/_app_model/__init__.py
+++ b/napari/_app_model/__init__.py
@@ -1,3 +1,3 @@
-from napari._app_model._app import get_app, get_app_model
+from napari._app_model._app import get_app_model
 
-__all__ = ['get_app', 'get_app_model']
+__all__ = ['get_app_model']

--- a/napari/_app_model/_app.py
+++ b/napari/_app_model/_app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from warnings import warn
 
 from app_model import Application
 
@@ -9,7 +8,6 @@ from napari._app_model.actions._layerlist_context_actions import (
     LAYERLIST_CONTEXT_ACTIONS,
     LAYERLIST_CONTEXT_SUBMENUS,
 )
-from napari.utils.translations import trans
 
 APP_NAME = 'napari'
 
@@ -56,21 +54,6 @@ def _napari_names() -> dict[str, object]:
         **_public_types(layers),
         **_public_types(viewer),
     }
-
-
-# TODO: Remove in 0.6.0
-def get_app() -> NapariApplication:
-    """Get the Napari Application singleton. Now deprecated, use `get_app_model`."""
-    warn(
-        trans._(
-            '`NapariApplication` instance access through `get_app` is deprecated and will be removed in 0.6.0.\n'
-            'Please use `get_app_model` instead.\n',
-            deferred=True,
-        ),
-        category=FutureWarning,
-        stacklevel=2,
-    )
-    return get_app_model()
 
 
 def get_app_model() -> NapariApplication:

--- a/napari/_app_model/_app.py
+++ b/napari/_app_model/_app.py
@@ -30,7 +30,7 @@ class NapariApplication(Application):
 
     @classmethod
     def get_app_model(cls, app_name: str = APP_NAME) -> NapariApplication:
-        return Application.get_app(app_name) or cls()  # type: ignore[return-value]
+        return Application.get_app_model(app_name) or cls()  # type: ignore[return-value]
 
 
 @lru_cache(maxsize=1)

--- a/napari/_app_model/_tests/test_app.py
+++ b/napari/_app_model/_tests/test_app.py
@@ -1,6 +1,4 @@
-import pytest
-
-from napari._app_model import get_app, get_app_model
+from napari._app_model import get_app_model
 from napari.layers import Points
 
 
@@ -11,12 +9,6 @@ def test_app(mock_app_model):
     assert list(app.menus)
     assert list(app.commands)
     # assert list(app.keybindings)  # don't have any yet
-    with pytest.warns(
-        FutureWarning,
-        match='`NapariApplication` instance access through `get_app` is deprecated and will be removed in 0.6.0.\nPlease use `get_app_model` instead.\n',
-    ):
-        deprecated_app = get_app()
-    assert app == deprecated_app
 
 
 def test_app_injection(mock_app_model):

--- a/napari/_event_loop.py
+++ b/napari/_event_loop.py
@@ -1,12 +1,9 @@
 try:
-    from napari._qt.qt_event_loop import gui_qt, run
+    from napari._qt.qt_event_loop import run
 
 # qtpy raises a RuntimeError if no Qt bindings can be found
 except (ImportError, RuntimeError) as e:
     exc = e
-
-    def gui_qt(**kwargs):
-        raise exc
 
     def run(
         *,

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -87,7 +87,7 @@ if tuple(int(x) for x in QtCore.__version__.split('.')[:3]) < (5, 12, 3):
     warn(message=warn_message, stacklevel=1)
 
 
-from napari._qt.qt_event_loop import get_app, get_qapp, gui_qt, quit_app, run
+from napari._qt.qt_event_loop import get_qapp, gui_qt, quit_app, run
 from napari._qt.qt_main_window import Window
 
-__all__ = ['Window', 'get_app', 'get_qapp', 'gui_qt', 'quit_app', 'run']
+__all__ = ['Window', 'get_qapp', 'gui_qt', 'quit_app', 'run']

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -87,7 +87,7 @@ if tuple(int(x) for x in QtCore.__version__.split('.')[:3]) < (5, 12, 3):
     warn(message=warn_message, stacklevel=1)
 
 
-from napari._qt.qt_event_loop import get_qapp, gui_qt, quit_app, run
+from napari._qt.qt_event_loop import get_qapp, quit_app, run
 from napari._qt.qt_main_window import Window
 
-__all__ = ['Window', 'get_qapp', 'gui_qt', 'quit_app', 'run']
+__all__ = ['Window', 'get_qapp', 'quit_app', 'run']

--- a/napari/_qt/_tests/test_app.py
+++ b/napari/_qt/_tests/test_app.py
@@ -7,21 +7,9 @@ from qtpy.QtWidgets import QAction, QShortcut
 
 from napari._qt.qt_event_loop import (
     _ipython_has_eventloop,
-    get_app,
-    get_qapp,
     run,
     set_app_id,
 )
-
-
-def test_qapp(qapp):
-    qapp = get_qapp()
-    with pytest.warns(
-        FutureWarning,
-        match='`QApplication` instance access through `get_app` is deprecated and will be removed in 0.6.0.\nPlease use `get_qapp` instead.\n',
-    ):
-        deprecated_qapp = get_app()
-    assert qapp == deprecated_qapp
 
 
 @pytest.mark.skipif(os.name != 'nt', reason='Windows specific')

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from magicgui import magic_factory, magicgui
@@ -84,7 +84,7 @@ dwidget_args = {
 def test_dock_widget_registration(
     arg, napari_plugin_manager, request, recwarn
 ):
-    """Test that dock widgets get validated and registerd correctly."""
+    """Test that dock widgets get validated and registered correctly."""
 
     class Plugin:
         @napari_hook_implementation
@@ -110,6 +110,11 @@ def test_inject_viewer_proxy(make_napari_viewer):
     viewer = make_napari_viewer()
     wdg = _instantiate_dock_widget(Widg3, viewer)
     assert isinstance(wdg.viewer, PublicOnlyProxy)
+
+    # simulate access from outside napari
+    with patch('napari.utils.misc.ROOT_DIR', new='/some/other/package'):
+        with pytest.warns(FutureWarning):
+            wdg.fail()
 
 
 @pytest.mark.parametrize(

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -88,7 +88,7 @@ def test_dock_widget_registration(
 
     class Plugin:
         @napari_hook_implementation
-        def napari_experimental_provide_dock_widget(self):
+        def napari_experimental_provide_dock_widget():
             return arg
 
     napari_plugin_manager.register(Plugin, name='Plugin')

--- a/napari/_qt/_tests/test_plugin_widgets.py
+++ b/napari/_qt/_tests/test_plugin_widgets.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from magicgui import magic_factory, magicgui
@@ -88,7 +88,7 @@ def test_dock_widget_registration(
 
     class Plugin:
         @napari_hook_implementation
-        def napari_experimental_provide_dock_widget():
+        def napari_experimental_provide_dock_widget(self):
             return arg
 
     napari_plugin_manager.register(Plugin, name='Plugin')
@@ -110,11 +110,6 @@ def test_inject_viewer_proxy(make_napari_viewer):
     viewer = make_napari_viewer()
     wdg = _instantiate_dock_widget(Widg3, viewer)
     assert isinstance(wdg.viewer, PublicOnlyProxy)
-
-    # simulate access from outside napari
-    with patch('napari.utils.misc.ROOT_DIR', new='/some/other/package'):
-        with pytest.warns(FutureWarning):
-            wdg.fail()
 
 
 @pytest.mark.parametrize(

--- a/napari/_qt/_tests/test_proxy_fixture.py
+++ b/napari/_qt/_tests/test_proxy_fixture.py
@@ -1,15 +1,5 @@
 import pytest
 
-from napari.utils import misc
-
-
-def test_proxy_fixture_warning(make_napari_viewer_proxy, monkeypatch):
-    viewer = make_napari_viewer_proxy()
-
-    monkeypatch.setattr(misc, 'ROOT_DIR', '/some/other/package')
-    with pytest.warns(FutureWarning, match='Private attribute access'):
-        viewer.window._qt_window
-
 
 def test_proxy_fixture_thread_error(
     make_napari_viewer_proxy, single_threaded_executor

--- a/napari/_qt/_tests/test_proxy_fixture.py
+++ b/napari/_qt/_tests/test_proxy_fixture.py
@@ -1,5 +1,15 @@
 import pytest
 
+from napari.utils import misc
+
+
+def test_proxy_fixture_warning(make_napari_viewer_proxy, monkeypatch):
+    viewer = make_napari_viewer_proxy()
+
+    monkeypatch.setattr(misc, 'ROOT_DIR', '/some/other/package')
+    with pytest.warns(FutureWarning, match='Private attribute access'):
+        viewer.window._qt_window
+
 
 def test_proxy_fixture_thread_error(
     make_napari_viewer_proxy, single_threaded_executor

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-from contextlib import contextmanager
 from typing import TYPE_CHECKING, cast
 from warnings import warn
 
@@ -89,21 +88,6 @@ def _focus_changed(old: QWidget | None, new: QWidget | None):
     else:
         for notification in notifications:
             notification.timer_stop()
-
-
-# TODO: Remove in napari 0.6.0
-def get_app(*args, **kwargs) -> QApplication:
-    """Get or create the Qt QApplication. Now deprecated, use `get_qapp`."""
-    warn(
-        trans._(
-            '`QApplication` instance access through `get_app` is deprecated and will be removed in 0.6.0.\n'
-            'Please use `get_qapp` instead.\n',
-            deferred=True,
-        ),
-        category=FutureWarning,
-        stacklevel=2,
-    )
-    return get_qapp(*args, **kwargs)
 
 
 def get_qapp(
@@ -302,53 +286,6 @@ def quit_app():
         from napari.components.experimental.monitor import monitor
 
         monitor.stop()
-
-
-@contextmanager
-def gui_qt(*, startup_logo=False, gui_exceptions=False, force=False):
-    """Start a Qt event loop in which to run the application.
-
-    NOTE: This context manager is deprecated!. Prefer using :func:`napari.run`.
-
-    Parameters
-    ----------
-    startup_logo : bool, optional
-        Show a splash screen with the napari logo during startup.
-    gui_exceptions : bool, optional
-        Whether to show uncaught exceptions in the GUI, by default they will be
-        shown in the console that launched the event loop.
-    force : bool, optional
-        Force the application event_loop to start, even if there are no top
-        level widgets to show.
-
-    Notes
-    -----
-    This context manager is not needed if running napari within an interactive
-    IPython session. In this case, use the ``%gui qt`` magic command, or start
-    IPython with the Qt GUI event loop enabled by default by using
-    ``ipython --gui=qt``.
-    """
-    warn(
-        trans._(
-            "\nThe 'gui_qt()' context manager is deprecated.\nIf you are running napari from a script, please use 'napari.run()' as follows:\n\n    import napari\n\n    viewer = napari.Viewer()  # no prior setup needed\n    # other code using the viewer...\n    napari.run()\n\nIn IPython or Jupyter, 'napari.run()' is not necessary. napari will automatically\nstart an interactive event loop for you: \n\n    import napari\n    viewer = napari.Viewer()  # that's it!\n",
-            deferred=True,
-        ),
-        FutureWarning,
-        stacklevel=2,
-    )
-
-    app = get_app()
-    splash = None
-    if startup_logo and app.applicationName() == 'napari':
-        from napari._qt.widgets.qt_splash_screen import NapariSplashScreen
-
-        splash = NapariSplashScreen()
-        splash.close()
-    try:
-        yield app
-    except Exception:  # noqa: BLE001
-        notification_manager.receive_error(*sys.exc_info())
-    run(force=force, gui_exceptions=gui_exceptions, _func_name='gui_qt')
 
 
 def _ipython_has_eventloop() -> bool:

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -103,7 +103,7 @@ def get_qapp(
     """Get or create the Qt QApplication.
 
     There is only one global QApplication instance, which can be retrieved by
-    calling get_app again, (or by using QApplication.instance())
+    calling get_app_model again, (or by using QApplication.instance())
 
     Parameters
     ----------
@@ -148,15 +148,7 @@ def get_qapp(
     app = QApplication.instance()
     if app:
         set_values.discard('ipy_interactive')
-        if set_values:
-            warn(
-                trans._(
-                    "QApplication already existed, these arguments to to 'get_app' were ignored: {args}",
-                    deferred=True,
-                    args=set_values,
-                ),
-                stacklevel=2,
-            )
+
         if perf_config and perf_config.trace_qt_events:
             warn(
                 trans._(
@@ -221,7 +213,7 @@ def get_qapp(
         # Will patch based on config file.
         perf_config.patch_callables()
 
-    if not _app_ref:  # running get_app for the first time
+    if not _app_ref:  # running get_app_model for the first time
         # see docstring of `wait_for_workers_to_quit` for caveats on killing
         # workers at shutdown.
         app.aboutToQuit.connect(wait_for_workers_to_quit)
@@ -375,7 +367,7 @@ def run(
     if not app:
         raise RuntimeError(
             trans._(
-                'No Qt app has been created. One can be created by calling `get_app()` or `qtpy.QtWidgets.QApplication([])`',
+                'No Qt app has been created. One can be created by calling `get_app_model()` or `qtpy.QtWidgets.QApplication([])`',
                 deferred=True,
             )
         )

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -345,7 +345,7 @@ def run(
         has at least ``max_loop_level`` event loops running.  By default, 1.
     _func_name : str, optional
         name of calling function, by default 'run'.  This is only here to
-        provide functions like `gui_qt` a way to inject their name into the
+        provide functions a way to inject their name into the
         warning message.
 
     Raises

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -844,21 +844,6 @@ class Window:
         self._disconnect_theme(theme)
 
     @property
-    def qt_viewer(self):
-        warnings.warn(
-            trans._(
-                'Public access to Window.qt_viewer is deprecated and will be removed in\n'
-                'v0.6.0. It is considered an "implementation detail" of the napari\napplication, '
-                'not part of the napari viewer model. If your use case\n'
-                'requires access to qt_viewer, please open an issue to discuss.',
-                deferred=True,
-            ),
-            category=FutureWarning,
-            stacklevel=2,
-        )
-        return self._qt_window._qt_viewer
-
-    @property
     def _qt_viewer(self):
         # this is starting to be "vestigial"... this property could be removed
         return self._qt_window._qt_viewer

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -266,36 +266,6 @@ class QtViewer(QSplitter):
         for layer in self.viewer.layers:
             self._add_layer(layer)
 
-    @property
-    def view(self):
-        """
-        Rectangular  vispy viewbox widget in which a subscene is rendered. Access directly within the QtViewer will
-        become deprecated.
-        """
-        warnings.warn(
-            trans._(
-                'Access to QtViewer.view is deprecated since 0.5.0 and will be removed in the napari 0.6.0. Change to QtViewer.canvas.view instead.'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.canvas.view
-
-    @property
-    def camera(self):
-        """
-        The Vispy camera class which contains both the 2d and 3d camera used to describe the perspective by which a
-        scene is viewed and interacted with. Access directly within the QtViewer will become deprecated.
-        """
-        warnings.warn(
-            trans._(
-                'Access to QtViewer.camera will become deprecated in the 0.6.0. Change to QtViewer.canvas.camera instead.'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.canvas.camera
-
     @staticmethod
     def _update_dask_cache_settings(
         dask_setting: DaskSettings | Event = None,

--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -296,17 +296,6 @@ class QtViewer(QSplitter):
         )
         return self.canvas.camera
 
-    @property
-    def chunk_receiver(self) -> None:
-        warnings.warn(
-            trans._(
-                'QtViewer.chunk_receiver is deprecated in version 0.5 and will be removed in a later version. '
-                'More generally the old approach to async loading was removed in version 0.5 so this value is always None. '
-                'If you need to specifically use the old approach, continue to use the latest 0.4 release.'
-            ),
-            DeprecationWarning,
-        )
-
     @staticmethod
     def _update_dask_cache_settings(
         dask_setting: DaskSettings | Event = None,

--- a/napari/_qt/widgets/qt_progress_bar.py
+++ b/napari/_qt/widgets/qt_progress_bar.py
@@ -10,7 +10,6 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from napari.utils.migrations import rename_argument
 from napari.utils.progress import cancelable_progress, progress
 from napari.utils.translations import trans
 
@@ -48,18 +47,6 @@ class QtLabeledProgressBar(QWidget):
 
         self.setLayout(base_layout)
 
-    @rename_argument(
-        from_name='min',
-        to_name='min_val',
-        version='0.6.0',
-        since_version='0.4.18',
-    )
-    @rename_argument(
-        from_name='max',
-        to_name='max_val',
-        version='0.6.0',
-        since_version='0.4.18',
-    )
     def setRange(self, min_val, max_val):
         self.qt_progress_bar.setRange(min_val, max_val)
 

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,4 +1,3 @@
-import warnings
 from enum import auto
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -59,10 +58,6 @@ class Camera(EventedModel):
         sets of Euler angles may lead to the same view.
     perspective : float
         Perspective (aka "field of view" in vispy) of the camera (if 3D).
-    interactive : bool
-        If the camera mouse pan/zoom is enabled or not.
-        This attribute is deprecated since 0.5.0 and should not be used.
-        Use the mouse_pan and mouse_zoom attributes instead.
     mouse_pan : bool
         If the camera interactive panning with the mouse is enabled or not.
     mouse_zoom : bool
@@ -266,20 +261,3 @@ class Camera(EventedModel):
             VerticalAxisOrientation(value[0]),
             HorizontalAxisOrientation(value[1]),
         )
-
-    @property
-    def interactive(self) -> bool:
-        warnings.warn(
-            '`Camera.interactive` is deprecated since 0.5.0 and will be removed in 0.6.0.',
-            category=DeprecationWarning,
-        )
-        return self.mouse_pan or self.mouse_zoom
-
-    @interactive.setter
-    def interactive(self, interactive: bool):
-        warnings.warn(
-            '`Camera.interactive` is deprecated since 0.5.0 and will be removed in 0.6.0.',
-            category=DeprecationWarning,
-        )
-        self.mouse_pan = interactive
-        self.mouse_zoom = interactive

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -86,7 +86,6 @@ from napari.utils.events import (
 )
 from napari.utils.events.event import WarningEmitter
 from napari.utils.key_bindings import KeymapProvider
-from napari.utils.migrations import rename_argument
 from napari.utils.misc import is_sequence
 from napari.utils.mouse_bindings import MousemapProvider
 from napari.utils.progress import progress
@@ -522,17 +521,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.camera.mouse_zoom = active_layer.mouse_zoom
             self.update_status_from_cursor()
 
-    @staticmethod
-    def rounded_division(min_val, max_val, precision):
-        warnings.warn(
-            trans._(
-                'Viewer.rounded_division is deprecated since v0.4.18 and will be removed in 0.6.0.'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return int(((min_val + max_val) / 2) / precision) * precision
-
     def _on_layers_change(self):
         if len(self.layers) == 0:
             self.dims.ndim = 2
@@ -824,12 +812,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.append(layer)
         return layer
 
-    @rename_argument(
-        from_name='interpolation',
-        to_name='interpolation2d',
-        version='0.6.0',
-        since_version='0.4.17',
-    )
     def add_image(
         self,
         data=None,

--- a/napari/layers/_scalar_field/scalar_field.py
+++ b/napari/layers/_scalar_field/scalar_field.py
@@ -24,7 +24,6 @@ from napari.layers.utils.plane import SlicingPlane
 from napari.utils._dask_utils import DaskIndexer
 from napari.utils.colormaps import AVAILABLE_COLORMAPS
 from napari.utils.events import Event
-from napari.utils.events.event import WarningEmitter
 from napari.utils.events.event_utils import connect_no_arg
 from napari.utils.geometry import clamp_point_to_bounding_box
 from napari.utils.naming import magic_name
@@ -247,13 +246,6 @@ class ScalarFieldBase(Layer, ABC):
             attenuation=Event,
             custom_interpolation_kernel_2d=Event,
             depiction=Event,
-            interpolation=WarningEmitter(
-                trans._(
-                    "'layer.events.interpolation' is deprecated please use `interpolation2d` and `interpolation3d`",
-                    deferred=True,
-                ),
-                type_name='select',
-            ),
             interpolation2d=Event,
             interpolation3d=Event,
             iso_threshold=Event,

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -6,7 +6,6 @@ import itertools
 import logging
 import os.path
 import uuid
-import warnings
 from abc import ABC, ABCMeta, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, Hashable, Mapping, Sequence
@@ -53,7 +52,6 @@ from napari.utils._magicgui import (
     get_layers,
 )
 from napari.utils.events import EmitterGroup, Event, EventedDict
-from napari.utils.events.event import WarningEmitter
 from napari.utils.geometry import (
     find_front_back_face,
     intersect_line_with_axis_aligned_bounding_box_3d,
@@ -482,13 +480,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             translate=Event,
             units=Event,
             visible=Event,
-            interactive=WarningEmitter(
-                trans._(
-                    'layer.events.interactive is deprecated since 0.4.18 and will be removed in 0.6.0. Please use layer.events.mouse_pan and layer.events.mouse_zoom',
-                    deferred=True,
-                ),
-                type_name='interactive',
-            ),
             _extent_augmented=Event,
             _overlays=Event,
         )
@@ -1171,30 +1162,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             return
         self._help = help_text
         self.events.help(help=help_text)
-
-    @property
-    def interactive(self) -> bool:
-        warnings.warn(
-            trans._(
-                'Layer.interactive is deprecated since napari 0.4.18 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.mouse_pan or self.mouse_zoom
-
-    @interactive.setter
-    def interactive(self, interactive: bool) -> None:
-        warnings.warn(
-            trans._(
-                'Layer.interactive is deprecated since napari 0.4.18 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        with self.events.interactive.blocker():
-            self.mouse_pan = interactive
-        self.mouse_zoom = interactive
 
     @property
     def mouse_pan(self) -> bool:

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -334,21 +334,12 @@ def test_interpolation():
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'nearest'
     assert layer.interpolation2d == 'nearest'
     assert layer.interpolation3d == 'linear'
-
-    with pytest.deprecated_call():
-        layer = Image(data, interpolation2d='bicubic')
     assert layer.interpolation2d == 'cubic'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'cubic'
 
     layer.interpolation2d = 'linear'
     assert layer.interpolation2d == 'linear'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'linear'
 
 
 def test_colormaps():

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -240,20 +240,11 @@ def test_interpolation():
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'nearest'
     assert layer.interpolation2d == 'nearest'
     assert layer.interpolation3d == 'linear'
-
-    with pytest.deprecated_call():
-        layer = Image(data, multiscale=True, interpolation2d='bicubic')
     assert layer.interpolation2d == 'cubic'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'cubic'
 
     layer.interpolation2d = 'linear'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'linear'
     assert layer.interpolation2d == 'linear'
 
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -25,7 +25,6 @@ from napari.layers.utils.layer_utils import calc_data_range
 from napari.utils._dtype import get_dtype_limits, normalize_dtype
 from napari.utils.colormaps import ensure_colormap
 from napari.utils.colormaps.colormap_utils import _coerce_contrast_limits
-from napari.utils.migrations import rename_argument
 from napari.utils.translations import trans
 
 __all__ = ('Image',)
@@ -223,12 +222,6 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
 
     _projectionclass = ImageProjectionMode
 
-    @rename_argument(
-        from_name='interpolation',
-        to_name='interpolation2d',
-        version='0.6.0',
-        since_version='0.4.17',
-    )
     def __init__(
         self,
         data,

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -53,9 +53,7 @@ from napari.utils.colormaps import Colormap, ValidColormapArg
 from napari.utils.colormaps.standardize_color import hex_to_name, rgb_to_hex
 from napari.utils.events import Event
 from napari.utils.events.custom_types import Array
-from napari.utils.events.migrations import deprecation_warning_event
 from napari.utils.geometry import project_points_onto_plane, rotate_points
-from napari.utils.migrations import add_deprecated_property, rename_argument
 from napari.utils.transforms import Affine
 from napari.utils.translations import trans
 
@@ -354,36 +352,6 @@ class Points(Layer):
     # If more points are present then they are randomly subsampled
     _max_points_thumbnail = 1024
 
-    @rename_argument(
-        'edge_width', 'border_width', since_version='0.5.0', version='0.6.0'
-    )
-    @rename_argument(
-        'edge_width_is_relative',
-        'border_width_is_relative',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
-    @rename_argument(
-        'edge_color', 'border_color', since_version='0.5.0', version='0.6.0'
-    )
-    @rename_argument(
-        'edge_color_cycle',
-        'border_color_cycle',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
-    @rename_argument(
-        'edge_colormap',
-        'border_colormap',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
-    @rename_argument(
-        'edge_contrast_limits',
-        'border_contrast_limits',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
     def __init__(
         self,
         data=None,
@@ -508,28 +476,6 @@ class Points(Layer):
             feature_defaults=Event,
         )
 
-        deprecated_events = {}
-        for attr in [
-            '{}_width',
-            'current_{}_width',
-            '{}_width_is_relative',
-            '{}_color',
-            'current_{}_color',
-        ]:
-            old_attr = attr.format('edge')
-            new_attr = attr.format('border')
-            old_emitter = deprecation_warning_event(
-                'layer.events',
-                old_attr,
-                new_attr,
-                since_version='0.5.0',
-                version='0.6.0',
-            )
-            getattr(self.events, new_attr).connect(old_emitter)
-            deprecated_events[old_attr] = old_emitter
-
-        self.events.add(**deprecated_events)
-
         # Save the point coordinates
         self._data = np.asarray(data)
 
@@ -614,30 +560,6 @@ class Points(Layer):
 
         # Trigger generation of view slice and thumbnail
         self.refresh(extent=False)
-
-    @classmethod
-    def _add_deprecated_properties(cls) -> None:
-        """Adds deprecated properties to class."""
-        deprecated_properties = [
-            'edge_width',
-            'edge_width_is_relative',
-            'current_edge_width',
-            'edge_color',
-            'edge_color_cycle',
-            'edge_colormap',
-            'edge_contrast_limits',
-            'current_edge_color',
-            'edge_color_mode',
-        ]
-        for old_property in deprecated_properties:
-            new_property = old_property.replace('edge', 'border')
-            add_deprecated_property(
-                cls,
-                old_property,
-                new_property,
-                since_version='0.5.0',
-                version='0.6.0',
-            )
 
     @property
     def data(self) -> np.ndarray:
@@ -989,32 +911,8 @@ class Points(Layer):
 
     @size.setter
     def size(self, size: float | np.ndarray | list) -> None:
-        try:
-            self._size = np.broadcast_to(size, len(self.data)).copy()
-        except ValueError as e:
-            # deprecated anisotropic sizes; extra check should be removed in future version
-            try:
-                self._size = np.broadcast_to(
-                    size, self.data.shape[::-1]
-                ).T.copy()
-            except ValueError:
-                raise ValueError(
-                    trans._(
-                        'Size is not compatible for broadcasting',
-                        deferred=True,
-                    )
-                ) from e
-            else:
-                self._size = np.mean(size, axis=1)
-                warnings.warn(
-                    trans._(
-                        'Since 0.4.18 point sizes must be isotropic; the average from each dimension will be'
-                        ' used instead. This will become an error in version 0.6.0.',
-                        deferred=True,
-                    ),
-                    category=DeprecationWarning,
-                    stacklevel=2,
-                )
+        self._size = np.broadcast_to(size, len(self.data)).copy()
+
         # TODO: technically not needed to cleat the non-augmented extent... maybe it's fine like this to avoid complexity
         self.refresh(highlight=False)
 
@@ -1026,15 +924,6 @@ class Points(Layer):
     @current_size.setter
     def current_size(self, size: None | float) -> None:
         if isinstance(size, list | tuple | np.ndarray):
-            warnings.warn(
-                trans._(
-                    'Since 0.4.18 point sizes must be isotropic; the average from each dimension will be used instead. '
-                    'This will become an error in version 0.6.0.',
-                    deferred=True,
-                ),
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
             size = size[-1]
         if not isinstance(size, numbers.Number):
             raise TypeError(

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2380,6 +2380,3 @@ class Points(Layer):
             and v[value] is not None
             and not (isinstance(v[value], float) and np.isnan(v[value]))
         ]
-
-
-Points._add_deprecated_properties()

--- a/napari/qt/__init__.py
+++ b/napari/qt/__init__.py
@@ -1,4 +1,4 @@
-from napari._qt.qt_event_loop import get_app, get_qapp, run
+from napari._qt.qt_event_loop import get_qapp, run
 from napari._qt.qt_main_window import Window
 from napari._qt.qt_resources import get_current_stylesheet, get_stylesheet
 from napari._qt.qt_viewer import QtViewer
@@ -12,7 +12,6 @@ __all__ = (
     'QtViewerButtons',
     'Window',
     'create_worker',
-    'get_app',
     'get_current_stylesheet',
     'get_qapp',
     'get_stylesheet',

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -60,31 +60,6 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         )
 
     @staticmethod
-    def _private_attr_warning(name: str, typ: str) -> None:
-        warnings.warn(
-            trans._(
-                "Private attribute access ('{typ}.{name}') in this context "
-                '(e.g. inside a plugin widget or dock widget) is deprecated '
-                'and will be unavailable in version 0.6.0',
-                deferred=True,
-                name=name,
-                typ=typ,
-            ),
-            category=FutureWarning,
-            stacklevel=3,
-        )
-
-        # This is code prepared for a moment where we want to block access to private attributes
-        # raise AttributeError(
-        #     trans._(
-        #         "Private attribute set/access ('{typ}.{name}') not allowed in this context.",
-        #         deferred=True,
-        #         name=name,
-        #         typ=typ,
-        #     )
-        # )
-
-    @staticmethod
     def _is_called_from_napari() -> bool:
         """
         Check if the getter or setter is called from inner napari.

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -74,6 +74,16 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
             stacklevel=3,
         )
 
+        # This is code prepared for a moment where we want to block access to private attributes
+        raise AttributeError(
+            trans._(
+                "Private attribute set/access ('{typ}.{name}') not allowed in this context.",
+                deferred=True,
+                name=name,
+                typ=typ,
+            )
+        )
+
     @staticmethod
     def _is_called_from_napari() -> bool:
         """

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -75,14 +75,14 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         )
 
         # This is code prepared for a moment where we want to block access to private attributes
-        raise AttributeError(
-            trans._(
-                "Private attribute set/access ('{typ}.{name}') not allowed in this context.",
-                deferred=True,
-                name=name,
-                typ=typ,
-            )
-        )
+        # raise AttributeError(
+        #     trans._(
+        #         "Private attribute set/access ('{typ}.{name}') not allowed in this context.",
+        #         deferred=True,
+        #         name=name,
+        #         typ=typ,
+        #     )
+        # )
 
     @staticmethod
     def _is_called_from_napari() -> bool:

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -60,6 +60,21 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         )
 
     @staticmethod
+    def _private_attr_warning(name: str, typ: str) -> None:
+        warnings.warn(
+            trans._(
+                "Private attribute access ('{typ}.{name}') in this context "
+                '(e.g. inside a plugin widget or dock widget) is deprecated '
+                'and will be unavailable in version 0.7.0',
+                deferred=True,
+                name=name,
+                typ=typ,
+            ),
+            category=FutureWarning,
+            stacklevel=3,
+        )
+
+    @staticmethod
     def _is_called_from_napari() -> bool:
         """
         Check if the getter or setter is called from inner napari.

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -61,6 +61,22 @@ def test_PublicOnlyProxy():
     assert proxy.x.method() == 2
 
     assert isinstance(proxy, Tester)
+
+    with pytest.warns(FutureWarning, match='Private attribute access'):
+        proxy._private
+
+    with pytest.warns(FutureWarning, match='Private attribute access'):
+        # warns on setattr
+        proxy._private = 4
+
+    with pytest.warns(FutureWarning, match='Private attribute access'):
+        # works on sub-objects too
+        proxy.x._b
+
+    with pytest.warns(FutureWarning, match='Private attribute access'):
+        # works on sub-items too
+        proxy[0]._b
+
     assert '_private' not in dir(proxy)
     assert '_private' in dir(t)
 

--- a/napari/utils/_tests/test_proxies.py
+++ b/napari/utils/_tests/test_proxies.py
@@ -61,21 +61,6 @@ def test_PublicOnlyProxy():
     assert proxy.x.method() == 2
 
     assert isinstance(proxy, Tester)
-    with pytest.warns(FutureWarning, match='Private attribute access'):
-        proxy._private
-
-    with pytest.warns(FutureWarning, match='Private attribute access'):
-        # warns on setattr
-        proxy._private = 4
-
-    with pytest.warns(FutureWarning, match='Private attribute access'):
-        # works on sub-objects too
-        proxy.x._b
-
-    with pytest.warns(FutureWarning, match='Private attribute access'):
-        # works on sub-items too
-        proxy[0]._b
-
     assert '_private' not in dir(proxy)
     assert '_private' in dir(t)
 

--- a/napari/utils/config.py
+++ b/napari/utils/config.py
@@ -1,9 +1,6 @@
 """Napari Configuration."""
 
 import os
-import warnings
-
-from napari.utils.translations import trans
 
 
 def _set(env_var: str) -> bool:
@@ -26,56 +23,6 @@ Experimental shared memory service. Only enabled if NAPARI_MON is set to
 the path of a config file. See this PR for more info:
 https://github.com/napari/napari/pull/1909.
 """
-
-
-# Handle old async/octree deprecated attributes by returning their
-# fixed values in the module level __getattr__
-# https://peps.python.org/pep-0562/
-# Other module attributes are defined as normal.
-def __getattr__(name: str) -> bool | None:
-    if name == 'octree_config':
-        warnings.warn(
-            trans._(
-                'octree_config is deprecated in version 0.5 and will be removed in a later version.'
-                'More generally, the experimental octree feature was removed in napari version 0.5 so this value is always None. '
-                'If you need to use that experimental feature, continue to use the latest 0.4 release. '
-                'Also look out for announcements regarding similar efforts.'
-            ),
-            DeprecationWarning,
-        )
-        return None
-    if name == 'async_octree':
-        warnings.warn(
-            trans._(
-                'async_octree is deprecated in version 0.5 and will be removed in a later version.'
-                'More generally, the experimental octree feature was removed in version 0.5 so this value is always False. '
-                'If you need to use that experimental feature, continue to use the latest 0.4 release. '
-                'Also look out for announcements regarding similar future efforts.'
-            ),
-            DeprecationWarning,
-        )
-        return False
-    if name == 'async_loading':
-        # For async_loading, we could get the value of the remaining
-        # async setting. We do not because that is dynamic, so will not
-        # handle an import of the form
-        #
-        # `from napari.utils.config import async_loading`
-        #
-        # consistently. Instead, we let this attribute effectively
-        # refer to the old async which is always off in napari now.
-        warnings.warn(
-            trans._(
-                'async_loading is deprecated in version 0.5 and will be removed in a later version. '
-                'The old approach to async loading was removed in version 0.5 so this value is always False. '
-                'Instead, please use napari.settings.get_settings().experimental.async_ to use a new approach. '
-                'If you need to specifically use the old approach, continue to use the latest 0.4 release.'
-            ),
-            DeprecationWarning,
-        )
-        return False
-    return None
-
 
 # Shared Memory Server
 monitor = _set('NAPARI_MON')

--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -68,7 +68,6 @@ from typing import (
 
 from vispy.util.logs import _handle_exception
 
-from napari.utils.migrations import rename_argument
 from napari.utils.translations import trans
 
 
@@ -96,12 +95,6 @@ class Event:
         All extra keyword arguments become attributes of the event object.
     """
 
-    @rename_argument(
-        from_name='type',
-        to_name='type_name',
-        version='0.6.0',
-        since_version='0.4.18',
-    )
     def __init__(
         self, type_name: str, native: Any = None, **kwargs: Any
     ) -> None:
@@ -283,7 +276,6 @@ class EventEmitter:
         The class of events that this emitter will generate.
     """
 
-    @rename_argument('type', 'type_name', '0.6.0', '0.4.18')
     def __init__(
         self,
         source: Any = None,

--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -51,17 +51,6 @@ def rename_argument(
         version when new argument was added
     """
 
-    if not since_version:
-        since_version = 'unknown'
-        warnings.warn(
-            trans._(
-                'The since_version argument was added in napari 0.4.18 and will be mandatory since 0.6.0 release.',
-                deferred=True,
-            ),
-            stacklevel=2,
-            category=FutureWarning,
-        )
-
     def _wrapper(func):
         if not hasattr(func, '_rename_argument'):
             func._rename_argument = []

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import builtins
 import collections.abc
 import contextlib
-import importlib.metadata
 import inspect
 import itertools
 import os
@@ -44,43 +43,6 @@ def parse_version(v: str) -> packaging.version._BaseVersion:
         return packaging.version.Version(v)
     except packaging.version.InvalidVersion:
         return packaging.version.LegacyVersion(v)  # type: ignore[attr-defined]
-
-
-def running_as_bundled_app(*, check_conda: bool = True) -> bool:
-    """Infer whether we are running as a bundle."""
-    # https://github.com/beeware/briefcase/issues/412
-    # https://github.com/beeware/briefcase/pull/425
-    # note that a module may not have a __package__ attribute
-    # From 0.4.12 we add a sentinel file next to the bundled sys.executable
-    warnings.warn(
-        trans._(
-            'Briefcase installations are no longer supported as of v0.4.18. '
-            'running_as_bundled_app() will be removed in a 0.6.0 release.',
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    if (
-        check_conda
-        and (Path(sys.executable).parent / '.napari_is_bundled').exists()
-    ):
-        return True
-
-    # TODO: Remove from here on?
-    try:
-        app_module = sys.modules['__main__'].__package__
-    except AttributeError:
-        return False
-
-    if not app_module:
-        return False
-
-    try:
-        metadata = importlib.metadata.metadata(app_module)
-    except importlib.metadata.PackageNotFoundError:
-        return False
-
-    return 'Briefcase-Version' in metadata
 
 
 def running_as_constructor_app() -> bool:

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -91,24 +91,11 @@ def str_to_rgb(arg: str) -> list[int]:
 
 def ensure_iterable(
     arg: None | str | Enum | float | list | npt.NDArray,
-    color: object | bool = _sentinel,
 ):
     """Ensure an argument is an iterable. Useful when an input argument
     can either be a single value or a list.
-    Argument color is deprecated since version 0.5.0 and will be removed in 0.6.0.
     """
-    # deprecate color
-    if color is not _sentinel:
-        warnings.warn(
-            trans._(
-                'Argument color is deprecated since version 0.5.0 and will be removed in 0.6.0.',
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,  # not sure what level to use here
-        )
-    if is_iterable(
-        arg, color=color
-    ):  # argument color is to be removed in 0.6.0
+    if is_iterable(arg):
         return arg
 
     return itertools.repeat(arg)
@@ -116,32 +103,15 @@ def ensure_iterable(
 
 def is_iterable(
     arg: None | str | Enum | float | list | npt.NDArray,
-    color: object | bool = _sentinel,
     allow_none: bool = False,
 ) -> bool:
-    """Determine if a single argument is an iterable.
-    Argument color is deprecated since version 0.5.0 and will be removed in 0.6.0.
-    """
-    # deprecate color
-    if color is not _sentinel:
-        warnings.warn(
-            trans._(
-                'Argument color is deprecated since version 0.5.0 and will be removed in 0.6.0.',
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,  # not sure what level to use here
-        )
-
+    """Determine if a single argument is an iterable."""
     if arg is None:
         return allow_none
 
     # Here if arg is None it used to return allow_none
     if isinstance(arg, str | Enum) or np.isscalar(arg):
         return False
-
-    # this is to be removed in 0.6.0, color is never set True
-    if color is True and isinstance(arg, list | np.ndarray):
-        return np.array(arg).ndim != 1 or len(arg) not in [3, 4]
 
     return isinstance(arg, collections.abc.Iterable)
 

--- a/napari/utils/misc.py
+++ b/napari/utils/misc.py
@@ -353,34 +353,6 @@ def abspath_or_url(relpath: T, *, must_exist: bool = False) -> T:
     return OriginType(path)
 
 
-class CallDefault(inspect.Parameter):
-    warnings.warn(
-        trans._(
-            '`CallDefault` in napari v0.5.0 and will be removed in v0.6.0.',
-        ),
-        category=DeprecationWarning,
-    )
-
-    def __str__(self) -> str:
-        """wrap defaults"""
-        kind = self.kind
-        formatted = self.name
-
-        # Fill in defaults
-        if (
-            self.default is not inspect._empty
-            or kind == inspect.Parameter.KEYWORD_ONLY
-        ):
-            formatted = f'{formatted}={formatted}'
-
-        if kind == inspect.Parameter.VAR_POSITIONAL:
-            formatted = '*' + formatted
-        elif kind == inspect.Parameter.VAR_KEYWORD:
-            formatted = '**' + formatted
-
-        return formatted
-
-
 def all_subclasses(cls: type) -> set:
     """Recursively find all subclasses of class ``cls``.
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -5,7 +5,7 @@ import re
 import sys
 from ast import literal_eval
 from contextlib import suppress
-from typing import Any, overload
+from typing import Any
 
 import npe2
 
@@ -231,18 +231,6 @@ def get_system_theme() -> str:
         id_ = 'dark'
 
     return id_
-
-
-@overload
-def get_theme(theme_id: str) -> Theme: ...
-
-
-@overload
-def get_theme(theme_id: str) -> Theme: ...
-
-
-@overload
-def get_theme(theme_id: str) -> dict[str, Any]: ...
 
 
 def get_theme(theme_id: str):

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -3,7 +3,6 @@
 import logging
 import re
 import sys
-import warnings
 from ast import literal_eval
 from contextlib import suppress
 from typing import Any, Literal, overload
@@ -246,8 +245,8 @@ def get_theme(theme_id: str, as_dict: Literal[False]) -> Theme: ...
 def get_theme(theme_id: str, as_dict: Literal[True]) -> dict[str, Any]: ...
 
 
-def get_theme(theme_id: str, as_dict: bool | None = None):
-    """Get a copy of theme based on it's id.
+def get_theme(theme_id: str):
+    """Get a copy of theme based on its id.
 
     If you get a copy of the theme, changes to the theme model will not be
     reflected in the UI unless you replace or add the modified theme to
@@ -257,13 +256,6 @@ def get_theme(theme_id: str, as_dict: bool | None = None):
     ----------
     theme_id : str
         ID of requested theme.
-    as_dict : bool
-        .. deprecated:: 0.5.0
-
-            Use ``get_theme(...).to_rgb_dict()``
-
-        Flag to indicate that the old-style dictionary
-        should be returned. This will emit deprecation warning.
 
     Returns
     -------
@@ -285,18 +277,6 @@ def get_theme(theme_id: str, as_dict: bool | None = None):
             )
         )
     theme = _themes[theme_id].copy()
-    if as_dict is not None:
-        warnings.warn(
-            trans._(
-                'The `as_dict` kwarg has been deprecated since Napari 0.5.0 and '
-                'will be removed in future version. You can use `get_theme(...).to_rgb_dict()`',
-                deferred=True,
-            ),
-            category=FutureWarning,
-            stacklevel=2,
-        )
-    if as_dict:
-        return theme.to_rgb_dict()
     return theme
 
 

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -5,7 +5,7 @@ import re
 import sys
 from ast import literal_eval
 from contextlib import suppress
-from typing import Any, Literal, overload
+from typing import Any, overload
 
 import npe2
 
@@ -134,7 +134,7 @@ def increase(font_size: str, pt: int) -> str:
     return f'{int(font_size[:-2]) + int(pt)}pt'
 
 
-def _parse_color_as_rgb(color: str | Color) -> tuple[int, int, int]:
+def _parse_color_as_rgb(color: str | Color) -> tuple | Any:
     if isinstance(color, str):
         if color.startswith('rgb('):
             return literal_eval(color.lstrip('rgb(').rstrip(')'))
@@ -238,11 +238,11 @@ def get_theme(theme_id: str) -> Theme: ...
 
 
 @overload
-def get_theme(theme_id: str, as_dict: Literal[False]) -> Theme: ...
+def get_theme(theme_id: str) -> Theme: ...
 
 
 @overload
-def get_theme(theme_id: str, as_dict: Literal[True]) -> dict[str, Any]: ...
+def get_theme(theme_id: str) -> dict[str, Any]: ...
 
 
 def get_theme(theme_id: str):


### PR DESCRIPTION
# References and relevant issues
Closes #7550

# Description
This PR removes deprecated:
- chunk_receiver
- old async deprecations
- as_dict parameter from get_theme
- run_as_bundled_app
- color param in iterable functions
- CallDefault class

It marks this for removal in 0.7.0:
- private attribute access in PublicOnlyProxy

It also updated typing.
