### PR TITLE
Add 3D support for `viewer.export_figure()`

### DIFF
--- a/examples/export_figure.py
+++ b/examples/export_figure.py
@@ -5,7 +5,7 @@ Export Figure
 Display a variety of layer types in the napari viewer and export the figure with `viewer.export_figure()`.
 The exported figure is then added back as an image layer.
 
-Exported figures include the extent of all data in 2D view, and does not presently work for 3D views.
+Exported figures include the extent of all data in 2D or 3D view.
 To capture the extent of the canvas, instead of the layers, see `viewer.screenshot()`: :ref:`sphx_glr_gallery_to_screenshot.py` and :ref:`sphx_glr_gallery_screenshot_and_export_figure.py`.
 
 .. tags:: visualization-advanced

--- a/examples/screenshot_and_export_figure.py
+++ b/examples/screenshot_and_export_figure.py
@@ -12,8 +12,6 @@ include the extent of the layers and any other elements overlayed
 on the canvas, such as the scale bar. Exported figures also move the scale bar
 to within the margins of the canvas.
 
-Currently, 'export_figure` does not support the 3D view, but screenshot does.
-
 In the final grid state shown below, the first row represents exported images. The first two show that zoom is not reflected in the exported figure. The final one shows how the exported figure adapts to change in the layer extent. In the second row are the screenshots, showing the fact that the entire canvas is captured and that zoom is preserved.
 
 .. tags:: visualization-advanced

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -282,7 +282,8 @@ def test_export_figure(make_napari_viewer, tmp_path):
 
     assert viewer.camera.center == camera_center
     assert viewer.camera.zoom == camera_zoom
-    assert img.shape == (250, 250, 4)
+    np.testing.assert_allclose(img.shape, (250, 250, 4), atol=1)
+    # assert img.shape == (250, 250, 4)
     assert np.all(img != np.array([0, 0, 0, 0]))
 
     assert (tmp_path / 'img.png').exists()
@@ -291,11 +292,11 @@ def test_export_figure(make_napari_viewer, tmp_path):
     img = viewer.export_figure(flash=False)
     # allclose accounts for rounding errors when computing size in hidpi aka
     # retina displays
-    np.testing.assert_allclose(img.shape, (250, 499, 4), atol=1)
+    np.testing.assert_allclose(img.shape, (250, 500, 4), atol=1)
 
     layer.scale = [0.12, 0.12]
     img = viewer.export_figure(flash=False)
-    assert img.shape == (250, 250, 4)
+    np.testing.assert_allclose(img.shape, (250, 250, 4), atol=1)
 
 
 def test_export_figure_3d(make_napari_viewer):
@@ -306,18 +307,24 @@ def test_export_figure_3d(make_napari_viewer):
     viewer.theme = 'light'
 
     data = np.random.randint(50, 100, size=(10, 250, 250))
-    viewer.add_image(data)
+    layer = viewer.add_image(data)
 
     # check the non-rotated data (angles = 0,0,90) are exported without any
     # visible background, since the margins should be 0
     img = viewer.export_figure()
     np.testing.assert_allclose(img.shape, (250, 250, 4), atol=1)
 
+    # check that changing the scale still gives the pixel size
+    layer.scale = [1, 0.12, 0.24]
+    img = viewer.export_figure()
+    np.testing.assert_allclose(img.shape, (250, 500, 4), atol=1)
+    layer.scale = [1, 1, 1]
+
     # rotate the data, export the figure, and check that the rotated figure
     # shape is greater than the original data shape
     viewer.camera.angles = (45, 45, 45)
     img = viewer.export_figure()
-    np.testing.assert_allclose(img.shape, (168, 338, 4), atol=1)
+    np.testing.assert_allclose(img.shape, (171, 339, 4), atol=1)
 
     # The theme is dark, so the canvas will be white. Test that the image
     # has a white background, roughly more background than the data itself.

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -298,6 +298,32 @@ def test_export_figure(make_napari_viewer, tmp_path):
     assert img.shape == (250, 250, 4)
 
 
+def test_export_figure_3d(make_napari_viewer):
+    viewer = make_napari_viewer()
+    np.random.seed(0)
+    # Add image, keep values low to contrast with white background
+    viewer.dims.ndisplay = 3
+    viewer.theme = 'light'
+
+    data = np.random.randint(50, 100, size=(10, 250, 250))
+    viewer.add_image(data)
+
+    # check the non-rotated data (angles = 0,0,90) are exported without any
+    # visible background, since the margins should be 0
+    img = viewer.export_figure()
+    np.testing.assert_allclose(img.shape, (250, 250, 4), atol=1)
+
+    # rotate the data, export the figure, and check that the rotated figure
+    # shape is greater than the original data shape
+    viewer.camera.angles = (45, 45, 45)
+    img = viewer.export_figure()
+    np.testing.assert_allclose(img.shape, (168, 338, 4), atol=1)
+
+    # The theme is dark, so the canvas will be white. Test that the image
+    # has a white background, roughly more background than the data itself.
+    assert img[img > 250].shape[0] > img[img <= 200].shape[0]
+
+
 def test_export_rois(make_napari_viewer, tmp_path):
     # Create an image with a defined shape (100x100) and a square in the middle
 

--- a/napari/_qt/_tests/test_qt_viewer.py
+++ b/napari/_qt/_tests/test_qt_viewer.py
@@ -321,7 +321,7 @@ def test_export_figure_3d(make_napari_viewer):
 
     # The theme is dark, so the canvas will be white. Test that the image
     # has a white background, roughly more background than the data itself.
-    assert img[img > 250].shape[0] > img[img <= 200].shape[0]
+    assert (img[img > 250].shape[0] / img[img <= 200].shape[0]) > 0.5
 
 
 def test_export_rois(make_napari_viewer, tmp_path):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1706,18 +1706,15 @@ class Window:
                 self._qt_viewer.viewer.layers.extent.step[-ndisplay:]
             )
 
-            if ndisplay == 2:
-                # adjust size by the scale, to return the size in real pixels
-                size = np.ceil(total_size / extent_scale).astype(int)
-
             if ndisplay == 3:
-                size = self._qt_viewer.viewer._calculate_bounding_box(
+                total_size = self._qt_viewer.viewer._calculate_bounding_box(
                     extent=extent,
                     view_direction=self._qt_viewer.viewer.camera.view_direction,
                     up_direction=self._qt_viewer.viewer.camera.up_direction,
                 )
-                # adjust size by the scale, to return the size in real pixels
-                size = np.ceil(size / extent_scale).astype(int)
+
+            # adjust size by the scale, to return the size in real pixels
+            size = np.ceil(total_size / extent_scale).astype(int)
 
         if size is not None:
             size = np.asarray(size) / self._qt_window.devicePixelRatio()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1702,9 +1702,13 @@ class Window:
             extent, _, _, total_size = (
                 self._qt_viewer.viewer._get_scene_parameters()
             )
+            extent_scale = min(
+                self._qt_viewer.viewer.layers.extent.step[-ndisplay:]
+            )
 
             if ndisplay == 2:
-                size = np.array(total_size[-ndisplay:]).astype(int)
+                # adjust size by the scale, to return the size in real pixels
+                size = np.ceil(total_size / extent_scale).astype(int)
 
             if ndisplay == 3:
                 size = self._qt_viewer.viewer._calculate_bounding_box(
@@ -1712,6 +1716,8 @@ class Window:
                     view_direction=self._qt_viewer.viewer.camera.view_direction,
                     up_direction=self._qt_viewer.viewer.camera.up_direction,
                 )
+                # adjust size by the scale, to return the size in real pixels
+                size = np.ceil(size / extent_scale).astype(int)
 
         if size is not None:
             size = np.asarray(size) / self._qt_window.devicePixelRatio()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1749,8 +1749,7 @@ class Window:
         This function finds a tight boundary around the data, resets the view
         around that boundary (and, when scale=1, such that 1 captured pixel is
         equivalent to one data pixel), takes a screenshot, then restores the
-        previous zoom and canvas sizes. Currently, only works when 2 dimensions
-        are displayed.
+        previous zoom and canvas sizes.
 
         Parameters
         ----------

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -1698,21 +1698,26 @@ class Window:
 
         # Part 2: compute canvas size and view based on parameters
         if fit_to_data_extent:
-            extent = self._qt_viewer.viewer.layers.extent
+            # Use the same scene parameter calculations as in viewer_model.fit_to_view
+            extent, _, _, total_size = (
+                self._qt_viewer.viewer._get_scene_parameters()
+            )
+
             if ndisplay == 2:
-                extent_world = extent.world[1][-ndisplay:]
-                extent_step = min(extent.step[-ndisplay:])
-                size = extent_world / extent_step + 1
+                size = np.array(total_size[-ndisplay:]).astype(int)
+
             if ndisplay == 3:
                 size = self._qt_viewer.viewer._calculate_bounding_box(
-                    extent=extent.world,
+                    extent=extent,
                     view_direction=self._qt_viewer.viewer.camera.view_direction,
                     up_direction=self._qt_viewer.viewer.camera.up_direction,
                 )
+
         if size is not None:
             size = np.asarray(size) / self._qt_window.devicePixelRatio()
         else:
             size = np.asarray(prev_size)
+
         if scale is not None:
             # multiply canvas dimensions by the scale factor to get new size
             size *= scale


### PR DESCRIPTION
# References and relevant issues
Follow up to #6730 and #7742 
Next PR will implement #7318

# Description

1. Adds support to `viewer.export_figure()` for `ndisplay=3` by using calculation for 3D bounding box from #7742.
2. Adds corresponding test for 3D, especially because it can be more complicated of a calculation
3. **Updates calculation for 2D export figure**. Reduces complexity and shares functions from `viewer_model`. _It is also technically more correct, I think, because it does not arbitrarily add 1 to the size array to accomodate (I assume) for rounding errors)_. Updates test to actually use this correct expected size rather than the 'real' behavior observed from previous.
4. Updates docstrings and examples where relevant for this change

```python
import napari

viewer = napari.Viewer()
viewer.open_sample('napari', 'cells3d')

viewer.theme = 'light'
viewer.dims.ndisplay = 3
viewer.camera.angles = (45, 45, 45)

img = viewer.export_figure()
viewer.add_image(img)
viewer.dims.ndisplay = 2
viewer.theme = 'dark'
```
Below is a screenshot of the canvas after running this code block. The representative, correct, 3D exported figure has the white background bounding the 3D rotated data. 
![image](https://github.com/user-attachments/assets/f4042268-c961-468f-9245-bccb8f5b1474)
