### PR TITLE
Remove deprecated and renamed points properties

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_points_layer.py
@@ -71,8 +71,7 @@ def test_current_size_display_in_range(qtbot):
     assert slider.value() == 20
     assert layer.current_size == 20
 
-    with pytest.warns(DeprecationWarning):
-        layer.current_size = [10, 10]
+    layer.current_size = 10
     layer.events.size()
     assert slider.maximum() == 201
     assert slider.minimum() == 1

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -1545,11 +1545,6 @@ def test_size_with_arrays(ndim):
     layer.size = sizes
     assert np.array_equal(layer.size, sizes)
 
-    # Un-broadcastable array should raise an exception
-    sizes = [5, 5]
-    with pytest.raises(ValueError, match='not compatible for broadcasting'):
-        layer.size = sizes
-
     # Create new layer with new size array data
     sizes = 5 * np.random.random(10)
     layer = Points(data, size=sizes)

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2641,7 +2641,7 @@ def test_thick_slice():
 
 
 @pytest.mark.parametrize(
-    ('new_name', 'value'),
+    ('name', 'value'),
     [
         ('border_width', 0.9),
         ('border_width_is_relative', False),
@@ -2650,15 +2650,15 @@ def test_thick_slice():
         ('current_border_color', 'pink'),
     ],
 )
-def test_events_callback(new_name, value):
+def test_events_callback(name, value):
     data = np.array([[0, 0, 0], [10, 10, 10]])
     layer = Points(data)
-    new_name_callback = Mock()
-    getattr(layer.events, new_name).connect(new_name_callback)
+    name_callback = Mock()
+    getattr(layer.events, name).connect(name_callback)
 
-    setattr(layer, new_name, value)
+    setattr(layer, name, value)
 
-    new_name_callback.assert_called_once()
+    name_callback.assert_called_once()
 
 
 def test_changing_symbol():

--- a/napari/layers/points/_tests/test_points.py
+++ b/napari/layers/points/_tests/test_points.py
@@ -2641,28 +2641,24 @@ def test_thick_slice():
 
 
 @pytest.mark.parametrize(
-    ('old_name', 'new_name', 'value'),
+    ('new_name', 'value'),
     [
-        ('edge_width', 'border_width', 0.9),
-        ('edge_width_is_relative', 'border_width_is_relative', False),
-        ('current_edge_width', 'current_border_width', 0.9),
-        ('edge_color', 'border_color', 'blue'),
-        ('current_edge_color', 'current_border_color', 'pink'),
+        ('border_width', 0.9),
+        ('border_width_is_relative', False),
+        ('current_border_width', 0.9),
+        ('border_color', 'blue'),
+        ('current_border_color', 'pink'),
     ],
 )
-def test_events_callback(old_name, new_name, value):
+def test_events_callback(new_name, value):
     data = np.array([[0, 0, 0], [10, 10, 10]])
     layer = Points(data)
-    old_name_callback = Mock()
     new_name_callback = Mock()
-    with pytest.warns(FutureWarning):
-        getattr(layer.events, old_name).connect(old_name_callback)
     getattr(layer.events, new_name).connect(new_name_callback)
 
     setattr(layer, new_name, value)
 
     new_name_callback.assert_called_once()
-    old_name_callback.assert_called_once()
 
 
 def test_changing_symbol():
@@ -2686,20 +2682,3 @@ def test_docstring():
     validate_all_params_in_docstring(Points)
     validate_kwargs_sorted(Points)
     validate_docstring_parent_class_consistency(Points)
-
-
-@pytest.mark.parametrize(
-    'key',
-    [
-        'edge_width',
-        'edge_width_is_relative',
-        'edge_color',
-        'edge_color_cycle',
-        'edge_colormap',
-        'edge_contrast_limits',
-    ],
-)
-def test_as_layer_data_tuple_read_deprecated_attr(key: str):
-    _, attrs, _ = Points().as_layer_data_tuple()
-    with pytest.warns(FutureWarning, match='is deprecated since'):
-        attrs[key]

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -2395,6 +2395,3 @@ class Points(Layer):
             and v[value] is not None
             and not (isinstance(v[value], float) and np.isnan(v[value]))
         ]
-
-
-Points._add_deprecated_properties()

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -913,21 +913,8 @@ class Points(Layer):
     def size(self, size: float | np.ndarray | list) -> None:
         try:
             self._size = np.broadcast_to(size, len(self.data)).copy()
-        except ValueError as e:
-            # deprecated anisotropic sizes; extra check should be removed in future version
-            try:
-                self._size = np.broadcast_to(
-                    size, self.data.shape[::-1]
-                ).T.copy()
-            except ValueError:
-                raise ValueError(
-                    trans._(
-                        'Size is not compatible for broadcasting',
-                        deferred=True,
-                    )
-                ) from e
-            else:
-                self._size = np.mean(size, axis=1)
+        except ValueError:
+            self._size = np.mean(size, axis=1)
         # TODO: technically not needed to cleat the non-augmented extent... maybe it's fine like this to avoid complexity
         self.refresh(highlight=False)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -913,12 +913,13 @@ class Points(Layer):
     def size(self, size: float | np.ndarray | list) -> None:
         try:
             self._size = np.broadcast_to(size, len(self.data)).copy()
-        except ValueError as e:
+        except ValueError:
             raise ValueError(
                 trans._(
-                    'Size is not compatible for broadcasting (may be anisotropic)', deferred=True,
-                 )
-             )
+                    'Size is not compatible for broadcasting (may be anisotropic)',
+                    deferred=True,
+                )
+            )
         # TODO: technically not needed to cleat the non-augmented extent... maybe it's fine like this to avoid complexity
         self.refresh(highlight=False)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -913,8 +913,12 @@ class Points(Layer):
     def size(self, size: float | np.ndarray | list) -> None:
         try:
             self._size = np.broadcast_to(size, len(self.data)).copy()
-        except ValueError:
-            self._size = np.mean(size, axis=1)
+except ValueError as e:
+    raise ValueError(
+        trans._(
+            'Size is not compatible for broadcasting (may be anisotropic)', deferred=True,
+         )
+     )
         # TODO: technically not needed to cleat the non-augmented extent... maybe it's fine like this to avoid complexity
         self.refresh(highlight=False)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -913,12 +913,12 @@ class Points(Layer):
     def size(self, size: float | np.ndarray | list) -> None:
         try:
             self._size = np.broadcast_to(size, len(self.data)).copy()
-except ValueError as e:
-    raise ValueError(
-        trans._(
-            'Size is not compatible for broadcasting (may be anisotropic)', deferred=True,
-         )
-     )
+        except ValueError as e:
+            raise ValueError(
+                trans._(
+                    'Size is not compatible for broadcasting (may be anisotropic)', deferred=True,
+                 )
+             )
         # TODO: technically not needed to cleat the non-augmented extent... maybe it's fine like this to avoid complexity
         self.refresh(highlight=False)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -913,13 +913,13 @@ class Points(Layer):
     def size(self, size: float | np.ndarray | list) -> None:
         try:
             self._size = np.broadcast_to(size, len(self.data)).copy()
-        except ValueError:
+        except ValueError as e:
             raise ValueError(
                 trans._(
                     'Size is not compatible for broadcasting (may be anisotropic)',
                     deferred=True,
                 )
-            )
+            ) from e
         # TODO: technically not needed to cleat the non-augmented extent... maybe it's fine like this to avoid complexity
         self.refresh(highlight=False)
 

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -53,9 +53,7 @@ from napari.utils.colormaps import Colormap, ValidColormapArg
 from napari.utils.colormaps.standardize_color import hex_to_name, rgb_to_hex
 from napari.utils.events import Event
 from napari.utils.events.custom_types import Array
-from napari.utils.events.migrations import deprecation_warning_event
 from napari.utils.geometry import project_points_onto_plane, rotate_points
-from napari.utils.migrations import add_deprecated_property, rename_argument
 from napari.utils.transforms import Affine
 from napari.utils.translations import trans
 
@@ -354,36 +352,6 @@ class Points(Layer):
     # If more points are present then they are randomly subsampled
     _max_points_thumbnail = 1024
 
-    @rename_argument(
-        'edge_width', 'border_width', since_version='0.5.0', version='0.6.0'
-    )
-    @rename_argument(
-        'edge_width_is_relative',
-        'border_width_is_relative',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
-    @rename_argument(
-        'edge_color', 'border_color', since_version='0.5.0', version='0.6.0'
-    )
-    @rename_argument(
-        'edge_color_cycle',
-        'border_color_cycle',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
-    @rename_argument(
-        'edge_colormap',
-        'border_colormap',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
-    @rename_argument(
-        'edge_contrast_limits',
-        'border_contrast_limits',
-        since_version='0.5.0',
-        version='0.6.0',
-    )
     def __init__(
         self,
         data=None,
@@ -508,28 +476,6 @@ class Points(Layer):
             feature_defaults=Event,
         )
 
-        deprecated_events = {}
-        for attr in [
-            '{}_width',
-            'current_{}_width',
-            '{}_width_is_relative',
-            '{}_color',
-            'current_{}_color',
-        ]:
-            old_attr = attr.format('edge')
-            new_attr = attr.format('border')
-            old_emitter = deprecation_warning_event(
-                'layer.events',
-                old_attr,
-                new_attr,
-                since_version='0.5.0',
-                version='0.6.0',
-            )
-            getattr(self.events, new_attr).connect(old_emitter)
-            deprecated_events[old_attr] = old_emitter
-
-        self.events.add(**deprecated_events)
-
         # Save the point coordinates
         self._data = np.asarray(data)
 
@@ -614,30 +560,6 @@ class Points(Layer):
 
         # Trigger generation of view slice and thumbnail
         self.refresh(extent=False)
-
-    @classmethod
-    def _add_deprecated_properties(cls) -> None:
-        """Adds deprecated properties to class."""
-        deprecated_properties = [
-            'edge_width',
-            'edge_width_is_relative',
-            'current_edge_width',
-            'edge_color',
-            'edge_color_cycle',
-            'edge_colormap',
-            'edge_contrast_limits',
-            'current_edge_color',
-            'edge_color_mode',
-        ]
-        for old_property in deprecated_properties:
-            new_property = old_property.replace('edge', 'border')
-            add_deprecated_property(
-                cls,
-                old_property,
-                new_property,
-                since_version='0.5.0',
-                version='0.6.0',
-            )
 
     @property
     def data(self) -> np.ndarray:
@@ -1006,15 +928,6 @@ class Points(Layer):
                 ) from e
             else:
                 self._size = np.mean(size, axis=1)
-                warnings.warn(
-                    trans._(
-                        'Since 0.4.18 point sizes must be isotropic; the average from each dimension will be'
-                        ' used instead. This will become an error in version 0.6.0.',
-                        deferred=True,
-                    ),
-                    category=DeprecationWarning,
-                    stacklevel=2,
-                )
         # TODO: technically not needed to cleat the non-augmented extent... maybe it's fine like this to avoid complexity
         self.refresh(highlight=False)
 
@@ -1026,15 +939,6 @@ class Points(Layer):
     @current_size.setter
     def current_size(self, size: None | float) -> None:
         if isinstance(size, list | tuple | np.ndarray):
-            warnings.warn(
-                trans._(
-                    'Since 0.4.18 point sizes must be isotropic; the average from each dimension will be used instead. '
-                    'This will become an error in version 0.6.0.',
-                    deferred=True,
-                ),
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
             size = size[-1]
         if not isinstance(size, numbers.Number):
             raise TypeError(


### PR DESCRIPTION
# References and relevant issues
Partially addresses https://github.com/napari/napari/issues/7550. Replaces https://github.com/napari/napari/pull/7731

# Description

This PR removes a group of properties that had been renamed and the old names were mapped to new names. The old property names are removed. The tests for the deprecated properties were removed or modified.