### PR TITLE
Add canvas color to public API

### DIFF
--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -99,11 +99,11 @@ viewer.scale_bar.length = 250
 
 # Export figure and change theme before and after exporting to show that the background canvas margins
 # are not in the exported figure.
-viewer.theme = "light"
+viewer.canvas_color = 'white'
 # Optionally for saving the exported figure: viewer.export_figure(path="export_figure.png")
 export_figure = viewer.export_figure()
 scaled_export_figure = viewer.export_figure(scale_factor=5)
-viewer.theme = "dark"
+viewer.canvas_color = 'black'
 
 viewer.add_image(export_figure, rgb=True, name='exported_figure')
 viewer.add_image(scaled_export_figure, rgb=True, name='scaled_exported_figure')

--- a/examples/screenshot_and_export_figure.py
+++ b/examples/screenshot_and_export_figure.py
@@ -58,7 +58,7 @@ viewer.scale_bar.box = True
 
 # Take screenshots and export figures in 'light' theme, to show the canvas
 # margins and the extent of the exported figure.
-viewer.theme = 'light'
+viewer.canvas_color = 'white'
 screenshot = viewer.screenshot()
 figure = viewer.export_figure()
 # optionally, save the exported figure: viewer.export_figure(path='export_figure.png')
@@ -85,7 +85,7 @@ figure_no_outside_shape = viewer.export_figure()
 # The final one shows how the exported figure adapts to change in the layer extent.
 # In the second row are the screenshots, showing the fact that the entire canvas
 # is captured and that zoom is preserved.
-viewer.theme = 'dark'
+viewer.canvas_color = 'black'
 viewer.layers.select_all()
 viewer.layers.remove_selected()
 

--- a/napari/_tests/test_viewer.py
+++ b/napari/_tests/test_viewer.py
@@ -98,6 +98,42 @@ def test_viewer(make_napari_viewer):
     assert viewer.dims.ndisplay == 2
 
 
+def test_canvas_color(make_napari_viewer):
+    """Test that changing canvas_color changes the canvas color."""
+    viewer = make_napari_viewer(show=True)
+    assert viewer.canvas_color == '#000000'
+
+    # test using a string changes the canvas color
+    viewer.canvas_color = 'white'
+    assert viewer.canvas_color == '#ffffff'
+
+    # check that the canvas is actually changed to white. Add a layer so
+    # that the canvas shows and not the welcome screen.
+    viewer._new_labels()
+    img = viewer.export_figure()
+    assert img[img > 250].shape[0] > img[img <= 250].shape[0]
+
+    # check that hex changes canvas color
+    viewer.canvas_color = '#0000ff'
+    assert viewer.canvas_color == '#0000ff'
+
+    # check that 3-tuple changes canvas color
+    viewer.canvas_color = (0, 1, 0)
+    assert viewer.canvas_color == '#00ff00'
+
+    # check that 4-tuple changes canvas color
+    viewer.canvas_color = (1, 0, 0, 0.5)
+    assert viewer.canvas_color == '#ff0000'
+
+    # check that numpy array changes canvas color
+    viewer.canvas_color = np.array([0, 0, 1])
+    assert viewer.canvas_color == '#0000ff'
+
+    # check that passing none resets the canvas color to default
+    viewer.canvas_color = None
+    assert viewer.canvas_color == '#000000'
+
+
 @pytest.mark.parametrize(('layer_class', 'data', 'ndim'), layer_test_data)
 def test_add_layer(make_napari_viewer, layer_class, data, ndim):
     viewer = make_napari_viewer()

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -201,9 +201,9 @@ class VispyCanvas:
 
     @background_color_override.setter
     def background_color_override(
-        self, value: str | npt.ArrayLike | None
+        self, value: str | tuple | npt.ArrayLike | None
     ) -> None:
-        if value:
+        if value is not None:
             self.view.bgcolor = value
         else:
             self.view.bgcolor = None

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -80,6 +80,9 @@ class Viewer(ViewerModel):
         When set to None, the canvas will use the theme's default background color.
         Otherwise, the canvas will use the specified color.
 
+        .. versionadded:: 0.6.0
+           The `canvas_color` property.
+
         Parameters
         ----------
         color : str or tuple or None
@@ -93,8 +96,7 @@ class Viewer(ViewerModel):
         Returns
         -------
         str or None
-            The current canvas background color as a hex string,
-            or None if using the theme's default.
+            The current canvas background color as a hex string.
         """
         return self.window._qt_viewer.canvas.background_color_override
 

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -4,6 +4,7 @@ from weakref import WeakSet
 
 import magicgui as mgui
 import numpy as np
+import numpy.typing as npt
 
 from napari.components.viewer_model import ViewerModel
 from napari.utils import _magicgui
@@ -71,6 +72,35 @@ class Viewer(ViewerModel):
     @property
     def window(self) -> 'Window':
         return self._window
+
+    @property
+    def canvas_color(self) -> str | None:
+        """Get or set the canvas background color override.
+
+        When set to None, the canvas will use the theme's default background color.
+        Otherwise, the canvas will use the specified color.
+
+        Parameters
+        ----------
+        color : str or tuple or None
+            The color to use for the canvas background. If None, the canvas
+            will use the theme's default background color.
+            If a string, it should be a any string in vispy.color.get_color_names
+            or hex color string (e.g., '#RRGGBB').
+            If a tuple or np.array, it should be 3 or 4 floats in the range [0, 1]
+            representing RGB or RGBA values.
+
+        Returns
+        -------
+        str or None
+            The current canvas background color as a hex string,
+            or None if using the theme's default.
+        """
+        return self.window._qt_viewer.canvas.background_color_override
+
+    @canvas_color.setter
+    def canvas_color(self, color: str | tuple | npt.ArrayLike | None) -> None:
+        self.window._qt_viewer.canvas.background_color_override = color
 
     def update_console(self, variables):
         """Update console's namespace with desired variables.


### PR DESCRIPTION
# References and relevant issues

Closes #3970
Follow up will add to GUI in order to address #5389


# Description

1. Adds `canvas_color` to `Viewer`. (see Why Viewer)
2. Adds corresponding tests to check each type of color that can be passed to ensure each works. Because this is public, I want to make sure we don't break it on accident. 
3. Updates two examples to use this canvas color property instead of changing theme, which is actually all that's needed for the example.

```python
viewer = napari.Viewer()
viewer._new_labels()
viewer.canvas_color = 'grey'
```

### Why Viewer
I added `canvas_color` to Viewer because I noted that window is made public on here. I originally thought that I would add it to ViewerModel, but those all seem to be other Evented components, so I thought Viewer might be the right place to add it since it seems to actually have qt attached. I do think in the future it makes sense to have a different implementation for changing the canvas color, especially if vispy is separated from qt, but for now this implementation serves to make the API public and will give it first class value should any architecture be changed. That said, I'm definitely looking for feedback because I do not feel confident that I've done the correct thing here! 


