### PR TITLE
Set focus after toggling dockwidget via `DockWidgetToggleAction`

### DIFF
--- a/src/napari/_qt/_qapp_model/qactions/_toggle_action.py
+++ b/src/napari/_qt/_qapp_model/qactions/_toggle_action.py
@@ -41,6 +41,7 @@ class DockWidgetToggleAction(Action):
         def toggle_dock_widget(window: Window) -> None:
             dock_widget_prop = getattr(window._qt_viewer, dock_widget)
             dock_widget_prop.setVisible(not dock_widget_prop.isVisible())
+            dock_widget_prop.setFocus()
 
         def get_current(window: Window) -> bool:
             dock_widget_prop = getattr(window._qt_viewer, dock_widget)


### PR DESCRIPTION
# References and relevant issues

Closes #7612 

# Description

Give focus to dockwidgets after toggling their visibility via `DockWidgetToggleAction`. For more details see https://github.com/napari/napari/issues/7612#issuecomment-3137316111

A preview:

![Image](https://github.com/user-attachments/assets/5c543a9d-dda4-48f7-a735-e3b0eb7b9d01)


