### PR TITLE
Use global register for units in ScaleBar

### DIFF
--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -7,7 +7,7 @@ import pint
 
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
 from napari._vispy.visuals.scale_bar import ScaleBar
-from napari.utils._units import PREFERRED_VALUES, get_unit_registry
+from napari.utils._units import PREFERRED_VALUES
 from napari.utils.colormaps.standardize_color import transform_color
 from napari.utils.theme import get_theme
 
@@ -43,7 +43,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.reset()
 
     def _on_unit_change(self):
-        self._unit = get_unit_registry()(self.overlay.unit)
+        self._unit = pint.get_application_registry()(self.overlay.unit)
         self._on_zoom_change(force=True)
 
     def _on_length_change(self):

--- a/src/napari/utils/_units.py
+++ b/src/napari/utils/_units.py
@@ -1,6 +1,5 @@
 """Units utilities."""
 
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -26,7 +25,6 @@ PREFERRED_VALUES = [
 ]
 
 
-@lru_cache(maxsize=1)
 def get_unit_registry() -> 'pint.UnitRegistry':
     """Get pint's UnitRegistry.
 
@@ -40,4 +38,4 @@ def get_unit_registry() -> 'pint.UnitRegistry':
     """
     import pint
 
-    return pint.UnitRegistry()
+    return pint.get_application_registry()


### PR DESCRIPTION
# References and relevant issues

https://github.com/brisvag/napari-tutorial-euroscipy2025/blob/460531e31d98ee7669b2bd501a9ba20ad56e906c/presentation.py#L4

# Description

During preparation of the EuroSciPy tutorial, we spot that ScaleBar is using its own register of units instead of a global one. 

This is different from my job for units in layers, hidden under private API. It also means that all packages that want to use units compatible with napari then need to import from napari instead of just using pint. 