### PR TITLE
Add simple didyouknow-style tips to the welcome widget

### DIFF
--- a/src/napari/_qt/widgets/qt_welcome.py
+++ b/src/napari/_qt/widgets/qt_welcome.py
@@ -20,6 +20,13 @@ from napari.utils.action_manager import action_manager
 from napari.utils.interactions import Shortcut
 from napari.utils.translations import trans
 
+# TODO: make them respect settings?
+TIPS = [
+    'You can take a screenshot and copy it to your clipboard by pressing alt+C',
+    'You can change most shortcuts from the File->Preferences->Shortcuts menu',
+    'You can right click many components of the graphical interface to access advanced controls',
+]
+
 
 class QtWelcomeLabel(QLabel):
     """Labels used for main message in welcome page."""
@@ -31,14 +38,6 @@ class QtShortcutLabel(QLabel):
 
 class QtVersionLabel(QLabel):
     """Label used for displaying version information."""
-
-
-# TODO: make them respect settings?
-TIPS = [
-    'You can take a screenshot and copy it to your clipboard by pressing alt+C',
-    'You can change most shortcuts from the File->Preferences->Shortcuts menu',
-    'You can right click many components of the graphical interface to access advanced controls',
-]
 
 
 class QtWelcomeWidget(QWidget):

--- a/src/napari/_qt/widgets/qt_welcome.py
+++ b/src/napari/_qt/widgets/qt_welcome.py
@@ -63,6 +63,7 @@ class QtWelcomeWidget(QWidget):
         self._tip_timer = QTimer()
         self._tip_timer.setInterval(10000)
         self._tip_timer.timeout.connect(self._next_tip)
+        self._next_tip()
 
         # Widget setup
         self.setAutoFillBackground(True)
@@ -212,7 +213,7 @@ class QtWelcomeWidget(QWidget):
         self._tip_timer.start()
 
     def hideEvent(self, event):
-        super().hideEvent()
+        super().hideEvent(event)
         self._tip_timer.stop()
 
     def _next_tip(self, event=None):

--- a/src/napari/_qt/widgets/qt_welcome.py
+++ b/src/napari/_qt/widgets/qt_welcome.py
@@ -62,8 +62,8 @@ class QtWelcomeWidget(QWidget):
         self._tip = QLabel()
         self._tips = cycle(sample(TIPS, len(TIPS)))
         self._tip_timer = QTimer()
+        self._tip_timer.setInterval(10000)
         self._tip_timer.timeout.connect(self._next_tip)
-        self._next_tip()
 
         # Widget setup
         self.setAutoFillBackground(True)
@@ -208,9 +208,16 @@ class QtWelcomeWidget(QWidget):
         self._update_property('drag', False)
         self.sig_dropped.emit(event)
 
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._tip_timer.start()
+
+    def hideEvent(self, event):
+        super().hideEvent()
+        self._tip_timer.stop()
+
     def _next_tip(self, event=None):
         self._tip.setText(f'Did You Know?\n{next(self._tips)}!')
-        self._tip_timer.start(5000)
 
 
 class QtWidgetOverlay(QStackedWidget):

--- a/src/napari/_qt/widgets/qt_welcome.py
+++ b/src/napari/_qt/widgets/qt_welcome.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from qtpy.QtCore import QSize, Qt, Signal
+from itertools import cycle
+from random import sample
+
+from qtpy.QtCore import QSize, Qt, QTimer, Signal
 from qtpy.QtGui import QKeySequence, QPainter
 from qtpy.QtWidgets import (
     QFormLayout,
@@ -30,6 +33,14 @@ class QtVersionLabel(QLabel):
     """Label used for displaying version information."""
 
 
+# TODO: make them respect settings?
+TIPS = [
+    'You can take a screenshot and copy it to your clipboard by pressing alt+C',
+    'You can change most shortcuts from the File->Preferences->Shortcuts menu',
+    'You can right click many components of the graphical interface to access advanced controls',
+]
+
+
 class QtWelcomeWidget(QWidget):
     """Welcome widget to display initial information and shortcuts to user."""
 
@@ -48,6 +59,11 @@ class QtWelcomeWidget(QWidget):
                 'Drag image(s) here to open\nor\nUse the menu shortcuts below:'
             )
         )
+        self._tip = QLabel()
+        self._tips = cycle(sample(TIPS, len(TIPS)))
+        self._tip_timer = QTimer()
+        self._tip_timer.timeout.connect(self._next_tip)
+        self._next_tip()
 
         # Widget setup
         self.setAutoFillBackground(True)
@@ -55,6 +71,7 @@ class QtWelcomeWidget(QWidget):
         self._image.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._version_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._tip.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         # Layout
         text_layout = QVBoxLayout()
@@ -98,6 +115,7 @@ class QtWelcomeWidget(QWidget):
         layout.addWidget(self._image)
         layout.addLayout(text_layout)
         layout.addLayout(shortcut_layout)
+        layout.addWidget(self._tip)
         layout.addStretch()
 
         self.setLayout(layout)
@@ -189,6 +207,10 @@ class QtWelcomeWidget(QWidget):
         """
         self._update_property('drag', False)
         self.sig_dropped.emit(event)
+
+    def _next_tip(self, event=None):
+        self._tip.setText(f'Did You Know?\n{next(self._tips)}!')
+        self._tip_timer.start(5000)
 
 
 class QtWidgetOverlay(QStackedWidget):


### PR DESCRIPTION
# Description
This PR adds simple "did yoou know"-style tips to the welcome widget. In terms of styling and layout it's very rough at the moment, but I was curious to gauge what people think of the idea :)

We can add/remove tips very easily by just updating the list, and we could make it fancier by ensuring that any custom shortcuts are respected.

This is what it looks like now:

![image](https://github.com/user-attachments/assets/75c67446-457f-46d5-967b-c3c6b89a6100)

