### PR TITLE
Fix scalebar color toggle with theme change

### DIFF
--- a/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import numpy as np
+
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari.components.overlays import ScaleBarOverlay
 
@@ -66,3 +68,29 @@ def test_scale_bar_positioning(make_napari_viewer):
     # check that the line is not at the center,
     # but offset down due to the font size (40)
     assert scale_bar.node.line.pos[0, 1] == scale_bar.node.box.height / 2 - 18
+
+
+def test_scale_bar_theme_change(make_napari_viewer):
+    """Test that the scale bar color updates correctly when the theme changes."""
+    viewer = make_napari_viewer()
+    model = ScaleBarOverlay()
+    scale_bar = VispyScaleBarOverlay(overlay=model, viewer=viewer)
+    assert viewer.theme == 'dark'
+    scale_bar_color_dark_theme = np.array([1.0, 1.0, 1.0, 1.0])  # white
+    # Assert that the scale bar color is white in the dark theme
+    np.testing.assert_array_equal(
+        np.array(scale_bar.node.text.color)[0], scale_bar_color_dark_theme
+    )
+
+    viewer.theme = 'light'
+    scale_bar_color_light_theme = np.array([0.0, 0.0, 0.0, 1.0])  # black
+    # Assert that the scale bar color is black in the light theme
+    np.testing.assert_array_equal(
+        np.array(scale_bar.node.text.color)[0], scale_bar_color_light_theme
+    )
+
+    viewer.theme = 'dark'
+    # Assert that the scale bar color is white in the dark theme
+    np.testing.assert_array_equal(
+        np.array(scale_bar.node.text.color)[0], scale_bar_color_dark_theme
+    )

--- a/napari/_vispy/overlays/scale_bar.py
+++ b/napari/_vispy/overlays/scale_bar.py
@@ -152,16 +152,8 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
                 # set scale color negative of theme background.
                 # the reason for using the `as_hex` here is to avoid
                 # `UserWarning` which is emitted when RGB values are above 1
-                if (
-                    self.node.parent is not None
-                    and self.node.parent.canvas.bgcolor
-                ):
-                    background_color = self.node.parent.canvas.bgcolor.rgba
-                else:
-                    background_color = get_theme(
-                        self.viewer.theme
-                    ).canvas.as_hex()
-                    background_color = transform_color(background_color)[0]
+                background_color = get_theme(self.viewer.theme).canvas.as_hex()
+                background_color = transform_color(background_color)[0]
                 color = np.subtract(1, background_color)
                 color[-1] = background_color[-1]
 


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7895

# Description
As noted in the issue here https://github.com/napari/napari/issues/7895#issuecomment-2860677504 the canvas bgcolor and the scale_bar color are both hooked up to the theme.changed event.
This appeared to cause a race condition, where the `self.node.parent.canvas.bgcolor` would return a stale color when the scale_bar `_on_data_changed` was triggered.
So in this PR I remove the if/else and always query the actual theme to get the background color.

I also added a test for the theme change -> scale_bar color behavior. Oddly, this test passes on main. I guess when using the fixtures and CI the race outcome is different?
