### PR TITLE
Colorblind friendly image sample of kidney and lily

### DIFF
--- a/src/napari_builtins/_skimage_data.py
+++ b/src/napari_builtins/_skimage_data.py
@@ -32,7 +32,12 @@ def _load_skimage_data(name, **kwargs):
                 skimage.data.lily(),
                 {
                     'channel_axis': -1,
-                    'name': ['lily-R', 'lily-G', 'lily-W', 'lily-B'],
+                    'name': [
+                        'lily-cyan',
+                        'lily-magenta',
+                        'lily-yellow',
+                        'lily-white',
+                    ],
                     'colormap': ['cyan', 'magenta', 'yellow', 'White'],
                 },
             )

--- a/src/napari_builtins/_skimage_data.py
+++ b/src/napari_builtins/_skimage_data.py
@@ -22,7 +22,7 @@ def _load_skimage_data(name, **kwargs):
                 {
                     'channel_axis': -1,
                     'name': ['nuclei', 'WGA', 'actin'],
-                    'colormap': ['blue', 'green', 'red'],
+                    'colormap': ['cyan', 'magenta', 'yellow'],
                 },
             )
         ]
@@ -33,7 +33,7 @@ def _load_skimage_data(name, **kwargs):
                 {
                     'channel_axis': -1,
                     'name': ['lily-R', 'lily-G', 'lily-W', 'lily-B'],
-                    'colormap': ['red', 'green', 'gray', 'blue'],
+                    'colormap': ['cyan', 'magenta', 'yellow'],
                 },
             )
         ]

--- a/src/napari_builtins/_skimage_data.py
+++ b/src/napari_builtins/_skimage_data.py
@@ -33,7 +33,7 @@ def _load_skimage_data(name, **kwargs):
                 {
                     'channel_axis': -1,
                     'name': ['lily-R', 'lily-G', 'lily-W', 'lily-B'],
-                    'colormap': ['cyan', 'magenta', 'yellow'],
+                    'colormap': ['cyan', 'magenta', 'yellow', 'White'],
                 },
             )
         ]

--- a/src/napari_builtins/_skimage_data.py
+++ b/src/napari_builtins/_skimage_data.py
@@ -33,12 +33,12 @@ def _load_skimage_data(name, **kwargs):
                 {
                     'channel_axis': -1,
                     'name': [
-                        'lily-cyan',
                         'lily-magenta',
+                        'lily-green',
                         'lily-yellow',
-                        'lily-white',
+                        'lily-blue',
                     ],
-                    'colormap': ['cyan', 'magenta', 'yellow', 'White'],
+                    'colormap': ['magenta', 'green', 'yellow', 'blue'],
                 },
             )
         ]


### PR DESCRIPTION
# References and relevant issues
Closes #8083 

# Description
updated colormap for kidney and lily 
for Kidney `colormap = ['cyan', 'magenta', 'yellow']`
for lily `colormap = ['magenta', 'green', 'yellow', 'blue']`
