### PR TITLE
Explicit copy of layers data for balls example

### DIFF
--- a/src/napari_builtins/_ndims_balls.py
+++ b/src/napari_builtins/_ndims_balls.py
@@ -8,9 +8,21 @@ def labeled_particles2d():
     )
 
     return [
-        (density, {'name': 'density', 'metadata': {'seed': seed}}, 'image'),
-        (labels, {'name': 'labels', 'metadata': {'seed': seed}}, 'labels'),
-        (points, {'name': 'points', 'metadata': {'seed': seed}}, 'points'),
+        (
+            density.copy(),
+            {'name': 'density', 'metadata': {'seed': seed}},
+            'image',
+        ),
+        (
+            labels.copy(),
+            {'name': 'labels', 'metadata': {'seed': seed}},
+            'labels',
+        ),
+        (
+            points.copy(),
+            {'name': 'points', 'metadata': {'seed': seed}},
+            'points',
+        ),
     ]
 
 
@@ -21,7 +33,19 @@ def labeled_particles3d():
     )
 
     return [
-        (density, {'name': 'density', 'metadata': {'seed': seed}}, 'image'),
-        (labels, {'name': 'labels', 'metadata': {'seed': seed}}, 'labels'),
-        (points, {'name': 'points', 'metadata': {'seed': seed}}, 'points'),
+        (
+            density.copy(),
+            {'name': 'density', 'metadata': {'seed': seed}},
+            'image',
+        ),
+        (
+            labels.copy(),
+            {'name': 'labels', 'metadata': {'seed': seed}},
+            'labels',
+        ),
+        (
+            points.copy(),
+            {'name': 'points', 'metadata': {'seed': seed}},
+            'points',
+        ),
     ]


### PR DESCRIPTION
# References and relevant issues

Fixes bug pointed out in https://github.com/napari/napari/pull/8202#issuecomment-3174611608

# Description

As the `labeled_particles` function caches data (for the performance of benchmarks), the edition labels in place are stored in a cached array. So re-adding the example adds the same, modified data. 

This PR explicitly copies the data before adding it to the viewer.  
