### PR TITLE
Fix angles not showing correctly in UI

### DIFF
--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -122,7 +122,7 @@ def labeled_double_slider(
     """Create a labeled double slider widget."""
     slider = QLabeledDoubleSlider(parent)
     slider.setRange(*value_range)
-    slider.setValue(float(value))
+    slider.setValue(value)
     slider.setDecimals(decimals)
     slider.valueChanged.connect(callback)
     return slider

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -121,8 +121,8 @@ def labeled_double_slider(
 ) -> QLabeledDoubleSlider:
     """Create a labeled double slider widget."""
     slider = QLabeledDoubleSlider(parent)
-    slider.setValue(value)
     slider.setRange(*value_range)
+    slider.setValue(float(value))
     slider.setDecimals(decimals)
     slider.valueChanged.connect(callback)
     return slider


### PR DESCRIPTION
# Description

It fixes an issue that only occasionally shows up.
I noticed that when you had 3-D dataset, right-clicked on the 2-D->3-D icon and the popup shows up, the angles were not correctly shown in the UI.
This happened if the angle was outside of the normal range of the slider, so if e.g. X-angle was 101 it would not show because the range (-180 to 180) was set AFTER the value was set.

To reproduce, load any 3-D dataset. Set the angles to something unexpected (e.g. 101, -50, 101) and right-click in the UI.

![image](https://github.com/user-attachments/assets/0ce16ead-803f-4031-8e40-567a9f08db94)



