### PR TITLE
[Shapes] Use the plural methods to update colors of all selected shapes at once

### DIFF
--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -904,8 +904,10 @@ class Shapes(Layer):
     def current_edge_color(self, edge_color):
         self._current_edge_color = transform_color(edge_color)
         if self._update_properties:
-            for i in self.selected_data:
-                self._data_view.update_edge_color(i, self._current_edge_color)
+            indices = np.fromiter(self.selected_data, dtype=int)
+            self._data_view.update_edge_colors(
+                indices, self._current_edge_color
+            )
             self.events.edge_color()
             self._update_thumbnail()
         self.events.current_edge_color()
@@ -920,8 +922,10 @@ class Shapes(Layer):
     def current_face_color(self, face_color):
         self._current_face_color = transform_color(face_color)
         if self._update_properties:
-            for i in self.selected_data:
-                self._data_view.update_face_color(i, self._current_face_color)
+            indices = np.fromiter(self.selected_data, dtype=int)
+            self._data_view.update_face_colors(
+                indices, self._current_face_color
+            )
             self.events.face_color()
             self._update_thumbnail()
         self.events.current_face_color()


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/7945

# Description
As noted here by Grzegorz: https://github.com/napari/napari/issues/7945#issuecomment-2889889537
on main there is a loop over every shape setting the color.
This switches from using the for loop over selected_data to using the already existing two plural methods added in #3867 
Interestingly, as far as I can tell they haven't been used anywhere?

Using this script (also based on #3867 ):
```
import napari
import numpy as np

NUM_SHAPES=150_000
TYPE='polygon'

def create_sample_coords(n_shapes=5_000, n_rays=32):
    radius = 500/np.sqrt(n_shapes)
    center = np.random.uniform(0,1000,(n_shapes,2))
    phi = np.linspace(0,2*np.pi,n_rays)
    rays = np.stack([np.sin(phi), np.cos(phi)],axis=1)
    rays = rays.reshape((1,-1,2))
    rays = rays*np.random.uniform(.9,1.1, (n_shapes,n_rays,2))
    center = center.reshape((-1,1,2))
    coords = center + radius*rays
    return coords

coords = create_sample_coords(NUM_SHAPES)

viewer = napari.Viewer()
kwargs = dict(shape_type=TYPE,edge_color="coral")

layer = napari.layers.Shapes(coords,**kwargs)
viewer.add_layer(layer)
layer.mode = 'select'

napari.run()
```

Press `a` to select all shapes (this will take a moment), then use the GUI to change the face or edge color.
With this PR, for me this takes ~5-6s from the moment I press OK to the color update on screen. On main, after >2 min of freeze, I kill napari.

I looked at edge_widths too, but that one is different, because it's stored per-shape and returned as a list comprehension, rather than being an array, like the colors. So that would require a refactor first?