### PR TITLE
Remove deprecated type kwarg from Events

### DIFF
--- a/napari/utils/events/event.py
+++ b/napari/utils/events/event.py
@@ -68,7 +68,6 @@ from typing import (
 
 from vispy.util.logs import _handle_exception
 
-from napari.utils.migrations import rename_argument
 from napari.utils.translations import trans
 
 
@@ -96,12 +95,6 @@ class Event:
         All extra keyword arguments become attributes of the event object.
     """
 
-    @rename_argument(
-        from_name='type',
-        to_name='type_name',
-        version='0.6.0',
-        since_version='0.4.18',
-    )
     def __init__(
         self, type_name: str, native: Any = None, **kwargs: Any
     ) -> None:
@@ -283,7 +276,6 @@ class EventEmitter:
         The class of events that this emitter will generate.
     """
 
-    @rename_argument('type', 'type_name', '0.6.0', '0.4.18')
     def __init__(
         self,
         source: Any = None,


### PR DESCRIPTION
Part of #7701

The arg was renamed type_name in 0.4.18.
