### PR TITLE
Reverse canvas grid order

### DIFF
--- a/src/napari/_tests/test_with_screenshot.py
+++ b/src/napari/_tests/test_with_screenshot.py
@@ -259,14 +259,14 @@ def test_grid_mode(make_napari_viewer):
         (3 / 4, 3 / 6),
         (3 / 4, 5 / 6),
     ]
-    # BGRMYC color order
+    # CYMRGB color order
     color = [
-        [0, 0, 255, 255],
-        [0, 255, 0, 255],
-        [255, 0, 0, 255],
-        [255, 0, 255, 255],
-        [255, 255, 0, 255],
         [0, 255, 255, 255],
+        [255, 255, 0, 255],
+        [255, 0, 255, 255],
+        [255, 0, 0, 255],
+        [0, 255, 0, 255],
+        [0, 0, 255, 255],
     ]
     for c, p in zip(color, pos, strict=False):
         coord = tuple(
@@ -282,12 +282,12 @@ def test_grid_mode(make_napari_viewer):
     screenshot = viewer.screenshot(canvas_only=True, flash=False)
     # CGRMYB color order
     color = [
-        [0, 255, 255, 255],
-        [0, 255, 0, 255],
-        [255, 0, 0, 255],
-        [255, 0, 255, 255],
-        [255, 255, 0, 255],
         [0, 0, 255, 255],
+        [255, 255, 0, 255],
+        [255, 0, 255, 255],
+        [255, 0, 0, 255],
+        [0, 255, 0, 255],
+        [0, 255, 255, 255],
     ]
     for c, p in zip(color, pos, strict=False):
         coord = tuple(
@@ -300,9 +300,6 @@ def test_grid_mode(make_napari_viewer):
     assert not viewer.grid.enabled
     assert viewer.grid.actual_shape(6) == (1, 1)
     assert viewer.grid.stride == 1
-
-    # check screenshot
-    screenshot = viewer.screenshot(canvas_only=True, flash=False)
 
 
 @skip_on_win_ci

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -725,12 +725,7 @@ class VispyCanvas:
             ):
                 if not layer_indices:
                     continue
-                # FIXME: the use of `len(self.viewer.layers) - 1 - idx` should be removed
-                # see https://github.com/napari/napari/pull/7870#issuecomment-2965031040
-                layers = [
-                    self.viewer.layers[len(self.viewer.layers) - 1 - idx]
-                    for idx in layer_indices
-                ]
+                layers = [self.viewer.layers[idx] for idx in layer_indices]
                 self._reorder_layers_in_the_same_view(layers)
         else:
             self._reorder_layers_in_the_same_view(self.viewer.layers)
@@ -825,11 +820,7 @@ class VispyCanvas:
             if isinstance(overlay, CanvasOverlay):
                 if self.viewer.grid.enabled:
                     row, col = self.viewer.grid.position(
-                        # FIXME: the use of `len(self.viewer.layers) - 1 - idx` should be removed
-                        # see https://github.com/napari/napari/pull/7870#issuecomment-2965031040
-                        len(self.viewer.layers)
-                        - 1
-                        - self.viewer.layers.index(layer),
+                        self.viewer.layers.index(layer),
                         len(self.viewer.layers),
                     )
                     parent = self.grid[row, col]
@@ -977,11 +968,7 @@ class VispyCanvas:
             self.grid_cameras.append(camera)
 
             for idx in layer_indices:
-                # FIXME: the use of `len(self.viewer.layers) - 1 - idx` should be removed
-                # see https://github.com/napari/napari/pull/7870#issuecomment-2965031040
-                napari_layer = self.viewer.layers[
-                    len(self.viewer.layers) - 1 - idx
-                ]
+                napari_layer = self.viewer.layers[idx]
                 vispy_layer = self.layer_to_visual[napari_layer]
                 vispy_layer.node.parent = view.scene
                 self._update_layer_overlays(napari_layer)


### PR DESCRIPTION
Alternative to #8044
Depends on #8057 
More context https://github.com/napari/napari/pull/8044#issuecomment-3001025258 and https://github.com/napari/napari/pull/7870#issuecomment-2965031040
Test with this script:

```python
import napari
from skimage import data

viewer, layer = napari.imshow(
        data.lily(),
        name='lily',
        channel_axis=2,
        colormap=['red', 'green', 'blue', 'gray'],
        blending='translucent',
        opacity=1,
        )

viewer.grid.enabled = True
viewer.grid.stride = 2

napari.run()
```

This PR reverses the default order of the panels with a default stride, so that later layers end up to the bottom-right of earlier layers.

To enable the earlier behaviour, set a stride of -1, which can be set as default in the viewer preferences.

![screenshot_4nFePQ5C@2x](https://github.com/user-attachments/assets/528aebca-d623-4f9a-97f4-691329d2a2a7)

## Script output:

main:

![screenshot_ikFxA97W@2x](https://github.com/user-attachments/assets/6d961f78-17ac-4ef7-aa8c-5fd66bc91dca)

this PR:

![screenshot_dlFFazIh@2x](https://github.com/user-attachments/assets/4516932d-0b2b-4e61-b378-6ff221d8c9be)

this PR with negative grid stride:

![screenshot_yQwsLxv6@2x](https://github.com/user-attachments/assets/4f791a10-9f00-4309-b029-50b6842f728d)
