### PR TITLE
Fix dump settings

### DIFF
--- a/napari/settings/_base.py
+++ b/napari/settings/_base.py
@@ -508,18 +508,19 @@ def _remove_bad_keys(data: dict, keys: list[tuple[int | str, ...]]):
 def _restore_config_data(dct: dict, delete: dict, defaults: dict) -> dict:
     """delete nested dict keys, restore from defaults."""
     for k, v in delete.items():
-        # restore from defaults if present, or just delete the key
-        if k in dct:
-            if k in defaults:
-                dct[k] = defaults[k]
-            else:
-                del dct[k]
         # recurse
-        elif isinstance(v, dict):
+        if isinstance(v, dict):
             dflt = defaults.get(k)
             if not isinstance(dflt, dict):
                 dflt = {}
             _restore_config_data(dct[k], v, dflt)
+        # restore from defaults if present, or just delete the key
+        elif k in dct:
+            if k in defaults:
+                dct[k] = defaults[k]
+            else:
+                del dct[k]
+
     return dct
 
 

--- a/napari/settings/_base.py
+++ b/napari/settings/_base.py
@@ -510,16 +510,15 @@ def _restore_config_data(dct: dict, delete: dict, defaults: dict) -> dict:
     for k, v in delete.items():
         # recurse
         if isinstance(v, dict):
-            dflt = defaults.get(k)
+            dflt = defaults.get(k, {})
             if not isinstance(dflt, dict):
                 dflt = {}
             _restore_config_data(dct[k], v, dflt)
         # restore from defaults if present, or just delete the key
+        elif k in defaults:
+            dct[k] = defaults[k]
         elif k in dct:
-            if k in defaults:
-                dct[k] = defaults[k]
-            else:
-                del dct[k]
+            del dct[k]
 
     return dct
 

--- a/napari/settings/_tests/test_settings.py
+++ b/napari/settings/_tests/test_settings.py
@@ -426,3 +426,11 @@ def test_shortcut_aliases():
         },
     )
     assert settings_original == settings_canonical
+
+
+def test_env_settings_restore(monkeypatch):
+    monkeypatch.setenv('NAPARI_ASYNC', '0')
+    s = NapariSettings()
+    s.experimental.completion_radius = 1
+    assert s.env_settings() == {'experimental': {'async_': '0'}}
+    assert s._save_dict()['experimental'] == {'completion_radius': 1}


### PR DESCRIPTION
# References and relevant issues

# Description

This PR fixes dumping settings if some settings value is overwritten by an environment variable.

The current order of checking first presence of key in dict always ends with true and does not go to `isinstance(v, dict)`.  
