### PR TITLE
Update README wording about scikit-image example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See here for the full [installation guide](https://napari.org/stable/tutorials/f
 
 ## simple example
 
-(The examples below require the `scikit-image` package to run. We just use data samples from this package for demonstration purposes. If you change the examples to use your own dataset, you may not need to install this package.)
+The examples below uses a data sample from the `scikit-image` library for demonstration purposes, but you can change the example to use your own dataset.
 
 From inside an IPython shell, you can open up an interactive viewer by calling
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See here for the full [installation guide](https://napari.org/stable/tutorials/f
 
 ## simple example
 
-This example uses a data sample from the `scikit-image` library, but you can change the example to use your own dataset.
+This example uses a data sample from the `scikit-image` library, but you can pass your own dataset as an array to `imshow`.
 From inside an IPython shell, you can open up an interactive viewer by calling
 
 ```python

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ See here for the full [installation guide](https://napari.org/stable/tutorials/f
 
 ## simple example
 
-The examples below uses a data sample from the `scikit-image` library for demonstration purposes, but you can change the example to use your own dataset.
-
+This example uses a data sample from the `scikit-image` library, but you can change the example to use your own dataset.
 From inside an IPython shell, you can open up an interactive viewer by calling
 
 ```python


### PR DESCRIPTION
# Description

Updates wording in README about the simple example. I remember this quip about samples and libraries and whether you needed scikit-image to be confusing when I started. I saw this today and realize that skimage is a dependency, so we should reword this _and_ it's hopefully not confusing now. 
