### PR TITLE
Change tox command for compatability with local Windows usage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,7 @@ extras =
     pyqt6_no_numba: pyqt6
     pyside6: pyside6_experimental
 allowlist_externals =
+    cmd
     echo
     mypy
     dot
@@ -101,7 +102,8 @@ indexserver =
     # this will be used only when using --pre with tox/pip as it only contains nightly.
     extra = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 commands =
-    echo "COVERAGE: {env:COVERAGE:}"
+    windows: cmd /c echo COVERAGE: {env:COVERAGE:}
+    !windows: echo "COVERAGE: {env:COVERAGE:}"
     cov: coverage run --parallel-mode \
     !cov: python \
         -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \


### PR DESCRIPTION
# Description

`tox` cannot be used locally with a typical Windows setup with current tox commands. In particular `echo` is not usable from CLI. This PR adds a Windows specific command `cmd /c echo COVERAGE: {env:COVERAGE}` so that `tox` can be run locally and not rely on bash. This PR assumes that Windows CI runners can use cmd in addition to bash. 

## Alternative

Remove `echo "COVERAGE: {env:COVERAGE:}"` because to me it seems to just serve as a 'print' statement. 
