### PR TITLE
Provide fallback version for setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ napari_builtins = [
 
 [tool.setuptools_scm]
 write_to = "napari/_version.py"
+fallback_version = "0.6.0.nogit"
 
 [tool.check-manifest]
 ignore = [


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari-plugin-template/issues/46

# Description

Just use `fallback_version` as people may check `pyproject.toml` from `napari` for inspiration. This also means that people can install napari after downloading a zip file of the code without git.
