### PR TITLE
Clean benchmark logs by using the non-deprecated layer-adding method

### DIFF
--- a/src/napari/benchmarks/benchmark_qt_viewer_image.py
+++ b/src/napari/benchmarks/benchmark_qt_viewer_image.py
@@ -2,6 +2,8 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 # or the napari documentation on benchmarking
 # https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
+from __future__ import annotations
+
 import os
 
 import numpy as np
@@ -9,12 +11,16 @@ from packaging.version import parse as parse_version
 from qtpy.QtWidgets import QApplication
 
 import napari
+import napari.layers
 
 NAPARI_0_4_19 = parse_version(napari.__version__) <= parse_version('0.4.19')
 
 
 class QtViewerViewImageSuite:
     """Benchmarks for viewing images in the viewer."""
+
+    data: np.ndarray
+    viewer: napari.Viewer | None
 
     params = [2**i for i in range(4, 13)]
 
@@ -23,8 +29,8 @@ class QtViewerViewImageSuite:
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
-        np.random.seed(0)
-        self.data = np.random.random((n, n))
+        rng = np.random.default_rng(0)
+        self.data = rng.random((n, n))
         self.viewer = None
 
     def teardown(self, n):
@@ -32,7 +38,7 @@ class QtViewerViewImageSuite:
 
     def time_view_image(self, n):
         """Time to view an image."""
-        self.viewer = napari.view_image(self.data)
+        self.viewer, _ = napari.imshow(self.data)
 
 
 class QtViewerAddImageSuite:
@@ -60,6 +66,9 @@ class QtViewerAddImageSuite:
 class QtViewerImageSuite:
     """Benchmarks for images in the viewer."""
 
+    viewer: napari.Viewer
+    data: np.ndarray
+
     params = [2**i for i in range(4, 13)]
 
     if 'PR' in os.environ:
@@ -67,9 +76,10 @@ class QtViewerImageSuite:
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
-        np.random.seed(0)
-        self.data = np.random.random((n, n))
-        self.viewer = napari.view_image(self.data)
+        rng = np.random.default_rng(0)
+        self.data = rng.random((n, n))
+        self.viewer = napari.Viewer()
+        self.viewer.add_image(self.data)
 
     def teardown(self, n):
         self.viewer.window.close()
@@ -111,12 +121,18 @@ class QtViewerImageSuite:
 class QtViewerSingleImageSuite:
     """Benchmarks for a single image layer in the viewer."""
 
+    data: np.ndarray
+    new_data: np.ndarray
+    viewer: napari.Viewer
+    layer: napari.layers.Image
+
     def setup(self):
         _ = QApplication.instance() or QApplication([])
-        np.random.seed(0)
-        self.data = np.random.random((128, 128, 128))
-        self.new_data = np.random.random((128, 128, 128))
-        self.viewer = napari.view_image(self.data)
+        rng = np.random.default_rng(0)
+        self.data = rng.random((128, 128, 128))
+        self.new_data = rng.random((128, 128, 128))
+        self.viewer = napari.Viewer()
+        self.layer = self.viewer.add_image(self.data)
 
     def teardown(self):
         self.viewer.window.close()
@@ -140,23 +156,23 @@ class QtViewerSingleImageSuite:
 
     def time_set_data(self):
         """Time to set view slice."""
-        self.viewer.layers[0].data = self.new_data
+        self.layer.data = self.new_data
 
     def time_refresh(self):
         """Time to refresh view."""
-        self.viewer.layers[0].refresh()
+        self.layer.refresh()
 
     def time_set_view_slice(self):
         """Time to set view slice."""
-        self.viewer.layers[0]._set_view_slice()
+        self.layer._set_view_slice()
 
     def time_update_thumbnail(self):
         """Time to update thumbnail."""
-        self.viewer.layers[0]._update_thumbnail()
+        self.layer._update_thumbnail()
 
     def time_get_value(self):
         """Time to get current value."""
-        self.viewer.layers[0].get_value((0,) * 3)
+        self.layer.get_value((0,) * 3)
 
     def time_ndisplay(self):
         """Time to enter 3D rendering."""
@@ -166,12 +182,18 @@ class QtViewerSingleImageSuite:
 class QtViewerSingleInvisbleImageSuite:
     """Benchmarks for a invisible single image layer in the viewer."""
 
+    data: np.ndarray
+    new_data: np.ndarray
+    viewer: napari.Viewer
+    layer: napari.layers.Image
+
     def setup(self):
         _ = QApplication.instance() or QApplication([])
-        np.random.seed(0)
-        self.data = np.random.random((128, 128, 128))
-        self.new_data = np.random.random((128, 128, 128))
-        self.viewer = napari.view_image(self.data, visible=False)
+        rng = np.random.default_rng(0)
+        self.data = rng.random((128, 128, 128))
+        self.new_data = rng.random((128, 128, 128))
+        self.viewer = napari.Viewer()
+        self.layer = self.viewer.add_image(self.data, visible=False)
 
     def teardown(self):
         self.viewer.window.close()
@@ -195,23 +217,23 @@ class QtViewerSingleInvisbleImageSuite:
 
     def time_set_data(self):
         """Time to set view slice."""
-        self.viewer.layers[0].data = self.new_data
+        self.layer.data = self.new_data
 
     def time_refresh(self):
         """Time to refresh view."""
-        self.viewer.layers[0].refresh()
+        self.layer.refresh()
 
     def time_set_view_slice(self):
         """Time to set view slice."""
-        self.viewer.layers[0]._set_view_slice()
+        self.layer._set_view_slice()
 
     def time_update_thumbnail(self):
         """Time to update thumbnail."""
-        self.viewer.layers[0]._update_thumbnail()
+        self.layer._update_thumbnail()
 
     def time_get_value(self):
         """Time to get current value."""
-        self.viewer.layers[0].get_value((0,) * 3)
+        self.layer.get_value((0,) * 3)
 
     def time_ndisplay(self):
         """Time to enter 3D rendering."""
@@ -221,6 +243,10 @@ class QtViewerSingleInvisbleImageSuite:
 class QtImageRenderingSuite:
     """Benchmarks for a single image layer in the viewer."""
 
+    data: np.ndarray
+    viewer: napari.Viewer
+    layer: napari.layers.Image
+
     params = [2**i for i in range(4, 13)]
 
     if 'PR' in os.environ:
@@ -228,28 +254,32 @@ class QtImageRenderingSuite:
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
-        np.random.seed(0)
-        self.data = np.random.random((n, n)) * 2**12
-        self.viewer = napari.view_image(self.data, ndisplay=2)
+        rng = np.random.default_rng(0)
+        self.data = rng.random((n, n)) * 2**12
+        self.viewer = napari.Viewer
+        self.layer = self.viewer.add_image(self.data, ndisplay=2)
 
     def teardown(self, n):
         self.viewer.close()
 
     def time_change_contrast(self, n):
         """Time to change contrast limits."""
-        self.viewer.layers[0].contrast_limits = (250, 3000)
-        self.viewer.layers[0].contrast_limits = (300, 2900)
-        self.viewer.layers[0].contrast_limits = (350, 2800)
+        self.layer.contrast_limits = (250, 3000)
+        self.layer.contrast_limits = (300, 2900)
+        self.layer.contrast_limits = (350, 2800)
 
     def time_change_gamma(self, n):
         """Time to change gamma."""
-        self.viewer.layers[0].gamma = 0.5
-        self.viewer.layers[0].gamma = 0.8
-        self.viewer.layers[0].gamma = 1.3
+        self.layer.gamma = 0.5
+        self.layer.gamma = 0.8
+        self.layer.gamma = 1.3
 
 
 class QtVolumeRenderingSuite:
     """Benchmarks for a single image layer in the viewer."""
+
+    data: np.ndarray
+    viewer: napari.Viewer
 
     params = [2**i for i in range(4, 10)]
 
@@ -258,9 +288,10 @@ class QtVolumeRenderingSuite:
 
     def setup(self, n):
         _ = QApplication.instance() or QApplication([])
-        np.random.seed(0)
-        self.data = np.random.random((n, n, n)) * 2**12
-        self.viewer = napari.view_image(self.data, ndisplay=3)
+        rng = np.random.default_rng(0)
+        self.data = rng.random((n, n, n)) * 2**12
+        self.viewer = napari.Viewer
+        self.viewer.add_image(self.data, ndisplay=3)
 
     def teardown(self, n):
         self.viewer.close()

--- a/src/napari/benchmarks/benchmark_qt_viewer_image.py
+++ b/src/napari/benchmarks/benchmark_qt_viewer_image.py
@@ -256,8 +256,8 @@ class QtImageRenderingSuite:
         _ = QApplication.instance() or QApplication([])
         rng = np.random.default_rng(0)
         self.data = rng.random((n, n)) * 2**12
-        self.viewer = napari.Viewer
-        self.layer = self.viewer.add_image(self.data, ndisplay=2)
+        self.viewer = napari.Viewer(ndisplay=2)
+        self.layer = self.viewer.add_image(self.data)
 
     def teardown(self, n):
         self.viewer.close()
@@ -290,8 +290,8 @@ class QtVolumeRenderingSuite:
         _ = QApplication.instance() or QApplication([])
         rng = np.random.default_rng(0)
         self.data = rng.random((n, n, n)) * 2**12
-        self.viewer = napari.Viewer
-        self.viewer.add_image(self.data, ndisplay=3)
+        self.viewer = napari.Viewer(ndisplay=3)
+        self.viewer.add_image(self.data)
 
     def teardown(self, n):
         self.viewer.close()

--- a/src/napari/benchmarks/benchmark_qt_viewer_labels.py
+++ b/src/napari/benchmarks/benchmark_qt_viewer_labels.py
@@ -13,6 +13,7 @@ from skimage.morphology import diamond, octahedron
 from vispy.app import MouseEvent
 
 import napari
+import napari.layers
 from napari.components.viewer_model import ViewerModel
 from napari.qt import QtViewer
 from napari.utils.colormaps import DirectLabelColormap
@@ -25,12 +26,17 @@ NAPARI_0_4_19 = parse_version(napari.__version__) <= parse_version('0.4.19')
 class QtViewerSingleLabelsSuite:
     """Benchmarks for editing a single labels layer in the viewer."""
 
+    data: np.ndarray
+    viewer: napari.Viewer
+    layer: napari.layers.Labels
+    event: MouseEvent
+
     def setup(self):
         _ = QApplication.instance() or QApplication([])
-        np.random.seed(0)
-        self.data = np.random.randint(10, size=(512, 512))
-        self.viewer = napari.view_labels(self.data)
-        self.layer = self.viewer.layers[0]
+        rng = np.random.default_rng(0)
+        self.data = rng.integers(10, size=(512, 512))
+        self.viewer = napari.Viewer()
+        self.layer = self.viewer.add_labels(self.data)
         self.layer.brush_size = 10
         self.layer.mode = 'paint'
         self.layer.selected_label = 3


### PR DESCRIPTION
# References and relevant issues


# Description

We still use the `view_image` and `view_labels` methods in benchmarks that flood logs with warnings. 

This PR fixes this. 