### PR TITLE
Updated code to use current symbol and border width for new points.

### DIFF
--- a/src/napari/layers/points/_tests/test_points.py
+++ b/src/napari/layers/points/_tests/test_points.py
@@ -390,6 +390,24 @@ def test_adding_points():
     np.testing.assert_equal(layer.data, np.vstack((data, coord)))
 
 
+def test_adding_points_symbol():
+    """Test that the current symbol is used for added point."""
+    # add a point with default (disc) symbol
+    shape = (1, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    layer = Points(data)
+
+    # update the current symbol
+    new_symbol = 'star'
+    layer.current_symbol = new_symbol
+    coord = [20, 20]
+    layer.add(coord)
+
+    # confirm that a newly created point has the updated symbol
+    assert layer.symbol[-1] == new_symbol
+
+
 def test_points_selection_with_setter():
     shape = (10, 2)
     np.random.seed(0)
@@ -1018,6 +1036,23 @@ def test_border_width():
     assert layer.border_width_is_relative is False
     with pytest.raises(ValueError, match='must be > 0'):
         layer.border_width = -2
+
+def test_border_width_update():
+    """Test that the current border width is updated."""
+    # add a point with default border width
+    shape = (1, 2)
+    np.random.seed(0)
+    data = 20 * np.random.random(shape)
+    layer = Points(data)
+
+    # update the current border width to an arbitrary value
+    new_border_width = 0.43
+    layer.current_border_width = new_border_width
+    coord = [20, 20]
+    layer.add(coord)
+
+    # confirm that a newly created point has the updated border width
+    assert layer.border_width[-1] == new_border_width
 
 
 @pytest.mark.parametrize(

--- a/src/napari/layers/points/_tests/test_points.py
+++ b/src/napari/layers/points/_tests/test_points.py
@@ -1037,6 +1037,7 @@ def test_border_width():
     with pytest.raises(ValueError, match='must be > 0'):
         layer.border_width = -2
 
+
 def test_border_width_update():
     """Test that the current border width is updated."""
     # add a point with default border width

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -628,16 +628,10 @@ class Points(Layer):
                 adding = len(data) - cur_npoints
                 size = np.repeat(self.current_size, adding, axis=0)
 
-                if len(self._border_width) > 0:
-                    new_border_width = copy(self._border_width[-1])
-                else:
-                    new_border_width = self.current_border_width
+                new_border_width = self.current_border_width
                 border_width = np.repeat([new_border_width], adding, axis=0)
 
-                if len(self._symbol) > 0:
-                    new_symbol = copy(self._symbol[-1])
-                else:
-                    new_symbol = self.current_symbol
+                new_symbol = self.current_symbol
                 symbol = np.repeat([new_symbol], adding, axis=0)
 
                 # Add new colors, updating the current property value before


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7292

# Description
When symbols already exist in the Points layer, the code was using the symbol and border width of the previous point, rather than using the current symbol and border width.  Deleting the code pointing to the previous symbol and always using the current properties produced the expected behavior. 


