### PR TITLE
Fix `test_view_menu.py::test_toggle_menubar` to pass locally

### DIFF
--- a/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -202,9 +202,11 @@ def test_toggle_menubar(make_napari_viewer, qtbot):
     app.commands.execute_command(action_id)
     assert not viewer.window._qt_window.menuBar().isVisible()
     assert viewer.window._qt_window._toggle_menubar_visibility
-
+    viewer.window._qt_window.move(0, 0)
+    qtbot.waitUntil(viewer.window._qt_window.isVisible)
     # Check menubar gets visible via mouse hovering over the window top area
-    qtbot.mouseMove(viewer.window._qt_window, pos=QPoint(10, 10))
+    qtbot.mouseMove(viewer.window._qt_window)
+    qtbot.wait(50)
     qtbot.mouseMove(viewer.window._qt_window, pos=QPoint(15, 15))
     qtbot.waitUntil(viewer.window._qt_window.menuBar().isVisible)
 


### PR DESCRIPTION
# References and relevant issues
Extracted from #7887

# Description

I have a problem, that when running a full test locally (with popups) the `test_toggle_menubar` always fails, that makes local testing annoying. 

As in #7887 I need to run tests multiple times I finally found what needs to be done to make it pass. 
