### PR TITLE
Update pyproject.toml to fix coverage paths (alt)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -858,7 +858,7 @@ source = [
 ]
 builtins = [
     "src/napari_builtins/",
-    "src/**/napari_builtins/",
+    "**/src/napari_builtins/",
     "**/.tox/*/lib/python*/site-packages/napari_builtins/",
     "**\\.tox\\*\\Lib\\site-packages\\napari_builtins",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -852,25 +852,13 @@ source = [
 [tool.coverage.paths]
 source = [
     "src/napari/",
-    "napari/",
-    ".tox/*/lib/python*/site-packages/napari/",
-    "/tmp/.tox/*/lib/python*/site-packages/napari/",
-    ".tox/*/Lib/site-packages/napari/",
-    "D:\\a\\napari\\napari\\src\\napari",
-    "D:\\a\\napari\\napari\\.tox\\*\\Lib\\site-packages\\napari",
-    "/home/runner/work/napari/napari/src/napari",
-    "/Users/runner/work/napari/napari/src/napari",
+    "**/.tox/*/lib/python*/site-packages/napari/",
+    "**\\.tox\\*\\Lib\\site-packages\\napari",
 ]
 builtins = [
     "src/napari_builtins/",
-    "napari_builtins/",
-    ".tox/*/lib/python*/site-packages/napari_builtins/",
-    "/tmp/.tox/*/lib/python*/site-packages/napari_builtins/",
-    ".tox/*/Lib/site-packages/napari_builtins/",
-    "D:\\a\\napari\\napari\\src\\napari_builtins",
-    "D:\\a\\napari\\napari\\.tox\\*\\Lib\\site-packages\\napari_builtins",
-    "/home/runner/work/napari/napari/src/napari_builtins",
-    "/Users/runner/work/napari/napari/src/napari_builtins",
+    "**/.tox/*/lib/python*/site-packages/napari_builtins/",
+    "**\\.tox\\*\\Lib\\site-packages\\napari_builtins",
 ]
 
 [tool.importlinter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -852,11 +852,13 @@ source = [
 [tool.coverage.paths]
 source = [
     "src/napari/",
+    "**/src/napari/",
     "**/.tox/*/lib/python*/site-packages/napari/",
     "**\\.tox\\*\\Lib\\site-packages\\napari",
 ]
 builtins = [
     "src/napari_builtins/",
+    "src/**/napari_builtins/",
     "**/.tox/*/lib/python*/site-packages/napari_builtins/",
     "**\\.tox\\*\\Lib\\site-packages\\napari_builtins",
 ]


### PR DESCRIPTION
# References and relevant issues

alternative to first part of #7992
closes #7961

# Description

Modify path to use `**` in pattern matching to accept possible localization of tox virtualenv. 
