### PR TITLE
[maint, enh] Add experimental settings status to napari --info

### DIFF
--- a/napari/settings/_experimental.py
+++ b/napari/settings/_experimental.py
@@ -87,6 +87,7 @@ class ExperimentalSettings(EventedSettings):
             "The 'pure python' backend uses the default Python triangulation from vispy.\n"
             "The 'fastest available' backend will select the fastest available backend.\n"
         ),
+        env='napari_triangulation_backend',
     )
 
     compiled_triangulation: bool = Field(

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -216,15 +216,15 @@ def sys_info(as_html: bool = False) -> str:
 
         _async_setting = get_settings().experimental.async_
         _autoswap_buffers = get_settings().experimental.autoswap_buffers
-        _triangulation_backend = (
+        _triangulation_backend = str(
             get_settings().experimental.triangulation_backend
         )
         _config_path = get_settings().config_path
     except ValueError:
         from napari.utils._appdirs import user_config_dir
 
-        _async_setting = os.getenv('NAPARI_ASYNC', False)
-        _autoswap_buffers = os.getenv('NAPARI_AUTOSWAP', False)
+        _async_setting = os.getenv('NAPARI_ASYNC', 'False')
+        _autoswap_buffers = os.getenv('NAPARI_AUTOSWAP', 'False')
         _triangulation_backend = os.getenv(
             'NAPARI_TRIANGULATION_BACKEND', 'Fastest available'
         )

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -211,15 +211,32 @@ def sys_info(as_html: bool = False) -> str:
         except PackageNotFoundError:
             text += f'  - {name} not installed<br>'
 
-    text += '<br><b>Settings path:</b><br>'
     try:
         from napari.settings import get_settings
 
-        text += f'  - {get_settings().config_path}'
+        _async_setting = get_settings().experimental.async_
+        _autoswap_buffers = get_settings().experimental.autoswap_buffers
+        _triangulation_backend = (
+            get_settings().experimental.triangulation_backend
+        )
+        _config_path = get_settings().config_path
     except ValueError:
         from napari.utils._appdirs import user_config_dir
 
-        text += f'  - {os.getenv("NAPARI_CONFIG", user_config_dir())}'
+        _async_setting = os.getenv('NAPARI_ASYNC', False)
+        _autoswap_buffers = os.getenv('NAPARI_AUTOSWAP', False)
+        _triangulation_backend = os.getenv(
+            'NAPARI_TRIANGULATION_BACKEND', 'Fastest available'
+        )
+        _config_path = os.getenv('NAPARI_CONFIG', user_config_dir())
+
+    text += '<br><b>Experimental Settings:</b><br>'
+    text += f'  - Async: {_async_setting}<br>'
+    text += f'  - Autoswap buffers: {_autoswap_buffers}<br>'
+    text += f'  - Triangulation backend: {_triangulation_backend}<br>'
+
+    text += '<br><b>Settings path:</b><br>'
+    text += f'  - {_config_path}'
 
     if not as_html:
         text = (

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -214,8 +214,8 @@ def sys_info(as_html: bool = False) -> str:
     try:
         from napari.settings import get_settings
 
-        _async_setting = get_settings().experimental.async_
-        _autoswap_buffers = get_settings().experimental.autoswap_buffers
+        _async_setting = str(get_settings().experimental.async_)
+        _autoswap_buffers = str(get_settings().experimental.autoswap_buffers)
         _triangulation_backend = str(
             get_settings().experimental.triangulation_backend
         )
@@ -223,10 +223,10 @@ def sys_info(as_html: bool = False) -> str:
     except ValueError:
         from napari.utils._appdirs import user_config_dir
 
-        _async_setting = os.getenv('NAPARI_ASYNC', 'False')
-        _autoswap_buffers = os.getenv('NAPARI_AUTOSWAP', 'False')
-        _triangulation_backend = os.getenv(
-            'NAPARI_TRIANGULATION_BACKEND', 'Fastest available'
+        _async_setting = str(os.getenv('NAPARI_ASYNC', 'False'))
+        _autoswap_buffers = str(os.getenv('NAPARI_AUTOSWAP', 'False'))
+        _triangulation_backend = str(
+            os.getenv('NAPARI_TRIANGULATION_BACKEND', 'Fastest available')
         )
         _config_path = os.getenv('NAPARI_CONFIG', user_config_dir())
 


### PR DESCRIPTION
# References and relevant issues
closes: https://github.com/napari/napari/issues/7856

# Description

This PR ensures that napari --info will report the experimental settings: async, autoswap_buffers, and triangulation backend. (For the latter one I added a env var.)
This will help troubleshooting when folks post napari info.

Edit: I specifically don't include the other settings from Experimental because they arn't really experimental, they are settings for individual tools (lasso tool and labels polygon tool) that were put there for lack of better place. They probably belong in either Application or a new pane. Also, they don't affect napari behavior as a whole.