### PR TITLE
Fix grid stride layering

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -727,10 +727,7 @@ class VispyCanvas:
                     continue
                 # FIXME: the use of `len(self.viewer.layers) - 1 - idx` should be removed
                 # see https://github.com/napari/napari/pull/7870#issuecomment-2965031040
-                layers = [
-                    self.viewer.layers[len(self.viewer.layers) - 1 - idx]
-                    for idx in layer_indices
-                ]
+                layers = [self.viewer.layers[idx] for idx in layer_indices]
                 self._reorder_layers_in_the_same_view(layers)
         else:
             self._reorder_layers_in_the_same_view(self.viewer.layers)

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -725,8 +725,6 @@ class VispyCanvas:
             ):
                 if not layer_indices:
                     continue
-                # FIXME: the use of `len(self.viewer.layers) - 1 - idx` should be removed
-                # see https://github.com/napari/napari/pull/7870#issuecomment-2965031040
                 layers = [self.viewer.layers[idx] for idx in layer_indices]
                 self._reorder_layers_in_the_same_view(layers)
         else:


### PR DESCRIPTION
# References and and Description

Follow up to #7870. After that PR, on main, stride results in layers stacking up in the wrong order, where lower indexed layers are on top of the stack. 

See #8053 and #8044 for original discussion

```python
import napari
from skimage import data

viewer, layer = napari.imshow(
        data.lily(),
        name='lily',
        channel_axis=2,
        colormap=['red', 'green', 'blue', 'gray'],
        blending='translucent',
        opacity=1,
        )

viewer.grid.enabled = True
viewer.grid.stride = 2

napari.run()
```

main:

![screenshot_XtB3XXSr@2x](https://github.com/user-attachments/assets/62725a9b-5409-405c-b0e4-b6cea548174e)

this PR:

![screenshot_tsNdp7E1@2x](https://github.com/user-attachments/assets/1671a4a3-9955-4653-af41-74b6c6d2617c)

