### PR TITLE
Fix slider label shifted down, by overrwite QLineEdit qss rules

### DIFF
--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -196,7 +196,7 @@ QWidget[emphasized="true"] QDoubleSlider::handle:disabled {
 }
 
 SliderLabel {
-  background-color: "white"; /*{{ darken(background, 15) }};*/
+  background-color: {{ darken(background, 15) }};
   color: {{ text }};
   min-height: 16px;
   padding: 0px;

--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -195,6 +195,19 @@ QWidget[emphasized="true"] QDoubleSlider::handle:disabled {
     background: {{ primary }};
 }
 
+SliderLabel {
+  background-color: "white"; /*{{ darken(background, 15) }};*/
+  color: {{ text }};
+  min-height: 16px;
+  padding: 0px;
+  border-radius: 2px;
+  font-size: {{ decrease(font_size, 1) }};
+}
+
+QWidget[emphasized="true"] SliderLabel {
+  background-color: {{ background }};
+}
+
 QWidget[emphasized="true"] SliderLabel:disabled {
     color: {{ opacity(text, 50) }};
 }


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/7355#issuecomment-3134232094

# Description

After long debugging, I found that the slider label is shifted because of 2px padding of QLineEdit set in our QSS. It was a long and not obvious debug route.  


So it means that the problem cannot be solved by a patch of superqt and will be with us until the next napari release.




