### PR TITLE
Use shared workflows for build docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build_docs.yml'
+      - 'resources/constraints/*docs*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,5 +1,3 @@
-# As much as possible, this file should be kept in sync with
-# https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy_docs.yml
 name: Build PR Docs
 
 on:
@@ -19,67 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-upload:
-    name: Build & Upload Artifact
-    runs-on: ubuntu-latest
-    env:
-      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
-    steps:
-      - name: Clone docs repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          path: docs  # place in a named directory
-          repository: napari/docs
-
-      - name: Clone main repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          path: napari  # place in a named directory
-          # ensure version metadata is proper
-          fetch-depth: 0
-
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-          cache-dependency-path: |
-            napari/pyproject.toml
-
-      - name: Cache pooch downloads
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          path: |
-            ${{ github.workspace }}/.cache/scikit-image
-            ${{ github.workspace }}/.cache/napari-*
-            ${{ github.workspace }}/.cache/pooch
-          key: pooch
-
-      - name: Setup headless display
-        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
-        with:
-          qt: true
-          wm: herbstluftwm
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "napari/[pyqt5, docs]"
-        env:
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
-
-      - name: Testing
-        run: |
-          python -c 'import napari; print(napari.__version__)'
-          python -c 'import napari.layers; print(napari.layers.__doc__)'
-
-      - name: Build Docs
-        run: make -C docs html
-        env:
-          GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
-          GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: docs
-          path: docs/docs/_build/html
+  build_docs:
+    uses: napari/shared-workflows/.github/workflows/build_docs.yml@build_docs
+    secrets: inherit

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,3 +26,4 @@ jobs:
       main-ref: ${{ github.sha }}
       docs-repo: napari/docs
       docs-ref: main
+      make_target: "html"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -20,3 +20,8 @@ jobs:
   build_docs:
     uses: napari/shared-workflows/.github/workflows/build_docs.yml@build_docs
     secrets: inherit
+    with:
+      main-repo: ${{ github.repository }}
+      main-ref: ${{ github.sha }}
+      docs-repo: napari/docs
+      docs-ref: main

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build_docs:
-    uses: napari/shared-workflows/.github/workflows/build_docs.yml@build_docs
+    uses: napari/shared-workflows/.github/workflows/build_docs.yml@main
     secrets: inherit
     with:
       main-repo: ${{ github.repository }}


### PR DESCRIPTION
# References and relevant issues

#8307
Depends on https://github.com/napari/shared-workflows/pull/2

# Description

Instead of syncing workflows, use one shared 
