### PR TITLE
Fix handle mouse events

### DIFF
--- a/examples/dev/overlays.py
+++ b/examples/dev/overlays.py
@@ -1,5 +1,6 @@
 import warnings
 
+import numpy as np
 from magicgui import magicgui
 from vispy.scene.visuals import Ellipse
 
@@ -74,7 +75,7 @@ overlay_to_visual[DotOverlay] = VispyDotOverlay
 viewer = napari.Viewer()
 # we also need to add at least a layer to see any overlay,
 # since the canvas is otherwise covered by the welcome widget
-viewer.add_shapes()
+viewer.add_image(np.random.rand(10, 10))
 
 # note that we're accessing private attributes externally, which triggers a bunch of warnings.
 # suppress them for the purpose of this example
@@ -86,23 +87,44 @@ with warnings.catch_warnings():
     # manually trigger the generation of the visual
     viewer.window._qt_viewer.canvas._add_overlay_to_visual(viewer._overlays['dot'])
 
+
 # let's make a simple widget to control the overlay
 @magicgui(
     auto_call=True,
     color={'choices': ['red', 'blue', 'green', 'magenta']},
-    size={'widget_type': 'Slider', 'min': 1, 'max': 100}
 )
-def control_dot(viewer: napari.Viewer, color='red', size=20, position: CanvasPosition = 'top_left'):
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        dot = viewer._overlays['dot']
-        dot.color = color
-        dot.size = size
-        dot.position = position
+def control_dot(viewer: napari.Viewer, color='red', position: CanvasPosition = 'top_left'):
+    dot = viewer._overlays['dot']
+    dot.color = color
+    dot.position = position
+
 
 viewer.window.add_dock_widget(control_dot)
-control_dot()
 
+
+# and let's also add a mouse callback to do something when dragging the mouse
+def change_size(viewer, event):
+    pos = np.array(event.pos)
+    size = viewer._overlays['dot'].size
+
+    # use event.handled to tell vispy to not drag the canvas
+    event.handled = True
+
+    yield
+
+    while event.type == 'mouse_move':
+        new_pos = event.pos
+        drag = new_pos[0] - pos[0]
+
+        viewer._overlays['dot'].size = size + drag
+        yield
+
+
+viewer.mouse_drag_callbacks.append(change_size)
 
 if __name__ == '__main__':
-    napari.run()
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+
+        control_dot()
+        napari.run()

--- a/napari/_vispy/canvas.py
+++ b/napari/_vispy/canvas.py
@@ -413,6 +413,8 @@ class VispyCanvas:
         if layer is not None:
             mouse_callbacks(layer, read_only_event)
 
+        event.handled = napari_event.handled
+
     def _on_mouse_double_click(self, event: MouseEvent) -> None:
         """Called whenever a mouse double-click happen on the canvas
 


### PR DESCRIPTION
# References and relevant issues
- fix #7931
- updates the overlay dev example to showcase how to use `event.handled`

# Description
Boy this was a rabbithole! In the end the solution was simple, but debugging was confusing. It turns out, we never transfered the `handled` attribute from our napari events to the vispy events, so vispy happily continued to call the callbacks.

You might think: but wait, doesn't our points callback for `add` use `handled`? And that works!

https://github.com/napari/napari/blob/c6c71329431b942a8e9379acc7cebda741640465/napari/layers/points/_points_mouse_bindings.py#L123-L134

Well... it doesn't actually work, somehow we thought it did xD

So great, this PR fixes it right? Well, actually not quite, cause even after the fix, there's a second issue, caused by the fact that we throttle canvas mouse move callbacks on the napari side:

https://github.com/napari/napari/blob/c6c71329431b942a8e9379acc7cebda741640465/napari/_vispy/canvas.py#L153-L155

However, only napari callbacks are throttled, not vispy ones... this, combined with the fact that our `add()` callback only declares the event as handled *in the while loop*, means that if you move your mouse fast enough, you'll still be able to move the canvas. You can test this by setting the drag threshold to a much higher number (like 1000) here:

https://github.com/napari/napari/blob/c6c71329431b942a8e9379acc7cebda741640465/napari/layers/points/_points_mouse_bindings.py#L120

This should make it impossible to ever drag the canvas in add mode, but if you move the mouse fast enough it still works.

So I thought: let's mark the event as `handled` before the first `yield`, and then set `handled = False` if the threshold is surpassed. However, this doesn't work, because if the first event is `handled` then the vispy camera never begins its drag callback, and will never restart it again. Also, we cannot change the `event.type` halfway through the callbacks, so that's also out of discussion.

----

So, in conclusion:

- this PR fixes the general issue of `event.handled` being ignored by vispy (fixes #7931)
- I have currently have no real solution for our points `add` event. However, it should be fine unless a user tries to add a point while making micromovements at super high speed :P