### PR TITLE
Track layer slider max value

### DIFF
--- a/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
@@ -108,8 +108,8 @@ def test_update_max_tail_length(null_data, properties, qtbot):
     # update max_length beyond the current value
     layer.tail_length = layer._max_length + 200
     assert controls.tail_length_slider.maximum() == layer._max_length
-    
-    
+
+
 def test_update_max_head_length(null_data, properties, qtbot):
     """Check updating of the head length slider beyond current maximum."""
     layer = Tracks(null_data, properties=properties)
@@ -122,4 +122,3 @@ def test_update_max_head_length(null_data, properties, qtbot):
     # update max_length beyond the current value
     layer.head_length = layer._max_length + 200
     assert controls.head_length_slider.maximum() == layer._max_length
-    

--- a/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_tracks_layer.py
@@ -28,27 +28,27 @@ def test_tracks_controls_color_by(null_data, properties, qtbot):
             null_data, properties=properties, color_by=inital_color_by
         )
     assert "Previous color_by key 'time' not present" in str(wrn[0].message)
-    qtctrl = QtTracksControls(layer)
-    qtbot.addWidget(qtctrl)
+    controls = QtTracksControls(layer)
+    qtbot.addWidget(controls)
 
     # verify the color_by argument is initialized correctly
     assert layer.color_by == inital_color_by
-    assert qtctrl.color_by_combobox.currentText() == inital_color_by
+    assert controls.color_by_combobox.currentText() == inital_color_by
 
     # update color_by from the layer model
     layer_update_color_by = 'speed'
     layer.color_by = layer_update_color_by
     assert layer.color_by == layer_update_color_by
-    assert qtctrl.color_by_combobox.currentText() == layer_update_color_by
+    assert controls.color_by_combobox.currentText() == layer_update_color_by
 
     # update color_by from the qt controls
     qt_update_color_by = 'track_id'
-    speed_index = qtctrl.color_by_combobox.findText(
+    speed_index = controls.color_by_combobox.findText(
         qt_update_color_by, Qt.MatchFixedString
     )
-    qtctrl.color_by_combobox.setCurrentIndex(speed_index)
+    controls.color_by_combobox.setCurrentIndex(speed_index)
     assert layer.color_by == qt_update_color_by
-    assert qtctrl.color_by_combobox.currentText() == qt_update_color_by
+    assert controls.color_by_combobox.currentText() == qt_update_color_by
 
 
 @pytest.mark.parametrize('color_by', ['track_id', 'speed'])
@@ -94,3 +94,32 @@ def test_color_by_missing_after_properties_change(
 
     assert layer.color_by == 'track_id'
     assert controls.color_by_combobox.currentText() == 'track_id'
+
+
+def test_update_max_tail_length(null_data, properties, qtbot):
+    """Check updating of the tail length slider beyond current maximum."""
+    layer = Tracks(null_data, properties=properties)
+    controls = QtTracksControls(layer)
+    qtbot.addWidget(controls)
+
+    # verify the max_length argument is initialized correctly
+    assert controls.tail_length_slider.maximum() == layer._max_length
+
+    # update max_length beyond the current value
+    layer.tail_length = layer._max_length + 200
+    assert controls.tail_length_slider.maximum() == layer._max_length
+    
+    
+def test_update_max_head_length(null_data, properties, qtbot):
+    """Check updating of the head length slider beyond current maximum."""
+    layer = Tracks(null_data, properties=properties)
+    controls = QtTracksControls(layer)
+    qtbot.addWidget(controls)
+
+    # verify the max_length argument is initialized correctly
+    assert controls.head_length_slider.maximum() == layer._max_length
+
+    # update max_length beyond the current value
+    layer.head_length = layer._max_length + 200
+    assert controls.head_length_slider.maximum() == layer._max_length
+    

--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -128,12 +128,16 @@ class QtTracksControls(QtLayerControls):
         """Receive layer model track line width change event and update slider."""
         with self.layer.events.tail_length.blocker():
             value = self.layer.tail_length
+            if value > self.tail_length_slider.maximum():
+                self.tail_length_slider.setMaximum(self.layer._max_length)
             self.tail_length_slider.setValue(value)
 
     def _on_head_length_change(self):
         """Receive layer model track line width change event and update slider."""
         with self.layer.events.head_length.blocker():
             value = self.layer.head_length
+            if value > self.head_length_slider.maximum():   
+                self.head_length_slider.setMaximum(self.layer._max_length)
             self.head_length_slider.setValue(value)
 
     def _on_properties_change(self):

--- a/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -136,7 +136,7 @@ class QtTracksControls(QtLayerControls):
         """Receive layer model track line width change event and update slider."""
         with self.layer.events.head_length.blocker():
             value = self.layer.head_length
-            if value > self.head_length_slider.maximum():   
+            if value > self.head_length_slider.maximum():
                 self.head_length_slider.setMaximum(self.layer._max_length)
             self.head_length_slider.setValue(value)
 

--- a/napari/_vispy/filters/tracks.py
+++ b/napari/_vispy/filters/tracks.py
@@ -56,11 +56,17 @@ class TracksFilter(Filter):
                 } else {
                     alpha = 0.;
                 }
+            } else if ($a_vertex_time < $current_time - $tail_length) {
+                if ($tail_length == 0){
+                    alpha = -1000.;
+                } else {
+                    alpha = 0.;
+                }
             } else {
                 // fade the track into the temporal distance, scaled by the
                 // maximum tail and head length from the gui
                 float fade = ($head_length + $current_time - $a_vertex_time) / ($tail_length + $head_length);
-                alpha = clamp(1.0-fade, 0.0, 1.0);
+                alpha = clamp(1.0-fade, 0.5, 1.0);
             }
 
             // when use_fade is disabled, the entire track is visible

--- a/napari/_vispy/filters/tracks.py
+++ b/napari/_vispy/filters/tracks.py
@@ -56,17 +56,11 @@ class TracksFilter(Filter):
                 } else {
                     alpha = 0.;
                 }
-            } else if ($a_vertex_time < $current_time - $tail_length) {
-                if ($tail_length == 0){
-                    alpha = -1000.;
-                } else {
-                    alpha = 0.;
-                }
             } else {
                 // fade the track into the temporal distance, scaled by the
                 // maximum tail and head length from the gui
                 float fade = ($head_length + $current_time - $a_vertex_time) / ($tail_length + $head_length);
-                alpha = clamp(1.0-fade, 0.5, 1.0);
+                alpha = clamp(1.0-fade, 0.0, 1.0);
             }
 
             // when use_fade is disabled, the entire track is visible


### PR DESCRIPTION
# References and relevant issues

Closes https://github.com/napari/napari/issues/7728

# Description
This PR takes care of ~~two~~ one thing: 
- In case users set a new `.tail_length` (or `.head_length`) on an existing tracks layer that is higher than the standard value of 300, display the track lengths correctly and adjust the new max of the tail or head length sliders to that new value

The below part was part of the original PR, but I scratched it since developers decided it would be best to separate it into a new project / PR in the future. 
~~I noticed that the shader tapers off alpha value of the earliest visible track points (points at the very beginning of tail or end of head) to 0 (zero). This counteracts the user's input because at a tail length of 500 for example, the earliest 100-200 points are barely visible. I clamped the alpha value to 0.5 instead of 0, which I feel is more reasonable because it leads to a "slide fade" (does not get rid of the effect completely), but maintains some visibility. One could think about enabling or disabling this feature with a checkbox. 
Below is a direct comparison. Note the change in visibility for blue (early) track points.~~

```
### Alpha zero (original)
![alpha 0](https://github.com/user-attachments/assets/c5171aba-753d-4878-97a2-c2c493a1344b)

### Alpha clamped to 0.5 (new)
![alpha 5 clamped](https://github.com/user-attachments/assets/784a120a-3260-4a65-a505-59ab864b0590)

```


