### PR TITLE
Remove deprecated Interpolation attribute from Image layer

### DIFF
--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -19,7 +19,6 @@ def test_image_rendering(make_napari_viewer):
 
     assert layer.rendering == 'mip'
 
-    # Change the interpolation property
     assert layer.interpolation2d == 'nearest'
     assert layer.interpolation3d == 'linear'
 

--- a/napari/_vispy/_tests/test_image_rendering.py
+++ b/napari/_vispy/_tests/test_image_rendering.py
@@ -20,11 +20,7 @@ def test_image_rendering(make_napari_viewer):
     assert layer.rendering == 'mip'
 
     # Change the interpolation property
-    with pytest.deprecated_call():
-        layer.interpolation = 'linear'
     assert layer.interpolation2d == 'nearest'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'linear'
     assert layer.interpolation3d == 'linear'
 
     # Change rendering property

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -329,26 +329,19 @@ def test_blending():
     assert layer.blending == 'minimum'
 
 
-def test_interpolation():
-    """Test setting image interpolation mode."""
+def test_interpolation_2d_3d():
+    """Test setting image interpolation2d and interpolation3d mode."""
     np.random.seed(0)
     data = np.random.random((10, 15))
     layer = Image(data)
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'nearest'
+
     assert layer.interpolation2d == 'nearest'
     assert layer.interpolation3d == 'linear'
 
-    with pytest.deprecated_call():
-        layer = Image(data, interpolation2d='bicubic')
-    assert layer.interpolation2d == 'cubic'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'cubic'
+    assert layer.interpolation2d != 'cubic'
 
     layer.interpolation2d = 'linear'
     assert layer.interpolation2d == 'linear'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'linear'
 
 
 def test_colormaps():

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -234,26 +234,19 @@ def test_blending():
     assert layer.blending == 'opaque'
 
 
-def test_interpolation():
+def test_interpolation_2d_3d():
     """Test setting image interpolation mode."""
     shapes = [(40, 20), (20, 10), (10, 5)]
     np.random.seed(0)
     data = [np.random.random(s) for s in shapes]
     layer = Image(data, multiscale=True)
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'nearest'
+
     assert layer.interpolation2d == 'nearest'
     assert layer.interpolation3d == 'linear'
 
-    with pytest.deprecated_call():
-        layer = Image(data, multiscale=True, interpolation2d='bicubic')
-    assert layer.interpolation2d == 'cubic'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'cubic'
+    assert layer.interpolation2d != 'cubic'
 
     layer.interpolation2d = 'linear'
-    with pytest.deprecated_call():
-        assert layer.interpolation == 'linear'
     assert layer.interpolation2d == 'linear'
 
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -25,7 +25,6 @@ from napari.layers.utils.layer_utils import calc_data_range
 from napari.utils._dtype import get_dtype_limits, normalize_dtype
 from napari.utils.colormaps import ensure_colormap
 from napari.utils.colormaps.colormap_utils import _coerce_contrast_limits
-from napari.utils.migrations import rename_argument
 from napari.utils.translations import trans
 
 __all__ = ('Image',)
@@ -223,12 +222,6 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
 
     _projectionclass = ImageProjectionMode
 
-    @rename_argument(
-        from_name='interpolation',
-        to_name='interpolation2d',
-        version='0.6.0',
-        since_version='0.4.17',
-    )
     def __init__(
         self,
         data,
@@ -440,63 +433,6 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
             self.reset_contrast_limits()
         self.events.data(value=self.data)
         self._reset_editable()
-
-    @property
-    def interpolation(self):
-        """Return current interpolation mode.
-
-        Selects a preset interpolation mode in vispy that determines how volume
-        is displayed.  Makes use of the two Texture2D interpolation methods and
-        the available interpolation methods defined in
-        vispy/gloo/glsl/misc/spatial_filters.frag
-
-        Options include:
-        'bessel', 'cubic', 'linear', 'blackman', 'catrom', 'gaussian',
-        'hamming', 'hanning', 'hermite', 'kaiser', 'lanczos', 'mitchell',
-        'nearest', 'spline16', 'spline36'
-
-        Returns
-        -------
-        str
-            The current interpolation mode
-        """
-        warnings.warn(
-            trans._(
-                'Interpolation attribute is deprecated since 0.4.17. Please use interpolation2d or interpolation3d',
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return str(
-            self._interpolation2d
-            if self._slice_input.ndisplay == 2
-            else self._interpolation3d
-        )
-
-    @interpolation.setter
-    def interpolation(self, interpolation):
-        """Set current interpolation mode."""
-        warnings.warn(
-            trans._(
-                'Interpolation setting is deprecated since 0.4.17. Please use interpolation2d or interpolation3d',
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        if self._slice_input.ndisplay == 3:
-            self.interpolation3d = interpolation
-        else:
-            if interpolation == 'bilinear':
-                interpolation = 'linear'
-                warnings.warn(
-                    trans._(
-                        "'bilinear' is invalid for interpolation2d (introduced in napari 0.4.17). "
-                        "Please use 'linear' instead, and please set directly the 'interpolation2d' attribute'.",
-                    ),
-                    category=DeprecationWarning,
-                    stacklevel=2,
-                )
-            self.interpolation2d = interpolation
 
     @property
     def interpolation2d(self) -> InterpolationStr:


### PR DESCRIPTION
# References and relevant issues
Partially addresses #7550 Replaces #7731 

# Description
Removes interpolation attribute which was replaced by interpolation 2d and interpolation 3d attributes in the image layer.