### PR TITLE
Add bermuda and triangle to docs dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ docs = [
     "imageio-ffmpeg",
     "pydeps",
     "seedir",
+    # triangle and bermuda needed for docs/guides/triangulation.md
     "triangle",
     "bermuda>=0.1.4",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,8 @@ docs = [
     "imageio-ffmpeg",
     "pydeps",
     "seedir",
+    "triangle",
+    "bermuda>=0.1.4",
     "pytest",
     "linkify-it-py",
 ]


### PR DESCRIPTION
Needed for the triangulation guide added in napari/docs#688
