### PR TITLE
Fix async refresh extent

### DIFF
--- a/napari/_qt/qt_viewer.py
+++ b/napari/_qt/qt_viewer.py
@@ -599,7 +599,7 @@ class QtViewer(QSplitter):
                 # slice.
                 layer.events.set_data()
                 layer._refresh_sync(
-                    data_displayed=True,
+                    data_displayed=False,
                     thumbnail=True,
                     highlight=True,
                     extent=True,


### PR DESCRIPTION
# References and relevant issues
- alternative to #7925
- I actually don't know if it fully handles #5591, the cache error might be a different one from what we're experiencing?
- TM: Closes #5591

# Description

Simply not passing `data_displayed` prevents the race/loop.
