### PR TITLE
fix `ScalarField._get_value_3d` to return information about data level for multiscale

### DIFF
--- a/napari/layers/_scalar_field/scalar_field.py
+++ b/napari/layers/_scalar_field/scalar_field.py
@@ -667,7 +667,7 @@ class ScalarFieldBase(Layer, ABC):
         start_point: np.ndarray | None,
         end_point: np.ndarray | None,
         dims_displayed: list[int],
-    ) -> int | None:
+    ) -> int | None | tuple[int, int | None]:
         """Get the first non-background value encountered along a ray.
 
         Parameters
@@ -681,15 +681,21 @@ class ScalarFieldBase(Layer, ABC):
 
         Returns
         -------
-        value : int
+        value : int or tuple
             The first non-zero value encountered along the ray. If a
             non-zero value is not encountered, returns None.
+            If multiscale is True, returns a tuple of (data_level, value).
         """
-        return self._get_value_ray(
+        value = self._get_value_ray(
             start_point=start_point,
             end_point=end_point,
             dims_displayed=dims_displayed,
         )
+
+        if self.multiscale and value is not None:
+            value = (self.data_level, value)
+
+        return value
 
     def _get_offset_data_position(self, position: npt.NDArray) -> npt.NDArray:
         """Adjust position for offset between viewer and data coordinates.

--- a/napari/layers/_scalar_field/scalar_field.py
+++ b/napari/layers/_scalar_field/scalar_field.py
@@ -693,7 +693,7 @@ class ScalarFieldBase(Layer, ABC):
         )
 
         if self.multiscale and value is not None:
-            value = (self.data_level, value)
+            return self.data_level, value
 
         return value
 

--- a/napari/layers/labels/_tests/test_labels_multiscale.py
+++ b/napari/layers/labels/_tests/test_labels_multiscale.py
@@ -68,36 +68,21 @@ def test_3D_multiscale_labels_in_3D():
     # [0,0,0] has value 0, which is transparent, so the ray will hit the next point
     # which is [1, 0, 0] and has value 4
     # the position array is in original data coords (no downsampling)
-    assert (
-        layer.get_value(
-            [0, 0, 0], view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
-        )
-        == 4
-    )
-    assert (
-        layer.get_value(
-            [0, 0, 0], view_direction=[-1, 0, 0], dims_displayed=[0, 1, 2]
-        )
-        == 4
-    )
-    assert (
-        layer.get_value(
-            [0, 1, 1], view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
-        )
-        == 4
-    )
-    assert (
-        layer.get_value(
-            [0, 5, 5], view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
-        )
-        == 3
-    )
-    assert (
-        layer.get_value(
-            [5, 0, 5], view_direction=[0, 0, -1], dims_displayed=[0, 1, 2]
-        )
-        == 5
-    )
+    assert layer.get_value(
+        [0, 0, 0], view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
+    ) == (2, 4)
+    assert layer.get_value(
+        [0, 0, 0], view_direction=[-1, 0, 0], dims_displayed=[0, 1, 2]
+    ) == (2, 4)
+    assert layer.get_value(
+        [0, 1, 1], view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
+    ) == (2, 4)
+    assert layer.get_value(
+        [0, 5, 5], view_direction=[1, 0, 0], dims_displayed=[0, 1, 2]
+    ) == (2, 3)
+    assert layer.get_value(
+        [5, 0, 5], view_direction=[0, 0, -1], dims_displayed=[0, 1, 2]
+    ) == (2, 5)
 
 
 def instantiate_3D_multiscale_labels():


### PR DESCRIPTION
# References and relevant issues

closes #7848 

# Description

Fix `ScalarFieldBase._get_value_3d` to properly handle multiscale 3d data consistently with multiscale 2d data, by including the level information in a tuple.
