### PR TITLE
[Maintenance] Remove redundant initialization in Points layer and restructure for clarity

### DIFF
--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -411,6 +411,7 @@ class Points(Layer):
         # Indices of selected points
         self._selected_data_stored = set()
         self._selected_data_history = set()
+        self._selected_data: Selection[int] = Selection()
         # Indices of selected points within the currently viewed slice
         self._selected_view = []
         # Index of hovered point
@@ -418,6 +419,8 @@ class Points(Layer):
         self._value_stored = None
         self._highlight_index = []
         self._highlight_box = None
+        self._mode = Mode.PAN_ZOOM
+        self._status = self.mode
 
         self._drag_start = None
         self._drag_normal = None
@@ -495,9 +498,6 @@ class Points(Layer):
         self._border_width_is_relative = False
         self._shown = np.empty(0).astype(bool)
 
-        # Indices of selected points
-        self._selected_data: Selection[int] = Selection()
-
         # The following point properties are for the new points that will
         # be added. For any given property, if a list is passed to the
         # constructor so each point gets its own value then the default
@@ -509,12 +509,6 @@ class Points(Layer):
         self.current_symbol = (
             np.asarray(symbol) if np.isscalar(symbol) else 'o'
         )
-
-        # Index of hovered point
-        self._value = None
-        self._value_stored = None
-        self._mode = Mode.PAN_ZOOM
-        self._status = self.mode
 
         color_properties = (
             self._feature_table.properties()

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -497,10 +497,6 @@ class Points(Layer):
 
         # Indices of selected points
         self._selected_data: Selection[int] = Selection()
-        self._selected_data_stored = set()
-        self._selected_data_history = set()
-        # Indices of selected points within the currently viewed slice
-        self._selected_view = []
 
         # The following point properties are for the new points that will
         # be added. For any given property, if a list is passed to the


### PR DESCRIPTION
# References and Relevant Issues

Closes #7999

# Description

This PR removes duplicate initialization code in the `Points.__init__` method found in `src/napari/layers/points/points.py`.

Specifically, the following lines (500–503), which are duplicates of lines 411–415, were removed:

```python
# Indices of selected points
self._selected_data_stored = set()
self._selected_data_history = set()
# Indices of selected points within the currently viewed slice
self._selected_view = []
```

These lines were likely added during separate commits and have since become redundant. Removal of this duplicate code does not impact the functionality, as confirmed by running the relevant tests.

# Testing

Executed the following unit tests:

```bash
pytest src/napari/layers/ -k 'points and not bindings'
```

**Result**: All tests passed ✅
However, two **deprecation warnings** were observed (unrelated to this PR):

```
DeprecationWarning: Pickle, copy, and deepcopy support will be removed from itertools in Python 3.14.
```

These warnings originate from:

* `/usr/lib/python3.12/copy.py:151`
* `/usr/lib/python3.12/copy.py:261`

Refer to [[Pytest docs](https://docs.pytest.org/en/stable/how-to/capture-warnings.html)](https://docs.pytest.org/en/stable/how-to/capture-warnings.html) for handling such warnings.

# Final Checklist

* [x] Duplicate code removed.
* [x] Tests passed (with unrelated warnings).
* [x] Minimal and non-breaking change.
* [x] No changes required in docs or localization.
