### PR TITLE
Add scale bar box toggle to view > scale bar menu

### DIFF
--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -59,6 +59,7 @@ def test_toggle_axes_scale_bar_attr(
         * `arrows`
     * Viewer `scale_bar` attributes:
         * `visible`
+        * `box`
         * `colored`
         * `ticks`
     """

--- a/napari/_qt/_qapp_model/qactions/_view.py
+++ b/napari/_qt/_qapp_model/qactions/_view.py
@@ -266,6 +266,12 @@ toggle_action_details = [
         'visible',
     ),
     (
+        'napari.window.view.toggle_viewer_scale_bar_box',
+        trans._('Scale Bar Box'),
+        'scale_bar',
+        'box',
+    ),
+    (
         'napari.window.view.toggle_viewer_scale_bar_colored',
         trans._('Scale Bar Colored'),
         'scale_bar',

--- a/tools/string_list.json
+++ b/tools/string_list.json
@@ -156,6 +156,7 @@
       "napari:window:view:toggle_viewer_axes_labels",
       "napari:window:view:toggle_viewer_axesdashed",
       "napari:window:view:toggle_viewer_scale_bar",
+      "napari:window:view:toggle_viewer_scale_bar_box",
       "napari:window:view:toggle_viewer_scale_bar_colored",
       "napari:window:view:toggle_viewer_scale_bar_ticks"
     ],


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/6991

# Description

This PR adds an action to toggle the scale bar box to the View menu.
This improves discoverability and enables the use of this from the command palette.
Given that the functionality was fixed in https://github.com/napari/napari/pull/7750 it seems worth it to better expose now, especially with the command palette.

