### PR TITLE
Add warning for big stride when toggling grid mode

### DIFF
--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -170,7 +170,7 @@ def rotate_layers(viewer: Viewer):
 @register_viewer_action(trans._('Toggle grid mode'))
 def toggle_grid(viewer: Viewer):
     if (
-        1 < len(viewer.layers) < abs(viewer.grid.stride)
+        1 < len(viewer.layers) <= abs(viewer.grid.stride)
         and not viewer.grid.enabled
     ):
         show_warning(

--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -169,7 +169,10 @@ def rotate_layers(viewer: Viewer):
 
 @register_viewer_action(trans._('Toggle grid mode'))
 def toggle_grid(viewer: Viewer):
-    if 1 < len(viewer.layers) < abs(viewer.grid.stride):
+    if (
+        1 < len(viewer.layers) < abs(viewer.grid.stride)
+        and not viewer.grid.enabled
+    ):
         show_warning(
             'Grid stride is too large for number of layers. Will render as 1x1 grid.'
         )

--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -7,7 +7,7 @@ from app_model.types import KeyCode, KeyMod
 
 from napari.components.viewer_model import ViewerModel
 from napari.utils.action_manager import action_manager
-from napari.utils.notifications import show_info
+from napari.utils.notifications import show_info, show_warning
 from napari.utils.theme import available_themes, get_system_theme
 from napari.utils.transforms import Affine
 from napari.utils.translations import trans
@@ -169,6 +169,10 @@ def rotate_layers(viewer: Viewer):
 
 @register_viewer_action(trans._('Toggle grid mode'))
 def toggle_grid(viewer: Viewer):
+    if 1 < len(viewer.layers) < abs(viewer.grid.stride):
+        show_warning(
+            'Grid stride is too large for number of layers. Will render as 1x1 grid.'
+        )
     viewer.grid.enabled = not viewer.grid.enabled
 
 


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E6.2E5/near/542368375

# Description

Add a warning if there are more than 1 layer and the stride is big enough to render only a 1x1 grid.  