### PR TITLE
Temporary increase timeout of macOS jobs

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -129,10 +129,12 @@ jobs:
             platform: macos-13
             backend: pyqt5
             coverage: no_cov
+            timeout-minutes: 60
           - python: "3.13"
             platform: macos-latest
             backend: pyqt5
             coverage: no_cov
+            timeout-minutes: 60
           # minimum specified requirements
           - python: "3.10"
             platform: ubuntu-22.04
@@ -171,6 +173,7 @@ jobs:
       min_req: ${{ matrix.MIN_REQ }}
       coverage: ${{ matrix.coverage }}
       tox_extras: ${{ matrix.tox_extras }}
+      timeout: ${{ matrix.timeout-minutes || 40 }}
 
 
   test_pip_install:


### PR DESCRIPTION
# References and relevant issues

# Description

In recent times we often see tests timing out in CI. We collect JSON reports with timing information that are expected to help solve this problem, but unfortunately it looks to be to big to load to existing viewer (see https://github.com/Carreau/pytest-json-report-viewer/issues/8) 

My next plan is to open a separate PR with running only a subset of tests to try to identify where the problem is. But for this time we should increase the timeout because double execution of a 40-minute run is longer than just one 50 minutes. 
