### PR TITLE
Add PyQt6 info to Qt bindings check ImportError message

### DIFF
--- a/napari/_qt/__init__.py
+++ b/napari/_qt/__init__.py
@@ -21,11 +21,12 @@ except Exception as e:
                     """
                 No Qt bindings could be found.
 
-                napari requires either PyQt5 (default) or PySide2 to be installed in the environment.
+                napari requires either PyQt5 (default), PyQt6 or PySide2 to be installed in the environment.
 
                 With pip, you can install either with:
                   $ pip install -U 'napari[all]'  # default choice
                   $ pip install -U 'napari[pyqt5]'
+                  $ pip install -U 'napari[pyqt6]'
                   $ pip install -U 'napari[pyside2]'
 
                 With conda, you need to do:


### PR DESCRIPTION
# References and relevant issues
Should close #7801.

# Description
Add PyQt6 in Qt bindings docs.


