### PR TITLE
Add setter for track colors

### DIFF
--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -296,6 +296,19 @@ def test_track_connex_validity() -> None:
     assert np.sum(~layer._manager.track_connex) == n_tracks
 
 
+def test_track_coloring() -> None:
+    """Test if the track colors are correctly set."""
+
+    data = np.zeros((100, 4))
+    data[:, 1] = np.arange(100)
+    layer = Tracks(data)
+
+    colors = np.random.randint(low=0, high=256, size=(100, 4))
+    layer.track_colors = colors
+
+    assert np.array_equal(layer._track_colors, colors)
+
+
 def test_docstring():
     validate_all_params_in_docstring(Tracks)
     validate_kwargs_sorted(Tracks)

--- a/napari/layers/tracks/_tests/test_tracks.py
+++ b/napari/layers/tracks/_tests/test_tracks.py
@@ -303,7 +303,7 @@ def test_track_coloring() -> None:
     data[:, 1] = np.arange(100)
     layer = Tracks(data)
 
-    colors = np.random.randint(low=0, high=256, size=(100, 4))
+    colors = np.random.random(size=(100, 4))
     layer.track_colors = colors
 
     assert np.array_equal(layer._track_colors, colors)

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -616,7 +616,7 @@ class Tracks(Layer):
         """return the vertex colors according to the currently selected
         property"""
         return self._track_colors
-    
+
     @track_colors.setter
     def track_colors(self, colors: np.ndarray) -> None:
         """set the vertex colors according to the currently selected

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -613,13 +613,22 @@ class Tracks(Layer):
 
     @property
     def track_colors(self) -> np.ndarray | None:
-        """return the vertex colors according to the currently selected
-        property"""
+        """Return current vertex colors."""
         return self._track_colors
 
     @track_colors.setter
     def track_colors(self, colors: np.ndarray) -> None:
-        """set the vertex colors based on the currently selected property and emit an event"""
+        """Set vertex colors directly and emit corresponding event.
+
+        Parameters
+        ----------
+        colors : np.ndarray
+            The desired color array, one color per data point. Note that the
+            data are internally lexicographically sorted first by track ID,
+            then by timepoint, so the color ordering must match this order,
+            which may not be the input order. Use `Tracks.data` to find the
+            current sorted data.
+        """
         self._track_colors = colors
         self.events.color_by()
 

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -619,8 +619,7 @@ class Tracks(Layer):
 
     @track_colors.setter
     def track_colors(self, colors: np.ndarray) -> None:
-        """set the vertex colors according to the currently selected
-        property"""
+        """set the vertex colors based on the currently selected property and emit an event"""
         self._track_colors = colors
         self.events.color_by()
 

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -616,6 +616,13 @@ class Tracks(Layer):
         """return the vertex colors according to the currently selected
         property"""
         return self._track_colors
+    
+    @track_colors.setter
+    def track_colors(self, colors: np.ndarray) -> None:
+        """set the vertex colors according to the currently selected
+        property"""
+        self._track_colors = colors
+        self.events.color_by()
 
     @property
     def graph_connex(self) -> np.ndarray | None:

--- a/napari/layers/tracks/tracks.py
+++ b/napari/layers/tracks/tracks.py
@@ -622,7 +622,7 @@ class Tracks(Layer):
 
         Parameters
         ----------
-        colors : np.ndarray
+        colors : np.ndarray, shape (N, 4)
             The desired color array, one color per data point. Note that the
             data are internally lexicographically sorted first by track ID,
             then by timepoint, so the color ordering must match this order,


### PR DESCRIPTION
Closes #7829

# Description
New feature: I added a `setter` method for the `tracks.track_colors` property. The method overwrites the internal `_track_colors` with a `Nx4` ndarray and emits the signal that applies the recoloring

- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- [x] I have added tests that prove my fix is effective or that my feature works