### PR TITLE
Stop benchmark reporting if benchmark action is skipped

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -196,7 +196,7 @@ jobs:
   combine-artifacts:
     runs-on: ubuntu-latest
     needs: benchmark
-    if: always()
+    if: always() && needs.benchmark.result != 'skipped'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   download:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: "Download artifact"
         uses: actions/github-script@v7


### PR DESCRIPTION
# References and relevant issues

When I merge PRs, I get spammed in my notifications that benchmarks reporting has failed -- it looks like it only succeeds on the chron run lately. https://github.com/napari/napari/actions/workflows/benchmarks_report.yml
The problem is that `combine-artifacts` always runs, regardless of whether benchmarks is skipped. The action triggers on PR merge, but is skipped unless the `benchmarks` label is added.

# Description

1. now `combine-artifacts` only runs if benchmarks is _not_ skipped.
2. Benchmark reporting only happens if Benchmarks succeeds, which I'm pretty sure is False if actions are skipped.

Thus, the benchmark report action will stop triggering fails if benchmarks are skipped. 

## Alternative

Remove running the benchmark action on merging of benchmark labeled PRs, but this would be a regression. I'm guessing this functionality is there to double check affected PRs. 


