### PR TITLE
Clarify color ValueError message

### DIFF
--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1591,7 +1591,7 @@ class Shapes(Layer):
 
         raise ValueError(
             trans._(
-                'face_color/edge_color should be the name of a color, an array of colors, or the name of a property',
+                'Should be the name of a color, an array of colors, or the name of a property',
                 deferred=True,
             )
         )

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -1591,7 +1591,7 @@ class Shapes(Layer):
 
         raise ValueError(
             trans._(
-                'face_color should be the name of a color, an array of colors, or the name of an property',
+                'face_color/edge_color should be the name of a color, an array of colors, or the name of a property',
                 deferred=True,
             )
         )


### PR DESCRIPTION
# References and relevant issues
Close #7722 

# Description
Clarify color ValueError message.
It could also drop the `face_color/edge_color` directly at the start of the sentence, I don't have a strong preference.


