### PR TITLE
Remove debug statement in tox.ini to be compatible with local Windows usage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,6 @@ extras =
     pyqt6_no_numba: pyqt6
     pyside6: pyside6_experimental
 allowlist_externals =
-    echo
     mypy
     dot
 indexserver =
@@ -101,7 +100,6 @@ indexserver =
     # this will be used only when using --pre with tox/pip as it only contains nightly.
     extra = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 commands =
-    echo "COVERAGE: {env:COVERAGE:}"
     cov: coverage run --parallel-mode \
     !cov: python \
         -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \


### PR DESCRIPTION
# References and relevant issues
Alternative to #7723 

# Description
1. Remove debug statement that uses `echo` so that tox works on local Windows testing with CLI. Windows does not by default have access to echo/bash
2. Removes echo from `allowlist_externals`
