### PR TITLE
[maint] Revert back to windows-2022 for windows runners

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-2022]
         python: ["3.10", "3.11", "3.12", "3.13"]
         backend: [pyqt5, pyside2]
         include:
@@ -80,7 +80,7 @@ jobs:
             backend: pyside2
           - python: "3.13"
             backend: pyside2
-          - platform: windows-latest
+          - platform: windows-2022
             backend: pyside2
     with:
       python_version: ${{ matrix.python }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-2022, macos-latest, ubuntu-latest]
         python: [3.12, 3.13]
         backend: [pyqt5, pyqt6]
         include:

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -118,11 +118,11 @@ jobs:
         include:
           # Windows py310
           - python: "3.11"
-            platform: windows-latest
+            platform: windows-2022
             backend: pyqt5 #,pyside2
             coverage: no_cov
           - python: "3.13"
-            platform: windows-latest
+            platform: windows-2022
             backend: pyqt6
             coverage: cov
           - python: "3.13"


### PR DESCRIPTION
# References and relevant issues
Windows jobs have all been failing, which seems to be connected to `windows-latest` runners being updated:
https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/#windows-latest-image-label-migration

# Description
Changes from using `windows-latest` which is now windows server 2025, to using `windows-2022` which is what `-latest` used to use.

This should only be a temporary change, to get CI to work again while we work on a workaround that works on `-latest` in a branch.
