### PR TITLE
Add napari to trove classifiers to populate builtins on napari hub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: X11 Applications :: Qt",
+    "Framework :: napari",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/hub-lite/issues/112
builtins are not currently populated on napari-hub, leaving a less than stellar experience for knowing supported i/o types

# Description
According to https://github.com/napari/hub-lite/issues/112#issuecomment-3299946502 we need to add the trove classifier so npe2api can find it and add builtins to the hub
