### PR TITLE
Declare Viewer action using decorator.

### DIFF
--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -35,7 +35,9 @@ def register_viewer_action(description, repeatable=False, *, keybindings=None):
                 id=f'napari:viewer:{func.__name__}',
                 title=description,
                 callback=func,
-                keybindings=keybindings,
+                keybindings=[{'primary': keybindings[0]}]
+                if keybindings
+                else None,
             )
         )
         action_manager.register_action(


### PR DESCRIPTION
# References and relevant issues


# Description

This PR is a proposition on how to centralize the declaration of app model actions next to their implementation by creating an action in the decorator. 

Do not auto-register it, but put the action in themodule-level list. 

Then such a list should be manually registered by call of `app.register_actions` 

This PR is to show an idea, so implementation is not finished yet. 

I need to find if repeatable actions could be easily implemented or require PR to app-model. 