### PR TITLE
[bugfix] ensure erasing and fill work with swap and preserve labels

### DIFF
--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -800,6 +800,32 @@ def test_paint_with_preserve_labels():
     assert np.unique(layer.data[:3, :3]) == 1
 
 
+def test_erase_with_preserve_labels():
+    """Test painting background with square brush while preserving existing labels."""
+    data = np.zeros((15, 10), dtype=np.uint32)
+    data[:3, :3] = 1
+    layer = Labels(data)
+
+    layer.preserve_labels = True
+    assert np.unique(layer.data[:3, :3]) == 1
+
+    layer.brush_size = 9
+    layer.selected_label = 2
+    layer.paint([0, 0], layer.selected_label)
+
+    assert np.unique(layer.data[3:5, 0:3]) == 2
+    assert np.unique(layer.data[0:3, 3:5]) == 2
+    assert np.unique(layer.data[:3, :3]) == 1
+
+    layer.swap_selected_and_background_labels()
+    assert layer.selected_label == 0
+    layer.paint([0, 0], layer.selected_label)
+
+    assert np.unique(layer.data[3:5, 0:3]) == 0
+    assert np.unique(layer.data[0:3, 3:5]) == 0
+    assert np.unique(layer.data[:3, :3]) == 1
+
+
 def test_paint_2d():
     """Test painting labels with circle brush."""
     data = np.zeros((40, 40), dtype=np.uint32)

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -800,6 +800,27 @@ def test_paint_with_preserve_labels():
     assert np.unique(layer.data[:3, :3]) == 1
 
 
+def test_setting_prev_selected_label():
+    """Test that _prev_selected_label is set when selected_label
+    is set to the colormap background_value."""
+    data = np.zeros((15, 10), dtype=np.uint32)
+    layer = Labels(data)
+
+    # set the selected label, _prev_selected_label should be None
+    layer.selected_label = 1
+    assert not layer._prev_selected_label
+
+    layer.selected_label = layer.colormap.background_value
+    assert layer._prev_selected_label == 1
+
+    layer.selected_label = 2
+    # swap the selected and background labels
+    # _prev_selected_label should be set
+    layer.swap_selected_and_background_labels()
+    assert layer.selected_label == layer.colormap.background_value
+    assert layer._prev_selected_label == 2
+
+
 def test_paint_swap_with_preserve_labels():
     """Test painting and swapping labels & background while preserving labels."""
     data = np.zeros((15, 10), dtype=np.uint32)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1119,10 +1119,11 @@ class Labels(ScalarFieldBase):
         old_label = np.asarray(self.data[int_coord]).item()
         if old_label == new_label:
             return
-        # If preserve_labels is True and old label is not same as
-        # the previous selected label or background, then also return
-        # this covers the case of using 0 (background) fill to erase
-        # accounting for swap_selected_and_background_labels
+        # If preserve_labels is True, then we only want to fill:
+        # - pixels of the background label, filling with the new label
+        # - pixels of the previous label, filling with the background
+        # the previous label is stored when the selected label is set
+        # to the background, e.g. by swap_selected_and_background_labels
         if (
             self.preserve_labels
             and old_label != self._prev_selected_label

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -709,6 +709,7 @@ class Labels(ScalarFieldBase):
         if selected_label == self.selected_label:
             return
 
+        self._prev_selected_label = self.selected_label
         self.colormap.selection = selected_label
         self._selected_label = selected_label
         self._selected_color = self.get_color(selected_label)

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -1113,10 +1113,12 @@ class Labels(ScalarFieldBase):
 
         # If requested new label doesn't change old label then return
         old_label = np.asarray(self.data[int_coord]).item()
-        if old_label == new_label or (
-            self.preserve_labels
-            and old_label != self.colormap.background_value
-        ):
+        if old_label == new_label:
+            return
+        # If preserve_labels is True and old label is not same as
+        # the previous selected label then also return
+        # this covers the case of using 0 (background) fill to erase
+        if self.preserve_labels and old_label != self._prev_selected_label:
             return
 
         dims_to_fill = sorted(
@@ -1313,7 +1315,9 @@ class Labels(ScalarFieldBase):
         # current label
         if self.preserve_labels:
             if new_label == self.colormap.background_value:
-                keep_coords = self.data[slice_coord] == self.selected_label
+                keep_coords = (
+                    self.data[slice_coord] == self._prev_selected_label
+                )
             else:
                 keep_coords = (
                     self.data[slice_coord] == self.colormap.background_value

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -708,8 +708,12 @@ class Labels(ScalarFieldBase):
     def selected_label(self, selected_label):
         if selected_label == self.selected_label:
             return
-
-        self._prev_selected_label = self.selected_label
+        # when setting the label to the background, store the previous
+        # otherwise, clear it
+        if selected_label == self.colormap.background_value:
+            self._prev_selected_label = self.selected_label
+        else:
+            self._prev_selected_label = None
         self.colormap.selection = selected_label
         self._selected_label = selected_label
         self._selected_color = self.get_color(selected_label)
@@ -722,7 +726,6 @@ class Labels(ScalarFieldBase):
     def swap_selected_and_background_labels(self):
         """Swap between the selected label and the background label."""
         if self.selected_label != self.colormap.background_value:
-            self._prev_selected_label = self.selected_label
             self.selected_label = self.colormap.background_value
         else:
             self.selected_label = self._prev_selected_label


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7812

# Description
This PR attempts to make the behavior of paint and fill work with `swap_selected_and_background_labels` (`X` keybind) and preserve labels:
- it enables erasing  the last used label with *both* paint/fill when swap has been used to switch to background, rather than returning, but checking the old label vs. the _prev_selected_label
e.g. on main, the following happens:
- paint a label, set preserve, hit swap binding, paint over to erase -> nada, nothing happens
- paint a label, set preserve, hit swap binding, fill over to erase -> nada, nothing happens

with this Pr:
- in both cases the label that was being painted (_prev_selected_label) will be erased

To make the behavior more predictable, e.g. when using the `selected_label` setter/spinbox vs. the `X` keybind, I have the setter only store `self._prev_selected_label` when the label is set to the background, rather than all the time. This also prevents confusing issues with un-expected fills or erases that could occur when selected_label and _prev_selected_label are different and neither is None.

I also added two tests that fail on main, as well as a test for the _prev_selected_label setting behavior.
