### PR TITLE
Remove deprecated camera.interactive

### DIFF
--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,4 +1,3 @@
-import warnings
 from enum import auto
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -59,10 +58,6 @@ class Camera(EventedModel):
         sets of Euler angles may lead to the same view.
     perspective : float
         Perspective (aka "field of view" in vispy) of the camera (if 3D).
-    interactive : bool
-        If the camera mouse pan/zoom is enabled or not.
-        This attribute is deprecated since 0.5.0 and should not be used.
-        Use the mouse_pan and mouse_zoom attributes instead.
     mouse_pan : bool
         If the camera interactive panning with the mouse is enabled or not.
     mouse_zoom : bool
@@ -266,20 +261,3 @@ class Camera(EventedModel):
             VerticalAxisOrientation(value[0]),
             HorizontalAxisOrientation(value[1]),
         )
-
-    @property
-    def interactive(self) -> bool:
-        warnings.warn(
-            '`Camera.interactive` is deprecated since 0.5.0 and will be removed in 0.6.0.',
-            category=DeprecationWarning,
-        )
-        return self.mouse_pan or self.mouse_zoom
-
-    @interactive.setter
-    def interactive(self, interactive: bool):
-        warnings.warn(
-            '`Camera.interactive` is deprecated since 0.5.0 and will be removed in 0.6.0.',
-            category=DeprecationWarning,
-        )
-        self.mouse_pan = interactive
-        self.mouse_zoom = interactive

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -60,8 +60,10 @@ class Camera(EventedModel):
         Perspective (aka "field of view" in vispy) of the camera (if 3D).
     mouse_pan : bool
         If the camera interactive panning with the mouse is enabled or not.
+        Camera interactive panning with the mouse was removed in napari 0.6.0
     mouse_zoom : bool
         If the camera interactive zooming with the mouse is enabled or not.
+        Camera interactive zooming with the mouse was removed in napari 0.6.0
     """
 
     # fields

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -60,7 +60,6 @@ class Camera(EventedModel):
         Perspective (aka "field of view" in vispy) of the camera (if 3D).
     mouse_pan : bool
         If the camera interactive panning with the mouse is enabled or not.
-        Camera interactive panning with the mouse was removed in napari 0.6.0
     mouse_zoom : bool
         If the camera interactive zooming with the mouse is enabled or not.
         Camera interactive zooming with the mouse was removed in napari 0.6.0

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -62,7 +62,6 @@ class Camera(EventedModel):
         If the camera interactive panning with the mouse is enabled or not.
     mouse_zoom : bool
         If the camera interactive zooming with the mouse is enabled or not.
-        Camera interactive zooming with the mouse was removed in napari 0.6.0
     """
 
     # fields

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -6,7 +6,6 @@ import itertools
 import logging
 import os.path
 import uuid
-import warnings
 from abc import ABC, ABCMeta, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Generator, Hashable, Mapping, Sequence
@@ -53,7 +52,6 @@ from napari.utils._magicgui import (
     get_layers,
 )
 from napari.utils.events import EmitterGroup, Event, EventedDict
-from napari.utils.events.event import WarningEmitter
 from napari.utils.geometry import (
     find_front_back_face,
     intersect_line_with_axis_aligned_bounding_box_3d,
@@ -231,10 +229,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         Size of cursor if custom. None yields default size
     help : str
         Displayed in status bar bottom right.
-    interactive : bool
-        Determine if canvas pan/zoom interactivity is enabled.
-        This attribute is deprecated since 0.5.0 and should not be used.
-        Use the mouse_pan and mouse_zoom attributes instead.
     mouse_pan : bool
         Determine if canvas interactive panning is enabled with the mouse.
     mouse_zoom : bool
@@ -482,13 +476,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             translate=Event,
             units=Event,
             visible=Event,
-            interactive=WarningEmitter(
-                trans._(
-                    'layer.events.interactive is deprecated since 0.4.18 and will be removed in 0.6.0. Please use layer.events.mouse_pan and layer.events.mouse_zoom',
-                    deferred=True,
-                ),
-                type_name='interactive',
-            ),
             _extent_augmented=Event,
             _overlays=Event,
         )
@@ -1173,30 +1160,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         self.events.help(help=help_text)
 
     @property
-    def interactive(self) -> bool:
-        warnings.warn(
-            trans._(
-                'Layer.interactive is deprecated since napari 0.4.18 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.mouse_pan or self.mouse_zoom
-
-    @interactive.setter
-    def interactive(self, interactive: bool) -> None:
-        warnings.warn(
-            trans._(
-                'Layer.interactive is deprecated since napari 0.4.18 and will be removed in 0.6.0. Please use Layer.mouse_pan and Layer.mouse_zoom instead'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        with self.events.interactive.blocker():
-            self.mouse_pan = interactive
-        self.mouse_zoom = interactive
-
-    @property
     def mouse_pan(self) -> bool:
         """bool: Determine if canvas interactive panning is enabled with the mouse."""
         return self._mouse_pan
@@ -1207,9 +1170,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             return
         self._mouse_pan = mouse_pan
         self.events.mouse_pan(mouse_pan=mouse_pan)
-        self.events.interactive(
-            interactive=self.mouse_pan or self.mouse_zoom
-        )  # Deprecated since 0.5.0
 
     @property
     def mouse_zoom(self) -> bool:
@@ -1222,9 +1182,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             return
         self._mouse_zoom = mouse_zoom
         self.events.mouse_zoom(mouse_zoom=mouse_zoom)
-        self.events.interactive(
-            interactive=self.mouse_pan or self.mouse_zoom
-        )  # Deprecated since 0.5.0
 
     @property
     def cursor(self) -> str:


### PR DESCRIPTION
# References and relevant issues
Partially addresses #7550. Replaces #7731 which is being split up.

Original PR that set the deprecation: #5701

# Description
- Remove deprecated camera.interactive.