### PR TITLE
Fix feature table widget sorting and editing of floats

### DIFF
--- a/src/napari_builtins/_qt/_tests/test_features_table.py
+++ b/src/napari_builtins/_qt/_tests/test_features_table.py
@@ -8,10 +8,12 @@ from qtpy.QtCore import QItemSelection, QItemSelectionModel, Qt
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import (
     QAbstractItemDelegate,
+    QAbstractSpinBox,
     QComboBox,
     QDoubleSpinBox,
     QFileDialog,
     QLineEdit,
+    QSpinBox,
 )
 
 from napari.components import ViewerModel
@@ -284,8 +286,8 @@ def test_features_table_copy_paste(qtbot, qapp):
 @pytest.mark.parametrize(
     ('dtype', 'val', 'rendered_val', 'editor_class', 'new_val'),
     [
-        (int, 2, 2, QLineEdit, 3),
-        (float, 123.45678, 123.45678, QLineEdit, 1e10),
+        (int, 2, 2, QSpinBox, 3),
+        (float, 123.45678, 123.45678, QDoubleSpinBox, 123456789),
         (
             'datetime64[ns]',
             '22-07-2025',
@@ -331,7 +333,8 @@ def test_features_tables_dtypes(
 
     editor = w.table.findChild(editor_class)
 
-    if issubclass(editor_class, QLineEdit | QDoubleSpinBox):
+    if issubclass(editor_class, QLineEdit | QAbstractSpinBox):
+        editor.selectAll()
         qtbot.keyClicks(editor, str(new_val))
         w.table.commitData(editor)
     elif editor_class == QComboBox:
@@ -343,7 +346,7 @@ def test_features_tables_dtypes(
     assert (
         layer.features.loc[0, 'a']
         == pd.Series(new_val, dtype=pandas_dtype(dtype))[0]
-    )
+    ), editor.value()
 
 
 def test_features_table_change_active_layer(qtbot):

--- a/src/napari_builtins/_qt/_tests/test_features_table.py
+++ b/src/napari_builtins/_qt/_tests/test_features_table.py
@@ -9,6 +9,7 @@ from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import (
     QAbstractItemDelegate,
     QComboBox,
+    QDoubleSpinBox,
     QFileDialog,
     QLineEdit,
 )
@@ -23,7 +24,7 @@ def test_pandas_model():
     view = PandasModel(df)
     assert view.rowCount() == 4
     assert view.columnCount() == 3  # 0 is index
-    assert view.data(view.index(0, 1)) == '1'
+    assert view.data(view.index(0, 1)) == 1
     assert view.headerData(1, Qt.Orientation.Horizontal) == 'a'
     assert view.headerData(2, Qt.Orientation.Horizontal) == 'b'
     assert view.headerData(1, Qt.Orientation.Vertical) == 1
@@ -110,9 +111,7 @@ def test_features_table(qtbot):
     # sorting should sort the proxy model but not the data
     w.table.sortByColumn(1, Qt.SortOrder.AscendingOrder)
     for i in range(3):
-        assert proxy.data(proxy.index(i, 1), Qt.ItemDataRole.EditRole) == str(
-            i
-        )
+        assert proxy.data(proxy.index(i, 1), Qt.ItemDataRole.EditRole) == i
         assert layer.features['a'][i] == original_a[i]
 
     # sorting bools should work
@@ -285,8 +284,8 @@ def test_features_table_copy_paste(qtbot, qapp):
 @pytest.mark.parametrize(
     ('dtype', 'val', 'rendered_val', 'editor_class', 'new_val'),
     [
-        (int, 2, '2', QLineEdit, 3),
-        (float, 123.45678, '123.457', QLineEdit, 1e10),
+        (int, 2, 2, QLineEdit, 3),
+        (float, 123.45678, 123.45678, QLineEdit, 1e10),
         (
             'datetime64[ns]',
             '22-07-2025',
@@ -332,7 +331,7 @@ def test_features_tables_dtypes(
 
     editor = w.table.findChild(editor_class)
 
-    if issubclass(editor_class, QLineEdit):
+    if issubclass(editor_class, QLineEdit | QDoubleSpinBox):
         qtbot.keyClicks(editor, str(new_val))
         w.table.commitData(editor)
     elif editor_class == QComboBox:

--- a/src/napari_builtins/_qt/features_table.py
+++ b/src/napari_builtins/_qt/features_table.py
@@ -85,19 +85,18 @@ class PandasModel(QAbstractTableModel):
         ):
             return Qt.CheckState.Checked if value else Qt.CheckState.Unchecked
 
-        if role in {Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole}:
-            # format based on dtype
+        if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
             if pd.api.types.is_float_dtype(dtype):
-                return f'{value:.6g}'
+                return float(value)
             if pd.api.types.is_integer_dtype(dtype):
-                return f'{value:d}'
+                return int(value)
             if pd.api.types.is_datetime64_any_dtype(dtype):
                 return value.strftime('%Y-%m-%d')
             if pd.api.types.is_bool_dtype(dtype):
                 if role == Qt.ItemDataRole.DisplayRole:
                     return ''  # do not show True/False text
                 if role == Qt.ItemDataRole.EditRole:
-                    return value  # needed for proper sorting
+                    return bool(value)  # needed for proper sorting
             return str(value)
 
         return None
@@ -215,6 +214,10 @@ class DelegateCategorical(QStyledItemDelegate):
 
             # force editor to open on first click, otherwise we need 2 clicks
             QTimer.singleShot(0, editor.showPopup)
+            return editor
+        if pd.api.types.is_float_dtype(dtype):
+            editor = super().createEditor(parent, option, index)
+            editor.setDecimals(10)
             return editor
 
         return super().createEditor(parent, option, index)


### PR DESCRIPTION
# References and relevant issues

# Description
During preparations for the euroscipy tutorial, we realised that our feature table widget sorts number wrong because we were returning them as strings. We change that here, and also update the (now) spinbox editor so that it doesn't truncate to the second decimal.
