### PR TITLE
Add multiplicative blending

### DIFF
--- a/napari/_vispy/utils/gl.py
+++ b/napari/_vispy/utils/gl.py
@@ -161,4 +161,11 @@ BLENDING_MODES = {
         'blend': True,
         'blend_equation': 'min',
     },
+    'multiplicative': {
+        'depth_test': False,
+        'cull_face': False,
+        'blend': True,
+        'blend_func': ('dst_color', 'zero', 'one', 'one'),
+        'blend_equation': 'func_add',
+    },
 }

--- a/napari/layers/base/_base_constants.py
+++ b/napari/layers/base/_base_constants.py
@@ -42,6 +42,7 @@ class Blending(StringEnum):
     ADDITIVE = auto()
     MINIMUM = auto()
     OPAQUE = auto()
+    MULTIPLICATIVE = auto()
 
 
 BLENDING_TRANSLATIONS = OrderedDict(
@@ -51,6 +52,7 @@ BLENDING_TRANSLATIONS = OrderedDict(
         (Blending.ADDITIVE, trans._('additive')),
         (Blending.MINIMUM, trans._('minimum')),
         (Blending.OPAQUE, trans._('opaque')),
+        (Blending.MULTIPLICATIVE, trans._('multiplicative')),
     ]
 )
 


### PR DESCRIPTION
# References and relevant issues
- discussed on zulip: https://napari.zulipchat.com/#narrow/channel/212875-general/topic/sparse.20probability.20.280-1.29.20on.20RGB.20.28WSI.29.3A.20how.20to.20visualize

# Description

Add multiplicative blending to our blending modes.

This can be useful in several scenarios, such as the example from the above discussion:

```py
import napari
import numpy as np
v = napari.Viewer()
v.open_sample('napari', 'astronaut')

gradient = np.arange(512 * 512).reshape(512, 512)
l = v.add_image(gradient, colormap='I Orange', blending='multiplicative')
```

![image](https://github.com/user-attachments/assets/27c721b6-7e98-475f-bda6-15ed31adb746)

