### PR TITLE
Remove deprecated gui_qt

### DIFF
--- a/napari/__init__.py
+++ b/napari/__init__.py
@@ -29,7 +29,7 @@ _proto_all_ = [
 ]
 
 _submod_attrs = {
-    '_event_loop': ['gui_qt', 'run'],
+    '_event_loop': ['run'],
     'plugins.io': ['save_layers'],
     'utils': ['sys_info'],
     'utils.notifications': ['notification_manager'],

--- a/napari/__init__.pyi
+++ b/napari/__init__.pyi
@@ -1,5 +1,5 @@
 import napari.utils.notifications
-from napari._qt.qt_event_loop import gui_qt, run
+from napari._qt.qt_event_loop import run
 from napari.plugins.io import save_layers
 from napari.view_layers import (
     view_image,
@@ -21,7 +21,6 @@ __all__ = (
     'Viewer',
     '__version__',
     'current_viewer',
-    'gui_qt',
     'notification_manager',
     'run',
     'save_layers',

--- a/napari/_event_loop.py
+++ b/napari/_event_loop.py
@@ -1,12 +1,9 @@
 try:
-    from napari._qt.qt_event_loop import gui_qt, run
+    from napari._qt.qt_event_loop import run
 
 # qtpy raises a RuntimeError if no Qt bindings can be found
 except (ImportError, RuntimeError) as e:
     exc = e
-
-    def gui_qt(**kwargs):
-        raise exc
 
     def run(
         *,

--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -87,7 +87,7 @@ if tuple(int(x) for x in QtCore.__version__.split('.')[:3]) < (5, 12, 3):
     warn(message=warn_message, stacklevel=1)
 
 
-from napari._qt.qt_event_loop import get_app, get_qapp, gui_qt, quit_app, run
+from napari._qt.qt_event_loop import get_app, get_qapp, quit_app, run
 from napari._qt.qt_main_window import Window
 
-__all__ = ['Window', 'get_app', 'get_qapp', 'gui_qt', 'quit_app', 'run']
+__all__ = ['Window', 'get_app', 'get_qapp', 'quit_app', 'run']

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import sys
-from contextlib import contextmanager
 from typing import TYPE_CHECKING, cast
 from warnings import warn
 
@@ -304,53 +303,6 @@ def quit_app():
         monitor.stop()
 
 
-@contextmanager
-def gui_qt(*, startup_logo=False, gui_exceptions=False, force=False):
-    """Start a Qt event loop in which to run the application.
-
-    NOTE: This context manager is deprecated!. Prefer using :func:`napari.run`.
-
-    Parameters
-    ----------
-    startup_logo : bool, optional
-        Show a splash screen with the napari logo during startup.
-    gui_exceptions : bool, optional
-        Whether to show uncaught exceptions in the GUI, by default they will be
-        shown in the console that launched the event loop.
-    force : bool, optional
-        Force the application event_loop to start, even if there are no top
-        level widgets to show.
-
-    Notes
-    -----
-    This context manager is not needed if running napari within an interactive
-    IPython session. In this case, use the ``%gui qt`` magic command, or start
-    IPython with the Qt GUI event loop enabled by default by using
-    ``ipython --gui=qt``.
-    """
-    warn(
-        trans._(
-            "\nThe 'gui_qt()' context manager is deprecated.\nIf you are running napari from a script, please use 'napari.run()' as follows:\n\n    import napari\n\n    viewer = napari.Viewer()  # no prior setup needed\n    # other code using the viewer...\n    napari.run()\n\nIn IPython or Jupyter, 'napari.run()' is not necessary. napari will automatically\nstart an interactive event loop for you: \n\n    import napari\n    viewer = napari.Viewer()  # that's it!\n",
-            deferred=True,
-        ),
-        FutureWarning,
-        stacklevel=2,
-    )
-
-    app = get_app()
-    splash = None
-    if startup_logo and app.applicationName() == 'napari':
-        from napari._qt.widgets.qt_splash_screen import NapariSplashScreen
-
-        splash = NapariSplashScreen()
-        splash.close()
-    try:
-        yield app
-    except Exception:  # noqa: BLE001
-        notification_manager.receive_error(*sys.exc_info())
-    run(force=force, gui_exceptions=gui_exceptions, _func_name='gui_qt')
-
-
 def _ipython_has_eventloop() -> bool:
     """Return True if IPython %gui qt is active.
 
@@ -416,7 +368,7 @@ def run(
         has at least ``max_loop_level`` event loops running.  By default, 1.
     _func_name : str, optional
         name of calling function, by default 'run'.  This is only here to
-        provide functions like `gui_qt` a way to inject their name into the
+        provide functions like a way to inject their name into the
         warning message.
 
     Raises

--- a/napari/_qt/qt_event_loop.py
+++ b/napari/_qt/qt_event_loop.py
@@ -367,8 +367,8 @@ def run(
         This function will prevent calling `exec_()` if the application already
         has at least ``max_loop_level`` event loops running.  By default, 1.
     _func_name : str, optional
-        name of calling function, by default 'run'.  This is only here to
-        provide functions like a way to inject their name into the
+        name of calling function, by default 'run'.  This is here to
+        provide functions a way to inject their name into the
         warning message.
 
     Raises


### PR DESCRIPTION
# References and relevant issues
Partially addresses #7550. Replaces #7731 

# Description
This PR removes `gui_qt` throughout the code base.