### PR TITLE
Replace duck-typing check with isinstance check for QRangeSlider, v2

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -387,7 +387,7 @@ def test_create_layer_controls_qslider(
             captured = capsys.readouterr()
             assert not captured.out
             assert not captured.err
-        if getattr(qslider, '_valuesChanged', None):
+        if isinstance(qslider, QRangeSlider):
             assert qslider.value()[0] == qslider.minimum()
         else:
             assert qslider.value() == qslider.maximum()


### PR DESCRIPTION
In #7712, I missed one more "hasattr" check for a private attribute. This
one replaces it with an isinstance check.
