### PR TITLE
Fix newline in message when fail to push to repository in update constraints

### DIFF
--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -97,7 +97,7 @@ def push(branch_name: str, update: bool = False):
         stdout = e.stdout.decode() if e.stdout else ''
         stderr = e.stderr.decode() if e.stderr else ''
         logging.exception(
-            'Error pushing to branch %s:\n\nstdout: %s\\nnstderr: %s\n\nWith error %d',
+            'Error pushing to branch %s:\n\nstdout: %s\n\nstderr: %s\n\nWith error %d',
             branch_name,
             stdout,
             stderr,


### PR DESCRIPTION
# References and relevant issues

Follow-up #7817

# Description

Neither me nor the reviewer spot the problem with new line markers. 

Merging #7817 helps me to debug failing workflow. 