### PR TITLE
Retry second fullscreen test

### DIFF
--- a/src/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -85,6 +85,9 @@ def test_toggle_axes_scale_bar_attr(
     QT_VERSION == '6.9.0',
     reason='bug in Qt with maximized windows, https://bugreports.qt.io/browse/QTBUG-135844',
 )
+@pytest.mark.flaky(
+    reruns=2, reruns_delay=5, condition=sys.platform == 'darwin'
+)  # sometimes fails on macos CI
 @pytest.mark.qt_log_level_fail('WARNING')
 def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
     """
@@ -128,7 +131,9 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
 
 
 @skip_local_popups
-@pytest.mark.flaky(reruns=2, reruns_delay=5)  # sometimes fails on macos CI
+@pytest.mark.flaky(
+    reruns=2, reruns_delay=5, condition=sys.platform == 'darwin'
+)  # sometimes fails on macos CI
 @pytest.mark.skipif(
     QT_VERSION == '6.9.0',
     reason='bug in Qt with maximized windows, https://bugreports.qt.io/browse/QTBUG-135844',


### PR DESCRIPTION
# References and relevant issues

Follow up for #8151

# Description

It looks like the second of the fullscreen tests needs to be rerun on macOS. 

https://github.com/napari/napari/actions/runs/16893414111/job/47916913910?pr=8202#logs