### PR TITLE
Block the recent pytest-qt version on python 3.10 to keep PySide2 support in testing.

### DIFF
--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -1,5 +1,4 @@
 pyopengl!=3.1.9a1
-pytest-cov
 PySide6 < 6.3.2 ; python_version < '3.10'
 PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.12'
 pytest-json-report
@@ -8,3 +7,4 @@ ipykernel!=7.0.0a0,!=7.0.0a1
 wrapt!=1.17.0 # problem with macOS intel
 zarr!=3.0.0b3,!=3.0.0b2,!=3.0.0rc1
 pydantic!=2.11.0a2,!=2.11.0a1
+pytest-qt!=4.5.0 # pyside2 support

--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -1,5 +1,4 @@
 pyopengl!=3.1.9a1
-PySide6 < 6.3.2 ; python_version < '3.10'
 PySide6 != 6.4.3, !=6.5.0, !=6.5.1, !=6.5.1.1, !=6.5.2, != 6.5.3, != 6.6.0, != 6.6.1, != 6.6.2 ; python_version >= '3.10' and python_version < '3.12'
 pytest-json-report
 tensorstore!=0.1.38,!=0.1.72
@@ -7,4 +6,4 @@ ipykernel!=7.0.0a0,!=7.0.0a1
 wrapt!=1.17.0 # problem with macOS intel
 zarr!=3.0.0b3,!=3.0.0b2,!=3.0.0rc1
 pydantic!=2.11.0a2,!=2.11.0a1
-pytest-qt!=4.5.0 # pyside2 support
+pytest-qt!=4.5.0 ; python_version <= '3.10' # pyside2 support


### PR DESCRIPTION
# References and relevant issues
https://napari.zulipchat.com/#narrow/channel/212875-general/topic/pytest-qt.3D.3D4.2E5.2E0.20drops.20PySide2/near/526779931

# Description

We still need PySide2 testing because our bundle is using it. So we need to block `pytest-qt` version that drop support for PySide2 

We need to debug segfaults of PySide6 tests and then drop Pyside2... 