### PR TITLE
Remove old path handle in napari start

### DIFF
--- a/src/napari/__main__.py
+++ b/src/napari/__main__.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from textwrap import wrap
 from typing import Any
 
+from napari import Viewer
 from napari.errors import ReaderPluginError
 from napari.utils.misc import maybe_patch_conda_exe
 from napari.utils.translations import trans
@@ -209,7 +210,7 @@ def parse_sys_argv():
 
 
 def _run() -> None:
-    from napari import Viewer, run
+    from napari import run
     from napari.settings import get_settings
 
     """Main program."""

--- a/src/napari/__main__.py
+++ b/src/napari/__main__.py
@@ -6,7 +6,6 @@ import argparse
 import contextlib
 import logging
 import os
-import runpy
 import sys
 import warnings
 from ast import literal_eval
@@ -245,23 +244,6 @@ def _run() -> None:
         # which emits "WARNING: No such plugin for spec 'builtins'"
         # so remove --plugin from sys.argv to prevent that warning
         sys.argv.remove('--plugin')
-
-    if any(p.endswith('.py') for p in args.paths):
-        # we're running a script
-        if len(args.paths) > 1:
-            sys.exit(
-                'When providing a python script, only a '
-                'single positional argument may be provided'
-            )
-
-        # run the file
-        mod = runpy.run_path(args.paths[0])
-
-        from napari_plugin_engine.markers import HookImplementationMarker
-
-        # if this file had any hook implementations, register and run as plugin
-        if any(isinstance(i, HookImplementationMarker) for i in mod.values()):
-            _run_plugin_module(mod, os.path.basename(args.paths[0]))
 
     else:
         if args.with_:

--- a/src/napari/_tests/test_cli.py
+++ b/src/napari/_tests/test_cli.py
@@ -78,9 +78,8 @@ def test_cli_raises(monkeypatch):
         assert str(e.value) == 'error: argument --gamma expected one argument'
 
 
-@mock.patch('qtpy.QtWidgets.QApplication.exec_')
 @pytest.mark.usefixtures('builtins')
-def test_cli_runscript(exec_, monkeypatch, tmp_path, make_napari_viewer):
+def test_cli_runscript(monkeypatch, tmp_path, make_napari_viewer):
     """Test that running napari script.py runs a script"""
     v = make_napari_viewer()
     script = tmp_path / 'test.py'
@@ -89,10 +88,12 @@ def test_cli_runscript(exec_, monkeypatch, tmp_path, make_napari_viewer):
     with monkeypatch.context() as m:
         m.setattr(sys, 'argv', ['napari', str(script)])
         m.setattr(__main__, 'Viewer', lambda: v)
+        m.setattr(
+            'qtpy.QtWidgets.QApplication.exec_', lambda: None
+        )  # revent event loop if run this test standalone
         __main__._run()
 
     assert len(v.layers) == 1
-    exec_.assert_called_once_with()
 
 
 @mock.patch('napari._qt.qt_viewer.QtViewer._qt_open')

--- a/src/napari/_tests/test_cli.py
+++ b/src/napari/_tests/test_cli.py
@@ -36,14 +36,16 @@ def test_cli_shows_plugins(monkeypatch, capsys, tmp_plugin):
 
 def test_cli_parses_unknowns(mock_run, monkeypatch, make_napari_viewer):
     """test that we can parse layer keyword arg variants"""
-    v = make_napari_viewer()  # our mock view_path will return this object
+    mocked_viewer = (
+        make_napari_viewer()
+    )  # our mock view_path will return this object
 
     def assert_kwargs(*args, **kwargs):
         assert ['file'] in args
         assert kwargs['contrast_limits'] == (0, 1)
 
     # testing all the variants of literal_evals
-    with mock.patch('napari.__main__.Viewer', return_value=v):
+    with mock.patch('napari.__main__.Viewer', return_value=mocked_viewer):
         monkeypatch.setattr(
             napari.components.viewer_model.ViewerModel, 'open', assert_kwargs
         )
@@ -159,7 +161,9 @@ def test_cli_passes_kwargs_stack(
 
 def test_cli_retains_viewer_ref(mock_run, monkeypatch, make_napari_viewer):
     """Test that napari.__main__ is retaining a reference to the viewer."""
-    v = make_napari_viewer()  # our mock view_path will return this object
+    mocked_viewer = (
+        make_napari_viewer()
+    )  # our mock view_path will return this object
     ref_count = None  # counter that will be updated before __main__._run()
 
     def _check_refs(**kwargs):
@@ -167,7 +171,7 @@ def test_cli_retains_viewer_ref(mock_run, monkeypatch, make_napari_viewer):
         # it forces garbage collection, and then makes sure that at least one
         # additional reference to our viewer exists.
         gc.collect()
-        if sys.getrefcount(v) <= ref_count:  # pragma: no cover
+        if sys.getrefcount(mocked_viewer) <= ref_count:  # pragma: no cover
             raise AssertionError(
                 'Reference to napari.viewer has been lost by '
                 'the time the event loop started in napari.__main__'
@@ -178,9 +182,11 @@ def test_cli_retains_viewer_ref(mock_run, monkeypatch, make_napari_viewer):
         m.setattr(sys, 'argv', ['napari', 'path/to/file.tif'])
         # return our local v
         with mock.patch(
-            'napari.__main__.Viewer', return_value=v
+            'napari.__main__.Viewer', return_value=mocked_viewer
         ) as mock_viewer:
-            ref_count = sys.getrefcount(v)  # count current references
+            ref_count = sys.getrefcount(
+                mocked_viewer
+            )  # count current references
             # mock gui open so we're not opening dialogs/throwing errors on fake path
             with mock.patch(
                 'napari._qt.qt_viewer.QtViewer._qt_open', return_value=None


### PR DESCRIPTION
# References and relevant issues

closes #8181

# Description
In #8135 we introduced a plugin to execute arbitrary Python code using reader. It also works when providing a `.py` file by argument. I do not have time earlier to check this.