### PR TITLE
Move scalar field _slice machinery to proper module and update naming

### DIFF
--- a/src/napari/layers/_scalar_field/scalar_field.py
+++ b/src/napari/layers/_scalar_field/scalar_field.py
@@ -12,13 +12,16 @@ from numpy import typing as npt
 from napari.layers import Layer
 from napari.layers._data_protocols import LayerDataProtocol
 from napari.layers._multiscale_data import MultiScaleData
+from napari.layers._scalar_field._slice import (
+    _ScalarFieldSliceRequest,
+    _ScalarFieldSliceResponse,
+)
 from napari.layers.image._image_constants import Interpolation, VolumeDepiction
 from napari.layers.image._image_mouse_bindings import (
     move_plane_along_normal as plane_drag_callback,
     set_plane_position as plane_double_click_callback,
 )
 from napari.layers.image._image_utils import guess_multiscale
-from napari.layers.image._slice import _ImageSliceRequest, _ImageSliceResponse
 from napari.layers.utils._slice_input import _SliceInput, _ThickNDSlice
 from napari.layers.utils.plane import SlicingPlane
 from napari.utils._dask_utils import DaskIndexer
@@ -286,7 +289,7 @@ class ScalarFieldBase(Layer, ABC):
             np.array(self.level_shapes)[self._data_level][displayed_axes] - 1
         )
 
-        self._slice = _ImageSliceResponse.make_empty(
+        self._slice = _ScalarFieldSliceResponse.make_empty(
             slice_input=self._slice_input,
             rgb=len(self.data.shape) != self.ndim,
             dtype=self._slice_dtype(),
@@ -499,7 +502,7 @@ class ScalarFieldBase(Layer, ABC):
         response = request()
         self._update_slice_response(response)
 
-    def _make_slice_request(self, dims: Dims) -> _ImageSliceRequest:
+    def _make_slice_request(self, dims: Dims) -> _ScalarFieldSliceRequest:
         """Make an image slice request based on the given dims and this image."""
         slice_input = self._make_slice_input(dims)
         # For the existing sync slicing, indices is passed through
@@ -521,14 +524,14 @@ class ScalarFieldBase(Layer, ABC):
         slice_input: _SliceInput,
         data_slice: _ThickNDSlice,
         dask_indexer: DaskIndexer,
-    ) -> _ImageSliceRequest:
+    ) -> _ScalarFieldSliceRequest:
         """Needed to support old-style sync slicing through _slice_dims and
         _set_view_slice.
 
         This is temporary scaffolding that should go away once we have completed
         the async slicing project: https://github.com/napari/napari/issues/4795
         """
-        return _ImageSliceRequest(
+        return _ScalarFieldSliceRequest(
             slice_input=slice_input,
             data=self.data,
             dask_indexer=dask_indexer,
@@ -543,7 +546,9 @@ class ScalarFieldBase(Layer, ABC):
             downsample_factors=self.downsample_factors,
         )
 
-    def _update_slice_response(self, response: _ImageSliceResponse) -> None:
+    def _update_slice_response(
+        self, response: _ScalarFieldSliceResponse
+    ) -> None:
         """Update the slice output state currently on the layer. Currently used
         for both sync and async slicing.
         """

--- a/src/napari/layers/image/_tests/test_image_utils.py
+++ b/src/napari/layers/image/_tests/test_image_utils.py
@@ -10,8 +10,8 @@ from hypothesis import given
 from hypothesis.extra.numpy import array_shapes
 from skimage.transform import pyramid_gaussian
 
+from napari.layers._scalar_field._slice import _ScalarFieldSliceRequest
 from napari.layers.image._image_utils import guess_multiscale, guess_rgb
-from napari.layers.image._slice import _ImageSliceRequest
 from napari.layers.utils._slice_input import _ThickNDSlice
 
 data_dask = da.random.random(
@@ -142,7 +142,7 @@ def test_timing_multiscale_big():
 
 def test_create_data_indexing():
     point = (np.nan, 10.1, 2.6, 4)
-    idx = _ImageSliceRequest._point_to_slices(point)
+    idx = _ScalarFieldSliceRequest._point_to_slices(point)
     expected = (slice(None), 10, 3, 4)
     assert idx == expected
 
@@ -153,7 +153,7 @@ def test_create_data_indexing():
         margin_left=(np.nan, 0, 1.6, 0.3, 1),
         margin_right=(np.nan, 0.1, 0.3, 0.5, 0.6),
     )
-    idx = _ImageSliceRequest._data_slice_to_slices(
+    idx = _ScalarFieldSliceRequest._data_slice_to_slices(
         data_slice, dims_displayed=(0,)
     )
     expected = (

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -11,6 +11,7 @@ from scipy import ndimage as ndi
 
 from napari.layers._data_protocols import LayerDataProtocol
 from napari.layers._multiscale_data import MultiScaleData
+from napari.layers._scalar_field._slice import _ScalarFieldSliceResponse
 from napari.layers._scalar_field.scalar_field import ScalarFieldBase
 from napari.layers.image._image_constants import (
     ImageProjectionMode,
@@ -19,7 +20,6 @@ from napari.layers.image._image_constants import (
     InterpolationStr,
 )
 from napari.layers.image._image_utils import guess_rgb
-from napari.layers.image._slice import _ImageSliceResponse
 from napari.layers.intensity_mixin import IntensityVisualizationMixin
 from napari.layers.utils.layer_utils import calc_data_range
 from napari.utils._dtype import get_dtype_limits, normalize_dtype
@@ -389,7 +389,9 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         )
         return state
 
-    def _update_slice_response(self, response: _ImageSliceResponse) -> None:
+    def _update_slice_response(
+        self, response: _ScalarFieldSliceResponse
+    ) -> None:
         if self._keep_auto_contrast:
             data = response.image.raw
             input_data = data[-1] if self.multiscale else data

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -16,6 +16,7 @@ from skimage.draw import polygon2mask
 
 from napari.layers._data_protocols import LayerDataProtocol
 from napari.layers._multiscale_data import MultiScaleData
+from napari.layers._scalar_field._slice import _ScalarFieldSliceResponse
 from napari.layers._scalar_field.scalar_field import ScalarFieldBase
 from napari.layers.base import Layer, no_op
 from napari.layers.base._base_mouse_bindings import (
@@ -23,7 +24,6 @@ from napari.layers.base._base_mouse_bindings import (
     transform_with_box,
 )
 from napari.layers.image._image_utils import guess_multiscale
-from napari.layers.image._slice import _ImageSliceResponse
 from napari.layers.labels._labels_constants import (
     IsoCategoricalGradientMode,
     LabelColorMode,
@@ -829,7 +829,9 @@ class Labels(ScalarFieldBase):
         """
         return vispy_texture_dtype(data)
 
-    def _update_slice_response(self, response: _ImageSliceResponse) -> None:
+    def _update_slice_response(
+        self, response: _ScalarFieldSliceResponse
+    ) -> None:
         """Override to convert raw slice data to displayed label colors."""
         response = response.to_displayed(self._raw_to_displayed)
         super()._update_slice_response(response)


### PR DESCRIPTION
# References and relevant issues


# Description

During working on #8149, the wrong naming on the slice led to confusion, as the usage in the Labels layer was not obvious when reading the code.

This PR updates the code structure and naming to reduce future confusion. 