### PR TITLE
Move Jaime Rodríguez-Guerra to core-team section of CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,6 +60,11 @@ authors:
   affiliation: Quansight
   orcid: https://orcid.org/0000-0002-3212-402X
   alias: melissawm
+- given-names: Jaime
+  family-names: Rodríguez-Guerra
+  affiliation: Quansight Labs
+  orcid: https://orcid.org/0000-0001-8974-1566
+  alias: jaimergp
 - given-names: Lucy
   family-names: Liu
   affiliation: Quansight
@@ -310,11 +315,6 @@ authors:
 - given-names: David
   family-names: Pinto
   alias: MarchisLost
-- given-names: Jaime
-  family-names: Rodríguez-Guerra
-  affiliation: Quansight Labs
-  orcid: https://orcid.org/0000-0001-8974-1566
-  alias: jaimergp
 - given-names: David
   family-names: Ross
   affiliation: NanoString Technologies, Inc.


### PR DESCRIPTION
# References and relevant issues


# Description

As Jaime Rodríguez-Guerra joined the core team, then we need to update the order in CITATION.cff