### PR TITLE
Demonstrate "pure" plugin commands, add required providers

### DIFF
--- a/napari_builtins/_filters.py
+++ b/napari_builtins/_filters.py
@@ -1,0 +1,22 @@
+from skimage import filters
+
+import napari
+
+
+def gaussian(layer: napari.layers.Image) -> napari.types.LayerDataTuple:
+    data = filters.gaussian(layer.data, preserve_range=True)
+    name = layer.name + '_gaussian'
+    dct = {**layer.as_layer_data_tuple()[1], 'name': name}
+    return (data, dct, 'image')
+
+
+def sobel(layer: napari.layers.Image) -> napari.types.LayerDataTuple:
+    data = filters.sobel(layer.data)
+    name = layer.name + '_sobel'
+    contrast_limits = data.min(), data.max()
+    dct = {
+        **layer.as_layer_data_tuple()[1],
+        'name': name,
+        'contrast_limits': contrast_limits,
+    }
+    return (data, dct, 'image')

--- a/napari_builtins/builtins.yaml
+++ b/napari_builtins/builtins.yaml
@@ -134,6 +134,10 @@ contributions:
       title: Generate 3d_balls sample
       python_name: napari_builtins._ndims_balls:labeled_particles3d
 
+  menus:
+    napari/layers/filter:
+      - command: napari.filters.gaussian
+      - command: napari.filters.sobel
   readers:
     - command: napari.get_reader
       accepts_directories: true

--- a/napari_builtins/builtins.yaml
+++ b/napari_builtins/builtins.yaml
@@ -23,6 +23,13 @@ contributions:
       python_name: napari_builtins.io:write_layer_data_with_plugins
       title: napari built-in save to folder
 
+    - id: napari.filters.gaussian
+      python_name: napari_builtins._filters:gaussian
+      title: built-in gaussian filtering
+    - id: napari.filters.sobel
+      python_name: napari_builtins._filters:sobel
+      title: built-in sobel filtering
+
     # samples
     - id: napari.data.astronaut
       title: Generate astronaut sample


### PR DESCRIPTION
Something I've been playing around with: with the app-model actions,
npe2, and the necessary providers, plugins can provide "pure" actions
that are executed with the relevant arguments (e.g. the active layer)
when invoked, via the menu or the command palette.

The actions added in this PR are just for demonstration purposes, and
should not be merged. 😅

Currently, I'm trying to figure out how to use "enablement" in the
action description or in the manifest so that this can only be run on
e.g. image layers. But I think this is very close and together with the
command palette will be a *huge* boost to plugin functionality in
napari!

With just the first commit here, this "just works":

https://github.com/user-attachments/assets/37e65454-6e4b-4cf2-8498-08985f08b093

(but currently you can run it with any layer selected, and get an error
with non-image layers.)