### PR TITLE
Update[shortcuts]: add Ctrl/Cmd-A as secondary keybinding for select_all_shapes

### DIFF
--- a/src/napari/utils/shortcuts.py
+++ b/src/napari/utils/shortcuts.py
@@ -81,7 +81,10 @@ _default_shortcuts = {
     'napari:paste_shape': [KeyMod.CtrlCmd | KeyCode.KeyV],
     'napari:move_shapes_selection_to_front': [KeyCode.KeyF],
     'napari:move_shapes_selection_to_back': [KeyCode.KeyB],
-    'napari:select_all_shapes': [KeyCode.KeyA],
+    'napari:select_all_shapes': [
+        KeyCode.KeyA,
+        KeyMod.CtrlCmd | KeyCode.KeyA,
+    ],
     'napari:delete_selected_shapes': [
         KeyCode.Digit3,
         KeyCode.Delete,


### PR DESCRIPTION
# References and Relevant Issues
Closes #7997 

# Description

This PR adds a secondary keybinding (`Ctrl/Cmd + A`) to the `select_all_shapes` action in the Shapes layer, aligning it with the existing Points layer behavior.

### 🔧 Changes Made:

* Updated the `napari:select_all_shapes` shortcut in `napari/utils/shortcuts.py` to:

  ```python
  'napari:select_all_shapes': [
      KeyCode.KeyA,
      KeyMod.CtrlCmd | KeyCode.KeyA,
  ]
  ```
