### PR TITLE
Fix `test_modified_scrollbar_click` on High DPI screens 

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_scrollbar.py
+++ b/napari/_qt/widgets/_tests/test_qt_scrollbar.py
@@ -1,3 +1,4 @@
+from qtpy import PYQT5, PYSIDE2
 from qtpy.QtCore import QPoint, Qt
 from qtpy.QtWidgets import QApplication
 
@@ -5,7 +6,8 @@ from napari._qt.widgets.qt_scrollbar import ModifiedScrollBar
 
 # Enable high DPI scaling prior to instantiating QApplication
 # This is required for the test to pass on high DPI displays
-QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+if PYQT5 or PYSIDE2:
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
 
 def test_modified_scrollbar_click(qtbot):

--- a/napari/_qt/widgets/_tests/test_qt_scrollbar.py
+++ b/napari/_qt/widgets/_tests/test_qt_scrollbar.py
@@ -1,6 +1,11 @@
 from qtpy.QtCore import QPoint, Qt
+from qtpy.QtWidgets import QApplication
 
 from napari._qt.widgets.qt_scrollbar import ModifiedScrollBar
+
+# Enable high DPI scaling prior to instantiating QApplication
+# This is required for the test to pass on high DPI displays
+QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
 
 def test_modified_scrollbar_click(qtbot):


### PR DESCRIPTION
# References and relevant issues

Closes #7428

# Description

Simplest implentation to enable high DPI scaling so that tests pass on high DPI screens. 
```python 
if PYQT5 or PYSIDE2:
    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
```
This works similarly / different from #7625 because `get_qapp` will be triggered by creating the qt viewer, and that function enables High DPI scaling in the same way. 

## Alternative that does work at least locally

```python
import os
os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
os.environ["QT_SCREEN_SCALE_FACTORS"] = "1"
```

## Alternatives that don't work 

Surprisingly to me, trying to get `devicePixelRatio` inside the test will always return 1.0 such as with the below attempt. I did fiddle around and was actually able to get it to click on the scrollbar, but the math made little sense, so the proposed implementation is likely more robust (it was somehow 176% the size? but 1.0 scaling, even though its actually 2.0 scaling on my screen, blah blah)

```python
from qtpy.QtCore import QPoint, Qt
from qtpy.QtWidgets import QApplication

from napari._qt.widgets.qt_scrollbar import ModifiedScrollBar


def test_modified_scrollbar_click(qtbot):
    w = ModifiedScrollBar(Qt.Horizontal)
    w.resize(100, 10)
    assert w.value() == 0
    
    device_pixel_ratio = QApplication.instance().devicePixelRatio()
    
    click_x = 50 / device_pixel_ratio
    click_y = 5 / device_pixel_ratio
    qtbot.mousePress(w, Qt.LeftButton, pos=QPoint(int(click_x), int(click_y)))
    
    # the normal QScrollBar would have moved to "10"
    assert w.value() >= 40 / device_pixel_ratio
```