### PR TITLE
ensure sync when taking a screenshot

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -839,7 +839,7 @@ class QtViewer(QSplitter):
 
         try:
             self.viewer._layer_slicer.wait_until_idle(timeout=5)
-        except TimeoutError as e:  # pragma: no cover 
+        except TimeoutError as e:  # pragma: no cover
             raise TimeoutError(
                 'Slicing was too slow. Wait for all layers to load before taking a screenshot, '
                 'or disable async slicing in Preferences->Experimental.'

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -836,7 +836,9 @@ class QtViewer(QSplitter):
             Flag to indicate whether flash animation should be shown after
             the screenshot was captured.
         """
-        img = self.canvas.screenshot()
+
+        with self.viewer._layer_slicer.force_sync():
+            img = self.canvas.screenshot()
         if flash:
             from napari._qt.utils import add_flash_animation
 

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -839,7 +839,7 @@ class QtViewer(QSplitter):
 
         try:
             self.viewer._layer_slicer.wait_until_idle(timeout=5)
-        except TimeoutError as e:
+        except TimeoutError as e:  # pragma: no cover 
             raise TimeoutError(
                 'Slicing was too slow. Wait for all layers to load before taking a screenshot, '
                 'or disable async slicing in Preferences->Experimental.'

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -837,8 +837,8 @@ class QtViewer(QSplitter):
             the screenshot was captured.
         """
 
-        with self.viewer._layer_slicer.force_sync():
-            img = self.canvas.screenshot()
+        self.viewer._layer_slicer.wait_until_idle(timeout=5)
+        img = self.canvas.screenshot()
         if flash:
             from napari._qt.utils import add_flash_animation
 

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -837,7 +837,14 @@ class QtViewer(QSplitter):
             the screenshot was captured.
         """
 
-        self.viewer._layer_slicer.wait_until_idle(timeout=5)
+        try:
+            self.viewer._layer_slicer.wait_until_idle(timeout=5)
+        except TimeoutError as e:
+            raise TimeoutError(
+                'Slicing was too slow. Wait for all layers to load before taking a screenshot, '
+                'or disable async slicing in Preferences->Experimental.'
+            ) from e
+
         img = self.canvas.screenshot()
         if flash:
             from napari._qt.utils import add_flash_animation


### PR DESCRIPTION
# References and relevant issues
- closes #8033

# Description
This forces async slicing to finish fully before taking the screenshot. I cannot imagine anyone ever wanting to screenshot mid-slicing, so I just made this mandatory, but I guess it could be conceivably made into a kwarg that's True by default.

cc @TimMonko

