### PR TITLE
[Points] Fix events.data_indices for ActionType.ADDED event when adding single point

### DIFF
--- a/src/napari/layers/points/_tests/test_points.py
+++ b/src/napari/layers/points/_tests/test_points.py
@@ -1178,7 +1178,18 @@ def test_add_colormap(attribute):
 
 
 @pytest.mark.parametrize('attribute', ['border', 'face'])
-def test_add_points_direct(attribute: str):
+@pytest.mark.parametrize(
+    ('coords', 'expected_indices', 'expected_colors'),
+    [
+        # single point
+        ([18, 18], (-1,), [[1, 0, 0, 1]]),
+        # multiple points
+        ([[18, 18], [18, 18]], (-2, -1), [[1, 0, 0, 1], [1, 0, 0, 1]]),
+    ],
+)
+def test_add_points_direct(
+    attribute: str, coords, expected_indices, expected_colors
+):
     """Test adding points to layer directly"""
     layer = Points()
     old_data = layer.data
@@ -1186,7 +1197,7 @@ def test_add_points_direct(attribute: str):
 
     layer.events.data = Mock()
     setattr(layer, f'current_{attribute}_color', 'red')
-    coords = [[18, 18], [18, 18]]
+    coords = coords
 
     layer.add(coords)
     assert layer.events.data.call_args_list[0][1] == {
@@ -1198,11 +1209,11 @@ def test_add_points_direct(attribute: str):
     assert layer.events.data.call_args[1] == {
         'value': layer.data,
         'action': ActionType.ADDED,
-        'data_indices': (-2, -1),
+        'data_indices': expected_indices,
         'vertex_indices': ((),),
     }
     np.testing.assert_allclose(
-        [[1, 0, 0, 1], [1, 0, 0, 1]], getattr(layer, f'{attribute}_color')
+        expected_colors, getattr(layer, f'{attribute}_color')
     )
 
 

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -2005,7 +2005,7 @@ class Points(Layer):
         self.events.data(
             value=self.data,
             action=ActionType.ADDED,
-            data_indices=tuple(np.arange(-len(coords), 0)),
+            data_indices=tuple(np.arange(-len(np.atleast_2d(coords)), 0)),
             vertex_indices=((),),
         )
         self.selected_data = set(np.arange(cur_points, len(self.data)))


### PR DESCRIPTION
# Description

(Bugfix) Events for adding/removing points have a data_indices property. This works as expected for ActionType.REMOVING, .REMOVED, and .ADDING.

For ActionType.ADDED, however, a bug occured when only a single point is added (which is the standard case in the GUI). The intention in the original code was to query the number of points via len(coords), but this does not produce the desired result when the coords variable is just a one-dimensional point.

The same np.atleast_2d function that I utilised for the fix was already used in _set_data a few lines above; I hope this fix is trivial enough to pass without test case.

## Edit: additional info

*Copied by @jni from @psobolewskiPhD's comments ([1][1], [2][2]) below.*

For anyone wanting a bit more details, for a single point, `coords` is e.g. `[18, 18]` but for multiple, it's e.g. `[[18, 18], [18, 18]]`. So for the single point case, the `len` returns the number of axes, rather than the number of points, so the `data_indexes` ends up being a e.g. (-2, -1), rather than (-1,). For multiple points it works fine of course. So the fix here is absolutely correct.

I looked at our tests and lo and behold, we *only* test the multiple point case, which is why this bug sailed through tests:
https://github.com/napari/napari/blob/18b263bb73eb2e87938a3f0e9af9e65d2d9ab6a5/src/napari/layers/points/_tests/test_points.py#L1189

[…]

I parameterized test_add_points_direct to also check adding a single point.
This fails on main but is fixed by this PR.

[1]: https://github.com/napari/napari/pull/7983#issuecomment-2927268669
[2]: https://github.com/napari/napari/pull/7983#pullrequestreview-2885768453