### PR TITLE
Migrate macos-13 to macos-15-intel runner

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -126,7 +126,7 @@ jobs:
             backend: pyqt6
             coverage: cov
           - python: "3.13"
-            platform: macos-13
+            platform: macos-15-intel
             backend: pyqt5
             coverage: no_cov
             timeout-minutes: 60


### PR DESCRIPTION
# References and relevant issues
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

# Description

To avoid workflow disruption 