### PR TITLE
Do not crash test with leaked graph if test failed

### DIFF
--- a/src/napari/utils/_testsupport.py
+++ b/src/napari/utils/_testsupport.py
@@ -354,12 +354,11 @@ def make_napari_viewer(
     else:
         gc.collect(1)
 
-    if request.config.getoption(_SAVE_GRAPH_OPNAME):
-        fail_obj_graph(QtViewer)
-
     if request.node.rep_call.failed:
         # IF test failed do not check for leaks
         QtViewer._instances.clear()
+    elif request.config.getoption(_SAVE_GRAPH_OPNAME):
+        fail_obj_graph(QtViewer)
 
     _do_not_inline_below = len(QtViewer._instances)
 


### PR DESCRIPTION
# References and relevant issues

motivation https://github.com/napari/napari/pull/8117#issuecomment-3095608056

# Description

With our current code, we report leaked `QtViewer`s instances on failed tests. This PR is fixing this by executing the check for leaked widgets only if the test is passed.  