### PR TITLE
Fix fallback version in setuptools_scm to pass schema validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ napari_builtins = [
 
 [tool.setuptools_scm]
 write_to = "src/napari/_version.py"
-fallback_version = "0.6.0.nogit"
+fallback_version = "0.6.4.dev0"
 
 [tool.check-manifest]
 ignore = [


### PR DESCRIPTION
# References and relevant issues

```
        File "/tmp/pip-build-env-ky8ku6dl/overlay/lib/python3.12/site-packages/setuptools_scm/_get_version_impl.py", line 41, in parse_scm_version
          return _entrypoints.version_from_entrypoint(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ky8ku6dl/overlay/lib/python3.12/site-packages/setuptools_scm/_entrypoints.py", line 56, in version_from_entrypoint
          maybe_version: version.ScmVersion | None = fn(root, config=config)
                                                     ^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ky8ku6dl/overlay/lib/python3.12/site-packages/setuptools_scm/git.py", line 319, in parse
          return _git_parse_inner(
                 ^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ky8ku6dl/overlay/lib/python3.12/site-packages/setuptools_scm/git.py", line 365, in _git_parse_inner
          tag = config.version_cls(config.fallback_version or "0.0")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ky8ku6dl/overlay/lib/python3.12/site-packages/packaging/version.py", line 202, in __init__
          raise InvalidVersion(f"Invalid version: {version!r}")
      packaging.version.InvalidVersion: Invalid version: '0.6.0.nogit'
      [end of output]
```

https://github.com/napari/napari/actions/runs/16755402793/job/47436622805?pr=8188

# Description
Just released version of `setuptools_scm` add validation if version is correctly formatted https://packaging.python.org/en/latest/specifications/version-specifiers/

I changed the `nogit` to `dev0` in suffix as it should not happen in nature. 

Also bump to 0.6.4 as base. 
