### PR TITLE
Don't add widgets to non-contributable menus

### DIFF
--- a/napari/_qt/_qplugins/_qnpe2.py
+++ b/napari/_qt/_qplugins/_qnpe2.py
@@ -361,6 +361,8 @@ def _build_widgets_submenu_actions(
     mf: PluginManifest,
 ) -> tuple[list[tuple[str, SubmenuItem]], list[Action]]:
     """Build widget submenu and actions for a single npe2 plugin manifest."""
+    from napari._app_model.constants._menus import is_menu_contributable
+
     # If no widgets, return
     if not mf.contributions.widgets:
         return [], []
@@ -407,6 +409,7 @@ def _build_widgets_submenu_actions(
             ._command_menu_map[mf.name][widget.command]
             .items()
             for menu_item in menu_items
+            if is_menu_contributable(menu_key)
         ] + [
             {
                 'id': default_submenu_id,


### PR DESCRIPTION
# References and relevant issues
N/A

# Description
This PR makes sure that widgets can only be added to contributable menus, rather than any valid napari menu.

Context: In #7262 we tried adding the shapes measuring action to the layerlist context menu, but this didn't work because the menu is not contributable. However, in #7877 adding the features table widget to the layerlist context menu worked fine! This is because we were never filtering menus for widgets to only include the contributable ones, but the shapes measuring action is **not** a widget, just a plain command, and that gets handled in a separate function. This PR fixes that.


