### PR TITLE
Use OIDC authorization only for push and pull requests from the same repository 

### DIFF
--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -7,7 +7,6 @@ jobs:
     permissions:
       id-token: write  # Required for OIDC authentication
       contents: read    # Required for code checkout
-      checks: read
     name: Upload coverage
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +39,7 @@ jobs:
           python -Im coverage report --format=markdown --skip-empty --skip-covered >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v5.4.2
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           use_oidc: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -39,6 +39,14 @@ jobs:
           # Report and write to summary.
           python -Im coverage report --format=markdown --skip-empty --skip-covered >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Print github.event
+        run: |
+          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.actor: ${{ github.actor }}"
+          echo "github.repository: ${{ github.repository }}"
+          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "github.event: ${{ toJSON(github.event) }}"
+
       - name: Upload coverage data
         uses: codecov/codecov-action@v5.4.2
         with:

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -43,4 +43,4 @@ jobs:
         uses: codecov/codecov-action@v5.4.2
         with:
           fail_ci_if_error: true
-          use_oidc: true
+          use_oidc: ${{ github.event_name == 'push' }}

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -39,14 +39,6 @@ jobs:
           # Report and write to summary.
           python -Im coverage report --format=markdown --skip-empty --skip-covered >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Print github.event
-        run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.actor: ${{ github.actor }}"
-          echo "github.repository: ${{ github.repository }}"
-          echo "github.ref_name: ${{ github.ref_name }}"
-          echo "github.event: ${{ toJSON(github.event) }}"
-
       - name: Upload coverage data
         uses: codecov/codecov-action@v5.4.2
         with:

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -43,4 +43,4 @@ jobs:
         uses: codecov/codecov-action@v5.4.2
         with:
           fail_ci_if_error: true
-          use_oidc: ${{ github.event_name == 'push' }}
+          use_oidc: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -40,7 +40,7 @@ jobs:
           python -Im coverage report --format=markdown --skip-empty --skip-covered >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage data
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.4.2
         with:
           fail_ci_if_error: true
           use_oidc: true

--- a/.github/workflows/reusable_coverage_upload.yml
+++ b/.github/workflows/reusable_coverage_upload.yml
@@ -7,6 +7,7 @@ jobs:
     permissions:
       id-token: write  # Required for OIDC authentication
       contents: read    # Required for code checkout
+      checks: read
     name: Upload coverage
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -196,7 +196,6 @@ jobs:
     permissions:
       id-token: write  # Required for OIDC authentication
       contents: read    # Required for code checkout
-      checks: read
     uses: ./.github/workflows/reusable_coverage_upload.yml
     secrets: inherit
 

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -194,8 +194,9 @@ jobs:
       - test
       - test_examples
     permissions:
-      id-token: write  # Required for OIDC
-      contents: read    # Required for checkout
+      id-token: write  # Required for OIDC authentication
+      contents: read    # Required for code checkout
+      checks: read
     uses: ./.github/workflows/reusable_coverage_upload.yml
     secrets: inherit
 


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/channel/270578-reviews/topic/Coverage.20CI.20is.20failing/near/512878159

# Description

Do not use OIDC authorization for pull request from forked repositories. 

The pre-commit is making PR from napari/napari repository, ant then OIDC is available and required to get upload to codecov.io 

