### PR TITLE
Update xarray_nD_image_.py to use xarray tag

### DIFF
--- a/examples/xarray_nD_image_.py
+++ b/examples/xarray_nD_image_.py
@@ -4,7 +4,7 @@ Xarray example
 
 Displays an xarray
 
-.. tags:: visualization-nD
+.. tags:: visualization-nD, xarray
 """
 
 try:


### PR DESCRIPTION
# References and relevant issues
NA

# Description
I noticed there was an `xarray` tag for examples, but this example which uses xarray doesn't have it.
