### PR TITLE
Fix: Default to RGB colormaps when splitting likely RGB images (#7781)

### DIFF
--- a/napari/layers/utils/stack_utils.py
+++ b/napari/layers/utils/stack_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -12,8 +11,6 @@ from napari.layers.image._image_utils import guess_multiscale, guess_rgb
 from napari.utils.colormaps import CYMRGB, MAGENTA_GREEN, Colormap
 from napari.utils.misc import ensure_iterable, ensure_sequence_of_iterables
 from napari.utils.translations import trans
-from .layer_utils import calc_data_range
-from .misc import StringEnum
 
 if TYPE_CHECKING:
     from napari.types import FullLayerData


### PR DESCRIPTION
# Description
This PR addresses an inconsistency in how `napari.layers.utils.stack_utils.split_channels` (used by `viewer.add_image(..., channel_axis=...)`) determines default colormaps. Previously, when splitting a 3-channel image without explicitly providing colormaps, it would always default to a cycle starting with Cyan, Magenta, Yellow (`CYMRGB`), even if the image was likely RGB. This contrasted with adding the same image without splitting (`viewer.add_image(...)`), where napari would correctly guess RGB.

This PR modifies `split_channels` to first check if the input data (when `n_channels == 3`) is likely RGB using the existing `guess_rgb` utility. If `guess_rgb` returns `True`, the default colormaps are now set to `('red', 'green', 'blue')`. Otherwise (if `n_channels != 3` or `guess_rgb` is `False`), the previous default logic (gray, magenta/green, or `CYMRGB` cycle) is applied. This provides a more intuitive default behavior when splitting RGB images via `channel_axis`.


