### PR TITLE
Add information about launch command to napari info dialog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
     attributes:
       label: "\U0001F30E Environment"
       description: |
-        Please provide detailed information regarding your environment. Please paste the output of `napari --info` here or copy  the information from the "napari info" dialog in the napari Help menu.
+        Please provide detailed information regarding your environment. Please paste the information from the "napari info" dialog in the napari Help menu or the output of `napari --info` here.
 
         Otherwise, please provide information regarding your operating system (OS), Python version, napari version, Qt backend and version, Qt platform, method of installation, and any other relevant information related to your environment.
 

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -96,6 +96,18 @@ def _napari_from_conda() -> bool:
     return any(napari_pattern.match(file.name) for file in napari_conda_files)
 
 
+def get_launch_commnad() -> str:
+    """Get the information how the program was launched.
+
+    Returns
+    -------
+    str
+        The command used to launch the program.
+    """
+
+    return ' '.join(sys.argv)
+
+
 def sys_info(as_html: bool = False) -> str:
     """Gathers relevant module versions for troubleshooting purposes.
 
@@ -237,6 +249,9 @@ def sys_info(as_html: bool = False) -> str:
 
     text += '<br><b>Settings path:</b><br>'
     text += f'  - {_config_path}'
+
+    text += '<br><b>Launch command</b><br>'
+    text += f'  - {get_launch_commnad()}<br>'
 
     if not as_html:
         text = (

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -96,7 +96,7 @@ def _napari_from_conda() -> bool:
     return any(napari_pattern.match(file.name) for file in napari_conda_files)
 
 
-def get_launch_commnad() -> str:
+def get_launch_command() -> str:
     """Get the information how the program was launched.
 
     Returns
@@ -251,7 +251,7 @@ def sys_info(as_html: bool = False) -> str:
     text += f'  - {_config_path}'
 
     text += '<br><b>Launch command</b><br>'
-    text += f'  - {get_launch_commnad()}<br>'
+    text += f'  - {get_launch_command()}<br>'
 
     if not as_html:
         text = (


### PR DESCRIPTION
# References and relevant issues


# Description

For better understanding of user bug report, add information about how napari was launched. 

Sample output, when napari launched from PartSeg 
![obraz](https://github.com/user-attachments/assets/0594b986-fd7a-4c46-83e6-81cde2b40666)
