### PR TITLE
[maint] Add pyopenGL version to napari info

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -133,6 +133,13 @@ def sys_info(as_html: bool = False) -> str:
 
     text += '<br><b>OpenGL:</b><br>'
 
+    try:
+        from OpenGL.version import __version__ as pyopengl_version
+
+        text += f'  - PyOpenGL: {pyopengl_version}<br>'
+    except ImportError:
+        text += '  - PyOpenGL: Import failed<br>'
+
     if loaded.get('vispy', False):
         from napari._vispy.utils.gl import get_max_texture_sizes
 


### PR DESCRIPTION
# References and relevant issues
To help debug OpenGL related issues, e.g.:
https://github.com/napari/napari/issues/7671
(there is some evidence that 3.1.7 from conda-forge is problematic on some platforms)

# Description

This PR adds a version check for PyOpenGL to the OpenGL section of `napari --info` (and also shows in Help > napari info).

Note: I tried adding the module along with the others, but it's annoying that the import and module name don't match. But then it dawned on me that it makes more sense to have this in the OpenGL section.
