### PR TITLE
[maintenance] Use Wandalen/wretry.action to auto-retry fail in --pre tests

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -73,9 +73,11 @@ jobs:
         uses: Wandalen/wretry.action@v3
         with:
           attempt_limit: 2
+          attempt_delay: 30000 # 30s
+          retry_condition: github.ref_name == 'main'  # avoid restart in PR
           action: aganders3/headless-gui@v2
           with: |
-            run: python -m tox -v --pre
+            run: python -m tox -v --pre  --recreate
         env:
           PLATFORM: ${{ matrix.platform }}
           BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -70,7 +70,7 @@ jobs:
           pip install setuptools tox tox-gh-actions
 
       - name: Test with tox (with retry)
-        uses: Wandalen/wretry.action@master
+        uses: Wandalen/wretry.action@v3
         with:
           attempt_limit: 2
           action: aganders3/headless-gui@v2

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -69,11 +69,13 @@ jobs:
           pip install --upgrade pip
           pip install setuptools tox tox-gh-actions
 
-      - name: Test with tox
-        # run tests using pip install --pre
-        uses: aganders3/headless-gui@v2
+      - name: Test with tox (with retry)
+        uses: Wandalen/wretry.action@master
         with:
-          run: python -m tox -v --pre
+          attempt_limit: 2
+          action: aganders3/headless-gui@v2
+          with: |
+            run: python -m tox -v --pre
         env:
           PLATFORM: ${{ matrix.platform }}
           BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   test:
     name: ${{ matrix.platform }} py${{ matrix.python }} ${{ matrix.backend }} --pre
-    timeout-minutes: 40
+    timeout-minutes: 60
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7978

Our prerelease testing seems particularly sensitive to flaky tests, so the issue is opened frequently which is then resolved by rerunning CI. Grzegorz noted that the frequency needs to be high because some packages have very short pre-release windows (https://github.com/napari/napari/pull/7803#issuecomment-2923000305)

# Description
This PR attempts to implement auto-rerunning of failed jobs for pre-release tests. The idea being that typically rerunning a flaky test resolves the issue, so let's bake that into the workflow 🤣
The wretry.action has a lot of other configurable settings we could use, but a simple, retry once on fail seems like a good start.