### PR TITLE
Do not expose vispy BaseColormaps

### DIFF
--- a/napari/layers/vectors/_tests/test_vectors.py
+++ b/napari/layers/vectors/_tests/test_vectors.py
@@ -116,7 +116,7 @@ def test_empty_layer_with_edge_colormap():
         data=data,
         property_choices=default_properties,
         edge_color='angle',
-        edge_colormap='grays',
+        edge_colormap='gray',
     )
 
     assert layer.edge_color_mode == 'colormap'

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -8,9 +8,9 @@ from typing import NamedTuple, Union
 import numpy as np
 import skimage.color as colorconv
 from vispy.color import (
-    BaseColormap as VispyColormap,
     Color,
     ColorArray,
+    Colormap as VispyColormap,
     get_colormap,
     get_colormaps,
 )
@@ -62,11 +62,11 @@ _MATPLOTLIB_COLORMAP_NAMES_REVERSE = {
     v: k for k, v in matplotlib_colormaps.items()
 }
 
-_VISPY_COLORMAPS_ORIGINAL = _VCO = get_colormaps()
 # some colormaps use BaseColormap and custom mapping functions instead of
 # standard colors/controls, so they are broken in napari
-for broken_colormap in ('grays', 'hot', 'ice'):
-    _VISPY_COLORMAPS_ORIGINAL.pop(broken_colormap)
+_VISPY_COLORMAPS_ORIGINAL = _VCO = {
+    k: v for k, v in get_colormaps().items() if isinstance(v, VispyColormap)
+}
 _VISPY_COLORMAPS_TRANSLATIONS = OrderedDict(
     autumn=(trans._p('colormap', 'autumn'), _VCO['autumn']),
     blues=(trans._p('colormap', 'blues'), _VCO['blues']),
@@ -75,11 +75,6 @@ _VISPY_COLORMAPS_TRANSLATIONS = OrderedDict(
     reds=(trans._p('colormap', 'reds'), _VCO['reds']),
     spring=(trans._p('colormap', 'spring'), _VCO['spring']),
     summer=(trans._p('colormap', 'summer'), _VCO['summer']),
-    fire=(trans._p('colormap', 'fire'), _VCO['fire']),
-    grays=(trans._p('colormap', 'grays'), _VCO['grays']),
-    hot=(trans._p('colormap', 'hot'), _VCO['hot']),
-    ice=(trans._p('colormap', 'ice'), _VCO['ice']),
-    winter=(trans._p('colormap', 'winter'), _VCO['winter']),
     light_blues=(trans._p('colormap', 'light blues'), _VCO['light_blues']),
     orange=(trans._p('colormap', 'orange'), _VCO['orange']),
     viridis=(trans._p('colormap', 'viridis'), _VCO['viridis']),
@@ -105,6 +100,7 @@ _PRIMARY_COLORS = OrderedDict(
     cyan=(trans._p('colormap', 'cyan'), [0.0, 1.0, 1.0]),
     magenta=(trans._p('colormap', 'magenta'), [1.0, 0.0, 1.0]),
     yellow=(trans._p('colormap', 'yellow'), [1.0, 1.0, 0.0]),
+    gray=(trans._p('colormap', 'gray'), [1.0, 1.0, 1.0]),
 )
 
 SIMPLE_COLORMAPS = {
@@ -114,16 +110,23 @@ SIMPLE_COLORMAPS = {
     for name, (display_name, color) in _PRIMARY_COLORS.items()
 }
 
-# add conventional grayscale colormap as a simple one
-SIMPLE_COLORMAPS.update(
-    {
-        'gray': Colormap(
-            name='gray',
-            display_name='gray',
-            colors=[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
-        )
-    }
-)
+# readd fire and ice colormap for backwards compatibility (see #7858)
+VISPY_OLD_COLORMAPS = {
+    'fire': Colormap(
+        name='fire',
+        display_name='fire',
+        colors=[
+            [1.0, 1.0, 1.0, 1.0],
+            [1.0, 1.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 1.0],
+        ],
+    ),
+    'ice': Colormap(
+        name='ice',
+        display_name='ice',
+        colors=[[0.0, 0.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]],
+    ),
+}
 
 # dictionary for bop colormap objects
 BOP_COLORMAPS = {
@@ -687,6 +690,7 @@ ALL_COLORMAPS = {
     k: vispy_or_mpl_colormap(k) for k in _MATPLOTLIB_COLORMAP_NAMES
 }
 ALL_COLORMAPS.update(SIMPLE_COLORMAPS)
+ALL_COLORMAPS.update(VISPY_OLD_COLORMAPS)
 ALL_COLORMAPS.update(BOP_COLORMAPS)
 ALL_COLORMAPS.update(INVERSE_COLORMAPS)
 

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -26,7 +26,7 @@ from napari.utils.colormaps.colormap import (
 )
 from napari.utils.colormaps.inverse_colormaps import inverse_cmaps
 from napari.utils.colormaps.standardize_color import transform_color
-from napari.utils.colormaps.vendored import cm
+from napari.utils.colormaps.vendored.cm import cmap_d
 from napari.utils.translations import trans
 
 # All parsable input color types that a user can provide
@@ -650,9 +650,9 @@ def vispy_or_mpl_colormap(name) -> Colormap:
         colormap = convert_vispy_colormap(cmap, name=name)
     else:
         try:
-            mpl_cmap = getattr(cm, name)
+            mpl_cmap = cmap_d[name]
             display_name = _MATPLOTLIB_COLORMAP_NAMES.get(name, name)
-        except AttributeError as e:
+        except KeyError as e:
             suggestion = _MATPLOTLIB_COLORMAP_NAMES_REVERSE.get(
                 name
             ) or _VISPY_COLORMAPS_TRANSLATIONS_REVERSE.get(name)
@@ -666,9 +666,7 @@ def vispy_or_mpl_colormap(name) -> Colormap:
                     )
                 ) from e
 
-            colormaps = set(_VISPY_COLORMAPS_ORIGINAL).union(
-                set(_MATPLOTLIB_COLORMAP_NAMES)
-            )
+            colormaps = set(_VISPY_COLORMAPS_ORIGINAL).union(set(cmap_d))
             raise KeyError(
                 trans._(
                     'Colormap "{name}" not found in either vispy or matplotlib. Recognized colormaps are: {colormaps}',

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -61,7 +61,12 @@ matplotlib_colormaps = _MATPLOTLIB_COLORMAP_NAMES = OrderedDict(
 _MATPLOTLIB_COLORMAP_NAMES_REVERSE = {
     v: k for k, v in matplotlib_colormaps.items()
 }
+
 _VISPY_COLORMAPS_ORIGINAL = _VCO = get_colormaps()
+# some colormaps use BaseColormap and custom mapping functions instead of
+# standard colors/controls, so they are broken in napari
+for broken_colormap in ('grays', 'hot', 'ice'):
+    _VISPY_COLORMAPS_ORIGINAL.pop(broken_colormap)
 _VISPY_COLORMAPS_TRANSLATIONS = OrderedDict(
     autumn=(trans._p('colormap', 'autumn'), _VCO['autumn']),
     blues=(trans._p('colormap', 'blues'), _VCO['blues']),

--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -209,20 +209,6 @@ def convert_vispy_colormap(colormap, name='vispy'):
             )
         )
 
-    # Not all vispy colormaps have an `_controls`
-    # but if they do, we want to use it
-    if hasattr(colormap, '_controls'):
-        controls = colormap._controls
-    else:
-        controls = np.zeros((0,))
-
-    # Not all vispy colormaps have an `interpolation`
-    # but if they do, we want to use it
-    if hasattr(colormap, 'interpolation'):
-        interpolation = colormap.interpolation
-    else:
-        interpolation = 'linear'
-
     if name in _VISPY_COLORMAPS_TRANSLATIONS:
         display_name, _cmap = _VISPY_COLORMAPS_TRANSLATIONS[name]
     else:
@@ -233,8 +219,8 @@ def convert_vispy_colormap(colormap, name='vispy'):
         name=name,
         display_name=display_name,
         colors=colormap.colors.rgba,
-        controls=controls,
-        interpolation=interpolation,
+        controls=colormap._controls,
+        interpolation=colormap.interpolation,
     )
 
 


### PR DESCRIPTION
# References and relevant issues
- fixes #7855

# Description
Some colormap from vispy are broken (see issue for explanation). This PR simply removes them from the available colormaps.

Updating them in vispy is another option, but I think it's worse because these colormaps have been in vispy a long time, and people might depend on their quirks. Also, `hot` is provided by matplotlib and `grays` is essentially a duplicate of matplotlib's `gray`, so we really only lose `ice`.

Note that #7846 additionally introduces a `HiLo` colormap, which also currently cannot be represented by our `Colormap` model. Support for that will need to be added in that PR.