### PR TITLE
Properly determine dtype for view of Labels

### DIFF
--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -177,21 +177,6 @@ def build_textures_from_dict(
     return data
 
 
-def _select_colormap_texture(
-    colormap: CyclicLabelColormap, view_dtype, raw_dtype
-) -> np.ndarray:
-    if raw_dtype.itemsize > 2:
-        color_texture = colormap._get_mapping_from_cache(view_dtype)
-    else:
-        color_texture = colormap._get_mapping_from_cache(raw_dtype)
-
-    if color_texture is None:
-        raise ValueError(  # pragma: no cover
-            f'Cannot build a texture for dtype {raw_dtype=} and {view_dtype=}'
-        )
-    return color_texture.reshape(256, -1, 4)
-
-
 class VispyLabelsLayer(VispyScalarFieldBaseLayer):
     layer: 'Labels'
 
@@ -251,9 +236,9 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
                 colormap.background_value = (
                     colormap._background_as_minimum_dtype(raw_dtype)
                 )
-            color_texture = _select_colormap_texture(
-                colormap, view_dtype, raw_dtype
-            )
+            color_texture = colormap._get_mapping_from_cache(
+                view_dtype
+            ).reshape(256, -1, 4)
             self.node.cmap = LabelVispyColormap(
                 colormap, view_dtype=view_dtype, raw_dtype=raw_dtype
             )

--- a/napari/_vispy/layers/labels.py
+++ b/napari/_vispy/layers/labels.py
@@ -177,6 +177,21 @@ def build_textures_from_dict(
     return data
 
 
+def _select_colormap_texture(
+    colormap: CyclicLabelColormap, view_dtype, raw_dtype
+) -> np.ndarray:
+    if raw_dtype.itemsize > 2:
+        color_texture = colormap._get_mapping_from_cache(view_dtype)
+    else:
+        color_texture = colormap._get_mapping_from_cache(raw_dtype)
+
+    if color_texture is None:
+        raise ValueError(  # pragma: no cover
+            f'Cannot build a texture for dtype {raw_dtype=} and {view_dtype=}'
+        )
+    return color_texture.reshape(256, -1, 4)
+
+
 class VispyLabelsLayer(VispyScalarFieldBaseLayer):
     layer: 'Labels'
 
@@ -236,9 +251,9 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
                 colormap.background_value = (
                     colormap._background_as_minimum_dtype(raw_dtype)
                 )
-            color_texture = colormap._get_mapping_from_cache(
-                view_dtype
-            ).reshape(256, -1, 4)
+            color_texture = _select_colormap_texture(
+                colormap, view_dtype, raw_dtype
+            )
             self.node.cmap = LabelVispyColormap(
                 colormap, view_dtype=view_dtype, raw_dtype=raw_dtype
             )

--- a/napari/layers/_scalar_field/scalar_field.py
+++ b/napari/layers/_scalar_field/scalar_field.py
@@ -289,7 +289,7 @@ class ScalarFieldBase(Layer, ABC):
         self._slice = _ImageSliceResponse.make_empty(
             slice_input=self._slice_input,
             rgb=len(self.data.shape) != self.ndim,
-            dtype=self.dtype,
+            dtype=self._slice_dtype(),
         )
 
         self._plane = SlicingPlane(thickness=1)
@@ -310,6 +310,10 @@ class ScalarFieldBase(Layer, ABC):
     def _post_init(self):
         # Trigger generation of view slice and thumbnail
         self.refresh()
+
+    def _slice_dtype(self):
+        """Return the dtype of the slice."""
+        return self.dtype
 
     @property
     def _data_view(self) -> np.ndarray:

--- a/napari/layers/_scalar_field/scalar_field.py
+++ b/napari/layers/_scalar_field/scalar_field.py
@@ -312,7 +312,11 @@ class ScalarFieldBase(Layer, ABC):
         self.refresh()
 
     def _slice_dtype(self):
-        """Return the dtype of the slice."""
+        """Return the dtype of the slice view.
+
+        Overridden in Labels subclass to properly handle the
+        32 and 64 bits dtypes.
+        """
         return self.dtype
 
     @property

--- a/napari/layers/image/_slice.py
+++ b/napari/layers/image/_slice.py
@@ -116,6 +116,7 @@ class _ImageSliceResponse:
             initialisation before attempting data loading.)
         dtype : np.dtype
             The dtype of the empty image slice.
+            Must match expected view dtype.
         """
         shape = (1,) * slice_input.ndisplay
         if rgb:

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1874,7 +1874,7 @@ def test_new_colormap_int8():
 
 
 @pytest.mark.parametrize('visible', [True, False])
-@pytest.mark.parametrize('dtype', [np.uint8, np.uint32, np.int64])
+@pytest.mark.parametrize('dtype', [np.uint8, np.int8, np.uint32, np.int64])
 def test_view_dtype(visible, dtype):
     layer = Labels(np.arange(25, dtype=dtype).reshape(5, 5), visible=visible)
     assert layer._slice.image.view.dtype == np.uint8

--- a/napari/layers/labels/_tests/test_labels.py
+++ b/napari/layers/labels/_tests/test_labels.py
@@ -1871,3 +1871,17 @@ def test_new_colormap_int8():
     data = np.arange(-128, 128, dtype=np.int8).reshape((16, 16))
     layer = Labels(data)
     layer.new_colormap(seed=0)
+
+
+@pytest.mark.parametrize('visible', [True, False])
+@pytest.mark.parametrize('dtype', [np.uint8, np.uint32, np.int64])
+def test_view_dtype(visible, dtype):
+    layer = Labels(np.arange(25, dtype=dtype).reshape(5, 5), visible=visible)
+    assert layer._slice.image.view.dtype == np.uint8
+
+
+@pytest.mark.parametrize('visible', [True, False])
+@pytest.mark.parametrize('dtype', [np.uint16, np.int16])
+def test_view_dtype_int16(visible, dtype):
+    layer = Labels(np.arange(25, dtype=dtype).reshape(5, 5), visible=visible)
+    assert layer._slice.image.view.dtype == np.uint16

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -411,6 +411,7 @@ class Labels(ScalarFieldBase):
         self._preserve_labels = False
 
     def _slice_dtype(self):
+        """Calculate dtype of data view based on data dtype and current colormap"""
         return self.colormap._data_to_texture(
             np.zeros(0, dtype=self.dtype)
         ).dtype

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -410,6 +410,11 @@ class Labels(ScalarFieldBase):
         self._status = self.mode
         self._preserve_labels = False
 
+    def _slice_dtype(self):
+        return self.colormap._data_to_texture(
+            np.zeros(0, dtype=self.dtype)
+        ).dtype
+
     def _post_init(self):
         self._reset_history()
         # Trigger generation of view slice and thumbnail

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -413,7 +413,7 @@ class Labels(ScalarFieldBase):
     def _slice_dtype(self):
         """Calculate dtype of data view based on data dtype and current colormap"""
         return self.colormap._data_to_texture(
-            np.zeros(0, dtype=self.dtype)
+            np.zeros(0, dtype=normalize_dtype(self.dtype))
         ).dtype
 
     def _post_init(self):


### PR DESCRIPTION
# References and relevant issues

closes #7880


# Description

As `make_empty` expects dtype of view, not raw, there is a need to calculate view dtype, not use raw one.  