### PR TITLE
Remove `np.asarray(self.cursor._view_direction)` that return unbound array

### DIFF
--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -721,7 +721,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         if self.tooltip.visible and active is not None and active._loaded:
             tooltip_text = active._get_tooltip_text(
                 np.asarray(self.cursor.position),
-                view_direction=np.asarray(self.cursor._view_direction),
+                view_direction=self.cursor._view_direction,
                 dims_displayed=list(self.dims.displayed),
                 world=True,
             )


### PR DESCRIPTION
# References and relevant issues

pointed: https://github.com/napari/napari/pull/8135#issuecomment-3136892140

# Description

This casting looks obsolete based on variable type annotations and crashes Napari on some machines. 