### PR TITLE
Mark key events as handled when processed

### DIFF
--- a/napari/utils/key_bindings.py
+++ b/napari/utils/key_bindings.py
@@ -505,6 +505,7 @@ class KeymapHandler:
             return
 
         self.press_key(kb)
+        event.handled = True
 
     def on_key_release(self, event):
         """Called whenever key released in canvas.
@@ -521,3 +522,5 @@ class KeymapHandler:
             return
         kb = _vispy2appmodel(event)
         self.release_key(kb)
+
+        event.handled = True


### PR DESCRIPTION
# References and relevant issues
- closes #7923
- alternative to #7927

# Description
Marking events as handled prevents later callbacks from being called.
