### PR TITLE
Fix numba fail of compile on GHA macOS runners

### DIFF
--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -151,7 +151,6 @@ jobs:
         env:
           BACKEND: ${{ env.MAIN }}
           TOX_WORK_DIR: .tox
-          NUMBA_FULL_TRACEBACKS: 1
 
       - name: Test with tox second
         timeout-minutes: ${{ inputs.timeout }}

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -151,6 +151,7 @@ jobs:
         env:
           BACKEND: ${{ env.MAIN }}
           TOX_WORK_DIR: .tox
+          NUMBA_FULL_TRACEBACKS: 1
 
       - name: Test with tox second
         timeout-minutes: ${{ inputs.timeout }}

--- a/src/napari/layers/shapes/_accelerated_triangulate_numba.py
+++ b/src/napari/layers/shapes/_accelerated_triangulate_numba.py
@@ -876,7 +876,8 @@ def reconstruct_polygons_from_edges(
                 # chain of vertices, without this break, we would enter an
                 # infinite loop. Therefore, we leave it here for safety.
                 break
-        polygons.append([vertices[x] for x in poly])
+        polygon = [vertices[x] for x in poly]
+        polygons.append(polygon)
     return polygons
 
 

--- a/src/napari/layers/shapes/_accelerated_triangulate_numba.py
+++ b/src/napari/layers/shapes/_accelerated_triangulate_numba.py
@@ -876,7 +876,7 @@ def reconstruct_polygons_from_edges(
                 # chain of vertices, without this break, we would enter an
                 # infinite loop. Therefore, we leave it here for safety.
                 break
-        polygon = [vertices[x] for x in poly]
+        polygon = vertices[np.array(poly)]
         polygons.append(polygon)
     return polygons
 

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,7 @@ passenv =
     NAPARI_TEST_SUBSET
     COVERAGE_*
     COVERAGE
+    NUMBA_*
 # Set various environment variables, depending on the factors in
 # the tox environment being run
 setenv =


### PR DESCRIPTION
# References and relevant issues

# Description

Update code to pass jut compilation on macOS GHA runners. 

Update tox configuration to pass numba variables. 



