### PR TITLE
Remove deprecated QtViewer.view and QtViewer.camera properties

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -266,36 +266,6 @@ class QtViewer(QSplitter):
         for layer in self.viewer.layers:
             self._add_layer(layer)
 
-    @property
-    def view(self):
-        """
-        Rectangular  vispy viewbox widget in which a subscene is rendered. Access directly within the QtViewer will
-        become deprecated.
-        """
-        warnings.warn(
-            trans._(
-                'Access to QtViewer.view is deprecated since 0.5.0 and will be removed in the napari 0.6.0. Change to QtViewer.canvas.view instead.'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.canvas.view
-
-    @property
-    def camera(self):
-        """
-        The Vispy camera class which contains both the 2d and 3d camera used to describe the perspective by which a
-        scene is viewed and interacted with. Access directly within the QtViewer will become deprecated.
-        """
-        warnings.warn(
-            trans._(
-                'Access to QtViewer.camera will become deprecated in the 0.6.0. Change to QtViewer.canvas.camera instead.'
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.canvas.camera
-
     @staticmethod
     def _update_dask_cache_settings(
         dask_setting: DaskSettings | Event = None,

--- a/napari/benchmarks/benchmark_qt_viewer_labels.py
+++ b/napari/benchmarks/benchmark_qt_viewer_labels.py
@@ -40,14 +40,18 @@ class QtViewerSingleLabelsSuite:
             pos=(500, 500),
             view_direction=None,
         )
+        try:
+            self.camera = self.viewer.window._qt_viewer.canvas.view.camera
+        except AttributeError:  # prior to 0.5.0
+            self.camera = self.viewer.window._qt_viewer.view.camera
 
     def teardown(self):
         self.viewer.window.close()
 
     def time_zoom(self):
         """Time to zoom in and zoom out."""
-        self.viewer.window._qt_viewer.view.camera.zoom(0.5, center=(0.5, 0.5))
-        self.viewer.window._qt_viewer.view.camera.zoom(2.0, center=(0.5, 0.5))
+        self.camera.zoom(0.5, center=(0.5, 0.5))
+        self.camera.zoom(2.0, center=(0.5, 0.5))
 
     def time_set_view_slice(self):
         """Time to set view slice."""

--- a/napari/benchmarks/benchmark_qt_viewer_labels.py
+++ b/napari/benchmarks/benchmark_qt_viewer_labels.py
@@ -40,10 +40,10 @@ class QtViewerSingleLabelsSuite:
             pos=(500, 500),
             view_direction=None,
         )
-        try:
-            self.camera = self.viewer.window._qt_viewer.canvas.view.camera
-        except AttributeError:  # prior to 0.5.0
+        if NAPARI_0_4_19:
             self.camera = self.viewer.window._qt_viewer.view.camera
+        else:
+            self.camera = self.viewer.window._qt_viewer.canvas.view.camera
 
     def teardown(self):
         self.viewer.window.close()


### PR DESCRIPTION
Part of #7701 in preparation for 0.6.0.
