### PR TITLE
Update napari-sphinx-theme constraint to 0.7.0

### DIFF
--- a/resources/constraints/constraints_py3.10_docs.txt
+++ b/resources/constraints/constraints_py3.10_docs.txt
@@ -268,7 +268,7 @@ napari-plugin-engine==0.2.0
     # via napari (pyproject.toml)
 napari-plugin-manager==0.1.4
     # via napari (pyproject.toml)
-napari-sphinx-theme==0.6.0
+napari-sphinx-theme==0.7.0
     # via napari (pyproject.toml)
 napari-svg==0.2.1
     # via napari (pyproject.toml)


### PR DESCRIPTION
# References and relevant issues

# Description
Updates napari-shinx-theme contraints to v0.7.0 which we just released. Critically, this new version uses the system default fonts instead of Barlow, due to concerns about legibility.


