### PR TITLE
Improve stability of tests by ensuring cleaning of QtViewer instances

### DIFF
--- a/src/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/src/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -165,6 +165,7 @@ def test_open_sample_data_shows_all_readers(
     )
 
 
+# qt_viewer fixture is used to ensure proper teardown procedure and prevent leaked QtWidgets at the beginning of `make_napari_viewer` fixture.
 def test_open_with_dialog_choices_persist(
     builtins, tmp_path, qt_viewer, viewer_model
 ):
@@ -186,6 +187,7 @@ def test_open_with_dialog_choices_persist(
     assert get_settings().plugins.extension2reader['*.npy'] == builtins.name
 
 
+# qt_viewer fixture is used to ensure proper teardown procedure and prevent leaked QtWidgets at the beginning of `make_napari_viewer` fixture.
 def test_open_with_dialog_choices_persist_dir(
     builtins, tmp_path, qt_viewer, viewer_model
 ):


### PR DESCRIPTION
# References and relevant issues

Extracted from #8077

# Description

The `make_napari_viewer` fixture, on begin, checks if there are no leaked `QtViewer` instances from previous tests. 

In #8077, it started failing at the beginning of `test_open_with_dialog_choices_raises` because the `QtViewer` instance from `test_open_with_dialog_choices_persist_dir` is not yet removed (the `qtbot` is not always cleaning immediately).

This PR fixes it by using `qt_viewer` fixture that has a proper teardown procedure to prevent such problems. 