### PR TITLE
Update to more recent circleci base image that uses uv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,19 +25,19 @@ jobs:
           name: Setup virtual environment
           command: |
             uv venv
-            . venv/bin/activate
+            . .venv/bin/activate
 
       - run:
           name: Install napari-dev
           command: |
-            . venv/bin/activate
+            . .venv/bin/activate
             uv pip install -e "napari/[pyqt5,docs]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:
           name: Build docs
           command: |
-            . venv/bin/activate
+            . .venv/bin/activate
             cd docs
             xvfb-run --auto-servernum make html
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   build-docs:
     docker:
       # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
-      - image: cimg/python:3.10.16
+      - image: cimg/python:3.10.17
     steps:
       - checkout:
           path: napari
@@ -24,15 +24,14 @@ jobs:
       - run:
           name: Setup virtual environment
           command: |
-            python -m venv venv
+            uv venv
             . venv/bin/activate
-            python -m pip install --upgrade pip
 
       - run:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[pyqt5,docs]"
+            uv pip install -e "napari/[pyqt5,docs]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:


### PR DESCRIPTION
# References and relevant issues
Related to napari docs pr https://github.com/napari/docs/pull/673

# Description
Use the circleci cimg 3.10.17 which includes uv. Update commands for venv and pip to use uv.
