### PR TITLE
Fix scalebar behaviour at high/low zoom

### DIFF
--- a/src/napari/_vispy/camera.py
+++ b/src/napari/_vispy/camera.py
@@ -113,10 +113,9 @@ class VispyCamera:
             scale = np.array(
                 [self._view.camera.rect.width, self._view.camera.rect.height]
             )
-            # we just never want this to be zero; however, ideally we should block zooming
-            # itself (currently we rely on vispy to do camera callbacks so we can't do this)
-            # other stuff breaks at lower than 1e-8, so we shhouldn't go there...
-            scale = np.clip(scale, 1e-8, np.inf)
+            # TODO: ideally we should block zooming after a certain threshold,
+            # (currently we rely on vispy to do camera callbacks so we can't do this)
+            # since other stuff breaks at high/low zooms...
         zoom = np.min(viewbox_size / scale)
         return zoom
 

--- a/src/napari/_vispy/camera.py
+++ b/src/napari/_vispy/camera.py
@@ -113,7 +113,10 @@ class VispyCamera:
             scale = np.array(
                 [self._view.camera.rect.width, self._view.camera.rect.height]
             )
-            scale[np.isclose(scale, 0)] = 1  # fix for #2875
+            # we just never want this to be zero; however, ideally we should block zooming
+            # itself (currently we rely on vispy to do camera callbacks so we can't do this)
+            # other stuff breaks at lower than 1e-8, so we shhouldn't go there...
+            scale = np.clip(scale, 1e-8, np.inf)
         zoom = np.min(viewbox_size / scale)
         return zoom
 

--- a/src/napari/_vispy/camera.py
+++ b/src/napari/_vispy/camera.py
@@ -113,9 +113,10 @@ class VispyCamera:
             scale = np.array(
                 [self._view.camera.rect.width, self._view.camera.rect.height]
             )
-            # TODO: ideally we should block zooming after a certain threshold,
-            # (currently we rely on vispy to do camera callbacks so we can't do this)
-            # since other stuff breaks at high/low zooms...
+            # we just never want this to be zero; however, ideally we should block zooming
+            # itself (currently we rely on vispy to do camera callbacks so we can't do this)
+            # other stuff breaks at lower than 1e-8, so we shhouldn't go there...
+            scale = np.clip(scale, 1e-8, np.inf)
         zoom = np.min(viewbox_size / scale)
         return zoom
 

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -88,7 +88,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             # return the last index.
             index -= 1
         new_value: float = PREFERRED_VALUES[index]
-        if new_quantity.dimensionless and new_quantity.magnitude < 1:
+        if new_quantity.dimensionless:
             # using Decimal is necessary to avoid `4.999999e-6`
             # at really small scale.
             new_value = float(


### PR DESCRIPTION
# References and relevant issues
- closes https://github.com/napari/napari/issues/7956
- closes (kinda?) https://github.com/napari/napari/issues/6055

# Description

1. This issue has been bothering me for a long time and I finally figured it out. On main, if you have the scalebar enabled and zoom out beyond 1000, it will suddenly collapse to a single pixel.

Turns out, when the scalebar is dimensionless we need to ensure to keep the world pixel length to the *real* lenght, because we don't have unit multiples. Funny thing is, we already had this check in place, but for some reason only applied to high zooms, and not low zooms. Anyways, AFAICT this works.

2. The second issue is ultimately caused by our camera reporting a zoom of `1` when it reaches a low enough scale factor. This code points to https://github.com/napari/napari/issues/2875, but I can't figure out why.

EDIT: it seems to be https://github.com/napari/napari/pull/2958. I tried to remove this guard completely and I don't actually see that issue anymore... I think it might be solved, either by the fact that we moved a lot of camera updates to `on_draw` in https://github.com/napari/napari/pull/7870 specifically because the viewbox was degenerate, or for some other reason. Maybe we can just remove this?