### PR TITLE
Mark key events as handled when processed

### DIFF
--- a/napari/layers/utils/_tests/test_layer_utils.py
+++ b/napari/layers/utils/_tests/test_layer_utils.py
@@ -487,14 +487,16 @@ def test_register_label_attr_action(monkeypatch):
     def set_value_1(x):
         x.value = 1
 
-    handler.press_key('K')
+    assert handler.press_key('K')
+    assert not handler.press_key('L')
     assert foo.value == 1
-    handler.release_key('K')
+    assert handler.release_key('K')
+    assert not handler.release_key('L')
     assert foo.value == 1
 
     foo.value = 0
-    handler.press_key('K')
+    assert handler.press_key('K')
     assert foo.value == 1
     monkeypatch.setattr(time, 'time', lambda: 2)
-    handler.release_key('K')
+    assert handler.release_key('K')
     assert foo.value == 0


### PR DESCRIPTION
# References and relevant issues
- closes #7923
- alternative to #7927
- alternative to #7930

# Description

Check if there is defined keybind in app-model and if found, then mark event as handled to 
told vispy to mark Qt event as accepted to prevent Qt from propagating `QKeyEvent` to the parent Widget of canvas. 