### PR TITLE
Use proper token in update dependencies workflow

### DIFF
--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -129,7 +129,7 @@ jobs:
           path: napari_repo  # place in a named directory
           repository: ${{ env.FULL_NAME }}
           ref: ${{ env.BRANCH }}
-          token: ${{ secrets.GHA_TOKEN_NAPARI_BOT_MAIN_REPO }}
+          token: ${{ secrets.GHA_TOKEN_BOT_REPO }}
 
       - name: Add napari-bot/napari to napari_repo upstreams
         run: |


### PR DESCRIPTION
# References and relevant issues

Follow up to #7820.

# Description

In #7820, we changed the dependencies update bot to make pull requests from its own fork, rather than by pushing to the main napari repo. However, the token used in that step had permissions for the main repo and not for the fork. This PR updates the token to use the one for commenting on the issue, which should have the correct permissions.
