### PR TITLE
Slightly increase pip test workflow timeout

### DIFF
--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -7,7 +7,7 @@ jobs:
   test_pip_install:
     name: ubuntu-latest 3.12 pip install
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# References and relevant issues


# Description

I have observed multiple timeouts of our test suite on the pip job. The test often takes around 25 minutes, so it is easy to hit the 30-minute limit. 

We should check if we could speed up the test suite itself, but let's slightly increase the time limit to stop having unrelated crashes to the PR content.
