### PR TITLE
Prevent `napari.run` from being executed when running scripts from napari

### DIFF
--- a/src/napari/_qt/_tests/test_viewer_qt_integration.py
+++ b/src/napari/_qt/_tests/test_viewer_qt_integration.py
@@ -38,7 +38,8 @@ def test_drop_python_file(qapp_mock, make_napari_viewer, tmp_path):
     # Check that the file was executed
     assert viewer.layers[0].name == 'Dropped Image'
 
-    # Ensure that napari.run is stopped early and event loops are not running
+    # Ensure that napari.run is stopped early and event loops are not started
+    # by call napari.run() in the script.
     qapp_mock.assert_not_called()
 
     # Check that the console is updated with locals from the script

--- a/src/napari/_qt/_tests/test_viewer_qt_integration.py
+++ b/src/napari/_qt/_tests/test_viewer_qt_integration.py
@@ -38,7 +38,8 @@ def test_drop_python_file(qapp_mock, make_napari_viewer, tmp_path):
     # Check that the file was executed
     assert viewer.layers[0].name == 'Dropped Image'
 
-    qapp_mock.assert_not_called()  # Ensure napari.run is early stopped
+    # Ensure that napari.run is stopped early and event loops are not running
+    qapp_mock.assert_not_called()
 
     # Check that the console is updated with locals from the script
     console = viewer.window._qt_viewer.console

--- a/src/napari/_qt/_tests/test_viewer_qt_integration.py
+++ b/src/napari/_qt/_tests/test_viewer_qt_integration.py
@@ -1,7 +1,7 @@
 """Tests of the Viewer class that interact directly with the Qt code"""
 
 import textwrap
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -11,17 +11,20 @@ from qtpy.QtCore import QUrl
 @pytest.mark.usefixtures('builtins')
 @pytest.mark.enable_console
 @pytest.mark.filterwarnings('ignore::DeprecationWarning:jupyter_client')
-def test_drop_python_file(make_napari_viewer, tmp_path):
+@patch('qtpy.QtWidgets.QApplication.topLevelWidgets')
+def test_drop_python_file(qapp_mock, make_napari_viewer, tmp_path):
     """Test dropping a python file on to the viewer."""
     viewer = make_napari_viewer()
     filename = tmp_path / 'image_to_drop.py'
     file_content = textwrap.dedent("""
     import numpy as np
-    from napari import Viewer
+    import napari
 
     data = np.zeros((10, 10))
-    viewer = Viewer()
+    viewer = napari.Viewer()
     viewer.add_image(data, name='Dropped Image')
+
+    napari.run()
     """)
     filename.write_text(file_content)
 
@@ -34,6 +37,8 @@ def test_drop_python_file(make_napari_viewer, tmp_path):
 
     # Check that the file was executed
     assert viewer.layers[0].name == 'Dropped Image'
+
+    qapp_mock.assert_not_called()  # Ensure napari.run is early stopped
 
     # Check that the console is updated with locals from the script
     console = viewer.window._qt_viewer.console

--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -363,6 +363,8 @@ def run(
     """
     if _ipython_has_eventloop():
         # If %gui qt is active, we don't need to block again.
+        # We patch _ipython_has_eventloop() to return True when executing
+        # scripts on drag and drop to prevent running the next event loop.
         return
 
     app = QApplication.instance()

--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -536,17 +536,20 @@ def _patch_run():
     """Context manager to patch the run method of the viewer."""
     from napari._qt import qt_event_loop
 
-    original_ipython_check = qt_event_loop._ipython_has_eventloop
+    ipython_check = qt_event_loop._ipython_has_eventloop
 
     def patched_ipython_check() -> bool:
-        # Do not call the original run method
+        """A patched ipython_check that always returns True.
+        
+        Drag and drop feature uses this to prevent running another event loop.
+        """
         return True
 
     qt_event_loop._ipython_has_eventloop = patched_ipython_check
     try:
         yield
     finally:
-        qt_event_loop._ipython_has_eventloop = original_ipython_check
+        qt_event_loop._ipython_has_eventloop = ipython_check
 
 
 def filter_variables(variables: dict[str, Any]) -> dict[str, Any]:

--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -536,7 +536,7 @@ def _patch_run():
     """Context manager to patch the run method of the viewer."""
     from napari._qt import qt_event_loop
 
-    origial_ipython_check = qt_event_loop._ipython_has_eventloop
+    original_ipython_check = qt_event_loop._ipython_has_eventloop
 
     def patched_ipython_check() -> bool:
         # Do not call the original run method
@@ -546,7 +546,7 @@ def _patch_run():
     try:
         yield
     finally:
-        qt_event_loop._ipython_has_eventloop = origial_ipython_check
+        qt_event_loop._ipython_has_eventloop = original_ipython_check
 
 
 def filter_variables(variables: dict[str, Any]) -> dict[str, Any]:

--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -576,21 +576,23 @@ def _add_dropped_scripts_to_console(
         console.push(variables)
 
 
-def load_and_execute_python_code(path: str) -> list['LayerData']:
+def load_and_execute_python_code(script_path: str) -> list['LayerData']:
     """Load and execute Python code from a file.
 
     Parameters
     ----------
-    path : str
+    script_path : str
         Path to the Python file to be executed.
     """
     from napari.viewer import current_viewer
 
-    code = Path(path).read_text()
+    code = Path(script_path).read_text()
     with _patch_viewer_new(), _patch_run():
         try:
             viewer = current_viewer()
-            script_namespace = _DROPPED_SCRIPTS_NAMESPACE.setdefault(path, {})
+            script_namespace = _DROPPED_SCRIPTS_NAMESPACE.setdefault(
+                script_path, {}
+            )
             # The `__name__` variable is storing the name of the module.
             # If a module is imported, it is set to the module name.
             # If a module is executed with `python -m ...` or
@@ -601,7 +603,7 @@ def load_and_execute_python_code(path: str) -> list['LayerData']:
             script_namespace['__name__'] = '__main__'
             exec(code, script_namespace)
             _add_dropped_scripts_to_console(
-                _DROPPED_SCRIPTS_NAMESPACE[path], viewer
+                _DROPPED_SCRIPTS_NAMESPACE[script_path], viewer
             )
         except BaseException as e:  # noqa: BLE001
             notification_manager.receive_error(type(e), e, e.__traceback__)

--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -534,16 +534,16 @@ def _patch_viewer_new():
 @contextmanager
 def _patch_napari_run():
     """Context manager to patch napari.run to always be a no-op.
-    
+
     napari.run() executes the Qt event loop, *except* when napari
     is running in IPython and therefore IPython's Qt integration
     already has the event loop.
-    
+
     When running a script by dragging-and-dropping onto a
     running napari Viewer, we already have an event loop, so we
     should not start a new nested loop, even though we are not
     in IPython.
-    
+
     This context manager temporarily patches the IPython check
     to always return True, causing a fast exit from napari.run()
     without a new event loop.

--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -540,7 +540,7 @@ def _patch_run():
 
     def patched_ipython_check() -> bool:
         """A patched ipython_check that always returns True.
-        
+
         Drag and drop feature uses this to prevent running another event loop.
         """
         return True


### PR DESCRIPTION
# References and relevant issues

Will solve https://github.com/napari/napari/pull/8185#issuecomment-3141371791

# Description

Here I add monkeypatching of `_ipython_has_eventloop` to early stop execution of `napari.run()` 
This prevents the creation of nested even loops. It is required to solve the problem pointed out in the linked comment. 

Also, this allows us to set `__name__` in the executed script to `'__main__'` which enables execution of code under `if __name__ == '__main__':`, allowing us to have working `multiple_viewer_widget.py` after drag and drop.