### PR TITLE
Prevent Shapes corruption when drawing tiny polygons with lasso

### DIFF
--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2650,15 +2650,16 @@ class Shapes(Layer):
                         epsilon=get_settings().experimental.rdp_epsilon,
                     )
                     if len(vertices) <= 3 and prev_vertices > 3:
-                        eps = get_settings().experimental.rdp_epsilon
-                        removed_vertices = prev_vertices - len(vertices)
                         show_warning(
                             trans._(
-                                'Polygon must have at least 3 vertices. With current rep epsilon value {eps},'
-                                ' the {removed_vertices} vertices were removed.',
-                                'Cannot create polygon.',
-                                eps=eps,
-                                removed_vertices=removed_vertices,
+                                'Polygons must have three or more vertices. '
+                                'Lasso polygons are simplified using an '
+                                'algorithm called RDP, which may cause '
+                                'polygons smaller than the RDP epsilon '
+                                'parameter to disappear entirely. If you are '
+                                'having trouble drawing small polygons, try '
+                                'reducing the value of napari > Settings > '
+                                'Experimental > RDP epsilon.'
                             ),
                         )
                 if len(vertices) <= 3:

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2642,18 +2642,17 @@ class Shapes(Layer):
                     self._data_view.edit(index, vertices[:-1])
             if self._mode in {Mode.ADD_POLYGON, Mode.ADD_POLYGON_LASSO}:
                 vertices = self._data_view.shapes[index].data
+                if self._mode == Mode.ADD_POLYGON_LASSO:
+                    vertices = rdp(
+                        vertices,
+                        epsilon=get_settings().experimental.rdp_epsilon,
+                    )
                 if len(vertices) <= 3:
                     self._data_view.remove(index)
                     # Clear selected data to prevent issues.
                     # See https://github.com/napari/napari/pull/6912#discussion_r1601169680
                     self.selected_data.clear()
-                elif self._mode == Mode.ADD_POLYGON:
-                    self._data_view.edit(index, vertices[:-1])
                 else:
-                    vertices = rdp(
-                        vertices,
-                        epsilon=get_settings().experimental.rdp_epsilon,
-                    )
                     self._data_view.edit(
                         index,
                         vertices[:-1],

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2654,13 +2654,12 @@ class Shapes(Layer):
                         show_warning(
                             trans._(
                                 'Polygons must have three or more vertices. '
-                                'Lasso polygons are simplified using an '
-                                'algorithm called RDP, which may cause '
-                                'polygons smaller than the RDP epsilon '
-                                'parameter to disappear entirely. If you are '
-                                'having trouble drawing small polygons, try '
-                                'reducing the value of napari > Settings > '
-                                'Experimental > RDP epsilon.'
+                                'Lasso polygons are simplified using the '
+                                'RDP algorithm, which may cause polygons '
+                                'smaller than RDP epsilon to disappear. If  '
+                                'you face issues drawing small polygons, '
+                                'try reducing napari > Settings > '
+                                'Experimental > RDP epsilon. '
                             ),
                         )
                 if len(vertices) <= 3:

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -2650,6 +2650,7 @@ class Shapes(Layer):
                         epsilon=get_settings().experimental.rdp_epsilon,
                     )
                     if len(vertices) <= 3 and prev_vertices > 3:
+                        # https://github.com/napari/napari/issues/7903
                         show_warning(
                             trans._(
                                 'Polygons must have three or more vertices. '


### PR DESCRIPTION
# References and relevant issues

Closes #7903

# Description

Fix bug in adding shapes, by first removing points based on epsilon, then checking if there are enough point to create a polygon. 