### PR TITLE
Remove console print action shortcut to prevent collision with command palette shortcut

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -527,6 +527,9 @@ class QtViewer(QSplitter):
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore')
                 console = QtConsole(self.viewer, style_sheet=self.styleSheet())
+                # Override actions shortcuts that collide with default napari shortcuts
+                # See napari/napari#8183
+                console.print_action.setShortcut('')
                 console.push(
                     {'napari': napari, 'action_manager': action_manager}
                 )


### PR DESCRIPTION
# References and relevant issues

Closes #8183 

# Description

See https://github.com/napari/napari/issues/8183#issuecomment-3211327650


