### PR TITLE
Add camera orientation parameters to application settings.

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -7,12 +7,12 @@ from qtpy.QtWidgets import QApplication
 from napari._app_model._app import get_app_model
 from napari._qt.dialogs.qt_modal import QtPopup
 from napari._qt.widgets.qt_viewer_buttons import QtViewerButtons
-from napari.components.camera import (
+from napari.components.viewer_model import ViewerModel
+from napari.utils.camera_orientations import (
     DepthAxisOrientation,
     HorizontalAxisOrientation,
     VerticalAxisOrientation,
 )
-from napari.components.viewer_model import ViewerModel
 from napari.viewer import Viewer
 
 

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -20,7 +20,8 @@ from napari._qt.dialogs.qt_modal import QtPopup
 from napari._qt.widgets.qt_dims_sorter import QtDimsSorter
 from napari._qt.widgets.qt_spinbox import QtSpinBox
 from napari._qt.widgets.qt_tooltip import QtToolTipLabel
-from napari.components.camera import (
+from napari.utils.action_manager import action_manager
+from napari.utils.camera_orientations import (
     DepthAxisOrientation,
     DepthAxisOrientationStr,
     HorizontalAxisOrientation,
@@ -28,7 +29,6 @@ from napari.components.camera import (
     VerticalAxisOrientation,
     VerticalAxisOrientationStr,
 )
-from napari.utils.action_manager import action_manager
 from napari.utils.misc import in_ipython, in_jupyter, in_python_repl
 from napari.utils.translations import trans
 

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -35,7 +35,7 @@ class Handedness(StringEnum):
 
 VerticalAxisOrientationStr = Literal['up', 'down']
 HorizontalAxisOrientationStr = Literal['left', 'right']
-DepthAxisOrientationStr = Literal['away', 'torwards']
+DepthAxisOrientationStr = Literal['away', 'towards']
 
 
 DEFAULT_ORIENTATION_TYPED = (

--- a/napari/components/camera.py
+++ b/napari/components/camera.py
@@ -1,49 +1,24 @@
-from enum import auto
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from napari._pydantic_compat import validator
+from napari.utils.camera_orientations import (
+    DEFAULT_ORIENTATION_TYPED,
+    DepthAxisOrientation,
+    Handedness,
+    HorizontalAxisOrientation,
+    HorizontalAxisOrientationStr,
+    VerticalAxisOrientation,
+    VerticalAxisOrientationStr,
+)
 from napari.utils.events import EventedModel
-from napari.utils.misc import StringEnum, ensure_n_tuple
+from napari.utils.misc import ensure_n_tuple
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-
-
-class VerticalAxisOrientation(StringEnum):
-    UP = auto()
-    DOWN = auto()
-
-
-class HorizontalAxisOrientation(StringEnum):
-    LEFT = auto()
-    RIGHT = auto()
-
-
-class DepthAxisOrientation(StringEnum):
-    AWAY = auto()
-    TOWARDS = auto()
-
-
-class Handedness(StringEnum):
-    RIGHT = auto()
-    LEFT = auto()
-
-
-VerticalAxisOrientationStr = Literal['up', 'down']
-HorizontalAxisOrientationStr = Literal['left', 'right']
-DepthAxisOrientationStr = Literal['away', 'towards']
-
-
-DEFAULT_ORIENTATION_TYPED = (
-    DepthAxisOrientation.TOWARDS,
-    VerticalAxisOrientation.DOWN,
-    HorizontalAxisOrientation.RIGHT,
-)
-DEFAULT_ORIENTATION = tuple(map(str, DEFAULT_ORIENTATION_TYPED))
 
 
 class Camera(EventedModel):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -234,6 +234,17 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self._tooltip_visible_update
         )
 
+        self._update_camera_orientation()
+        settings.application.events.depth_axis_orientation.connect(
+            self._update_camera_orientation
+        )
+        settings.application.events.vertical_axis_orientation.connect(
+            self._update_camera_orientation
+        )
+        settings.application.events.horizontal_axis_orientation.connect(
+            self._update_camera_orientation
+        )
+
         self._update_viewer_grid()
         settings.application.events.grid_stride.connect(
             self._update_viewer_grid
@@ -311,6 +322,16 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
     def _tooltip_visible_update(self, event):
         self.tooltip.visible = event.value
+
+    def _update_camera_orientation(self):
+        """Update camera orientation based on settings."""
+        settings = get_settings()
+
+        self.camera.orientation = (
+            settings.application.depth_axis_orientation,
+            settings.application.vertical_axis_orientation,
+            settings.application.horizontal_axis_orientation,
+        )
 
     def _update_viewer_grid(self):
         """Keep viewer grid settings up to date with settings values."""

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from psutil import virtual_memory
 
 from napari._pydantic_compat import Field, validator
+from napari.components.camera import (
+    DEFAULT_ORIENTATION_TYPED,
+    DepthAxisOrientation,
+    HorizontalAxisOrientation,
+    VerticalAxisOrientation,
+)
 from napari.settings._constants import (
     BrushSizeOnMouseModifiers,
     LabelDTypes,
@@ -153,6 +159,26 @@ class ApplicationSettings(EventedModel):
         LoopMode.LOOP,
         title=trans._('Playback loop mode'),
         description=trans._('Loop mode for playback.'),
+    )
+
+    depth_axis_orientation: DepthAxisOrientation = Field(
+        default=DEFAULT_ORIENTATION_TYPED[0],
+        title=trans._('Depth Axis Orientation'),
+        description=trans._('Orientation of the depth axis in 3D view.'),
+    )
+    vertical_axis_orientation: VerticalAxisOrientation = Field(
+        default=DEFAULT_ORIENTATION_TYPED[1],
+        title=trans._('Vertical Axis Orientation'),
+        description=trans._(
+            'Orientation of the vertical axis in 2D and 3D view.'
+        ),
+    )
+    horizontal_axis_orientation: HorizontalAxisOrientation = Field(
+        default=DEFAULT_ORIENTATION_TYPED[2],
+        title=trans._('Horizontal Axis Orientation'),
+        description=trans._(
+            'Orientation of the horizontal axis in 2D and 3D view.'
+        ),
     )
 
     grid_stride: GridStride = Field(  # type: ignore [valid-type]

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -3,12 +3,6 @@ from __future__ import annotations
 from psutil import virtual_memory
 
 from napari._pydantic_compat import Field, validator
-from napari.components.camera import (
-    DEFAULT_ORIENTATION_TYPED,
-    DepthAxisOrientation,
-    HorizontalAxisOrientation,
-    VerticalAxisOrientation,
-)
 from napari.settings._constants import (
     BrushSizeOnMouseModifiers,
     LabelDTypes,
@@ -16,6 +10,12 @@ from napari.settings._constants import (
 )
 from napari.settings._fields import Language
 from napari.utils._base import _DEFAULT_LOCALE
+from napari.utils.camera_orientations import (
+    DEFAULT_ORIENTATION_TYPED,
+    DepthAxisOrientation,
+    HorizontalAxisOrientation,
+    VerticalAxisOrientation,
+)
 from napari.utils.events.custom_types import confloat, conint
 from napari.utils.events.evented_model import EventedModel
 from napari.utils.notifications import NotificationSeverity

--- a/napari/utils/camera_orientations.py
+++ b/napari/utils/camera_orientations.py
@@ -1,0 +1,37 @@
+from enum import auto
+from typing import Literal
+
+from napari.utils.misc import StringEnum
+
+
+class VerticalAxisOrientation(StringEnum):
+    UP = auto()
+    DOWN = auto()
+
+
+class HorizontalAxisOrientation(StringEnum):
+    LEFT = auto()
+    RIGHT = auto()
+
+
+class DepthAxisOrientation(StringEnum):
+    AWAY = auto()
+    TOWARDS = auto()
+
+
+class Handedness(StringEnum):
+    RIGHT = auto()
+    LEFT = auto()
+
+
+VerticalAxisOrientationStr = Literal['up', 'down']
+HorizontalAxisOrientationStr = Literal['left', 'right']
+DepthAxisOrientationStr = Literal['away', 'towards']
+
+
+DEFAULT_ORIENTATION_TYPED = (
+    DepthAxisOrientation.TOWARDS,
+    VerticalAxisOrientation.DOWN,
+    HorizontalAxisOrientation.RIGHT,
+)
+DEFAULT_ORIENTATION = tuple(map(str, DEFAULT_ORIENTATION_TYPED))


### PR DESCRIPTION
# References and relevant issues

Closes #7784. Follow up to #7663.
Discussed previously in #7683.

# Description

Adds `camera.orientation` parameters to application settings. 

Maybe someone can think of more creative Field descriptions than I've used for the tooltip hovers. 
