### PR TITLE
Prevent Windows Access Violation with GPU resource cleanup on layer removal

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 from functools import partial
 from typing import TYPE_CHECKING
 from weakref import WeakSet
@@ -709,12 +710,18 @@ class VispyCanvas:
             layer._overlays.events, self._overlay_callbacks[layer]
         )
         del self._overlay_callbacks[layer]
+
         vispy_layer = self.layer_to_visual.pop(layer)
         disconnect_events(self.viewer.camera.events, vispy_layer)
         vispy_layer.close()
         del vispy_layer
+
         self._remove_layer_overlays(layer)
         del self._layer_overlay_to_visual[layer]
+
+        gc.collect()
+        self._scene_canvas.context.finish()
+
         self._update_scenegraph()
 
     def _reorder_layers(self) -> None:


### PR DESCRIPTION
# References and relevant issues

Closes #7345 
Closes #7351 
Closes #6472
Closes #5543 
https://forum.image.sc/t/vispy-non-reproducible-bugs/113771/22
(there have been some other image.sc posts that I'm not tracking down atm)

There is a bug on some Window's machines (hardware specific, seemingly _some_ NVIDIA GPUs) that results in an Access Violation error, also seen as `0x000000000000001C` if popped outside a plugin, or `0x000000000000034C` inside a plugin. There are many reproducers, namely the error pops after an event which causes a canvas draw event in such minimal scenarios:

1. Adding and removing a points layer
2. Adding a labels layer, painting, then removing (but not without painting)
3. Adding a shapes layer, adding a shape, then removing (but not without adding a shape)
4. Transforming any layer type with the transform button (including image layers!)

Then, any layer _that is not the same layer type_ that is either already present _or_ added an layer causes the error to pop and rendering to completely break. 

Notably, adding TWO of a layer type, such as points, and deleting only one resulted in no error; this implied to me that there are shared OpenGL resources, that were perhaps not cleaning correctly on full removal of that layer's context.

In my lengthy testing, I identified this was clearly a degradation of resources on the GPU that happened during cleanup. (partly because it could happen to layers _already present_ when removing another layer). You can also even force the drawing to happen regardless and you get to see really fun GPU artifacting of the layers -- so yeah, it's clearly a GPU resource corruption. 

I have worked on this nagging bug for many weeks, including many lengthy conversations with copilot, but don't use copilot to try to fix it, it will constantly give a 1000line diff that doesn't work. 😬 Overall, the goal was to figure out a way to properly clean resources because it seemed to not be synced correctly. 

This is absolutely the hardest two line bugfix I've ever worked on, I really really hope it actually fixes across all the machines with this issue. I will test on 3 other machines with various builds.

# Description

Ultimately, the bugfix ends up being quite simple, though both are _absolutely required_. I added this thorough commenting to the code itself, and I'll regurgitate it here. When removing layers from the VispyCanvas, after the deletion of all related layer properties, we need to call BOTH `gc.collect()` and `self._scene_canvas.context.finish()`. 

This first forces garbage collection of the intended cleaned OpenGL resources after the `layer.close()` is called. This seemingly cleans up the uncleaned OpenGL resources on my machine. HOWEVER, the GPU also needs synced properly with this deleted context, so `self._scene_canvas.context.finish()` is called to ensure that all OpenGL commands complete before continuing, resulting in proper synchronization between removed resources and the GPU before updating the scenegraph. `self._scene_canvas.context.flush()` also works, but I am guessing that `finish()` is safer given that syncing with the GPU seems to be needed.

