### PR TITLE
Remove `layers_change` event that is marked to be removed in 0.5.0

### DIFF
--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -258,6 +258,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         )
         settings.experimental.events.async_.connect(self._update_async)
 
+        # Add extra reset_view event. Ideally this should be removed in the
+        # future.
+        self.events.add(reset_view=Event)
+
         # Connect events
         self.grid.events.connect(self.fit_to_view)
         self.grid.events.connect(self._on_grid_change)

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -84,7 +84,6 @@ from napari.utils.events import (
     EventedModel,
     disconnect_events,
 )
-from napari.utils.events.event import WarningEmitter
 from napari.utils.key_bindings import KeymapProvider
 from napari.utils.misc import ensure_list_of_layer_data_tuple, is_sequence
 from napari.utils.mouse_bindings import MousemapProvider
@@ -258,18 +257,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self._update_viewer_grid
         )
         settings.experimental.events.async_.connect(self._update_async)
-
-        # Add extra events - ideally these will be removed too!
-        self.events.add(
-            layers_change=WarningEmitter(
-                trans._(
-                    'This event will be removed in 0.5.0. Please use viewer.layers.events instead',
-                    deferred=True,
-                ),
-                type_name='layers_change',
-            ),
-            reset_view=Event,
-        )
 
         # Connect events
         self.grid.events.connect(self.fit_to_view)
@@ -688,7 +675,6 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             self.cursor.position = tuple(
                 list(self.cursor.position) + [0] * dim_diff
             )
-        self.events.layers_change()
 
     def _update_mouse_pan(self, event):
         """Set the viewer interactive mouse panning"""


### PR DESCRIPTION
When working on #7889 I found this deprecated (warning) event, that should have been removed long ago. 