### PR TITLE
[bugfix] Adjust scale_bar box scaling and positioning with font size increases

### DIFF
--- a/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -24,19 +24,29 @@ def test_scale_bar_positioning(make_napari_viewer):
 
     assert model.position == 'bottom_right'
     assert model.font_size == 10
-    assert scale_bar.y_offset == 20
+    assert scale_bar.node.box.height == pytest.approx(36.3, abs=0.1)
+    assert scale_bar.y_offset == 7
 
     model.position = 'top_right'
-    assert scale_bar.y_offset == pytest.approx(20.333, abs=0.1)
+    # y_offset should be increase to account for box height
+    assert scale_bar.y_offset == 7 + scale_bar.node.box.height / 2
 
-    # increasing size while at top should increase y_offset to 7 + font_size*1.33
+    # increasing font while at top increases y_offset due to new box height
     model.font_size = 30
-    assert scale_bar.y_offset == pytest.approx(47, abs=0.1)
+    assert scale_bar.node.box.height == 63
+    assert scale_bar.y_size == 63 / 2
+    assert scale_bar.y_offset == 7 + scale_bar.y_size
 
-    # moving scale bar back to bottom should reset y_offset to 20
+    # moving scale bar back to bottom should reset y_offset to 7
+    # y_size and box height should remain the same
     model.position = 'bottom_right'
-    assert scale_bar.y_offset == 20
+    assert scale_bar.y_offset == 7
+    assert scale_bar.node.box.height == 63
+    assert scale_bar.y_size == 63 / 2
 
-    # changing font_size at bottom should have no effect
-    model.font_size = 50
-    assert scale_bar.y_offset == 20
+    # changing font_size at bottom should have no effect on the offset
+    # but should increase the box height and y_size
+    model.font_size = 40
+    assert scale_bar.y_offset == 7
+    assert scale_bar.y_size == pytest.approx(38.1, abs=0.1)
+    assert scale_bar.node.box.height == pytest.approx(76.3, abs=0.1)

--- a/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -48,3 +48,21 @@ def test_scale_bar_positioning(make_napari_viewer):
     assert scale_bar.y_offset == 7
     assert scale_bar.y_size == 38
     assert scale_bar.node.box.height == 76
+
+    # setting `colored` should have no effect
+    model.colored = True
+    assert scale_bar.y_offset == 7
+    assert scale_bar.y_size == 38
+    assert scale_bar.node.box.height == 76
+    # check that the line is not at the center,
+    # but offset down due to the font size (40)
+    assert scale_bar.node.line.pos[0, 1] == scale_bar.node.box.height / 2 - 18
+
+    # changing `ticks` should have no effect
+    model.ticks = False
+    assert scale_bar.y_offset == 7
+    assert scale_bar.y_size == 38
+    assert scale_bar.node.box.height == 76
+    # check that the line is not at the center,
+    # but offset down due to the font size (40)
+    assert scale_bar.node.line.pos[0, 1] == scale_bar.node.box.height / 2 - 18

--- a/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari.components.overlays import ScaleBarOverlay
 
@@ -24,7 +22,7 @@ def test_scale_bar_positioning(make_napari_viewer):
 
     assert model.position == 'bottom_right'
     assert model.font_size == 10
-    assert scale_bar.node.box.height == pytest.approx(36.3, abs=0.1)
+    assert scale_bar.node.box.height == 36
     assert scale_bar.y_offset == 7
 
     model.position = 'top_right'
@@ -48,5 +46,5 @@ def test_scale_bar_positioning(make_napari_viewer):
     # but should increase the box height and y_size
     model.font_size = 40
     assert scale_bar.y_offset == 7
-    assert scale_bar.y_size == pytest.approx(38.1, abs=0.1)
-    assert scale_bar.node.box.height == pytest.approx(76.3, abs=0.1)
+    assert scale_bar.y_size == 38
+    assert scale_bar.node.box.height == 76

--- a/napari/_vispy/visuals/scale_bar.py
+++ b/napari/_vispy/visuals/scale_bar.py
@@ -42,6 +42,33 @@ class ScaleBar(Compound):
     def box(self):
         return self._subvisuals[0]
 
+    def _update_layout(self, font_size):
+        # convert font_size to logical pixels as vispy does
+        # in vispy/visuals/text/text.py
+        # 96 dpi is used as the napari reference dpi
+        font_logical_pixels = font_size * 96 / 72
+
+        # 18 is the bottom half of the default/initial box
+        # 5 is the padding at the top of the text
+        self.box.height = 18 + font_logical_pixels + 5
+
+        # Text and line should be fixed at the bottom of the box.
+        # At the default font size (10) and box height (36), the position
+        # is in the center (0), so subtract half of the default box height (18)
+        fixed_position_in_box = self.box.height / 2 - 18
+        self.text.pos = [0.5, fixed_position_in_box]
+        line_data = np.array(
+            [
+                [0, fixed_position_in_box],
+                [1, fixed_position_in_box],
+                [0, fixed_position_in_box - 5],
+                [0, fixed_position_in_box + 5],
+                [1, fixed_position_in_box - 5],
+                [1, fixed_position_in_box + 5],
+            ]
+        )
+        self.line.set_data(pos=line_data)
+
     def set_data(self, color, ticks):
         data = self._data if ticks else self._data[:2]
         self.line.set_data(data, color)

--- a/napari/_vispy/visuals/scale_bar.py
+++ b/napari/_vispy/visuals/scale_bar.py
@@ -46,7 +46,8 @@ class ScaleBar(Compound):
         # convert font_size to logical pixels as vispy does
         # in vispy/visuals/text/text.py
         # 96 dpi is used as the napari reference dpi
-        font_logical_pixels = font_size * 96 / 72
+        # round to ensure box.height for font_size 10 is 36
+        font_logical_pixels = np.round(font_size * 96 / 72)
 
         # 18 is the bottom half of the default/initial box
         # 5 is the padding at the top of the text

--- a/napari/_vispy/visuals/scale_bar.py
+++ b/napari/_vispy/visuals/scale_bar.py
@@ -58,7 +58,7 @@ class ScaleBar(Compound):
         # is in the center (0), so subtract half of the default box height (18)
         fixed_position_in_box = self.box.height / 2 - 18
         self.text.pos = [0.5, fixed_position_in_box]
-        line_data = np.array(
+        self._data = np.array(
             [
                 [0, fixed_position_in_box],
                 [1, fixed_position_in_box],
@@ -68,7 +68,7 @@ class ScaleBar(Compound):
                 [1, fixed_position_in_box + 5],
             ]
         )
-        self.line.set_data(pos=line_data)
+        self.line.set_data(pos=self._data)
 
     def set_data(self, color, ticks):
         data = self._data if ticks else self._data[:2]


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7516
Closes https://github.com/napari/napari/issues/7136
(this last one requested a drop shadow, but we agreed the working box is a better experience)

# Description
This PR does a few things things:
1. it adds a method to ScaleBar visual to recalculate the box height for a given font size and adjust the layout of the box contexts (the bar and the text positioning). I use this method when the font size is changed in the overlay. This method keeps the layout of the box the same *relative to the bottom of the box* as the font grows the box upwards.
2. Changes the y_size and y_offset defaults in the overlay to actually match what they do/are: the half-size of the default box and the offset from the edge. The sum remains the same, so default behavior is unchanged, but it's easier to reason about the needed changes when the font and box height change.
3. The above mentioned method is called when the font size of the scale bar overlay is changed, and for the top positions, the y_offset is adjusted by the new y_size (half of the box height) such that the top edge of the box is fixed even as the font increases and the box expands downwards.
4. updates the tests to check/account for the new behavior.

All of this results in the following, a font_size 30 overlay, at top right:
With this PR:
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/cc231800-c2e1-4423-854a-30c26058221e" />

With main:
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/397bf7af-6f66-4f1b-a4d8-7418495c0601" />
