### PR TITLE
Remove deprecated interpolation argument from add_image

### DIFF
--- a/examples/image_custom_kernel.py
+++ b/examples/image_custom_kernel.py
@@ -22,7 +22,7 @@ from skimage import data
 
 import napari
 
-viewer = napari.view_image(data.astronaut(), rgb=True, interpolation='custom')
+viewer = napari.view_image(data.astronaut(), rgb=True, interpolation2d='custom')
 
 
 def gaussian_kernel(size, sigma):

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -86,7 +86,6 @@ from napari.utils.events import (
 )
 from napari.utils.events.event import WarningEmitter
 from napari.utils.key_bindings import KeymapProvider
-from napari.utils.migrations import rename_argument
 from napari.utils.misc import is_sequence
 from napari.utils.mouse_bindings import MousemapProvider
 from napari.utils.progress import progress
@@ -955,12 +954,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         self.layers.append(layer)
         return layer
 
-    @rename_argument(
-        from_name='interpolation',
-        to_name='interpolation2d',
-        version='0.6.0',
-        since_version='0.4.17',
-    )
     def add_image(
         self,
         data=None,


### PR DESCRIPTION
Part of #7701

ViewerModel.add_image is specially defined and doesn't rely on the
Image layer constructor, which is why it was not caught in #7741.
This completes the removal of the argument by removing it from
add_image.
