### PR TITLE
Check return value is valid LayerDataTuple

### DIFF
--- a/napari/components/_tests/test_viewer_model.py
+++ b/napari/components/_tests/test_viewer_model.py
@@ -996,6 +996,35 @@ def test_open_or_get_error_preferred_fails(builtins, tmp_path):
         viewer._open_or_raise_error([str(pth)])
 
 
+def test_open_sample_invalid_layer_data_tuple(tmp_plugin):
+    """Test that sample returning malformed layer data tuple raises error."""
+    viewer = ViewerModel()
+
+    @tmp_plugin.contribute.sample_data
+    def return_invalid_ldt():
+        return [('image', np.zeros((10, 10)))]
+
+    with pytest.raises(
+        TypeError, match='Not a valid list of layer data tuples!'
+    ):
+        viewer.open_sample('tmp_plugin', 'return_invalid_ldt')
+
+
+def test_open_sample_null_layer_sentinel(tmp_plugin):
+    """Test that sample returning null layer sentinel raises error."""
+    viewer = ViewerModel()
+
+    @tmp_plugin.contribute.sample_data
+    def return_null_layer():
+        return [(None,)]
+
+    with pytest.raises(
+        ValueError,
+        match='Sample "return_null_layer" from plugin "tmp_plugin" did not return any valid layer data tuples.',
+    ):
+        viewer.open_sample('tmp_plugin', 'return_null_layer')
+
+
 def test_slice_order_with_mixed_dims():
     viewer = ViewerModel(ndisplay=2)
     image_2d = viewer.add_image(np.zeros((4, 5)))

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1311,7 +1311,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             if callable(data):
                 added = []
                 needs_error = True
-                for datum in ensure_list_of_layer_data_tuple(data(**kwargs)):
+                for datum in ensure_list_of_layer_data_tuple(
+                    list(data(**kwargs))
+                ):
                     if datum[0] is not None:
                         needs_error = False
                         added.extend(self._add_layer_from_data(*datum))

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -86,7 +86,7 @@ from napari.utils.events import (
 )
 from napari.utils.events.event import WarningEmitter
 from napari.utils.key_bindings import KeymapProvider
-from napari.utils.misc import is_sequence
+from napari.utils.misc import ensure_list_of_layer_data_tuple, is_sequence
 from napari.utils.mouse_bindings import MousemapProvider
 from napari.utils.progress import progress
 from napari.utils.theme import available_themes, is_theme_available
@@ -1310,8 +1310,19 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         with layer_source(sample=(plugin, sample)):
             if callable(data):
                 added = []
-                for datum in data(**kwargs):
-                    added.extend(self._add_layer_from_data(*datum))
+                needs_warning = True
+                for datum in ensure_list_of_layer_data_tuple(data(**kwargs)):
+                    if datum[0] is not None:
+                        needs_warning = False
+                        added.extend(self._add_layer_from_data(*datum))
+                if needs_warning:
+                    warnings.warn(
+                        trans._(
+                            'Reader for sample {sample} returned no layers.',
+                            deferred=True,
+                            sample=sample,
+                        )
+                    )
                 return added
             if isinstance(data, str | Path):
                 try:

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -1310,17 +1310,18 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         with layer_source(sample=(plugin, sample)):
             if callable(data):
                 added = []
-                needs_warning = True
+                needs_error = True
                 for datum in ensure_list_of_layer_data_tuple(data(**kwargs)):
                     if datum[0] is not None:
-                        needs_warning = False
+                        needs_error = False
                         added.extend(self._add_layer_from_data(*datum))
-                if needs_warning:
-                    warnings.warn(
+                if needs_error:
+                    raise ValueError(
                         trans._(
-                            'Reader for sample {sample} returned no layers.',
+                            'Sample "{sample}" from plugin "{plugin}" did not return any valid layer data tuples.',
                             deferred=True,
                             sample=sample,
+                            plugin=plugin,
                         )
                     )
                 return added


### PR DESCRIPTION
# References and relevant issues
Closes #7834

# Description
This PR updates our `open_sample` logic to raise a more useful error when a sample command contribution returns an invalid list of `LayerDataTuple`s OR only returns a null layer sentinel.


