### PR TITLE
Add pyqt5-qt5 pin for `uv add` compatibility on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ pyside = [
 ]
 pyqt5 = [
     "PyQt5>=5.15.8"
+    "pyqt5-qt5<=5.15.2; sys_platform == 'Windows'", # 5.15.2 is latest to build on Windows, required for `uv add` compatability as of uv 0.6.9
 ]
 pyqt = [
     "napari[pyqt5]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,8 @@ pyside = [
     "napari[pyside2]"
 ]
 pyqt5 = [
-    "PyQt5>=5.15.8"
-    "pyqt5-qt5<=5.15.2; sys_platform == 'Windows'", # 5.15.2 is latest to build on Windows, required for `uv add` compatability as of uv 0.6.9
+    "PyQt5>=5.15.8",
+    "pyqt5-qt5<=5.15.2; sys_platform == 'Windows'",  # 5.15.2 is latest to build on Windows, required for `uv add` compatability as of uv 0.6.9
 ]
 pyqt = [
     "napari[pyqt5]"


### PR DESCRIPTION
# References and relevant issues

`uv add napari[all]` (or some equivalent installing pyqt5) will result in the following error:
```
error: Distribution `pyqt5-qt5==5.15.16 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're on Windows (`win_amd64`), but `pyqt5-qt5` (v5.15.16) only has wheels for the following platforms: `manylinux2014_x86_64`, `macosx_10_13_x86_64`, `macosx_11_0_arm64`
```
This also occurs when using `uv sync` on a project with napari as a dependences. However, `uv pip install napari[all]` does solve correctly. So, this fix is specifically for `uv add/sync`.

I've been having this problem for quite a while in various projects, and this is the cleanest and most intuitive work around I have found so far.

# Description

Adds a pin for `pyqt5-qt5` for windows, so that `uv add` solves correctly. 
