### PR TITLE
Fix multiscale clim estimation by using full visible data, not first row

### DIFF
--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -569,8 +569,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         if mode == 'data':
             input_data = self.data[-1] if self.multiscale else self.data
         elif mode == 'slice':
-            data = self._slice.image.raw  # ugh
-            input_data = data[-1] if self.multiscale else data
+            input_data = self._slice.image.raw  # ugh
         else:
             raise ValueError(
                 trans._(


### PR DESCRIPTION
# References and relevant issues
addresses part of #8150 (multiscale)

# Description

The `self._slice.image.raw` already contains information from a single level of multi scale data. 

It is still not ideal, as on chunked data it will use only the visible portion of data, but still an improvement from the current state 