### PR TITLE
Move non-qt file actions from qactions module

### DIFF
--- a/src/napari/_app_model/_app.py
+++ b/src/napari/_app_model/_app.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 
 from app_model import Application
 
+from napari._app_model.actions._file import FILE_ACTIONS
 from napari._app_model.actions._layerlist_context_actions import (
     LAYERLIST_CONTEXT_ACTIONS,
     LAYERLIST_CONTEXT_SUBMENUS,
@@ -36,6 +37,7 @@ class NapariApplication(Application):
 
         self.register_actions(LAYERLIST_CONTEXT_ACTIONS)
         self.register_actions(VIEW_ACTIONS)
+        self.register_actions(FILE_ACTIONS)
         self.menus.append_menu_items(LAYERLIST_CONTEXT_SUBMENUS)
 
     @classmethod

--- a/src/napari/_app_model/_app.py
+++ b/src/napari/_app_model/_app.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from itertools import chain
 
 from app_model import Application
 
-from napari._app_model.actions._file import FILE_ACTIONS
+from napari._app_model.actions._file import FILE_ACTIONS, FILE_SUBMENUS
 from napari._app_model.actions._layerlist_context_actions import (
     LAYERLIST_CONTEXT_ACTIONS,
     LAYERLIST_CONTEXT_SUBMENUS,
@@ -38,7 +39,9 @@ class NapariApplication(Application):
         self.register_actions(LAYERLIST_CONTEXT_ACTIONS)
         self.register_actions(VIEW_ACTIONS)
         self.register_actions(FILE_ACTIONS)
-        self.menus.append_menu_items(LAYERLIST_CONTEXT_SUBMENUS)
+        self.menus.append_menu_items(
+            chain(LAYERLIST_CONTEXT_SUBMENUS, FILE_SUBMENUS)
+        )
 
     @classmethod
     def get_app_model(cls, app_name: str = APP_NAME) -> NapariApplication:

--- a/src/napari/_app_model/actions/_file.py
+++ b/src/napari/_app_model/actions/_file.py
@@ -57,14 +57,14 @@ FILE_SUBMENUS = [
 
 
 def add_new_points(viewer: 'ViewerModel') -> None:
-    viewer.add_points(
+    viewer.add_points(  # type: ignore[attr-defined]
         ndim=max(viewer.dims.ndim, 2),
         scale=viewer.layers.extent.step,
     )
 
 
 def add_new_shapes(viewer: 'ViewerModel') -> None:
-    viewer.add_shapes(
+    viewer.add_shapes(  # type: ignore[attr-defined]
         ndim=max(viewer.dims.ndim, 2),
         scale=viewer.layers.extent.step,
     )
@@ -74,11 +74,11 @@ def new_labels(viewer: ViewerModel) -> None:
     viewer._new_labels()
 
 
-def new_points(viewer: ViewerModel):
+def new_points(viewer: ViewerModel) -> None:
     add_new_points(viewer)
 
 
-def new_shapes(viewer: ViewerModel):
+def new_shapes(viewer: ViewerModel) -> None:
     add_new_shapes(viewer)
 
 

--- a/src/napari/_app_model/actions/_file.py
+++ b/src/napari/_app_model/actions/_file.py
@@ -1,0 +1,104 @@
+from app_model.types import (
+    Action,
+    SubmenuItem,
+)
+
+from napari._app_model.constants import MenuGroup, MenuId
+from napari.components import ViewerModel
+from napari.utils.translations import trans
+
+FILE_SUBMENUS = [
+    (
+        MenuId.MENUBAR_FILE,
+        SubmenuItem(
+            submenu=MenuId.FILE_NEW_LAYER,
+            title=trans._('New Layer'),
+            group=MenuGroup.NAVIGATION,
+            order=0,
+        ),
+    ),
+    (
+        MenuId.MENUBAR_FILE,
+        SubmenuItem(
+            submenu=MenuId.FILE_OPEN_WITH_PLUGIN,
+            title=trans._('Open with Plugin'),
+            group=MenuGroup.OPEN,
+            order=99,
+        ),
+    ),
+    (
+        MenuId.MENUBAR_FILE,
+        SubmenuItem(
+            submenu=MenuId.FILE_SAMPLES,
+            title=trans._('Open Sample'),
+            group=MenuGroup.OPEN,
+            order=100,
+        ),
+    ),
+    (
+        MenuId.MENUBAR_FILE,
+        SubmenuItem(
+            submenu=MenuId.FILE_IO_UTILITIES,
+            title=trans._('IO Utilities'),
+            group=MenuGroup.UTIL,
+            order=101,
+        ),
+    ),
+    (
+        MenuId.MENUBAR_FILE,
+        SubmenuItem(
+            submenu=MenuId.FILE_ACQUIRE,
+            title=trans._('Acquire'),
+            group=MenuGroup.UTIL,
+            order=101,
+        ),
+    ),
+]
+
+
+def add_new_points(viewer: 'ViewerModel') -> None:
+    viewer.add_points(
+        ndim=max(viewer.dims.ndim, 2),
+        scale=viewer.layers.extent.step,
+    )
+
+
+def add_new_shapes(viewer: 'ViewerModel') -> None:
+    viewer.add_shapes(
+        ndim=max(viewer.dims.ndim, 2),
+        scale=viewer.layers.extent.step,
+    )
+
+
+def new_labels(viewer: ViewerModel) -> None:
+    viewer._new_labels()
+
+
+def new_points(viewer: ViewerModel):
+    add_new_points(viewer)
+
+
+def new_shapes(viewer: ViewerModel):
+    add_new_shapes(viewer)
+
+
+FILE_ACTIONS: list[Action] = [
+    Action(
+        id='napari.window.file.new_layer.new_labels',
+        title=trans._('Labels'),
+        callback=new_labels,
+        menus=[{'id': MenuId.FILE_NEW_LAYER, 'group': MenuGroup.NAVIGATION}],
+    ),
+    Action(
+        id='napari.window.file.new_layer.new_points',
+        title=trans._('Points'),
+        callback=new_points,
+        menus=[{'id': MenuId.FILE_NEW_LAYER, 'group': MenuGroup.NAVIGATION}],
+    ),
+    Action(
+        id='napari.window.file.new_layer.new_shapes',
+        title=trans._('Shapes'),
+        callback=new_shapes,
+        menus=[{'id': MenuId.FILE_NEW_LAYER, 'group': MenuGroup.NAVIGATION}],
+    ),
+]

--- a/src/napari/_qt/_qapp_model/qactions/__init__.py
+++ b/src/napari/_qt/_qapp_model/qactions/__init__.py
@@ -30,7 +30,6 @@ def init_qactions() -> None:
     - registering Qt-dependent actions with app-model (i.e. Q_*_ACTIONS actions).
     """
     from napari._app_model import get_app_model
-    from napari._app_model.actions._file import FILE_SUBMENUS
     from napari._qt._qapp_model.qactions._debug import (
         DEBUG_SUBMENUS,
         Q_DEBUG_ACTIONS,
@@ -86,7 +85,7 @@ def init_qactions() -> None:
 
     # register menubar submenus
     app.menus.append_menu_items(
-        chain(FILE_SUBMENUS, VIEW_SUBMENUS, DEBUG_SUBMENUS, LAYERS_SUBMENUS)
+        chain(VIEW_SUBMENUS, DEBUG_SUBMENUS, LAYERS_SUBMENUS)
     )
 
 

--- a/src/napari/_qt/_qapp_model/qactions/__init__.py
+++ b/src/napari/_qt/_qapp_model/qactions/__init__.py
@@ -30,12 +30,12 @@ def init_qactions() -> None:
     - registering Qt-dependent actions with app-model (i.e. Q_*_ACTIONS actions).
     """
     from napari._app_model import get_app_model
+    from napari._app_model.actions._file import FILE_SUBMENUS
     from napari._qt._qapp_model.qactions._debug import (
         DEBUG_SUBMENUS,
         Q_DEBUG_ACTIONS,
     )
     from napari._qt._qapp_model.qactions._file import (
-        FILE_SUBMENUS,
         Q_FILE_ACTIONS,
     )
     from napari._qt._qapp_model.qactions._help import Q_HELP_ACTIONS

--- a/src/napari/_qt/_qapp_model/qactions/_file.py
+++ b/src/napari/_qt/_qapp_model/qactions/_file.py
@@ -8,9 +8,9 @@ from app_model.types import (
     KeyCode,
     KeyMod,
     StandardKeyBinding,
-    SubmenuItem,
 )
 
+from napari._app_model.actions._file import FILE_ACTIONS
 from napari._app_model.constants import MenuGroup, MenuId
 from napari._app_model.context import (
     LayerListContextKeys as LLCK,
@@ -18,77 +18,10 @@ from napari._app_model.context import (
 )
 from napari._qt.qt_main_window import Window
 from napari._qt.qt_viewer import QtViewer
-from napari._qt.widgets.qt_viewer_buttons import add_new_points, add_new_shapes
 from napari.utils.translations import trans
-
-# File submenus
-FILE_SUBMENUS = [
-    (
-        MenuId.MENUBAR_FILE,
-        SubmenuItem(
-            submenu=MenuId.FILE_NEW_LAYER,
-            title=trans._('New Layer'),
-            group=MenuGroup.NAVIGATION,
-            order=0,
-        ),
-    ),
-    (
-        MenuId.MENUBAR_FILE,
-        SubmenuItem(
-            submenu=MenuId.FILE_OPEN_WITH_PLUGIN,
-            title=trans._('Open with Plugin'),
-            group=MenuGroup.OPEN,
-            order=99,
-        ),
-    ),
-    (
-        MenuId.MENUBAR_FILE,
-        SubmenuItem(
-            submenu=MenuId.FILE_SAMPLES,
-            title=trans._('Open Sample'),
-            group=MenuGroup.OPEN,
-            order=100,
-        ),
-    ),
-    (
-        MenuId.MENUBAR_FILE,
-        SubmenuItem(
-            submenu=MenuId.FILE_IO_UTILITIES,
-            title=trans._('IO Utilities'),
-            group=MenuGroup.UTIL,
-            order=101,
-        ),
-    ),
-    (
-        MenuId.MENUBAR_FILE,
-        SubmenuItem(
-            submenu=MenuId.FILE_ACQUIRE,
-            title=trans._('Acquire'),
-            group=MenuGroup.UTIL,
-            order=101,
-        ),
-    ),
-]
 
 
 # File actions
-
-
-def new_labels(qt_viewer: QtViewer):
-    viewer = qt_viewer.viewer
-    viewer._new_labels()
-
-
-def new_points(qt_viewer: QtViewer):
-    viewer = qt_viewer.viewer
-    add_new_points(viewer)
-
-
-def new_shapes(qt_viewer: QtViewer):
-    viewer = qt_viewer.viewer
-    add_new_shapes(viewer)
-
-
 def _open_files_with_plugin(qt_viewer: QtViewer):
     qt_viewer._open_files_dialog(choose_plugin=True)
 
@@ -118,24 +51,7 @@ def _close_app(window: Window):
 
 
 Q_FILE_ACTIONS: list[Action] = [
-    Action(
-        id='napari.window.file.new_layer.new_labels',
-        title=trans._('Labels'),
-        callback=new_labels,
-        menus=[{'id': MenuId.FILE_NEW_LAYER, 'group': MenuGroup.NAVIGATION}],
-    ),
-    Action(
-        id='napari.window.file.new_layer.new_points',
-        title=trans._('Points'),
-        callback=new_points,
-        menus=[{'id': MenuId.FILE_NEW_LAYER, 'group': MenuGroup.NAVIGATION}],
-    ),
-    Action(
-        id='napari.window.file.new_layer.new_shapes',
-        title=trans._('Shapes'),
-        callback=new_shapes,
-        menus=[{'id': MenuId.FILE_NEW_LAYER, 'group': MenuGroup.NAVIGATION}],
-    ),
+    *FILE_ACTIONS,
     Action(
         id='napari.window.file._image_from_clipboard',
         title=trans._('New Image from Clipboard'),

--- a/src/napari/_qt/_qapp_model/qactions/_file.py
+++ b/src/napari/_qt/_qapp_model/qactions/_file.py
@@ -10,7 +10,6 @@ from app_model.types import (
     StandardKeyBinding,
 )
 
-from napari._app_model.actions._file import FILE_ACTIONS
 from napari._app_model.constants import MenuGroup, MenuId
 from napari._app_model.context import (
     LayerListContextKeys as LLCK,
@@ -51,7 +50,6 @@ def _close_app(window: Window):
 
 
 Q_FILE_ACTIONS: list[Action] = [
-    *FILE_ACTIONS,
     Action(
         id='napari.window.file._image_from_clipboard',
         title=trans._('New Image from Clipboard'),

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -16,6 +16,7 @@ from qtpy.QtWidgets import (
 )
 from superqt import QEnumComboBox, QLabeledDoubleSlider
 
+from napari._app_model.actions._file import add_new_points, add_new_shapes
 from napari._qt.dialogs.qt_modal import QtPopup
 from napari._qt.widgets.qt_dims_sorter import QtDimsSorter
 from napari._qt.widgets.qt_spinbox import QtSpinBox
@@ -37,20 +38,6 @@ if TYPE_CHECKING:
     from typing import Any
 
     from napari.viewer import ViewerModel
-
-
-def add_new_points(viewer):
-    viewer.add_points(
-        ndim=max(viewer.dims.ndim, 2),
-        scale=viewer.layers.extent.step,
-    )
-
-
-def add_new_shapes(viewer):
-    viewer.add_shapes(
-        ndim=max(viewer.dims.ndim, 2),
-        scale=viewer.layers.extent.step,
-    )
 
 
 class QtLayerButtons(QFrame):

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -586,7 +586,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
 
         return np.array([displayed_height, displayed_width])
 
-    def _new_labels(self):
+    def _new_labels(self) -> None:
         """Create new labels layer filling full world coordinates space."""
         layers_extent = self.layers.extent
         extent = layers_extent.world

--- a/src/napari/plugins/_tests/test_npe2.py
+++ b/src/napari/plugins/_tests/test_npe2.py
@@ -182,8 +182,9 @@ def test_plugin_actions(mock_pm: 'TestPluginManager', mock_app_model):
     from napari.plugins import _initialize_plugins
 
     app = get_app_model()
-    # nothing yet registered with this menu
-    assert 'napari/file/new_layer' not in app.menus
+    # default actions registered
+    assert 'napari/file/new_layer' in app.menus
+    assert len(list(app.menus.get_menu('napari/file/new_layer'))) == 3
     # menus_items1 = list(app.menus.get_menu('napari/file/new_layer'))
     # assert 'my-plugin.hello_world' not in app.commands
 
@@ -194,16 +195,17 @@ def test_plugin_actions(mock_pm: 'TestPluginManager', mock_app_model):
     menus_items2 = list(app.menus.get_menu('napari/file/new_layer'))
     assert 'my-plugin.hello_world' in app.commands
 
-    assert len(menus_items2) == 2
+    assert len(menus_items2) == 5
 
     # then disable and re-enable the plugin
 
     mock_pm.disable(PLUGIN_NAME)
 
-    assert 'napari/file/new_layer' not in app.menus
+    assert 'napari/file/new_layer' in app.menus
+    assert len(list(app.menus.get_menu('napari/file/new_layer'))) == 3
 
     mock_pm.enable(PLUGIN_NAME)
 
     menus_items4 = list(app.menus.get_menu('napari/file/new_layer'))
-    assert len(menus_items4) == 2
+    assert len(menus_items4) == 5
     assert 'my-plugin.hello_world' in app.commands


### PR DESCRIPTION
# References and relevant issues


# Description

Move `Actions` that do not require qt from `qactions/_file.py` to `actions/_file.py`.
