### PR TITLE
Compare slice_key array instead of value for use with 4+D data

### DIFF
--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -1365,7 +1365,10 @@ class ShapeList:
             return [
                 (i, s)
                 for i, s in enumerate(self.shapes)
-                if s.slice_key[0] <= slice_key <= s.slice_key[1]
+                if (
+                    np.all(s.slice_key[0] <= slice_key)
+                    and np.all(slice_key <= s.slice_key[1])
+                )
             ]
         return list(enumerate(self.shapes))
 

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -559,6 +559,14 @@ class ShapeList:
             self.__update_displayed_called += 1
             return
 
+        # if no shapes or empty slice key, display all shapes
+        # prevents broadcasting erors when slice_key is empty or when
+        # arrays have incompatible shaopes, such as self.slice_keys (3,2,2) -- 3 shapes in 2D
+        # but a displayed slice_key of (2,0), resulting in mismatched arrays
+        if len(self.shapes) == 0 or len(self.slice_key) == 0:
+            self._displayed = np.ones(len(self.shapes), dtype=bool)
+            return
+
         # The list slice key is repeated to check against both the min and
         # max values stored in the shapes slice key.
         slice_key = np.array([self.slice_key, self.slice_key])

--- a/napari/layers/shapes/_shape_list.py
+++ b/napari/layers/shapes/_shape_list.py
@@ -559,14 +559,6 @@ class ShapeList:
             self.__update_displayed_called += 1
             return
 
-        # if no shapes or empty slice key, display all shapes
-        # prevents broadcasting erors when slice_key is empty or when
-        # arrays have incompatible shaopes, such as self.slice_keys (3,2,2) -- 3 shapes in 2D
-        # but a displayed slice_key of (2,0), resulting in mismatched arrays
-        if len(self.shapes) == 0 or len(self.slice_key) == 0:
-            self._displayed = np.ones(len(self.shapes), dtype=bool)
-            return
-
         # The list slice key is repeated to check against both the min and
         # max values stored in the shapes slice key.
         slice_key = np.array([self.slice_key, self.slice_key])

--- a/napari/layers/shapes/_tests/test_shape_list.py
+++ b/napari/layers/shapes/_tests/test_shape_list.py
@@ -173,3 +173,61 @@ def test_inside():
     shape_list.add([shape1, shape2, shape3])
     shape_list.slice_key = (1,)
     assert shape_list.inside((0.5, 0.5)) == 1
+
+
+def test_visible_shapes_4d():
+    """Test _visible_shapes with 4D data like those from OME-Zarr/OMERO."""
+    shape1 = Polygon(
+        np.array(
+            [
+                [0, 0, 10, 10],
+                [0, 0, 10, 50],
+                [0, 0, 50, 50],
+                [0, 0, 50, 10],
+            ]
+        )
+    )
+    shape2 = Polygon(
+        np.array(
+            [
+                [0, 1, 10, 10],
+                [0, 1, 10, 50],
+                [0, 1, 50, 50],
+                [0, 1, 50, 10],
+            ]
+        )
+    )
+    shape3 = Polygon(
+        np.array(
+            [
+                [0, 0, 10, 10],
+                [0, 0, 10, 50],
+                [0, 1, 50, 50],
+                [0, 1, 50, 10],
+            ]
+        )
+    )
+
+    shape_list = ShapeList()
+    shape_list.add([shape1, shape2, shape3])
+
+    # initially, slice key is an empty array because self.slice_key is (3,2,2) and slice_key is (2,0)
+    assert shape_list.slice_key.size == 0  # check slice_key is empty array
+    visible = shape_list._visible_shapes
+    assert len(visible) == 3
+
+    # at (0,0) - should show shape1 and shape3
+    shape_list.slice_key = np.array([0, 0])
+    visible = shape_list._visible_shapes
+    assert len(visible) == 2
+    visible_shapes = [v[1] for v in visible]
+    assert shape1 in visible_shapes
+    assert shape3 in visible_shapes
+
+    # at (0,1) - should show shape2 and shape3
+    shape_list.slice_key = np.array([0, 1])
+    visible = shape_list._visible_shapes
+    assert len(visible) == 2
+    visible_shapes = [v[1] for v in visible]
+    assert shape2 in visible_shapes
+    assert shape3 in visible_shapes

--- a/napari/layers/shapes/_tests/test_shape_list.py
+++ b/napari/layers/shapes/_tests/test_shape_list.py
@@ -209,12 +209,9 @@ def test_visible_shapes_4d():
     )
 
     shape_list = ShapeList()
+    # set slice_key first to avoid empty array broadcasting error
+    shape_list.slice_key = np.array([0, 0])
     shape_list.add([shape1, shape2, shape3])
-
-    # initially, slice key is an empty array because self.slice_key is (3,2,2) and slice_key is (2,0)
-    assert shape_list.slice_key.size == 0  # check slice_key is empty array
-    visible = shape_list._visible_shapes
-    assert len(visible) == 3
 
     # at (0,0) - should show shape1 and shape3
     shape_list.slice_key = np.array([0, 0])


### PR DESCRIPTION
# References and relevant issues

Closes #7878 

# Description

Compare array rather than value because slice_key[n] is array when greater than 3D.

Peter summarizes the issue/fix, nicely (thanks! I was scrambling between things)

> I think this is correct based on poking around the slice_key code.
> slice_key stores values of the the non-displayed dims, so for 3D array, slice_key is just a single value array and the comparison is easy. But for 4D+, its multiple values, so need to do an array comparison


