### PR TITLE
Update the Shapes select_all_shapes action to allow selection in all modes and add notification of number

### DIFF
--- a/src/napari/layers/shapes/_shapes_key_bindings.py
+++ b/src/napari/layers/shapes/_shapes_key_bindings.py
@@ -12,6 +12,7 @@ from napari.layers.utils.layer_utils import (
     register_layer_action,
     register_layer_attr_action,
 )
+from napari.utils.notifications import show_info
 from napari.utils.translations import trans
 
 
@@ -163,16 +164,23 @@ def paste_shape(layer: Shapes) -> None:
 )
 def select_all_shapes(layer: Shapes) -> None:
     """Select/Deselect all shapes in the current view slice."""
-    if layer._mode in (Mode.DIRECT, Mode.SELECT):
-        new_selected = set(np.nonzero(layer._data_view._displayed)[0])
+    new_selected = set(np.nonzero(layer._data_view._displayed)[0])
 
-        if new_selected & layer.selected_data == new_selected:
-            # If all visible shapes are already selected, deselect them
-            layer.selected_data = layer.selected_data - new_selected
-        else:
-            # If not all visible shapes are selected, select them
-            layer.selected_data = layer.selected_data | new_selected
-        layer._set_highlight()
+    if new_selected & layer.selected_data == new_selected:
+        # If all visible shapes are already selected, deselect them
+        layer.selected_data = layer.selected_data - new_selected
+    else:
+        # If not all visible shapes are selected, select them
+        layer.selected_data = layer.selected_data | new_selected
+        show_info(
+            trans._(
+                'Selected {n_new} shapes in this slice. ({n_total} selected)',
+                n_new=len(new_selected),
+                n_total=len(layer.selected_data),
+                deferred=True,
+            )
+        )
+    layer._set_highlight()
 
 
 @register_shapes_action(trans._('Delete any selected shapes'))

--- a/src/napari/layers/shapes/_shapes_key_bindings.py
+++ b/src/napari/layers/shapes/_shapes_key_bindings.py
@@ -174,9 +174,8 @@ def select_all_shapes(layer: Shapes) -> None:
         layer.selected_data = layer.selected_data | new_selected
         show_info(
             trans._(
-                'Selected {n_new} shapes in this slice. ({n_total} selected)',
+                'Selected {n_new} shapes in this slice.',
                 n_new=len(new_selected),
-                n_total=len(layer.selected_data),
                 deferred=True,
             )
         )


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/8291
Closes https://github.com/napari/napari/issues/8290
(Part of https://github.com/napari/napari/issues/7478)


# Description
This PR
1. removes the requirement that the layer mode be SELECT or DIRECT. This means you can draw some shapes and select them to change face color/edge colors, etc. and then draw a new set. This is the same as Points layer.
2. Adds a notification that informs how many shapes were selected. This is the same as Points layer.
