### PR TITLE
Fix constraints generation 

### DIFF
--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -151,7 +151,7 @@ jobs:
           set -x
           pip install -U uv
           cd napari_repo
-          flags=(--no-emit-package=napari --quiet --extra pyqt6 --extra pyside2 --extra pyside6 --group testing --group testing_extra --extra all_optional)
+          flags=(--quiet --extra pyqt6 --extra pyside2 --extra pyside6 --extra testing --group testing_extra --extra all_optional)
 
           # Explanation of below commands
           # uv pip compile --python-version 3.9 - call uv pip compile but ensure proper interpreter

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -151,7 +151,7 @@ jobs:
           set -x
           pip install -U uv
           cd napari_repo
-          flags=(--quiet --extra pyqt6 --extra pyside2 --extra pyside6 --group testing --group testing_extra --extra all_optional)
+          flags=(--no-emit-package=napari --quiet --extra pyqt6 --extra pyside2 --extra pyside6 --group testing --group testing_extra --extra all_optional)
 
           # Explanation of below commands
           # uv pip compile --python-version 3.9 - call uv pip compile but ensure proper interpreter


### PR DESCRIPTION
# References and relevant issues

fix bug relevaled in https://github.com/napari/napari/pull/8306

# Description

Because in testing we want to use all optional napari dependencies, there is `napari[optional-base]` in testing dependency group. It led to situation where napari is included in compiled constraints. 

This PR changes compilation to use again `testing` as extras, not group. 

I will work to find a better solution. 
