### PR TITLE
fix vendored script and trigger workflow on pull_request

### DIFF
--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -28,6 +28,10 @@ jobs:
         run: echo "vendored=$(cat 'tools/vendored_modules.txt')" >> "$GITHUB_OUTPUT"
         shell: bash
 
+      - name: git diff
+        run: |
+          git diff 
+
       - name: Create PR updating vendored modules
         uses: peter-evans/create-pull-request@v7
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   vendor:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Vendored
     runs-on: ubuntu-latest
     steps:
@@ -47,7 +50,7 @@ jobs:
             action cron to keep vendored modules up to date.
 
             It look like ${{ steps.check_v.outputs.vendored }} has a new version.
-          token: ${{ secrets.GHA_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           author: napari-bot <napari-bot@users.noreply.github.com>
           # Token permissions required by the action:
           # * pull requests: write and read

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 2 * * *'
+  pull_request:
+    paths:
+      - '.github/workflows/test_vendored.yml'
 
 jobs:
   vendor:

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test_vendored.yml'
+      - 'tools/check_vendored_modules.py'
 
 jobs:
   vendor:

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -30,9 +30,11 @@ jobs:
 
       - name: Create PR updating vendored modules
         uses: peter-evans/create-pull-request@v7
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         with:
           commit-message: Update vendored modules.
           branch: update-vendored-examples
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
           delete-branch: true
           title: "[Automatic] Update ${{ steps.check_v.outputs.vendored }} vendored module"
           labels: maintenance

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # Allow running on-demand
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 2 * * *'
+    - cron:  '0 2 * * 1'    # Mondays, 2AM
   pull_request:
     paths:
       - '.github/workflows/test_vendored.yml'

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           commit-message: Update vendored modules.
           branch: update-vendored-examples
-          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
           delete-branch: true
           title: "[Automatic] Update ${{ steps.check_v.outputs.vendored }} vendored module"
           labels: maintenance

--- a/tools/check_vendored_modules.py
+++ b/tools/check_vendored_modules.py
@@ -67,7 +67,7 @@ def check_vendored_module(org: str, reponame: str, tag: str) -> str:
     """
     repo_path = _clone(org, reponame, tag)
 
-    vendor_path = REPO_ROOT_PATH / NAPARI_FOLDER / VENDOR_FOLDER / reponame
+    vendor_path = REPO_ROOT_PATH / 'src' / NAPARI_FOLDER / VENDOR_FOLDER / reponame
     if vendor_path.is_dir():
         shutil.rmtree(vendor_path)
 

--- a/tools/check_vendored_modules.py
+++ b/tools/check_vendored_modules.py
@@ -40,7 +40,7 @@ def check_vendored_files(
     org: str, reponame: str, tag: str, source_paths: List[Path], target_path: Path
 ) -> str:
     repo_path = _clone(org, reponame, tag)
-    vendor_path = REPO_ROOT_PATH / NAPARI_FOLDER / target_path
+    vendor_path = REPO_ROOT_PATH / 'src' / NAPARI_FOLDER / target_path
     for s in source_paths:
         shutil.copy(repo_path / s, vendor_path)
     return check_output(["git", "diff"], cwd=vendor_path).decode("utf-8")


### PR DESCRIPTION
# References and relevant issues

extracted from #7966

# Description

Fix path in `tools/check_vendored_modules.py` and trigger `.github/workflows/test_vendored.yml` on edit related files 
