### PR TITLE
Remove deprecated rounded_division static method from viewer model

### DIFF
--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -522,17 +522,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.camera.mouse_zoom = active_layer.mouse_zoom
             self.update_status_from_cursor()
 
-    @staticmethod
-    def rounded_division(min_val, max_val, precision):
-        warnings.warn(
-            trans._(
-                'Viewer.rounded_division is deprecated since v0.4.18 and will be removed in 0.6.0.'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return int(((min_val + max_val) / 2) / precision) * precision
-
     def _on_layers_change(self):
         if len(self.layers) == 0:
             self.dims.ndim = 2


### PR DESCRIPTION
# References and relevant issues
Partially addresses #7550. Replaces #7731.

# Description
Remove the deprecated static method rounded_division from viewer model.