### PR TITLE
Refresh extent on async slicing

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -598,8 +598,12 @@ class QtViewer(QSplitter):
                 # `set_data` notifies the corresponding vispy layer of the new
                 # slice.
                 layer.events.set_data()
-                layer._update_thumbnail()
-                layer._set_highlight(force=True)
+                layer._refresh_sync(
+                    data_displayed=True,
+                    thumbnail=True,
+                    highlight=True,
+                    extent=True,
+                )
 
     def _on_active_change(self):
         """When active layer changes change keymap handler."""

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1526,9 +1526,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             return
         logger.debug('Layer.refresh: %s', self)
         # If async is enabled then emit an event that the viewer should handle.
-        if get_settings().experimental.async_:
+        if get_settings().experimental.async_ and data_displayed:
+            # full async slice reload, it will also update everything when done slicing
+            # via the callback of layer.loaded which calls _refresh_sync
             self.events.reload(layer=self)
-            self._refresh_sync(extent=True, force=force)
         # Otherwise, slice immediately on the calling thread.
         else:
             self._refresh_sync(

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1528,6 +1528,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         # If async is enabled then emit an event that the viewer should handle.
         if get_settings().experimental.async_:
             self.events.reload(layer=self)
+            self._refresh_sync(extent=True, force=force)
         # Otherwise, slice immediately on the calling thread.
         else:
             self._refresh_sync(


### PR DESCRIPTION
# References and relevant issues
- closes #7495

# Description
There might be a smarter way to do this (e.g: as a callback from the end of the async slicing maybe?), but this seems to to the job for me.

@psobolewskiPhD  does this solve the issue for you?

Test with async slicing enabled:

```py
import napari
import numpy as np

data = np.random.random([256, 256])

viewer = napari.Viewer()

viewer.add_image(data)

print(viewer.layers.extent)

viewer.layers[0].scale = (.1, .1)

print(viewer.layers.extent)
viewer.reset_view()

napari.run()
```
