### PR TITLE
Add link layers button to Layer List widget

### DIFF
--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -84,6 +84,11 @@ class QtLayerButtons(QFrame):
             'delete_button', action='napari:delete_selected_layers'
         )
 
+        self.linkLayersButton = QtViewerPushButton(
+            'link_layers_button',
+            action='napari:link_selected_layers',
+        )
+
         self.newPointsButton = QtViewerPushButton(
             'new_points',
             trans._('New points layer'),
@@ -107,6 +112,7 @@ class QtLayerButtons(QFrame):
         layout.addWidget(self.newShapesButton)
         layout.addWidget(self.newLabelsButton)
         layout.addStretch(0)
+        layout.addWidget(self.linkLayersButton)
         layout.addWidget(self.deleteButton)
         self.setLayout(layout)
 

--- a/napari/components/_viewer_key_bindings.py
+++ b/napari/components/_viewer_key_bindings.py
@@ -6,6 +6,7 @@ import numpy as np
 from app_model.types import KeyCode, KeyMod
 
 from napari.components.viewer_model import ViewerModel
+from napari.layers.utils._link_layers import layer_is_linked
 from napari.utils.action_manager import action_manager
 from napari.utils.notifications import show_info
 from napari.utils.theme import available_themes, get_system_theme
@@ -98,6 +99,18 @@ def reset_view(viewer: Viewer):
 @register_viewer_action(trans._('Delete selected layers'))
 def delete_selected_layers(viewer: Viewer):
     viewer.layers.remove_selected()
+
+
+@register_viewer_action(trans._('Link/Unlink selected layers'))
+def link_selected_layers(viewer: Viewer):
+    """Link/Unlink selected layers"""
+    layers = viewer.layers.selection
+    if len(layers) < 2:
+        return
+    if all(layer_is_linked(layer) for layer in layers):
+        viewer.layers.unlink_layers(layers)
+    else:
+        viewer.layers.link_layers(layers)
 
 
 @register_viewer_action(


### PR DESCRIPTION
# References and relevant issues

Hmm, lots of issues, but most recently reminded by #7935 

# Description

This shows minimal functionality for linking/unlinking layers in the layer list with a button. The purpose of this is to increase discoverability of this very useful feature, and because its relevant for every layer type, it would be nice if it lived somewhere easy to get to. (I also have no idea if this is supposed to be a viewer action or app_model thing, I'm kind of lost on that point...)

If this is liked, then I will polish it up, but don't want to spend time if this feature is not desired. 

![python_vQMLVAOMs3](https://github.com/user-attachments/assets/c80fb3af-5cd9-4ea6-8b57-e4c0b7a6df80)


