### PR TITLE
Add sphinx opengraph dependency to docs for better social media preview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ docs = [
     "sphinx-gallery",
     "sphinx_autodoc_typehints==1.12.0",
     "sphinxcontrib-mermaid>=1.0.0",
+    "sphinxext-opengraph[social-cards]",
     "myst-nb",
     "napari-sphinx-theme>=0.3.0",
     "matplotlib",

--- a/resources/constraints/constraints_py3.10_docs.txt
+++ b/resources/constraints/constraints_py3.10_docs.txt
@@ -241,6 +241,7 @@ matplotlib==3.10.1
     # via
     #   napari (pyproject.toml)
     #   glasbey
+    #   sphinxext-opengraph
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -643,6 +644,7 @@ sphinx==7.4.7
     #   sphinx-tabs
     #   sphinx-tags
     #   sphinxcontrib-mermaid
+    #   sphinxext-opengraph
 sphinx-autobuild==2024.10.3
     # via napari (pyproject.toml)
 sphinx-autodoc-typehints==1.12.0
@@ -675,6 +677,8 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
+sphinxext-opengraph==0.10.0
+    # via napari (pyproject.toml)
 sqlalchemy==2.0.40
     # via jupyter-cache
 stack-data==0.6.3


### PR DESCRIPTION
# References and relevant issues

Required for https://github.com/napari/docs/pull/667


# Description

Adds sphinxext-opengraph to docs dependencies to allow for generating better social media previews of the website. 
https://github.com/napari/docs/pull/667#issuecomment-2798015515 suggests we will also need to update constraints (in follow up PR or this one?)



