### PR TITLE
Add PR dependency workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,10 @@
 # References and relevant issues
 <!-- What relevant resources were used in the creation of this PR?
 If this PR addresses an existing issue on the repo,
-please link to that issue here as "Closes #(issue-number)". -->
+please link to that issue here as "Closes #(issue-number)"
+If this PR depends on another PR/issue (even in another repo),
+please link to it with "Depends on #PR-number" or "Depends on org/repo#PR-number"
+-->
 
 # Description
 <!-- What does this pull request (PR) do? Is it a new feature, a bug fix,

--- a/.github/workflows/pr_dependency.yml
+++ b/.github/workflows/pr_dependency.yml
@@ -1,0 +1,16 @@
+# https://github.com/marketplace/actions/pr-dependency-check
+name: "PR Dependency Check"
+on:
+  pull_request:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, 'merge')) || github.event_name == 'pull_request'
+    name: Check Dependencies
+    steps:
+    - uses: gregsdennis/dependencies-action@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_dependency.yml
+++ b/.github/workflows/pr_dependency.yml
@@ -11,6 +11,6 @@ jobs:
     if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, 'merge')) || github.event_name == 'pull_request'
     name: Check Dependencies
     steps:
-    - uses: gregsdennis/dependencies-action@main
+    - uses: gregsdennis/dependencies-action@v1.4.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# References and relevant issues
napari/docs#124

# Description
Add a CI check whenever phrases like `depends on #...` are used, which blocks merging until the tagger PR/issue is merged/closed. Works cross-repo.

A while back we added this to the docs repo, and I think it proved useful over there.

At the time we briefly discussed adding it here as well, but never got around to it. What does everyone think?
