### PR TITLE
Use custom logger formatting to most of argument to string

### DIFF
--- a/src/napari/utils/_testsupport.py
+++ b/src/napari/utils/_testsupport.py
@@ -1,4 +1,5 @@
 import gc
+import logging
 import os
 import sys
 import warnings
@@ -456,3 +457,29 @@ def MouseEvent():
         handled: bool = False
 
     return Event
+
+
+class LeakSafeLogRecord(logging.LogRecord):
+    """LogRecord that converts args to strings to prevent reference retention."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Convert args to strings immediately
+        if self.args:
+            self.args = tuple(
+                str(arg) if not isinstance(arg, int | float) else arg
+                for arg in self.args
+            )
+
+
+@pytest.fixture(autouse=True, scope='session')
+def use_leak_safe_log_records():
+    """Use custom LogRecord factory that doesn't retain object references."""
+    original_record_factory = logging.getLogRecordFactory()
+
+    logging.setLogRecordFactory(LeakSafeLogRecord)
+
+    yield
+
+    # Restore original factory
+    logging.setLogRecordFactory(original_record_factory)


### PR DESCRIPTION
# References and relevant issues

closes #8287

# Description

Add a fixture to enforce conversion of logging arguments into strings. 