### PR TITLE
Fix disappearing points

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -19,13 +19,12 @@ def test_remove_selected_with_derived_text():
     properties = {'class': np.array(['A', 'B', 'C'])}
     layer = Points(points, text='class', properties=properties)
     vispy_layer = VispyPointsLayer(layer)
-    text_node = vispy_layer._get_text_node()
-    np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
+    np.testing.assert_array_equal(vispy_layer.node.text.text, ['A', 'B', 'C'])
 
     layer.selected_data = {1}
     layer.remove_selected()
 
-    np.testing.assert_array_equal(text_node.text, ['A', 'C'])
+    np.testing.assert_array_equal(vispy_layer.node.text.text, ['A', 'C'])
 
 
 def test_change_text_updates_node_string():
@@ -36,12 +35,15 @@ def test_change_text_updates_node_string():
     }
     layer = Points(points, text='class', properties=properties)
     vispy_layer = VispyPointsLayer(layer)
-    text_node = vispy_layer._get_text_node()
-    np.testing.assert_array_equal(text_node.text, properties['class'])
+    np.testing.assert_array_equal(
+        vispy_layer.node.text.text, properties['class']
+    )
 
     layer.text = 'name'
 
-    np.testing.assert_array_equal(text_node.text, properties['name'])
+    np.testing.assert_array_equal(
+        vispy_layer.node.text.text, properties['name']
+    )
 
 
 def test_change_text_color_updates_node_color():
@@ -50,12 +52,11 @@ def test_change_text_color_updates_node_color():
     text = {'string': 'class', 'color': [1, 0, 0]}
     layer = Points(points, text=text, properties=properties)
     vispy_layer = VispyPointsLayer(layer)
-    text_node = vispy_layer._get_text_node()
-    np.testing.assert_array_equal(text_node.color.rgb, [[1, 0, 0]])
+    np.testing.assert_array_equal(vispy_layer.node.text.color.rgb, [[1, 0, 0]])
 
     layer.text.color = [0, 0, 1]
 
-    np.testing.assert_array_equal(text_node.color.rgb, [[0, 0, 1]])
+    np.testing.assert_array_equal(vispy_layer.node.text.color.rgb, [[0, 0, 1]])
 
 
 def test_change_properties_updates_node_strings():
@@ -63,12 +64,11 @@ def test_change_properties_updates_node_strings():
     properties = {'class': np.array(['A', 'B', 'C'])}
     layer = Points(points, properties=properties, text='class')
     vispy_layer = VispyPointsLayer(layer)
-    text_node = vispy_layer._get_text_node()
-    np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
+    np.testing.assert_array_equal(vispy_layer.node.text.text, ['A', 'B', 'C'])
 
     layer.properties = {'class': np.array(['D', 'E', 'F'])}
 
-    np.testing.assert_array_equal(text_node.text, ['D', 'E', 'F'])
+    np.testing.assert_array_equal(vispy_layer.node.text.text, ['D', 'E', 'F'])
 
 
 def test_update_property_value_then_refresh_text_updates_node_strings():
@@ -76,13 +76,12 @@ def test_update_property_value_then_refresh_text_updates_node_strings():
     properties = {'class': np.array(['A', 'B', 'C'])}
     layer = Points(points, properties=properties, text='class')
     vispy_layer = VispyPointsLayer(layer)
-    text_node = vispy_layer._get_text_node()
-    np.testing.assert_array_equal(text_node.text, ['A', 'B', 'C'])
+    np.testing.assert_array_equal(vispy_layer.node.text.text, ['A', 'B', 'C'])
 
     layer.properties['class'][1] = 'D'
     layer.refresh_text()
 
-    np.testing.assert_array_equal(text_node.text, ['A', 'D', 'C'])
+    np.testing.assert_array_equal(vispy_layer.node.text.text, ['A', 'D', 'C'])
 
 
 def test_change_canvas_size_limits():
@@ -102,16 +101,15 @@ def test_text_with_non_empty_constant_string():
 
     vispy_layer = VispyPointsLayer(layer)
 
-    text_node = vispy_layer._get_text_node()
     # Vispy cannot broadcast a constant string and assert_array_equal
     # automatically broadcasts, so explicitly check length.
-    assert len(text_node.text) == 3
-    np.testing.assert_array_equal(text_node.text, ['a', 'a', 'a'])
+    assert len(vispy_layer.node.text.text) == 3
+    np.testing.assert_array_equal(vispy_layer.node.text.text, ['a', 'a', 'a'])
 
     # Ensure we do position calculation for constants.
     # See https://github.com/napari/napari/issues/5378
     # We want row, column coordinates so drop 3rd dimension and flip.
-    actual_position = text_node.pos[:, 1::-1]
+    actual_position = vispy_layer.node.text.pos[:, 1::-1]
     np.testing.assert_allclose(actual_position, points)
 
 

--- a/src/napari/_vispy/layers/points.py
+++ b/src/napari/_vispy/layers/points.py
@@ -154,13 +154,9 @@ class VispyPointsLayer(VispyBaseLayer):
         update_node : bool
             If true, update the node after setting the properties
         """
-        update_text(node=self._get_text_node(), layer=self.layer)
+        update_text(node=self.node.text, layer=self.layer)
         if update_node:
             self.node.update()
-
-    def _get_text_node(self):
-        """Function to get the text node from the Compound visual"""
-        return self.node.text
 
     def _on_text_change(self, event=None):
         if event is not None:
@@ -173,12 +169,10 @@ class VispyPointsLayer(VispyBaseLayer):
 
     def _on_blending_change(self, event=None):
         """Function to set the blending mode"""
-        points_blending_kwargs = BLENDING_MODES[self.layer.blending]
-        self.node.set_gl_state(**points_blending_kwargs)
+        super()._on_blending_change()
 
-        text_node = self._get_text_node()
         text_blending_kwargs = BLENDING_MODES[self.layer.text.blending]
-        text_node.set_gl_state(**text_blending_kwargs)
+        self.node.text.set_gl_state(**text_blending_kwargs)
 
         # selection box is always without depth
         box_blending_kwargs = BLENDING_MODES['translucent_no_depth']

--- a/src/napari/_vispy/layers/points.py
+++ b/src/napari/_vispy/layers/points.py
@@ -106,10 +106,10 @@ class VispyPointsLayer(VispyBaseLayer):
                 )
             symbol = self.layer._view_symbol[self.layer._highlight_index]
         else:
-            data = np.zeros((1, self.layer._slice_input.ndisplay))
+            data = np.empty((0, self.layer._slice_input.ndisplay))
             size = 0
             symbol = ['o']
-            border_width = np.array([0])
+            border_width = np.empty(0)
 
         scale = self.layer.scale[-1]
         highlight_thickness = settings.appearance.highlight.highlight_thickness

--- a/src/napari/_vispy/visuals/markers.py
+++ b/src/napari/_vispy/visuals/markers.py
@@ -31,7 +31,7 @@ class Markers(BaseMarkers):
         if self._data is None:
             return None
         pos = self._data['a_position']
-        if pos is None:
+        if pos is None or pos.size == 0:
             return None
         if pos.shape[1] > axis:
             return (pos[:, axis].min(), pos[:, axis].max())


### PR DESCRIPTION
# References and relevant issues
- https://forum.image.sc/t/napari-translucent-blending-for-point-layer/115566

# Description
This is an issue that I've seen since forever at random times. It's pretty bad, but never affected me enough to get around to figuring it out. Try this on main:

```py
import napari
import numpy as np
v = napari.Viewer(ndisplay=3)
v.add_points(np.random.rand(100, 3) * 100, face_color='red')
v.add_points(np.random.rand(100, 3) * 100)
napari.run()
```

then, rotate the camera to look backwards. You'll see the points slowly disappear, unexplicably.

After some digging, I realized that the culprit was the selection highlights of point layers that are *lower* in the stack. If you select the bottommost points layer, click on the canvas and then press `Ctrl+A` to select all points, you'll see the the points from the second layer magically reappear.

Unfortunately I was not able to figure out *why* this affects *subsequent* point layers, of all things, I did track this down to having a point with size `0`. So, when nothing is selected, if instead of creating a single point of size 0 we create *no* points, everything seems to work fine. :shrug: 

PS: I also changed some nearby code while debugging cause it was confusing, but the only relevant change is in `_on_highlight_change`.