### PR TITLE
Add configurable suffix for test artifacts

### DIFF
--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -38,6 +38,10 @@ on:
         required: false
         type: string
         default: ""
+      artifacts_suffix:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -195,7 +199,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: test artifacts ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
+          name: test artifacts ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }} ${{ inputs.artifacts_suffix }}
           path: .pytest_tmp
           include-hidden-files: true
 
@@ -203,13 +207,13 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: leaked ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
+          name: leaked ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }} ${{ inputs.artifacts_suffix }}
           path: ./*leak-backref-graph*.pdf
 
       - name: Upload pytest timing reports as json ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
         uses: actions/upload-artifact@v4
         with:
-          name: upload pytest timing json ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }} ${{ inputs.tox_extras }}
+          name: upload pytest timing json ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }} ${{ inputs.tox_extras }} ${{ inputs.artifacts_suffix }}
           path: |
             ./report-*.json
 
@@ -217,7 +221,7 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         if: ${{ inputs.coverage == 'cov' }}
         with:
-          name: coverage reports ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }}
+          name: coverage reports ${{ inputs.platform }} py ${{ inputs.python_version }} ${{ inputs.toxenv || inputs.qt_backend }} ${{ inputs.artifacts_suffix }}
           include-hidden-files: true
           path: |
             ./.coverage.*

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -102,6 +102,7 @@ jobs:
       qt_backend: ${{ matrix.backend }}
       coverage: ${{ matrix.coverage }}
       min_req: ${{ matrix.MIN_REQ }}
+      artifacts_suffix: "initial"
 
   test:
     name: ${{ matrix.platform }}


### PR DESCRIPTION
# References and relevant issues

# Description

Allow to add optional suffix for artifacts to avoid false negative test crash because of artifacts name. 

When debugging test failing only on a specific CI configuration, it may be a good idea to copy such a configuration into "Initial test" section to reduce CI usage. But once the test passed, we got a false negative test suite crash because of conflict of artifacts name. 


https://github.com/napari/napari/actions/runs/16061339574/job/45328714764?pr=7950

![image](https://github.com/user-attachments/assets/23d69dcd-a914-4a61-83bb-6dcc55c81937)


```
Run actions/upload-artifact@v4
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

Also configure artifacts for the initial section to reduce changes in future PRs. 
