### PR TITLE
Use EffVer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![DOI](https://zenodo.org/badge/144513571.svg)](https://zenodo.org/badge/latestdoi/144513571)
 [![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0%20(aspiring!)-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/)
+[![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 
 **napari** is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, and analyzing large multi-dimensional images. It's built on top of Qt (for the GUI), vispy (for performant GPU-based rendering), and the scientific Python stack (numpy, scipy).
 


### PR DESCRIPTION
# References and relevant issues
- https://jacobtomlinson.dev/effver/

# Description
This has been discussed off and on among the core team for some time, and we recently decided to make an explicit switch to [EffVer](https://jacobtomlinson.dev/effver/) from SemVer. This has basically zero consequences in practice, and it's more about making explicit something that has been implicit for a while: we do not follow the strict SemVer rules, but instead use version numbers to signal the impact adopting a new version will have on the user (Expected **Eff**ort).

I encourage everyone to read through the link above!
