### PR TITLE
Add information about installed plugins to info dialog

### DIFF
--- a/napari/__main__.py
+++ b/napari/__main__.py
@@ -23,14 +23,11 @@ from napari.utils.translations import trans
 class InfoAction(argparse.Action):
     def __call__(self, *args, **kwargs):
         # prevent unrelated INFO logs when doing "napari --info"
-        from npe2 import cli
 
         from napari.utils import sys_info
 
         logging.basicConfig(level=logging.WARNING)
         print(sys_info())  # noqa: T201
-        print('Plugins:')  # noqa: T201
-        cli.list(fields='', sort='0', format='compact')
         sys.exit()
 
 

--- a/napari/_tests/test_sys_info.py
+++ b/napari/_tests/test_sys_info.py
@@ -1,13 +1,18 @@
+import pytest
+
 from napari.utils.info import sys_info
 
 
 # vispy use_app tries to start Qt, which can cause segfaults when running
 # sys_info on CI unless we provide a pytest Qt app
-def test_sys_info(qapp):
+@pytest.mark.usefixtures('qapp')
+def test_sys_info():
     str_info = sys_info()
     assert isinstance(str_info, str)
     assert '<br>' not in str_info
     assert '<b>' not in str_info
+
+    assert 'Plugins' in str_info
 
     html_info = sys_info(as_html=True)
     assert isinstance(html_info, str)

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -109,7 +109,7 @@ def get_plugin_list() -> str:
 
         pm = PluginManager.instance()
         pm.discover(include_npe1=True)
-        pm.index_npe1_adapters()
+        pm.index_npe1_adapters()  # type: ignore[no-untyped-call]
         fields = [
             'name',
             'package_metadata.version',

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -129,7 +129,7 @@ def get_plugin_list() -> str:
                 f'  - {plugin["name"]} {plugin["package_metadata"]["version"]} ({count_contributions} contributions)'
             )
         return '<br>'.join(res) + '<br>'
-    except ImportError as e:
+    except ImportError as e:  # pragma: no cover
         return f'Failed to load plugin information: <br> {e}'
 
 

--- a/napari/utils/info.py
+++ b/napari/utils/info.py
@@ -138,7 +138,7 @@ def get_plugin_list() -> str:
                 if x is not None
             )
             res.append(
-                f'  - {plugin["name"]} {plugin["package_metadata"]["version"]} ({count_contributions} contributions)'
+                f'  - {plugin["name"]}: {plugin["package_metadata"]["version"]} ({count_contributions} contributions)'
             )
         return '<br>'.join(res) + '<br>'
     except ImportError as e:  # pragma: no cover
@@ -287,7 +287,7 @@ def sys_info(as_html: bool = False) -> str:
     text += '<br><b>Settings path:</b><br>'
     text += f'  - {_config_path}<br>'
 
-    text += '<br><b>Launch command</b><br>'
+    text += '<br><b>Launch command:</b><br>'
     text += f'  - {get_launch_command()}<br>'
 
     text += '<br><b>Plugins:</b><br>'


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/7897#discussion_r2078557546

# Description

This PR moves the plugin listing from `napari.__main__.py:InfoAction` into `napari.utils.info.sys_info` to make it visible also in the info dialog, not only in `napari --info`