### PR TITLE
fix slice_from_axis to wrap zarr in dask to keep lazy behavior

### DIFF
--- a/src/napari/layers/utils/_tests/test_stack_utils.py
+++ b/src/napari/layers/utils/_tests/test_stack_utils.py
@@ -366,7 +366,13 @@ def test_slice_from_axis_different_array_types(
     axis, element = 1, 2
     expected_shape = (3, 4)
 
-    result = slice_from_axis(data, axis=axis, element=element)
+    if array_type == 'zarr':
+        with pytest.warns(
+            UserWarning, match='zarr array cannot be sliced lazily'
+        ):
+            result = slice_from_axis(data, axis=axis, element=element)
+    else:
+        result = slice_from_axis(data, axis=axis, element=element)
 
     # Check result type and shape
     assert isinstance(result, expected_result_type)

--- a/src/napari/layers/utils/_tests/test_stack_utils.py
+++ b/src/napari/layers/utils/_tests/test_stack_utils.py
@@ -1,10 +1,13 @@
+import dask.array as da
 import numpy as np
 import pytest
+import zarr
 
 from napari.layers import Image
 from napari.layers.utils.stack_utils import (
     images_to_stack,
     merge_rgb,
+    slice_from_axis,
     split_channels,
     split_rgb,
     stack_to_images,
@@ -338,3 +341,40 @@ def test_split_channels_multi_affine_napari(kwargs):
             meta['affine'].affine_matrix,
             Affine(scale=[idx + 1, idx + 1]).affine_matrix,
         )
+
+
+@pytest.mark.parametrize(
+    ('array_type', 'expected_result_type'),
+    [
+        ('numpy', np.ndarray),
+        ('dask', da.Array),
+        ('zarr', da.Array),
+    ],
+)
+def test_slice_from_axis_different_array_types(
+    array_type, expected_result_type
+):
+    """Test slice_from_axis with numpy, dask, and zarr arrays."""
+    # Create test data
+    if array_type == 'numpy':
+        data = np.zeros((3, 4, 4))
+    elif array_type == 'dask':
+        data = da.zeros((3, 4, 4))
+    elif array_type == 'zarr':
+        data = zarr.zeros((3, 4, 4))
+
+    axis, element = 1, 2
+    expected_shape = (3, 4)
+
+    result = slice_from_axis(data, axis=axis, element=element)
+
+    # Check result type and shape
+    assert isinstance(result, expected_result_type)
+    assert result.shape == expected_shape
+
+    # Check result values - compare with expected slice
+    result_computed = (
+        result.compute() if hasattr(result, 'compute') else result
+    )
+    expected = data[:, element, :]
+    np.testing.assert_array_equal(result_computed, expected)

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -42,6 +43,12 @@ def slice_from_axis(array, *, axis, element):
         import dask.array as da
 
         array = da.from_zarr(array)
+        warnings.warn(
+                    trans._(
+                        'zarr array cannot be sliced lazily, converted to dask array.',
+                        deferred=True,
+                    )
+                )
 
     slices = [slice(None) for i in range(array.ndim)]
     slices[axis] = element

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -44,11 +44,11 @@ def slice_from_axis(array, *, axis, element):
 
         array = da.from_zarr(array)
         warnings.warn(
-                    trans._(
-                        'zarr array cannot be sliced lazily, converted to dask array.',
-                        deferred=True,
-                    )
-                )
+            trans._(
+                'zarr array cannot be sliced lazily, converted to dask array.',
+                deferred=True,
+            )
+        )
 
     slices = [slice(None) for i in range(array.ndim)]
     slices[axis] = element

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -36,6 +36,13 @@ def slice_from_axis(array, *, axis, element):
     sliced : NumPy or other array
         The sliced output array, which has one less dimension than the input.
     """
+    # Check if array is a zarr array and wrap it with dask
+    # to keep lazy behavior andavoid loading into memory
+    if hasattr(array, '__module__') and array.__module__.startswith('zarr'):
+        import dask.array as da
+
+        array = da.from_zarr(array)
+
     slices = [slice(None) for i in range(array.ndim)]
     slices[axis] = element
     return array[tuple(slices)]


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8008
see also discussion at: https://napari.zulipchat.com/#narrow/channel/212875-general/topic/handling.20zarr.2Fdask.2Fetc.20when.20splitting.20or.20merging.20layers/with/532610558

# Description
So the issue is that when you slice a zarr array, it returns a numpy array.
This means that the slice_from_axis function breaks the laziness for zarr arrays and loads everything into memory.
This is a known issue with zarr: https://github.com/zarr-developers/zarr-python/discussions/1603

In this PR, I add code to check if an array is a zarr array and if so, wrap it in a dask.array, so that lazy behavior is preserved. I got some help from Claude to come up with a way to check for being a zarr without importing -- if someone is passing a zarr, they have zarr obviously, but napari does not depend on zarr so using the simple `isinstance(array, zarr.Array)` would result in errors.
I'm open to other solutions, could try/except obviously, but this seemed better?