### PR TITLE
Fix script for checking for updated dependencies.

### DIFF
--- a/tools/check_updated_packages.py
+++ b/tools/check_updated_packages.py
@@ -142,7 +142,7 @@ def calc_only_direct_updates(
         + optional_dependencies['pyqt5']
         + optional_dependencies['pyqt6']
         + optional_dependencies['pyside2']
-        + optional_dependencies['pyside6_experimental']
+        + optional_dependencies['pyside6']
         + optional_dependencies['testing']
         + optional_dependencies['all']
     )


### PR DESCRIPTION
# References and relevant issues

followup #7887

https://github.com/napari/napari/actions/runs/16874495015/job/47795775933

# Description

In #7887 I have renamed the PySide6 dependencies group from `pyside6_experimental` to `pyside6` but do not update it in our dependencies bumping script. 

This PR fixes this and updates our dependencies workflow. 