### PR TITLE
Use proper name for ruff pre-commit hook and reorder hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.12
   hooks:
-  - id: ruff-format
-    exclude: examples
   - id: ruff-check
 #    args:
 #      - "--unsafe-fixes"
+  - id: ruff-format
+    exclude: examples
 - repo: https://github.com/seddonym/import-linter
   rev: v2.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   hooks:
   - id: ruff-format
     exclude: examples
-  - id: ruff
+  - id: ruff-check
 #    args:
 #      - "--unsafe-fixes"
 - repo: https://github.com/seddonym/import-linter


### PR DESCRIPTION
# References and relevant issues


# Description

When running pre-commit there is a line:

```
ruff (legacy alias)..................................
```

To avoid a possible future break, just update the name to ruff-check. 