### PR TITLE
Remove warning about since_version parameter in deprecation warnings

### DIFF
--- a/napari/utils/migrations.py
+++ b/napari/utils/migrations.py
@@ -51,17 +51,6 @@ def rename_argument(
         version when new argument was added
     """
 
-    if not since_version:
-        since_version = 'unknown'
-        warnings.warn(
-            trans._(
-                'The since_version argument was added in napari 0.4.18 and will be mandatory since 0.6.0 release.',
-                deferred=True,
-            ),
-            stacklevel=2,
-            category=FutureWarning,
-        )
-
     def _wrapper(func):
         if not hasattr(func, '_rename_argument'):
             func._rename_argument = []


### PR DESCRIPTION
# References and relevant issues
Partially addresses: #7550 Replaces #7731

# Description
Remove a warning about since_version becoming required in 0.6.0.