### PR TITLE
Add menu-xdg to XPRA containers

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update && \
         xpra \
         xvfb \
         menu-xdg \
+        xdg-utils \
         xterm \
         sshfs && \
     apt-get clean && \

--- a/dockerfile
+++ b/dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update && \
     apt-get install -yqq \
         xpra \
         xvfb \
+        menu-xdg \
         xterm \
         sshfs && \
     apt-get clean && \


### PR DESCRIPTION
# References and relevant issues

N/A

# Description

I was debugging some Linux issues on this Docker image and found that the Applications menu was not populated due to some missing system config files:

```
2025-09-12 05:48:57,529 Error parsing xdg menu data:
2025-09-12 05:48:57,529  ParsingError in file '/etc/xdg/menus/debian-menu.menu', File not found
2025-09-12 05:48:57,529  this is either a bug in python-xdg,
2025-09-12 05:48:57,529  or an invalid system menu configuration
2025-09-12 05:48:57,529  for more information, please see:
2025-09-12 05:48:57,529  https://github.com/Xpra-org/xpra/issues/2174
```

The added package (`menu-xdg`) provides such file and makes the Application menus work again.


