### PR TITLE
Rename action by add missed word separator

### DIFF
--- a/napari/_app_model/actions/_view.py
+++ b/napari/_app_model/actions/_view.py
@@ -22,7 +22,7 @@ toggle_action_details = [
         'labels',
     ),
     (
-        'napari.window.view.toggle_viewer_axesdashed',
+        'napari.window.view.toggle_viewer_axes_dashed',
         trans._('Axes Dashed'),
         'axes',
         'dashed',


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/napari/pull/7885#discussion_r2085714242

# Description

The #7885 was merged too fast, and I was unable to apply suggestion from review.
