### PR TITLE
Add cache for pooch on CI for Linux jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           path: napari
       - restore_cache:
           keys:
-            - pooch-v1
+            - pooch
       - run:
           name: Clone docs repo into a subdirectory
           command: git clone git@github.com:napari/docs.git docs
@@ -51,7 +51,7 @@ jobs:
       - store_artifacts:
           path: docs/docs/_build/html/
       - save_cache:
-          key: pooch-v1
+          key: pooch
           paths:
             - ~/.cache/pooch
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,14 @@ jobs:
     docker:
       # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
       - image: cimg/python:3.12.10
+    environment:
+      POOCH_HOME: ~/.cache/pooch
     steps:
       - checkout:
           path: napari
+      - restore_cache:
+          keys:
+            - pooch-v1
       - run:
           name: Clone docs repo into a subdirectory
           command: git clone git@github.com:napari/docs.git docs
@@ -45,6 +50,10 @@ jobs:
           no_output_timeout: 30m
       - store_artifacts:
           path: docs/docs/_build/html/
+      - save_cache:
+          key: pooch-v1
+          paths:
+            - ~/.cache/pooch
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
       - image: cimg/python:3.12.10
     environment:
-      XDG_CACHE_HOME: ~/.cache
+      XDG_CACHE_HOME: /home/circleci/.cache
     steps:
       - checkout:
           path: napari

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
       - image: cimg/python:3.12.10
     environment:
-      POOCH_HOME: ~/.cache/pooch
+      XDG_CACHE_HOME: ~/.cache
     steps:
       - checkout:
           path: napari
@@ -53,6 +53,8 @@ jobs:
       - save_cache:
           key: pooch
           paths:
+            - ~/.cache/scikit-image
+            - ~/.cache/napari-*
             - ~/.cache/pooch
       - persist_to_workspace:
           root: .

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,6 +22,8 @@ jobs:
   build-and-upload:
     name: Build & Upload Artifact
     runs-on: ubuntu-latest
+    env:
+      POOCH_HOME: ${{ github.workspace }}/.pooch
     steps:
       - name: Clone docs repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -41,6 +43,12 @@ jobs:
           python-version: "3.12"
           cache-dependency-path: |
             napari/pyproject.toml
+
+      - name: Cache pooch downloads
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        with:
+          path: ${{ env.POOCH_HOME }}
+          key: pooch-v1
 
       - name: Setup headless display
         uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ env.POOCH_HOME }}
-          key: pooch-v1
+          key: pooch
 
       - name: Setup headless display
         uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build & Upload Artifact
     runs-on: ubuntu-latest
     env:
-      POOCH_HOME: ${{ github.workspace }}/.pooch
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - name: Clone docs repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -47,7 +47,10 @@ jobs:
       - name: Cache pooch downloads
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
-          path: ${{ env.POOCH_HOME }}
+          path: |
+            ${{ github.workspace }}/.cache/scikit-image
+            ${{ github.workspace }}/.cache/napari-*
+            ${{ github.workspace }}/.cache/pooch
           key: pooch
 
       - name: Setup headless display

--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ env.POOCH_HOME }}
-          key: pooch-v1
+          key: pooch
 
       - name: Set up Python 3.12
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     env:
-      POOCH_HOME: ${{ github.workspace }}/.pooch
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -17,7 +17,10 @@ jobs:
       - name: Cache pooch downloads
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
-          path: ${{ env.POOCH_HOME }}
+          path: |
+            ${{ github.workspace }}/.cache/scikit-image
+            ${{ github.workspace }}/.cache/napari-*
+            ${{ github.workspace }}/.cache/pooch
           key: pooch
 
       - name: Set up Python 3.12

--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -8,10 +8,17 @@ jobs:
     name: ubuntu-latest 3.12 pip install
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    env:
+      POOCH_HOME: ${{ github.workspace }}/.pooch
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: napari-from-github
+      - name: Cache pooch downloads
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        with:
+          path: ${{ env.POOCH_HOME }}
+          key: pooch-v1
 
       - name: Set up Python 3.12
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ env.POOCH_HOME }}
-          key: pooch-v
+          key: pooch
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -64,8 +64,14 @@ jobs:
       COVERAGE: ${{ inputs.coverage }}
       TOX_WORK_DIR: .tox
       TOX_EXTRAS: ${{ inputs.tox_extras }}
+      POOCH_HOME: ${{ github.workspace }}/.pooch
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Cache pooch downloads
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        with:
+          path: ${{ env.POOCH_HOME }}
+          key: pooch-v
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -64,13 +64,16 @@ jobs:
       COVERAGE: ${{ inputs.coverage }}
       TOX_WORK_DIR: .tox
       TOX_EXTRAS: ${{ inputs.tox_extras }}
-      POOCH_HOME: ${{ github.workspace }}/.pooch
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Cache pooch downloads
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
-          path: ${{ env.POOCH_HOME }}
+          path: |
+            ${{ github.workspace }}/.cache/scikit-image
+            ${{ github.workspace }}/.cache/napari-*
+            ${{ github.workspace }}/.cache/pooch
           key: pooch
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/channel/298358-working-group-documentation/topic/docs.20CI

# Description

To reduce the fragility of our test suite, add a cache. This will reduce the chance that the test is failing because of a network error. 