### PR TITLE
Add toggle 3D view action

### DIFF
--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -9,9 +9,11 @@ from qtpy.QtWidgets import QApplication
 from napari._app_model import get_app_model
 from napari._qt._qapp_model.qactions._view import (
     _get_current_tooltip_visibility,
+    _toggle_canvas_ndim,
     toggle_action_details,
 )
 from napari._tests.utils import skip_local_focus, skip_local_popups
+from napari.viewer import ViewerModel
 
 
 def check_windows_style(viewer):
@@ -314,3 +316,12 @@ def test_zoom_actions(make_napari_viewer):
     # Zoom should be reset, but angle unchanged
     assert viewer.camera.zoom == pytest.approx(initial_zoom)
     assert viewer.camera.angles == (90, 0, 0)
+
+
+@pytest.mark.parametrize(('initial', 'expected'), [(3, 2), (2, 3)])
+def test_toggle_canvas_ndim(initial, expected):
+    """Check that _toggle_canvas_ndim toggles the canvas ndims."""
+    viewer = ViewerModel()
+    viewer.dims.ndisplay = initial
+    _toggle_canvas_ndim(viewer)
+    assert viewer.dims.ndisplay == expected

--- a/napari/_qt/_qapp_model/injection/_qproviders.py
+++ b/napari/_qt/_qapp_model/injection/_qproviders.py
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
     from napari._qt.qt_viewer import QtViewer
 
 
-def _provide_viewer(public_proxy: bool = True) -> viewer.Viewer | None:
+def _provide_viewer(
+    public_proxy: bool = True,
+) -> viewer.ViewerModel | viewer.Viewer | None:
     """Provide `PublicOnlyProxy` (allows internal napari access) of current viewer."""
     if current_viewer := viewer.current_viewer():
         if public_proxy:

--- a/napari/_qt/_qapp_model/injection/_qproviders.py
+++ b/napari/_qt/_qapp_model/injection/_qproviders.py
@@ -10,21 +10,25 @@ from typing import TYPE_CHECKING
 from napari import components, layers, viewer
 from napari.utils._proxies import PublicOnlyProxy
 from napari.utils.translations import trans
+from napari.viewer import ViewerModel
 
 if TYPE_CHECKING:
     from napari._qt.qt_main_window import Window
     from napari._qt.qt_viewer import QtViewer
 
 
-def _provide_viewer(
-    public_proxy: bool = True,
-) -> viewer.ViewerModel | viewer.Viewer | None:
+def _provide_viewer(public_proxy: bool = True) -> viewer.Viewer | None:
     """Provide `PublicOnlyProxy` (allows internal napari access) of current viewer."""
     if current_viewer := viewer.current_viewer():
         if public_proxy:
             return PublicOnlyProxy(current_viewer)
         return current_viewer
     return None
+
+
+def _provide_viewer_model(public_proxy: bool = True) -> ViewerModel | None:
+    """Provide a Viewer (subclass of ViewerModel) if ViewerModel is needed."""
+    return _provide_viewer(public_proxy)
 
 
 def _provide_viewer_or_raise(
@@ -102,6 +106,7 @@ def _provide_active_layer_list() -> components.LayerList | None:
 # https://github.com/tlambert03/in-n-out/issues/31
 QPROVIDERS = [
     (_provide_viewer,),
+    (_provide_viewer_model,),
     (_provide_qt_viewer,),
     (_provide_window,),
     (_provide_active_layer,),

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -82,11 +82,6 @@ def _toggle_canvas_ndim(viewer: ViewerModel):
         viewer.dims.ndisplay = 2
 
 
-def _current_view_is_3d(viewer: Viewer):
-    """True if viewer.dims.ndisplay is 3."""
-    return viewer.dims.ndisplay == 3
-
-
 Q_VIEW_ACTIONS: list[Action] = [
     Action(
         id='napari.window.view.toggle_fullscreen',

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -194,7 +194,7 @@ Q_VIEW_ACTIONS: list[Action] = [
         keybindings=[StandardKeyBinding.ZoomOut],
     ),
     Action(
-        id='napari.viewer.dims.ndisplay',
+        id='napari.window.view.toggle_ndisplay',
         title=trans._('Toggle 2D/3D Camera'),
         menus=[
             {

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -17,7 +17,7 @@ from napari._qt.qt_main_window import Window
 from napari._qt.qt_viewer import QtViewer
 from napari.settings import get_settings
 from napari.utils.translations import trans
-from napari.viewer import Viewer
+from napari.viewer import Viewer, ViewerModel
 
 # View submenus
 VIEW_SUBMENUS = [
@@ -74,7 +74,7 @@ def _zoom_out(viewer: Viewer):
     viewer.camera.zoom /= 1.5
 
 
-def _toggle_canvas_ndim(viewer: Viewer):
+def _toggle_canvas_ndim(viewer: ViewerModel):
     """Toggle the current canvas between 3D and 2D."""
     if viewer.dims.ndisplay == 2:
         viewer.dims.ndisplay = 3

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -195,7 +195,7 @@ Q_VIEW_ACTIONS: list[Action] = [
     ),
     Action(
         id='napari.viewer.dims.ndisplay',
-        title=trans._('3D View'),
+        title=trans._('Toggle 2D/3D Camera'),
         menus=[
             {
                 'id': MenuId.MENUBAR_VIEW,
@@ -204,7 +204,6 @@ Q_VIEW_ACTIONS: list[Action] = [
             }
         ],
         callback=_toggle_canvas_ndim,
-        toggled=ToggleRule(get_current=_current_view_is_3d),
     ),
     Action(
         id='napari.window.view.toggle_activity_dock',

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -74,6 +74,19 @@ def _zoom_out(viewer: Viewer):
     viewer.camera.zoom /= 1.5
 
 
+def _toggle_canvas_ndim(viewer: Viewer):
+    """Toggle the current canvas between 3D and 2D."""
+    if viewer.dims.ndisplay == 2:
+        viewer.dims.ndisplay = 3
+    else:  # == 3
+        viewer.dims.ndisplay = 2
+
+
+def _current_view_is_3d(viewer: Viewer):
+    """True if viewer.dims.ndisplay is 3."""
+    return viewer.dims.ndisplay == 3
+
+
 Q_VIEW_ACTIONS: list[Action] = [
     Action(
         id='napari.window.view.toggle_fullscreen',
@@ -179,6 +192,19 @@ Q_VIEW_ACTIONS: list[Action] = [
         ],
         callback=_zoom_out,
         keybindings=[StandardKeyBinding.ZoomOut],
+    ),
+    Action(
+        id='napari.viewer.dims.ndisplay',
+        title=trans._('3D View'),
+        menus=[
+            {
+                'id': MenuId.MENUBAR_VIEW,
+                'group': MenuGroup.ZOOM,
+                'order': 2,
+            }
+        ],
+        callback=_toggle_canvas_ndim,
+        toggled=ToggleRule(get_current=_current_view_is_3d),
     ),
     Action(
         id='napari.window.view.toggle_activity_dock',


### PR DESCRIPTION
Closes #7706.

# Description

This adds a simple "Toggle 2D/3D Camera" menu item, which allows toggling the camera from the command palette.

# Original message 👇 

Adds a toggle 3D view action with the title "3D View", which appears ticked in
the menu if the view is 3D, and unticked otherwise. This action allows toggling
3D view in the command palette.

One thing I don't like is that we have Cmd-Y as a shortcut for toggling 3D, but
that does not appear in the menu here. I *think* (correct me if I'm wrong
@DragaDoncila) that currently we can't change app-model keyboard shortcuts in
the settings panel. So adding Cmd-Y here would mean losing the configurability
of that shortcut. It might still be worth it because most people aren't aware
of the keyboard shortcuts, and this would increase discoverability?
