### PR TITLE
Update branch name, for update dependencies workflow, to avoid branch name collisions, that prevents push

### DIFF
--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -134,10 +134,7 @@ def create_pr_with_push(branch_name: str, access_token: str, repo=''):
     """
     Create a PR.
     """
-    if branch_name == 'main':
-        new_branch_name = DEFAULT_BRANCH_NAME
-    else:
-        new_branch_name = f'{DEFAULT_BRANCH_NAME}-{branch_name}'
+    new_branch_name = f'{DEFAULT_BRANCH_NAME}-{branch_name}'
 
     if not repo:
         repo = os.environ.get('GITHUB_REPOSITORY', 'napari/napari')

--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -15,7 +15,8 @@ from check_updated_packages import get_changed_dependencies
 REPO_DIR = Path(__file__).parent.parent / 'napari_repo'
 # GitHub API base URL
 BASE_URL = 'https://api.github.com'
-DEFAULT_BRANCH_NAME = 'auto-update-dependencies'
+DEFAULT_BRANCH_NAME_PREFIX = 'auto-update-dependencies'
+DEFAULT_BRANCH_NAME = f'{DEFAULT_BRANCH_NAME_PREFIX}-main'
 
 
 @contextmanager
@@ -134,7 +135,7 @@ def create_pr_with_push(branch_name: str, access_token: str, repo=''):
     """
     Create a PR.
     """
-    new_branch_name = f'{DEFAULT_BRANCH_NAME}-{branch_name}'
+    new_branch_name = f'{DEFAULT_BRANCH_NAME_PREFIX}-{branch_name}'
 
     if not repo:
         repo = os.environ.get('GITHUB_REPOSITORY', 'napari/napari')


### PR DESCRIPTION
# References and relevant issues

Follow up to #7821

# Description

Today I learned that if you have branch `branch/something` you cannot have branch `branch` 

```
stderr: To https://github.com/napari-bot/napari.git
 ! [remote rejected] auto-update-dependencies -> auto-update-dependencies (cannot lock ref 'refs/heads/auto-update-dependencies': 'refs/heads/auto-update-dependencies/Carreau/napari/qtpy6-mypy' exists; cannot create 'refs/heads/auto-update-dependencies')
error: failed to push some refs to 'https://github.com/napari-bot/napari.git'
```

So this PR add suffix `-main` to distinguish it. 

