### PR TITLE
Fix broken dims order popup and add to 3D

### DIFF
--- a/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
+++ b/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
@@ -18,6 +18,12 @@ def test_dims_sorter(qtbot):
     assert tuple(dim_sorter.axis_list) == ('x', 'y')
     assert tuple(dims.order) == (1, 0)
 
+    dims.order = (0, 1)
+    assert tuple(dim_sorter.axis_list) == (0, 1)
+    dim_sorter.axis_list.move(1, 0)
+    assert tuple(dim_sorter.axis_list) == (1, 0)
+    assert tuple(dims.order) == (1, 0)
+
 
 def test_dims_sorter_callback_management(qtbot):
     dims = Dims()
@@ -28,6 +34,11 @@ def test_dims_sorter_callback_management(qtbot):
 
     # assert callback hook up
     assert len(dims.events.order.callbacks) == base_callback_count + 1
+    assert len(dim_sorter.axis_list.events.reordered.callbacks) == 2
+
+    # Change dims order to trigger axis_list recreation
+    # then test that a fresh callback is added
+    dims.order = (1, 0)
     assert len(dim_sorter.axis_list.events.reordered.callbacks) == 2
 
 

--- a/napari/_qt/widgets/qt_dims_sorter.py
+++ b/napari/_qt/widgets/qt_dims_sorter.py
@@ -85,3 +85,6 @@ class QtDimsSorter(QWidget):
         # Regenerate AxisList upon Dims side order changes for easy cleanup
         self.axis_list = AxisList.from_dims(self.dims)
         self.view.setRoot(self.axis_list)
+        self.axis_list.events.reordered.connect(
+            self._axis_list_reorder_callback,
+        )

--- a/napari/_qt/widgets/qt_dims_sorter.py
+++ b/napari/_qt/widgets/qt_dims_sorter.py
@@ -60,7 +60,9 @@ class QtDimsSorter(QWidget):
         widget_tooltip.setObjectName('help_label')
         widget_tooltip.setToolTip(
             trans._(
-                'Drag dimensions to reorder, click lock icon to lock dimension in place.'
+                'Drag dimensions to reorder.'
+                '\nDouble-click to edit axis label.'
+                '\nClick lock icon to lock dimension in place.'
             )
         )
 

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -534,10 +534,6 @@ class QtViewerButtons(QFrame):
 
     def _open_roll_popup(self):
         """Open a grid popup to manually order the dimensions"""
-        if self.viewer.dims.ndisplay != 2:
-            return
-
-        # popup
         pop = QtPopup(self)
 
         # dims sorter widget


### PR DESCRIPTION
# References and relevant issues

Closes #7916
Fixes https://github.com/napari/napari/pull/7928#pullrequestreview-2845668364
Based on discussion in #7928 

# Description

1. Adds dim slider popup to 3D
2. Properly connects events to new axis list created whens dims are reorder -- this fixes the currently broken behavior
3. Updates dims button help text to hint at renaming possibility.
4. Adds tests that fail on main (due to it being broken) that pass properly with this PR

![python_NhhdFfnirX](https://github.com/user-attachments/assets/bbbe7c18-b26c-4750-85fe-4350b47345e9)



