### PR TITLE
Block opacity events when doing Labels super().__init__ because slicing may not be complete

### DIFF
--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -348,28 +348,32 @@ class Labels(ScalarFieldBase):
 
         data = self._ensure_int_labels(data)
 
-        super().__init__(
-            data,
-            affine=affine,
-            axis_labels=axis_labels,
-            blending=blending,
-            cache=cache,
-            depiction=depiction,
-            experimental_clipping_planes=experimental_clipping_planes,
-            rendering=rendering,
-            metadata=metadata,
-            multiscale=multiscale,
-            name=name,
-            scale=scale,
-            shear=shear,
-            plane=plane,
-            opacity=opacity,
-            projection_mode=projection_mode,
-            rotate=rotate,
-            translate=translate,
-            units=units,
-            visible=visible,
-        )
+        # prevent the default opacity change from triggering thumbnail update
+        # because depending on visibility and viewer.ndisplay,
+        # slicing may not be complete
+        with self.events.opacity.blocker():
+            super().__init__(
+                data,
+                affine=affine,
+                axis_labels=axis_labels,
+                blending=blending,
+                cache=cache,
+                depiction=depiction,
+                experimental_clipping_planes=experimental_clipping_planes,
+                rendering=rendering,
+                metadata=metadata,
+                multiscale=multiscale,
+                name=name,
+                scale=scale,
+                shear=shear,
+                plane=plane,
+                opacity=opacity,
+                projection_mode=projection_mode,
+                rotate=rotate,
+                translate=translate,
+                units=units,
+                visible=visible,
+            )
 
         self.events.add(
             brush_shape=Event,
@@ -416,6 +420,9 @@ class Labels(ScalarFieldBase):
 
         self._status = self.mode
         self._preserve_labels = False
+
+        # emit the opacity event, because it was blocked earlier
+        self.events.opacity()
 
     def _slice_dtype(self):
         """Calculate dtype of data view based on data dtype and current colormap"""


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/7918

# Description
So in #7918 there are two parts to the issue and both have to be satisfied: `ndisplay = 3` and `visible = False` if either is flipped the other way there is no error. 
In https://github.com/napari/napari/pull/7150 @Czaki changed the events order and now we get the error. It's related to the interaction between slicing and because Labels set opacity to 0.7. So the opacity setter is triggered in the __init__ but the event order is different now and the slicing hasn't been done and opacity setter triggers  _update_thumbnails which fails. So it's like a race condition.
So in this PR i try to block opacity events during the super()__init__ to prevent this from happening.