### PR TITLE
Better refresh extent on async slicing

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -598,12 +598,8 @@ class QtViewer(QSplitter):
                 # `set_data` notifies the corresponding vispy layer of the new
                 # slice.
                 layer.events.set_data()
-                layer._refresh_sync(
-                    data_displayed=True,
-                    thumbnail=True,
-                    highlight=True,
-                    extent=True,
-                )
+                layer._update_thumbnail()
+                layer._set_highlight(force=True)
 
     def _on_active_change(self):
         """When active layer changes change keymap handler."""

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1526,9 +1526,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             return
         logger.debug('Layer.refresh: %s', self)
         # If async is enabled then emit an event that the viewer should handle.
-        if get_settings().experimental.async_ and data_displayed:
-            # full async slice reload, it will also update everything when done slicing
-            # via the callback of layer.loaded which calls _refresh_sync
+        if get_settings().experimental.async_:
             self.events.reload(layer=self)
         # Otherwise, slice immediately on the calling thread.
         else:

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1527,7 +1527,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         logger.debug('Layer.refresh: %s', self)
         # If async is enabled then emit an event that the viewer should handle.
         if get_settings().experimental.async_:
-            self.events.reload(layer=self)
+            self._refresh_async(
+                data_displayed=data_displayed,
+                extent=extent,
+                force=force,
+            )
         # Otherwise, slice immediately on the calling thread.
         else:
             self._refresh_sync(
@@ -1560,6 +1564,22 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             self._update_thumbnail()
         if highlight:
             self._set_highlight(force=True)
+
+    def _refresh_async(
+        self,
+        *,
+        data_displayed: bool = False,
+        extent: bool = False,
+        force: bool = False,
+    ) -> None:
+        logger.debug('Layer._refresh_async: %s', self)
+        if not (self.visible or force):
+            return
+        if extent:
+            self._clear_extent()
+            self._clear_extent_augmented()
+        if data_displayed:
+            self.events.reload(layer=self)
 
     def world_to_data(self, position: npt.ArrayLike) -> npt.NDArray:
         """Convert from world coordinates to data coordinates.


### PR DESCRIPTION
This reverts commit 6cac059.# References and relevant issues

closes #5591

# Description

Just check if the extent cache needs to be invalidated and then do this. 
