### PR TITLE
Allow to use ViewerModel as annotation of plugin constructor argument

### DIFF
--- a/src/napari/_qt/_qplugins/_qnpe2.py
+++ b/src/napari/_qt/_qplugins/_qnpe2.py
@@ -33,7 +33,7 @@ from napari.plugins import menu_item_template, plugin_manager
 from napari.plugins._npe2 import _when_group_order, get_widget_contribution
 from napari.utils.events import Event
 from napari.utils.translations import trans
-from napari.viewer import Viewer
+from napari.viewer import Viewer, ViewerModel
 
 if TYPE_CHECKING:
     from npe2.manifest import PluginManifest
@@ -297,6 +297,10 @@ def _get_widget_viewer_param(
                 if param.name == 'napari_viewer' or param.annotation in (
                     'napari.viewer.Viewer',
                     Viewer,
+                    'napari.viewer.ViewerModel',
+                    'napari.components.ViewerModel',
+                    'napari.components.viewer_model.ViewerModel',
+                    ViewerModel,
                 ):
                     widget_param = param.name
                     break

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -1991,7 +1991,7 @@ class Window:
 
 def _instantiate_dock_widget(wdg_cls, viewer: 'Viewer'):
     # if the signature is looking a for a napari viewer, pass it.
-    from napari.viewer import Viewer
+    from napari.viewer import Viewer, ViewerModel
 
     kwargs = {}
     try:
@@ -2004,7 +2004,14 @@ def _instantiate_dock_widget(wdg_cls, viewer: 'Viewer'):
             if param.name == 'napari_viewer':
                 kwargs['napari_viewer'] = PublicOnlyProxy(viewer)
                 break
-            if param.annotation in ('napari.viewer.Viewer', Viewer):
+            if param.annotation in (
+                'napari.viewer.Viewer',
+                Viewer,
+                'napari.viewer.ViewerModel',
+                'napari.components.ViewerModel',
+                'napari.components.viewer_model.ViewerModel',
+                ViewerModel,
+            ):
                 kwargs[param.name] = PublicOnlyProxy(viewer)
                 break
             # cannot look for param.kind == param.VAR_KEYWORD because


### PR DESCRIPTION
# References and relevant issues

extracted from #7877

# Description

This PR allows annotating constructor argument as `ViewerModel` instead of `Viewer` to allow easier reuse of code and properly mark widgets that do not need `Viewer` specific API. 