### PR TITLE
Report benchmark on non skipped status

### DIFF
--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   download:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
     steps:
       - name: "Download artifact"
         uses: actions/github-script@v7


### PR DESCRIPTION
# References and relevant issues

When running benchmarks on #8006 I got no report because one performance was decreased (and the job failed).

# Description

Fix  misconfiguration from #8037.

Skip report steep only if workflow is skipped. 