### PR TITLE
Only use scale to transform margins in thick slices

### DIFF
--- a/src/napari/layers/utils/_slice_input.py
+++ b/src/napari/layers/utils/_slice_input.py
@@ -201,11 +201,10 @@ class _SliceInput:
         world_slice_not_disp = self.world_slice[self.not_displayed].as_array()
 
         data_slice = slice_world_to_data(world_slice_not_disp)
-        try:
-            scale = slice_world_to_data.scale
-        except ValueError:
-            scale = 1
-        data_slice[1:] = world_slice_not_disp[1:] * scale
+        # the margins (data_slice[1:]) should be relative to the origin,
+        # but properly rescaled based on the transform, so we remove the translation
+        # to bring them back around zero.
+        data_slice[1:] -= slice_world_to_data.translate
 
         full_data_slice = np.full((3, self.ndim), np.nan)
 

--- a/src/napari/layers/utils/_slice_input.py
+++ b/src/napari/layers/utils/_slice_input.py
@@ -201,6 +201,11 @@ class _SliceInput:
         world_slice_not_disp = self.world_slice[self.not_displayed].as_array()
 
         data_slice = slice_world_to_data(world_slice_not_disp)
+        try:
+            scale = slice_world_to_data.scale
+        except ValueError:
+            scale = 1
+        data_slice[1:] = world_slice_not_disp[1:] * scale
 
         full_data_slice = np.full((3, self.ndim), np.nan)
 


### PR DESCRIPTION
# References and relevant issues
- zulip discussion: https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E6.2E3/near/530366809

# Description
Ok I think I got it. Instead of using the scale only (which was both not strictlly correct and also broken due to some exception trhrown every time the `Affine.scale` was requested), I'm simply *subtracting the translation* instead, which is exactly what we want.

Now as far as I can tell it works ok with the example `xarray-latlon-timeseries.py`. Also, testing with this works:

```py
import napari
import numpy as np

v = napari.Viewer()
data = np.zeros((5, 5, 5))
data[2, 2, 2] = 1
l = v.add_image(data, translate=(3, 10, -4), scale=(2, 3, 1))
l.bounding_box.visible = True
```

(ignore the delayed update on the bounding box, separate bug)

Also, testing with `examples/nD_image.py` and doing a bunch of manual transformations (including rotations and scale), changing the thickness of various dimensions, and rolling dimensions, all seem to work as expected.

By the way, this was broken since thick slicing was introduced, we just never noticed cause I guess no one tested with translations :sweat_smile:  
