### PR TITLE
Use napari url for test rather than Fiji

### DIFF
--- a/src/napari_builtins/_tests/test_reader.py
+++ b/src/napari_builtins/_tests/test_reader.py
@@ -54,7 +54,7 @@ def test_animated_gif_reader(save_image):
 @pytest.mark.slow
 def test_reader_plugin_url():
     layer_data = npe2.read(
-        ['https://samples.fiji.sc/FakeTracks.tif'], stack=False
+        ['https://github.com/napari/napari/raw/main/src/napari/resources/logo.png'], stack=False
     )
     assert isinstance(layer_data, list)
     assert len(layer_data) == 1

--- a/src/napari_builtins/_tests/test_reader.py
+++ b/src/napari_builtins/_tests/test_reader.py
@@ -54,7 +54,10 @@ def test_animated_gif_reader(save_image):
 @pytest.mark.slow
 def test_reader_plugin_url():
     layer_data = npe2.read(
-        ['https://github.com/napari/napari/raw/main/src/napari/resources/logo.png'], stack=False
+        [
+            'https://github.com/napari/napari/raw/main/src/napari/resources/logo.png'
+        ],
+        stack=False,
     )
     assert isinstance(layer_data, list)
     assert len(layer_data) == 1


### PR DESCRIPTION
# References and relevant issues

Part of test fails observed today https://github.com/napari/napari/issues/8194#issuecomment-3160730435

# Description

Use our logo.png which should always be a part of our repo, spams Github instead, and is also much smaller than the previous file (150kb vs 800kb). 


