### PR TITLE
Fix Shapes layer to work with Features Table

### DIFF
--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2697,6 +2697,7 @@ class Shapes(Layer):
                 data_indices=(-1,),
                 vertex_indices=((),),
             )
+            self.events.features()
         self._is_creating = False
         self._update_dims()
 

--- a/src/napari_builtins/_qt/_tests/test_features_table.py
+++ b/src/napari_builtins/_qt/_tests/test_features_table.py
@@ -172,6 +172,26 @@ def test_features_table_selection_labels(qtbot):
     assert layer.selected_label == 2
 
 
+def test_features_table_selection_shapes(qtbot):
+    v = ViewerModel()
+    features = pd.DataFrame(
+        {'shape_type': ['rectangle', 'ellipse'], 'value': [1, 2]}
+    )
+    data = [
+        np.array([[0, 0], [1, 1], [1, 0], [0, 1]]),
+        np.array([[2, 2], [3, 3], [3, 2], [2, 3]]),
+    ]
+    layer = v.add_shapes(data, features=features)
+
+    w = FeaturesTable(v)
+    qtbot.add_widget(w)
+
+    assert layer.selected_data == set()
+
+    w.table.selectRow(1)
+    assert layer.selected_data == {1}
+
+
 def test_features_table_edit(qtbot):
     v = ViewerModel()
     w = FeaturesTable(v)

--- a/src/napari_builtins/_qt/features_table.py
+++ b/src/napari_builtins/_qt/features_table.py
@@ -425,7 +425,11 @@ class FeaturesTable(QWidget):
         if hasattr(layer, 'selected_label'):
             return layer.events.selected_label
         if hasattr(layer, 'selected_data'):
-            return layer.selected_data.events
+            # Points layer has selected_data.events, but Shapes layer uses highlight event
+            if hasattr(layer.selected_data, 'events'):
+                return layer.selected_data.events
+            if hasattr(layer.events, 'highlight'):
+                return layer.events.highlight
         raise RuntimeError(  # pragma: no cover
             "Layer with features must have either 'selected_label' or 'selected_data'."
         )


### PR DESCRIPTION
# References and relevant issues

Closes #8047 
Follow up to #7877 

# Description

1. Uses the highlight event for selected_data for shapes layer, to prevent traceback in #8047 
2. Adds feature event emission to adding shape layer via GUI to trigger live updates to feature table widget like with points layer.
3. Adds feature table test for shapes layer that fails on main.

Test with `add_shapes_with_features.py` to see it working now, but breaking on main.

![image](https://github.com/user-attachments/assets/7ae2fd1b-e5c8-4018-92bd-d53dae86685f)
