### PR TITLE
Fix typo causing mypy error

### DIFF
--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -577,8 +577,8 @@ class Tracks(Layer):
 
     # Ignored type because mypy doesn't recognise colormaps_dict as a property
     # TODO: investigate and fix this - not sure why this is the case?
-    @colormaps_dict.setter  # type: ignore[attr-defined]
-    def colomaps_dict(self, colormaps_dict: dict[str, Colormap]) -> None:
+    @colormaps_dict.setter
+    def colormaps_dict(self, colormaps_dict: dict[str, Colormap]) -> None:
         # validate the dictionary entries?
         self._colormaps_dict = colormaps_dict
 

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -575,8 +575,6 @@ class Tracks(Layer):
     def colormaps_dict(self) -> dict[str, Colormap]:
         return self._colormaps_dict
 
-    # Ignored type because mypy doesn't recognise colormaps_dict as a property
-    # TODO: investigate and fix this - not sure why this is the case?
     @colormaps_dict.setter
     def colormaps_dict(self, colormaps_dict: dict[str, Colormap]) -> None:
         # validate the dictionary entries?


### PR DESCRIPTION
# References and relevant issues
A comment in the tracks layer states in the `colormaps_dict` setter method:
```
# Ignored type because mypy doesn't recognise colormaps_dict as a property
# TODO: investigate and fix this - not sure why this is the case?
```
I think the issue is just a small typo: `colomaps_dict` instead of `colormaps_dict`.

# Description
This PR fixes the typo in the name of the setter method.

After correcting the typo and removing the `# type: ignore`, running `tox -e mypy` throws no errors.


