### PR TITLE
Revert status bar changes for single active layer

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -657,22 +657,10 @@ def test_active_layer_status_update():
     time.sleep(1)
     viewer.mouse_over_canvas = True
     viewer.cursor.position = [1, 1, 1, 1, 1]
-    viewer_cursor_status = viewer._calc_status_from_cursor()[0]
-    active_layer_status = viewer.layers.selection.active.get_status(
+    assert viewer._calc_status_from_cursor()[
+        0
+    ] == viewer.layers.selection.active.get_status(
         viewer.cursor.position, world=True
-    )
-    # check coords, value and layer name
-    assert (
-        viewer_cursor_status.split('»')[0].rstrip(' ')
-        == active_layer_status['coords']
-    )
-    assert (
-        viewer_cursor_status.rstrip(' ').split(' ')[-1]
-        == active_layer_status['value']
-    )
-    assert (
-        viewer_cursor_status.split('»')[1].split(':')[0].lstrip(' ')
-        == active_layer_status['layer_name']
     )
 
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -1056,16 +1056,34 @@ def test_get_status_text():
     )
     viewer.tooltip.visible = False
     assert viewer._calc_status_from_cursor() == (
-        ' [1 2] » Labels: 0; a: 1    ',
+        {
+            'coordinates': ' [1 2]: 0; a: 1',
+            'layer_base': 'Labels',
+            'layer_name': 'Labels',
+            'plugin': '',
+            'source_type': '',
+        },
         '',
     )
     viewer.tooltip.visible = True
     assert viewer._calc_status_from_cursor() == (
-        ' [1 2] » Labels: 0; a: 1    ',
+        {
+            'coordinates': ' [1 2]: 0; a: 1',
+            'layer_base': 'Labels',
+            'layer_name': 'Labels',
+            'plugin': '',
+            'source_type': '',
+        },
         'a: 1',
     )
     viewer.update_status_from_cursor()
-    assert viewer.status == ' [1 2] » Labels: 0; a: 1    '
+    assert viewer.status == {
+        'coordinates': ' [1 2]: 0; a: 1',
+        'layer_base': 'Labels',
+        'layer_name': 'Labels',
+        'plugin': '',
+        'source_type': '',
+    }
     assert viewer.tooltip.text == 'a: 1'
 
 

--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -1046,10 +1046,12 @@ def test_get_status_text():
     assert viewer._calc_status_from_cursor() == (
         {
             'coordinates': ' [1 2]: 0; a: 1',
+            'coords': ' [1 2]',
             'layer_base': 'Labels',
             'layer_name': 'Labels',
             'plugin': '',
             'source_type': '',
+            'value': '0; a: 1',
         },
         '',
     )
@@ -1057,20 +1059,24 @@ def test_get_status_text():
     assert viewer._calc_status_from_cursor() == (
         {
             'coordinates': ' [1 2]: 0; a: 1',
+            'coords': ' [1 2]',
             'layer_base': 'Labels',
             'layer_name': 'Labels',
             'plugin': '',
             'source_type': '',
+            'value': '0; a: 1',
         },
         'a: 1',
     )
     viewer.update_status_from_cursor()
     assert viewer.status == {
         'coordinates': ' [1 2]: 0; a: 1',
+        'coords': ' [1 2]',
         'layer_base': 'Labels',
         'layer_name': 'Labels',
         'plugin': '',
         'source_type': '',
+        'value': '0; a: 1',
     }
     assert viewer.tooltip.text == 'a: 1'
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -704,7 +704,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         selection = self.layers.selection
         active = selection.active
 
-        # the tooltip is computed in all cases, so we compute it first
+        # Compute the tooltip first since it is always needed.
         if self.tooltip.visible and active is not None and active._loaded:
             tooltip_text = active._get_tooltip_text(
                 np.asarray(self.cursor.position),
@@ -713,8 +713,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                 world=True,
             )
 
-        # if we have an active layer and a single selection, we use that to get
-        # status "the classic way" then return
+        # If there is an active layer and a single selection, calculate status using "the classic way".
+        # Then return the status and the tooltip.
         if active is not None and active._loaded and len(selection) < 2:
             status = active.get_status(
                 self.cursor.position,
@@ -724,8 +724,8 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             )
             return status, tooltip_text
 
-        # otherwise, we return the layer status of multiple selected layers
-        # or gridded layers
+        # Otherwise, return the layer status of multiple selected layers
+        # or gridded layers as well as the tooltip.
         for layer in self.layers[::-1]:
             if (
                 not layer.visible

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -703,6 +703,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         tooltip_text = ''
         selection = self.layers.selection
         active = selection.active
+        grid = self.grid.enabled
 
         # the tooltip is computed in all cases, so we compute it first
         if self.tooltip.visible and active is not None and active._loaded:
@@ -713,6 +714,24 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
                 world=True,
             )
 
+        # if we have an active layer and a single selection, we use that to get
+        # status "the classic way" then return
+        if (
+            active is not None
+            and active._loaded
+            and len(selection) < 2
+            and not grid
+        ):
+            status = active.get_status(
+                self.cursor.position,
+                view_direction=self.cursor._view_direction,
+                dims_displayed=list(self.dims.displayed),
+                world=True,
+            )
+            return status, tooltip_text
+
+        # otherwise, we return the layer status of multiple selected layers
+        # or gridded layers
         for layer in self.layers[::-1]:
             if (
                 not layer.visible

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -704,6 +704,15 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         selection = self.layers.selection
         active = selection.active
 
+        # the tooltip is computed in all cases, so we compute it first
+        if self.tooltip.visible and active is not None and active._loaded:
+            tooltip_text = active._get_tooltip_text(
+                np.asarray(self.cursor.position),
+                view_direction=np.asarray(self.cursor._view_direction),
+                dims_displayed=list(self.dims.displayed),
+                world=True,
+            )
+
         for layer in self.layers[::-1]:
             if (
                 not layer.visible
@@ -744,14 +753,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             status_str = '[empty]'
         else:
             status_str = 'Ready'
-
-        if self.tooltip.visible and active is not None and active._loaded:
-            tooltip_text = active._get_tooltip_text(
-                np.asarray(self.cursor.position),
-                view_direction=np.asarray(self.cursor._view_direction),
-                dims_displayed=list(self.dims.displayed),
-                world=True,
-            )
 
         return status_str, tooltip_text
 

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -703,7 +703,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         tooltip_text = ''
         selection = self.layers.selection
         active = selection.active
-        grid = self.grid.enabled
 
         # the tooltip is computed in all cases, so we compute it first
         if self.tooltip.visible and active is not None and active._loaded:
@@ -716,12 +715,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         # if we have an active layer and a single selection, we use that to get
         # status "the classic way" then return
-        if (
-            active is not None
-            and active._loaded
-            and len(selection) < 2
-            and not grid
-        ):
+        if active is not None and active._loaded and len(selection) < 2:
             status = active.get_status(
                 self.cursor.position,
                 view_direction=self.cursor._view_direction,


### PR DESCRIPTION
This is a partial fix for #7700. This is actually what I had intended to
do in #7673 but didn't get done in time: with this PR, single layer
status messages don't change, and we only have the new "wonky" status
bar with multiple selections or grid mode, which were broken on main
before.

I still want to make some status bar improvements but this was otherwise
holding up 0.6.0, so I'd like to get this in for the next alpha, and
then work on the improvements, which require a bit more surgery in the
Qt status bar display.

@psobolewskiPhD what do you think? With this PR, #7673 becomes a strict
improvement because it doesn't touch the status bar display *unless* we
are in a formerly broken state, that is, with multiple layers selected.
I think, anyway!

So by merging this, we would buy ourselves more time to implement status
bar improvements without holding up the release.
