### PR TITLE
Postpone QtViewer deprecation to 0.7.0

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -848,7 +848,7 @@ class Window:
         warnings.warn(
             trans._(
                 'Public access to Window.qt_viewer is deprecated and will be removed in\n'
-                'v0.6.0. It is considered an "implementation detail" of the napari\napplication, '
+                'v0.7.0. It is considered an "implementation detail" of the napari\napplication, '
                 'not part of the napari viewer model. If your use case\n'
                 'requires access to qt_viewer, please open an issue to discuss.',
                 deferred=True,


### PR DESCRIPTION
Part of #7701. We haven't created the necessary models to complete this
deprecation (for example, a way to query canvas size or coordinate
limits), so we have to postpone it.
