### PR TITLE
Add viewbox coordinates to events and Cursor

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -915,7 +915,7 @@ class VispyCanvas:
         w, h = self.size
         nd = self.viewer.dims.ndisplay
 
-        view, _ = self._get_viewbox_at(event_pos)[0] or self.view
+        view = self._get_viewbox_at(event_pos)[0] or self.view
         # combine the viewbox transform wit the scene transform
         # so each viewbox in grid mode maps back to the main scene
         transform = view.transform * view.scene.transform

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -406,15 +406,20 @@ class VispyCanvas:
         return tuple(position_world)
 
     def _get_viewbox_at(self, position):
+        """Get the viewbox and its grid coordinates from the mouse position."""
         if not self.viewer.grid.enabled:
-            return self.view
+            return self.view, (0, 0)
 
-        for viewbox in self.grid_views:
+        for (coords, _), viewbox in zip(
+            self.viewer.grid.iter_viewboxes(len(self.viewer.layers)),
+            self.grid_views,
+            strict=False,
+        ):
             shifted_pos = position - viewbox.transform.translate[:2]
             if viewbox.inner_rect.contains(*shifted_pos):
-                return viewbox
+                return viewbox, coords
 
-        return None
+        return None, None
 
     def _process_mouse_event(
         self, mouse_callbacks: Callable, event: MouseEvent
@@ -453,9 +458,11 @@ class VispyCanvas:
         # ensure that events which began in a specific viewbox continue to be
         # calculated based on that viewbox's coordinates
         if event.press_event is not None:
-            viewbox = self._get_viewbox_at(event.press_event.pos)
+            viewbox, grid_coords = self._get_viewbox_at(event.press_event.pos)
         else:
-            viewbox = self._get_viewbox_at(event.pos)
+            viewbox, grid_coords = self._get_viewbox_at(event.pos)
+
+        self.viewer.cursor.viewbox = grid_coords
 
         if viewbox is None:
             # this means we're in an empty viewbox, so do nothing
@@ -472,6 +479,7 @@ class VispyCanvas:
             position=self._map_canvas2world(event.pos, viewbox),
             dims_displayed=list(self.viewer.dims.displayed),
             dims_point=list(self.viewer.dims.point),
+            viewbox=grid_coords,
         )
 
         # Update the cursor position
@@ -907,7 +915,7 @@ class VispyCanvas:
         w, h = self.size
         nd = self.viewer.dims.ndisplay
 
-        view = self._get_viewbox_at(event_pos) or self.view
+        view, _ = self._get_viewbox_at(event_pos)[0] or self.view
         # combine the viewbox transform wit the scene transform
         # so each viewbox in grid mode maps back to the main scene
         transform = view.transform * view.scene.transform

--- a/src/napari/_vispy/mouse_event.py
+++ b/src/napari/_vispy/mouse_event.py
@@ -28,6 +28,8 @@ class NapariMouseEvent(MouseEvent):
         The dimensions displayed in the viewer.
     dims_point : list[float]
         The point in data coordinates that the mouse is over.
+    viewbox : tuple[int, int]
+        The coordinates of the grid viewbox containing the mouse.
     """
 
     def __init__(
@@ -39,6 +41,7 @@ class NapariMouseEvent(MouseEvent):
         position: tuple[float, float],
         dims_displayed: list[int],
         dims_point: list[float],
+        viewbox: tuple[int, int],
     ):
         public_attrs = {
             k: v for k, v in event.__dict__.items() if not k.startswith('_')
@@ -61,3 +64,4 @@ class NapariMouseEvent(MouseEvent):
         self.position = position
         self.dims_displayed = dims_displayed
         self.dims_point = dims_point
+        self.viewbox = viewbox

--- a/src/napari/components/cursor.py
+++ b/src/napari/components/cursor.py
@@ -12,6 +12,8 @@ class Cursor(EventedModel):
     position : tuple of float
         Position of the cursor in world coordinates. If the cursor is outside of,
         the canvas, then the last known position is stored instead.
+    viewbox : tuple[int, int] or None
+        Position of the cursor in the grid.
     scaled : bool
         Flag to indicate whether cursor size should be scaled to zoom.
         Only relevant for circle and square cursors which are drawn
@@ -36,6 +38,7 @@ class Cursor(EventedModel):
 
     # fields
     position: tuple[float, ...] = (1.0, 1.0)
+    viewbox: tuple[int, int] | None = None
     scaled: bool = True
     size = 1.0
     style: CursorStyle = CursorStyle.STANDARD


### PR DESCRIPTION
# References and relevant issues
- closes #8126

# Description
This adds information about the coordinates of the current viewbox to both `event` and the cursor model.

This allows for things like:

```py
viewer.cursor.events.viewbox.connect(my_callback)
```

or

```py
def some_mouse_move_callback(event):
    viewbox = event.viewbox
```


Which can be for example used as follows to obtain the layers in the hovered viewbox (original request from #8126):

```py
layer_indices = viewer.grid.contents_at(viewbox, nlayers=len(viewer.layers))

layers = [viewer.layers[i] for i in layer_indices]
```

@coreyelowsky does this work for you?

PS: This is also a good set-up to improve our `viewer.status` machinery to account for the hovered viewbox as well.
