### PR TITLE
Enable SIM117 ruff rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
   - id: ruff-format
     exclude: examples
   - id: ruff
-#    args:
-#      - "--unsafe-fixes"
+    args:
+      - "--unsafe-fixes"
 - repo: https://github.com/seddonym/import-linter
   rev: v2.3
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
   - id: ruff-format
     exclude: examples
   - id: ruff
-    args:
-      - "--unsafe-fixes"
+#    args:
+#      - "--unsafe-fixes"
 - repo: https://github.com/seddonym/import-linter
   rev: v2.3
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -344,7 +344,6 @@ ignore = [
     "A003", # flake8-builtins - we have class attributes violating these rule
     "COM812", # flake8-commas - we don't like adding comma on single line of arguments
     "COM819", # conflicts with ruff-format
-    "SIM117", # flake8-simplify - we some of merged with statements are not looking great with black, reanble after drop python 3.9
     "RET504", # not fixed yet https://github.com/charliermarsh/ruff/issues/2950
     "TRY003", # require implement multiple exception class
     "RUF005", # problem with numpy compatybility, see https://github.com/charliermarsh/ruff/issues/2142#issuecomment-1451038741

--- a/src/napari/_qt/_tests/test_plugin_widgets.py
+++ b/src/napari/_qt/_tests/test_plugin_widgets.py
@@ -112,9 +112,11 @@ def test_inject_viewer_proxy(make_napari_viewer):
     assert isinstance(wdg.viewer, PublicOnlyProxy)
 
     # simulate access from outside napari
-    with patch('napari.utils.misc.ROOT_DIR', new='/some/other/package'):
-        with pytest.warns(FutureWarning):
-            wdg.fail()
+    with (
+        patch('napari.utils.misc.ROOT_DIR', new='/some/other/package'),
+        pytest.warns(FutureWarning),
+    ):
+        wdg.fail()
 
 
 @pytest.mark.parametrize(

--- a/src/napari/_qt/_tests/test_qt_utils.py
+++ b/src/napari/_qt/_tests/test_qt_utils.py
@@ -37,10 +37,12 @@ def test_signal_blocker(qtbot):
         obj.go()
 
     # make sure blocker works
-    with qt_signals_blocked(obj):
-        with pytest.raises(pytestqt.exceptions.TimeoutError):
-            with qtbot.waitSignal(obj.test_signal, timeout=500):
-                obj.go()
+    with (
+        qt_signals_blocked(obj),
+        pytest.raises(pytestqt.exceptions.TimeoutError),
+        qtbot.waitSignal(obj.test_signal, timeout=500),
+    ):
+        obj.go()
 
 
 def test_is_qbyte_valid():

--- a/src/napari/_qt/widgets/_tests/test_qt_play.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_play.py
@@ -93,11 +93,11 @@ def test_animation_thread_variants(qtbot, nframes, fps, mode, rng, result):
 def test_animation_thread_once(qtbot):
     """Single shot animation should stop when it reaches the last frame"""
     nframes = 13
-    with make_worker(
-        qtbot, nframes=nframes, loop_mode=LoopMode.ONCE
-    ) as worker:
-        with qtbot.waitSignal(worker.finished, timeout=8000):
-            worker.start()
+    with (
+        make_worker(qtbot, nframes=nframes, loop_mode=LoopMode.ONCE) as worker,
+        qtbot.waitSignal(worker.finished, timeout=8000),
+    ):
+        worker.start()
     assert worker.current == worker.nz
 
 

--- a/src/napari/_tests/test_cli.py
+++ b/src/napari/_tests/test_cli.py
@@ -11,9 +11,11 @@ from napari import __main__
 @pytest.fixture
 def mock_run():
     """mock to prevent starting the event loop."""
-    with mock.patch('napari._qt.widgets.qt_splash_screen.NapariSplashScreen'):
-        with mock.patch('napari.run'):
-            yield napari.run
+    with (
+        mock.patch('napari._qt.widgets.qt_splash_screen.NapariSplashScreen'),
+        mock.patch('napari.run'),
+    ):
+        yield napari.run
 
 
 def test_cli_works(monkeypatch, capsys):
@@ -94,10 +96,12 @@ def test_cli_passes_kwargs(qt_open, mock_run, monkeypatch, make_napari_viewer):
     """test that we can parse layer keyword arg variants"""
     v = make_napari_viewer()
 
-    with mock.patch('napari.Viewer', return_value=v):
-        with monkeypatch.context() as m:
-            m.setattr(sys, 'argv', ['n', 'file', '--name', 'some name'])
-            __main__._run()
+    with (
+        mock.patch('napari.Viewer', return_value=v),
+        monkeypatch.context() as m,
+    ):
+        m.setattr(sys, 'argv', ['n', 'file', '--name', 'some name'])
+        __main__._run()
 
     qt_open.assert_called_once_with(
         ['file'],
@@ -116,25 +120,27 @@ def test_cli_passes_kwargs_stack(
     """test that we can parse layer keyword arg variants"""
     v = make_napari_viewer()
 
-    with mock.patch('napari.Viewer', return_value=v):
-        with monkeypatch.context() as m:
-            m.setattr(
-                sys,
-                'argv',
-                [
-                    'n',
-                    'file',
-                    '--stack',
-                    'file1',
-                    'file2',
-                    '--stack',
-                    'file3',
-                    'file4',
-                    '--name',
-                    'some name',
-                ],
-            )
-            __main__._run()
+    with (
+        mock.patch('napari.Viewer', return_value=v),
+        monkeypatch.context() as m,
+    ):
+        m.setattr(
+            sys,
+            'argv',
+            [
+                'n',
+                'file',
+                '--stack',
+                'file1',
+                'file2',
+                '--stack',
+                'file3',
+                'file4',
+                '--name',
+                'some name',
+            ],
+        )
+        __main__._run()
 
     qt_open.assert_called_once_with(
         ['file'],

--- a/src/napari/components/_tests/test_viewer_model.py
+++ b/src/napari/components/_tests/test_viewer_model.py
@@ -929,11 +929,13 @@ def test_open_or_get_error_no_prefered_plugin_many_available(
 
     get_settings().plugins.extension2reader = {'*.fake': 'not-a-plugin'}
 
-    with pytest.warns(RuntimeWarning, match="Can't find not-a-plugin plugin"):
-        with pytest.raises(
+    with (
+        pytest.warns(RuntimeWarning, match="Can't find not-a-plugin plugin"),
+        pytest.raises(
             MultipleReaderError, match='Multiple plugins found capable'
-        ):
-            viewer._open_or_raise_error(['my_file.fake'])
+        ),
+    ):
+        viewer._open_or_raise_error(['my_file.fake'])
 
 
 def test_open_or_get_error_preferred_fails(builtins, tmp_path):

--- a/src/napari/layers/_tests/test_source.py
+++ b/src/napari/layers/_tests/test_source.py
@@ -57,7 +57,6 @@ def test_source_context():
 
 def test_source_assert_parent():
     assert current_source() == Source()
-    with pytest.raises(ValidationError):
-        with layer_source(parent=''):
-            current_source()
+    with pytest.raises(ValidationError), layer_source(parent=''):
+        current_source()
     assert current_source() == Source()


### PR DESCRIPTION
# References and relevant issues

# Description

We put a comment to enable the Ruff SIM117 rule after dropping Python 3.9, and we dropped it some time ago.  