### PR TITLE
Fix test for hdpi scaling

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -893,6 +893,9 @@ with contextlib.suppress(ImportError):
     # So we cannot inherit from QtBot and declare the fixture
 
     from pytestqt.qtbot import QtBot
+    from qtpy import PYQT5, PYSIDE2
+    from qtpy.QtCore import Qt
+    from qtpy.QtWidgets import QApplication
 
     class QtBotWithOnCloseRenaming(QtBot):
         """Modified QtBot that renames widgets when closing them in tests.
@@ -944,6 +947,12 @@ with contextlib.suppress(ImportError):
         before, so we need it, even without using it directly in this fixture.
         """
         return QtBotWithOnCloseRenaming(request)
+
+    @pytest.fixture(scope='session')
+    def qapp_cls():
+        if PYQT5 or PYSIDE2:
+            QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+        return QApplication
 
 
 @pytest.fixture

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -950,7 +950,18 @@ with contextlib.suppress(ImportError):
 
     @pytest.fixture(scope='session')
     def qapp_cls():
+        """The qapp fixture uses the qapp_cls fixture to select
+        the class to use for create the QApplication instance.
+
+        As qapp fixture is using more complex logic, we decided
+        not to override it but overwrite the fixture used by it.
+
+        We need to set attributte before the QApplication is created.
+        """
         if PYQT5 or PYSIDE2:
+            # As Qt6 autodetect High dpi scaling, we need to
+            # enable it only on Qt5 bindings.
+            # https://doc.qt.io/qtforpython-6/faq/porting_from2.html#class-function-deprecations
             QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
         return QApplication
 


### PR DESCRIPTION
# References and relevant issues

Closes #7751
Closes #7428

# Description

Set relevant HiDPI Qt attributes *before* creating an instance of QApplication in tests by overriding the qapp_cls fixture.