### PR TITLE
Remove dotenv from dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,6 @@ dev = [
     "check-manifest>=0.42",
     "pre-commit>=2.9.0",
     "pydantic",
-    "python-dotenv",
     "tox",
     "tox-min-req",
     "napari[testing]",

--- a/src/napari/conftest.py
+++ b/src/napari/conftest.py
@@ -37,26 +37,21 @@ import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
+from datetime import timedelta
 from functools import partial
 from itertools import chain
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
+from time import perf_counter
 from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
-
-from npe2 import PackageMetadata
-
-with suppress(ModuleNotFoundError):
-    __import__('dotenv').load_dotenv()
-
-from datetime import timedelta
-from time import perf_counter
 
 import dask.threaded
 import numpy as np
 import pytest
 from _pytest.pathlib import bestrelpath
 from IPython.core.history import HistoryManager
+from npe2 import PackageMetadata
 from packaging.version import parse as parse_version
 from pytest_pretty import CustomTerminalReporter
 

--- a/src/napari/utils/events/debugging.py
+++ b/src/napari/utils/events/debugging.py
@@ -16,10 +16,6 @@ except ModuleNotFoundError:
             'TIP: run `pip install rich` for much nicer event debug printout.'
         )
     )
-try:
-    import dotenv
-except ModuleNotFoundError:
-    dotenv = None  # type: ignore
 
 if TYPE_CHECKING:
     from napari.utils.events.event import Event
@@ -29,9 +25,8 @@ class EventDebugSettings(BaseSettings):
     """Parameters controlling how event debugging logs appear.
 
     To enable Event debugging:
-        1. pip install rich pydantic[dotenv]
-        2. export NAPARI_DEBUG_EVENTS=1  # or modify the .env_sample file
-        3. see .env_sample file for ways to set these fields here.
+        1. export NAPARI_DEBUG_EVENTS=1  # or modify the .env_sample file
+        2. see .env_sample file for ways to set these fields here.
     """
 
     # event emitters (e.g. 'Shapes') and event names (e.g. 'set_data')
@@ -54,7 +49,7 @@ class EventDebugSettings(BaseSettings):
 
     class Config:
         env_prefix = 'event_debug_'
-        env_file = '.env' if dotenv is not None else ''
+        env_file = '.env'
 
 
 _SETTINGS = EventDebugSettings()

--- a/src/napari/utils/events/event.py
+++ b/src/napari/utils/events/event.py
@@ -49,7 +49,6 @@ For more information see http://github.com/vispy/vispy/wiki/API_Events
 
 """
 
-import contextlib
 import inspect
 import os
 import warnings
@@ -1212,11 +1211,6 @@ def _is_pos_arg(param: inspect.Parameter):
         ]
         and param.default == inspect.Parameter.empty
     )
-
-
-with contextlib.suppress(ModuleNotFoundError):
-    # this could move somewhere higher up in napari imports ... but where?
-    __import__('dotenv').load_dotenv()
 
 
 def _noop(*a, **k):


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/packaging/issues/261#issuecomment-3062229648

# Description

The pydantic no longer depends on the `python-dotenv` file to load settings from `.env` file. 

Also, every IDE has nice integration with .env files. Shells also have extensions for this.

If someone depends on dotenv he may start napari with `python -m dotenv -m napari`   
