### PR TITLE
Update Qt backends used in tests to test more on Qt6 than Qt5

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -112,8 +112,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ ubuntu-latest ]
-        python: [ "3.11" ]
-        backend: [ "pyqt5,pyside6" ]
+        python: [ "3.13" ]
+        backend: [ "pyqt5,pyqt6" ]
         coverage: [ cov ]
         include:
           # Windows py310
@@ -131,7 +131,7 @@ jobs:
             coverage: no_cov
           - python: "3.13"
             platform: macos-latest
-            backend: pyqt5
+            backend: pyqt6
             coverage: no_cov
           # minimum specified requirements
           - python: "3.10"
@@ -141,7 +141,7 @@ jobs:
             coverage: cov
           - python: "3.12"
             platform: ubuntu-22.04
-            backend: pyqt5
+            backend: pyqt6
             coverage: cov
             tox_extras: "all_optional"
           # test without any Qt backends
@@ -149,6 +149,7 @@ jobs:
             platform: ubuntu-22.04
             backend: headless
             coverage: no_cov
+          # test with torch
           - python: "3.13"
             platform: ubuntu-latest
             backend: pyqt6
@@ -158,6 +159,11 @@ jobs:
           - python: "3.13"
             platform: ubuntu-latest
             backend: pyqt6_no_numba
+            coverage: cov
+          # pyside6 test
+          - python: "3.13"
+            platform: ubuntu-latest
+            backend: Pyside6
             coverage: cov
           # pyside2 test
           - python: "3.10"

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -165,7 +165,7 @@ jobs:
           # pyside6 test
           - python: "3.13"
             platform: ubuntu-latest
-            backend: Pyside6
+            backend: pyside6
             coverage: cov
           # pyside2 test
           - python: "3.10"

--- a/src/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -1,5 +1,6 @@
 import os
 import random
+import re
 import sys
 from typing import NamedTuple
 from unittest.mock import Mock
@@ -54,6 +55,11 @@ from napari.utils._test_utils import (
 )
 from napari.utils.colormaps import DirectLabelColormap
 from napari.utils.events.event import Event
+
+
+def strip_ansi_codes(text: str) -> str:
+    """Remove ANSI color codes from text."""
+    return re.sub(r'\x1b\[[0-9;]*m', '', text)
 
 
 class LayerTypeWithData(NamedTuple):
@@ -278,8 +284,6 @@ def test_create_layer_controls_spin(
 ):
     # create layer controls widget
     ctrl = create_layer_controls(layer_type_with_data)
-    qtbot.addWidget(ctrl)
-
     # check create widget corresponds to the expected class for each type of layer
     assert isinstance(ctrl, layer_type_with_data.expected_isinstance)
 
@@ -317,6 +321,7 @@ def test_create_layer_controls_spin(
             captured = capsys.readouterr()
             assert not captured.out
             if captured.err:
+                cleaned_err = strip_ansi_codes(captured.err)
                 # since an error was found check if it is associated with a known issue still open
                 expected_errors = [
                     'MemoryError: Unable to allocate',  # See https://github.com/napari/napari/issues/5798
@@ -326,7 +331,7 @@ def test_create_layer_controls_spin(
                     'RuntimeWarning: overflow encountered',  # See https://github.com/napari/napari/issues/4864
                 ]
                 assert any(
-                    expected_error in captured.err
+                    expected_error in cleaned_err
                     for expected_error in expected_errors
                 ), f'value: {value}, range {value_range}\nerr: {captured.err}'
 

--- a/src/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -282,6 +282,7 @@ skip_predicate = sys.version_info >= (3, 11) and (
 def test_create_layer_controls_spin(
     qtbot, create_layer_controls, layer_type_with_data, capsys
 ):
+    random.seed(0)
     # create layer controls widget
     ctrl = create_layer_controls(layer_type_with_data)
     # check create widget corresponds to the expected class for each type of layer


### PR DESCRIPTION
# References and relevant issues

# Description

In recent times we started shifting to make Qt6 binding our default one. We  also plan to drop PySide2 shortly. 

So it is time to depend more on Qt6 in our test matrix. 

Currently, PySide6 is a fragile one and bundled with PyQt5. It means that a failure in PySide6 requires rerunning the whole PyQt5 test step. This PR gives PySide6 its own job. I do not see which test may be removed from our cases. So it is one additional job. Will try to fix. 
