### PR TITLE
Upload failed triangulations as artifacts from benchmarks run

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -159,6 +159,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/tmp
+          include-hidden-files: true
 
       - name: Add more info to artifact
         if: always()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -93,6 +93,7 @@ jobs:
           GIT_LFS_SKIP_SMUDGE: 1
           HEAD_LABEL: ${{ github.event.pull_request.head.label }}
           PIP_CONSTRAINT: ${{ github.workspace }}/resources/constraints/benchmark.txt
+          TMPDIR: ${{ github.workspace }}/tmp
         run: |
           set -euxo pipefail
           read -ra cmd_options <<< "$ASV_OPTIONS"
@@ -147,6 +148,15 @@ jobs:
         with:
           filename: .github/TEST_FAIL_TEMPLATE.md
           update_existing: true
+
+      - name: Upload additional information about failure
+#         upload the tmp directory to the artifact
+#         this is where our code stores the dumped
+#         structures that crash triangulation
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ github.workspace }}/tmp
 
       - name: Add more info to artifact
         if: always()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -96,8 +96,8 @@ jobs:
           TMPDIR: ${{ github.workspace }}/tmp
         run: |
           set -euxo pipefail
-          mkdir -p $TMPDIR
-          touch $TMPDIR/empty
+          mkdir -p "${TMPDIR}"
+          touch "${TMPDIR}/empty"
           read -ra cmd_options <<< "$ASV_OPTIONS"
 
           # ID this runner

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/tmp
           include-hidden-files: true
+          name: tmp-${{ matrix.benchmark-name }}
 
       - name: Add more info to artifact
         if: always()

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -96,6 +96,8 @@ jobs:
           TMPDIR: ${{ github.workspace }}/tmp
         run: |
           set -euxo pipefail
+          mkdir -p $TMPDIR
+          touch $TMPDIR/empty
           read -ra cmd_options <<< "$ASV_OPTIONS"
 
           # ID this runner

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docs
+tmp
 # Byte-compiled / optimized / DLL files
 tools/vendored_modules.txt
 tools/matplotlib


### PR DESCRIPTION
# References and relevant issues

For easier debugging of #7747

# Description

In #7632 I have added dump of problematic shapes that crash triangulation. I think that such an option to debug problematic cases may be introduced in other part of the codebase. 

This PR adds to benchmarks an upload of this data dump for easier debugging of CI.

