### PR TITLE
Change properties for features usage in the Vectors layer controls

### DIFF
--- a/src/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/src/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -6,7 +6,7 @@ from napari._qt.layer_controls.widgets import (
     QtProjectionModeControl,
 )
 from napari._qt.layer_controls.widgets._vectors import (
-    QtEdgeColorPropertyControl,
+    QtEdgeColorFeatureControl,
     QtLengthSpinBoxControl,
     QtVectorStyleComboBoxControl,
     QtWidthSpinBoxControl,
@@ -27,8 +27,8 @@ class QtVectorsControls(QtLayerControls):
 
     Attributes
     ----------
-    _edge_color_property_control : napari._qt.layer_controls.widgets._vectors.QtEdgeColorPropertyControl
-        Widget that wraps the widgets used to select vectors edge color mode, property and color.
+    _edge_color_feature_control : napari._qt.layer_controls.widgets._vectors.QtEdgeColorFeatureControl
+        Widget that wraps the widgets used to select vectors edge color mode, feature and color.
     _length_spinbox_control : napari._qt.layer_controls.widgets._vectors.QtLengthSpinBoxControl
         Widget that wraps a spinbox widget controlling length of vectors.
     _out_slice_checkbox_control : napari._qt.layer_controls.widgets.QtOutSliceCheckBoxControl
@@ -59,10 +59,10 @@ class QtVectorsControls(QtLayerControls):
             self, layer
         )
         self._add_widget_controls(self._vector_style_combobox_control)
-        self._edge_color_property_control = QtEdgeColorPropertyControl(
+        self._edge_color_feature_control = QtEdgeColorFeatureControl(
             self, layer
         )
-        self._add_widget_controls(self._edge_color_property_control)
+        self._add_widget_controls(self._edge_color_feature_control)
         self._out_slice_checkbox_control = QtOutSliceCheckBoxControl(
             self, layer
         )

--- a/src/napari/_qt/layer_controls/widgets/_vectors/__init__.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/__init__.py
@@ -1,5 +1,5 @@
 from napari._qt.layer_controls.widgets._vectors.qt_edge_color import (
-    QtEdgeColorPropertyControl,
+    QtEdgeColorFeatureControl,
 )
 from napari._qt.layer_controls.widgets._vectors.qt_line_dimension_spinbox import (
     QtLengthSpinBoxControl,
@@ -10,7 +10,7 @@ from napari._qt.layer_controls.widgets._vectors.qt_vector_style_combobox import 
 )
 
 __all__ = [
-    'QtEdgeColorPropertyControl',
+    'QtEdgeColorFeatureControl',
     'QtLengthSpinBoxControl',
     'QtVectorStyleComboBoxControl',
     'QtWidthSpinBoxControl',

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -162,8 +162,8 @@ class QtEdgeColorPropertyControl(QtWidgetControlsBase):
         Returns
         -------
         feature_values : np.ndarray
-            array of all of the union of the property names (feature table columns)
-            in Vectors.features and Vectors.property_choices
+            array of all of the union of the property names and choices in
+            Vectors.features (columns in the layer features table)
 
         """
         feature_choices = [

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox, QWidget
 
@@ -52,13 +53,13 @@ class QtEdgeColorPropertyControl(QtWidgetControlsBase):
         self._layer.events.edge_color.connect(self._on_edge_color_change)
 
         # Setup widgets
-        # dropdown to select the property for mapping edge_color
-        color_properties = self._get_property_values()
+        # dropdown to select the feature for mapping edge_color
+        color_features = self._get_feature_values()
         self.color_prop_box = QComboBox(parent)
         self.color_prop_box.currentTextChanged.connect(
             self.change_edge_color_property
         )
-        self.color_prop_box.addItems(color_properties)
+        self.color_prop_box.addItems(color_features)
         self.edge_prop_label = QtWrappedLabel(trans._('edge property:'))
 
         # vector direct color mode adjustment and widget
@@ -155,21 +156,25 @@ class QtEdgeColorPropertyControl(QtWidgetControlsBase):
                 index = self.color_prop_box.findText(prop, Qt.MatchFixedString)
                 self.color_prop_box.setCurrentIndex(index)
 
-    def _get_property_values(self):
-        """Get the current property values from the Vectors layer
+    def _get_feature_values(self):
+        """Get the current feature values from the Vectors layer
 
         Returns
         -------
-        property_values : np.ndarray
-            array of all of the union of the property names (keys)
-            in Vectors.properties and Vectors.property_choices
+        feature_values : np.ndarray
+            array of all of the union of the property names (feature table columns)
+            in Vectors.features and Vectors.property_choices
 
         """
-        property_choices = [*self._layer.property_choices]
-        properties = [*self._layer.properties]
-        property_values = np.union1d(property_choices, properties)
+        feature_choices = [
+            choice
+            for choice, series in self._layer.features.items()
+            if isinstance(series.dtype, pd.CategoricalDtype)
+        ]
+        features = self._layer.features.columns.tolist()
+        feature_values = np.union1d(feature_choices, features)
 
-        return property_values
+        return feature_values
 
     def _update_edge_color_gui(self, mode: str):
         """Update the GUI element associated with edge_color.

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -13,10 +13,10 @@ from napari.utils.events.event_utils import connect_setattr
 from napari.utils.translations import trans
 
 
-class QtEdgeColorPropertyControl(QtWidgetControlsBase):
+class QtEdgeColorFeatureControl(QtWidgetControlsBase):
     """
     Class that wraps the connection of events/signals between the current edge
-    color, color mode and color property selection from the layer attributes and
+    color, color mode and color feature selection from the layer attributes and
     Qt widgets.
 
     Parameters
@@ -83,8 +83,7 @@ class QtEdgeColorPropertyControl(QtWidgetControlsBase):
         self._on_edge_color_mode_change()
 
     def change_edge_color_feature(self, feature: str):
-        """Change edge_color_property of vectors on the layer model.
-        This property is the property the edge color is mapped to.
+        """Change edge_color feature of vectors on the layer model.
 
         Parameters
         ----------


### PR DESCRIPTION
# References and relevant issues

Closes #8156 

# Description

Use `features` instead of `properties`/`property_choices` for Vectors controls


