### PR TITLE
[Maint] Update dockerfile for napari 0.6.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/docker-publish.yml'
+      - 'dockerfile'
 
 #  schedule:
 #    - cron: '31 0 * * *'

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,11 @@
-FROM --platform=linux/amd64 ubuntu:22.04 AS napari
-# if you change the Ubuntu version, remember to update
+# official python 3.11 image
+# if you upgrade it, ensure you update the constraints file used
+FROM --platform=linux/amd64 python:3.11-slim-bookworm AS napari
+# if you change the distro version, remember to update
 # the APT definitions for Xpra below so it reflects the
-# new codename (e.g. 20.04 was focal, 22.04 had jammy)
+# new codename (e.g. bookworm)
 
-# below env var required to install libglib2.0-0 non-interactively
+# below env var required to install non-interactively
 ENV TZ=America/Los_Angeles
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NAPARI_COMMIT=main
@@ -12,20 +14,13 @@ ARG NAPARI_COMMIT=main
 RUN apt-get update && \
     apt-get install -qqy  \
         build-essential \
-        python3.9 \
-        python3-pip \
         git \
         mesa-utils \
-        x11-utils \
-        libegl1-mesa \
-        libopengl0 \
-        libgl1-mesa-glx \
-        libglib2.0-0 \
-        libfontconfig1 \
-        libxrender1 \
+        libglx-mesa0 \
+        # tlambert03/setup-qt-libs
+        libegl1 \
         libdbus-1-3 \
         libxkbcommon-x11-0 \
-        libxi6 \
         libxcb-icccm4 \
         libxcb-image0 \
         libxcb-keysyms1 \
@@ -34,13 +29,25 @@ RUN apt-get update && \
         libxcb-xinerama0 \
         libxcb-xinput0 \
         libxcb-xfixes0 \
+        x11-utils \
+        libxcb-cursor0 \
+        libopengl0 \
+        # other/remaining
+        libfontconfig1 \
+        libxrender1 \
+        libxi6 \
         libxcb-shape0 \
         && apt-get clean
 
 # install napari from repo
+# Grab the constraints file to use for the install
+# make sure it matches the base image python version!
+COPY resources/constraints/constraints_py3.11.txt /tmp/constraints_py3.11.txt
+
 # see https://github.com/pypa/pip/issues/6548#issuecomment-498615461 for syntax
 RUN pip install --upgrade pip && \
-    pip install "napari[all] @ git+https://github.com/napari/napari.git@${NAPARI_COMMIT}"
+    pip install "napari[all] @ git+https://github.com/napari/napari.git@${NAPARI_COMMIT}" \
+    -c /tmp/constraints_py3.11.txt
 
 # copy examples
 COPY examples /tmp/examples
@@ -56,10 +63,11 @@ FROM napari AS napari-xpra
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Xpra and dependencies
+# Remember to update the xpra.sources link for any change in distro version
 RUN apt-get update && apt-get install -y wget gnupg2 apt-transport-https \
     software-properties-common ca-certificates && \
     wget -O "/usr/share/keyrings/xpra.asc" https://xpra.org/xpra.asc && \
-    wget -O "/etc/apt/sources.list.d/xpra.sources" https://raw.githubusercontent.com/Xpra-org/xpra/master/packaging/repos/jammy/xpra.sources
+    wget -O "/etc/apt/sources.list.d/xpra.sources" https://raw.githubusercontent.com/Xpra-org/xpra/master/packaging/repos/bookworm/xpra.sources
 
 
 RUN apt-get update && \

--- a/dockerfile
+++ b/dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     apt-get install -qqy  \
         build-essential \
         git \
+        libglib2.0-0 \
         mesa-utils \
         libglx-mesa0 \
         # tlambert03/setup-qt-libs


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7847

# Description
This PR does the following:
1. uses the official Python 3.11 base image -- I had trouble with python 3.11 in Ubuntu 22.04 (only a release candidate is available). Ubuntu 24.04 has python 3.12, which I guess could be ok? but it had issues with pip/pipx and extra warnings from xpra. So I figured the official Python image was the easiest. Then when we want to update to 3.12 we just change the version at the top and we don't need to mess round with apt install changes.
3. Sorts the apt installs to match the Talley setup-qt-libs README, to make it easier to check that it's correct. Also updated the libegl1 and libglx-mesa0 installs. Not strictly needed yet, but will be for newer Linux distros, see: https://github.com/tlambert03/setup-qt-libs/issues/65  ~~Finally, I removed `libglib2.0-0` because it's not recommended to be installed anymore.~~
4. uses the constraints for the pip install to ensure the container is what passes tests.
5. I tried to get the workflow to fire when the Dockerfile is updated...

I tested locally and it build and ran correctly. Hopefully the workflow fires...
I will followup with some additional changes to the xpra part, but that's not needed for 0.6.0