### PR TITLE
Print contents of stderr and stdout in update dependencies workflow

### DIFF
--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -62,36 +62,48 @@ def push(branch_name: str, update: bool = False):
     """
     Push the current branch to the remote.
     """
-    with cd(REPO_DIR):
-        logging.info('go to dir %s', REPO_DIR)
-        if update:
-            logging.info('Pushing to %s', branch_name)
-            subprocess.run(
-                [
-                    'git',
-                    'push',
-                    '--force',
-                    '--set-upstream',
-                    'napari-bot',
-                    branch_name,
-                ],
-                check=True,
-                capture_output=True,
-            )
-        else:
-            logging.info('Force pushing to %s', branch_name)
-            subprocess.run(
-                [
-                    'git',
-                    'push',
-                    '--force',
-                    '--set-upstream',
-                    'origin',
-                    branch_name,
-                ],
-                check=True,
-                capture_output=True,
-            )  # nosec
+    try:
+        with cd(REPO_DIR):
+            logging.info('go to dir %s', REPO_DIR)
+            if update:
+                logging.info('Pushing to %s', branch_name)
+                subprocess.run(
+                    [
+                        'git',
+                        'push',
+                        '--force',
+                        '--set-upstream',
+                        'napari-bot',
+                        branch_name,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+            else:
+                logging.info('Force pushing to %s', branch_name)
+                subprocess.run(
+                    [
+                        'git',
+                        'push',
+                        '--force',
+                        '--set-upstream',
+                        'origin',
+                        branch_name,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )  # nosec
+    except subprocess.CalledProcessError as e:
+        stdout = e.stdout.decode() if e.stdout else ''
+        stderr = e.stderr.decode() if e.stderr else ''
+        logging.exception(
+            'Error pushing to branch %s:\n\nstdout: %s\\nnstderr: %s\n\nWith error %d',
+            branch_name,
+            stdout,
+            stderr,
+            e.returncode,
+        )
+        raise
 
 
 def commit_message(branch_name) -> str:


### PR DESCRIPTION
# References and relevant issues


# Description

When `Upgrade test constraints` fails, then Traceback does not contain stderr and stdout so we do not know  why it fails. 

Here example part of traceback

```
INFO:root:Force pushing to auto-update-dependencies
Traceback (most recent call last):
  File "/home/runner/work/napari/napari/tools/create_pr_or_update_existing_one.py", line 348, in <module>
    main()
  File "/home/runner/work/napari/napari/tools/create_pr_or_update_existing_one.py", line 335, in main
    create_pr_with_push(branch_name, access_token)
  File "/home/runner/work/napari/napari/tools/create_pr_or_update_existing_one.py", line 135, in create_pr_with_push
    push(new_branch_name)
  File "/home/runner/work/napari/napari/tools/create_pr_or_update_existing_one.py", line 83, in push
    subprocess.run(
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'push', '--force', '--set-upstream', 'origin', 'auto-update-dependencies']' returned non-zero exit status 128.
```