### PR TITLE
[maint] Add whether napari was installed using conda to napari info

### DIFF
--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -1,9 +1,11 @@
 import contextlib
 import os
 import platform
+import re
 import subprocess
 import sys
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 import napari
 
@@ -71,6 +73,29 @@ def _sys_name() -> str:
     return ''
 
 
+def _napari_from_conda() -> bool:
+    """
+    Try to check if napari was installed using conda.
+
+    This is done by checking for the presence of a conda metadata json file
+    in the current environment's conda-meta directory.
+
+    Returns
+    -------
+    bool
+        True if the main napari application is installed via conda, False otherwise.
+    """
+    # Check for napari-related conda metadata files
+    napari_conda_files = list(
+        Path(sys.prefix, 'conda-meta').glob('napari-*.json')
+    )
+    # Match only the napari package by using napari-<version>.json
+    # This is to exclude plugins napari-svg, etc.
+    napari_pattern = re.compile(r'^napari-\d+(\.\d+)*.*\.json$')
+
+    return any(napari_pattern.match(file.name) for file in napari_conda_files)
+
+
 def sys_info(as_html: bool = False) -> str:
     """Gathers relevant module versions for troubleshooting purposes.
 
@@ -80,10 +105,10 @@ def sys_info(as_html: bool = False) -> str:
         if True, info will be returned as HTML, suitable for a QTextEdit widget
     """
     sys_version = sys.version.replace('\n', ' ')
-    text = (
-        f'<b>napari</b>: {napari.__version__}<br>'
-        f'<b>Platform</b>: {platform.platform()}<br>'
-    )
+    text = f'<b>napari</b>: {napari.__version__}'
+    if _napari_from_conda():
+        text += ' (from conda)'
+    text += f'<br><b>Platform</b>: {platform.platform()}<br>'
 
     __sys_name = _sys_name()
     if __sys_name:


### PR DESCRIPTION
# References and relevant issues
Motivation:
Particularly when the plugin manager is involved, there can be differences between napari from conda and from PyPI.
We ask for `napari --info`, but this doesn't include how napari was installed, so then we need to followup with that question.


# Description
Adds a simple check for napari metadata file in the conda-meta to `utils/info`. If it exists, it's safe to assume that napari was installed using conda. If true, this is then used to indicate that napari was from conda. I also added a test for this.

Here's an example output (i 'touched' a sham json file):
```
napari: 0.6.0a0 (from conda)
Platform: macOS-14.5-arm64-arm-64bit-Mach-O
System: MacOS 14.5
Python: 3.13.2 | packaged by conda-forge | (main, Feb 17 2025, 14:02:48) [Clang 18.1.8 ]
Qt: 6.8.2
PyQt6: 6.8.1
NumPy: 2.1.3
SciPy: 1.15.2
Dask: 2025.2.0
VisPy: 0.14.3
magicgui: 0.10.0
superqt: 0.7.1
in-n-out: 0.2.1
app-model: 0.3.1
psygnal: 0.12.0
npe2: 0.7.8
pydantic: 2.10.6

OpenGL:
  - GL version:  2.1 Metal - 88.1
  - MAX_TEXTURE_SIZE: 16384
  - GL_MAX_3D_TEXTURE_SIZE: 2048

Screens:
  - screen 1: resolution 1680x1050, scale 2.0

Optional:
  - numba: 0.61.0
  - triangle not installed
  - napari-plugin-manager: 0.1.4

Settings path:
  - /Users/piotrsobolewski/Library/Application Support/napari/napari-dev_a1eb8b76ba95fa16ad06e26097b46b8455dfbf0b/settings.yaml
Plugins:
  - napari: 0.6.0a0 (81 contributions)
  - napari-console: 0.1.3 (0 contributions)
  - napari-svg: 0.2.1 (2 contributions)

```