### PR TITLE
Prevent from triggering notification animation in tests

### DIFF
--- a/napari/_qt/dialogs/qt_notification.py
+++ b/napari/_qt/dialogs/qt_notification.py
@@ -422,6 +422,7 @@ class NapariQtNotification(QDialog):
             notification.severity
             >= settings.application.gui_notification_level
             and _QtMainWindow.current()
+            and _QtMainWindow.current().isVisible()
         ):
             canvas = _QtMainWindow.current()._qt_viewer._welcome_widget
             cls.from_notification(notification, canvas).show()

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -496,7 +496,8 @@ class _QtMainWindow(QMainWindow):
         if (
             not confirm_need_local
             or not get_settings().application.confirm_close_window
-            or ConfirmCloseDialog(self, quit_app).exec_() == QDialog.Accepted
+            or ConfirmCloseDialog(self, quit_app).exec_()
+            == QDialog.DialogCode.Accepted
         ):
             self._quit_app = quit_app
             self._is_close_dialog[quit_app] = True

--- a/napari/_qt/utils.py
+++ b/napari/_qt/utils.py
@@ -318,6 +318,7 @@ def remove_flash_animation(widget_ref: weakref.ref[QWidget]):
     widget = widget_ref()
     try:
         widget.setGraphicsEffect(None)
+        widget._flash_animation.deleteLater()
         del widget._flash_animation
     except RuntimeError:
         # RuntimeError: wrapped C/C++ object of type QtWidgetOverlay deleted

--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -534,6 +534,9 @@ def _disable_notification_dismiss_timer(monkeypatch):
         monkeypatch.setattr(NapariQtNotification, 'FADE_IN_RATE', 0)
         monkeypatch.setattr(NapariQtNotification, 'FADE_OUT_RATE', 0)
 
+        # disable slide in animation
+        monkeypatch.setattr(NapariQtNotification, 'slide_in', lambda x: None)
+
 
 @pytest.fixture
 def single_threaded_executor():


### PR DESCRIPTION
# References and relevant issues
extracted from #7780

# Description

Do not start `slide_in` animation for notification in tests. 
Prevent from creating a notification dialog if the current main window is hidden.

 

