### PR TITLE
Remove `numpydoc` as core dependency, instead use `docstring_parser`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "cachey>=0.2.1",
     "certifi>=2018.1.18",
     "dask[array]>=2021.10.0",
+    "docstring_parser>=0.15",
     "imageio>=2.20,!=2.22.1",
     "jsonschema>=3.2.0",
     "lazy_loader>=0.3",
@@ -51,7 +52,6 @@ dependencies = [
     "napari-svg>=0.1.8",
     "npe2>=0.7.9",
     "numpy>=1.24.2",
-    "numpydoc>=1.0.0",
     "pandas>=1.3.3",
     "Pillow>=9.0",
     "pint>=0.17",
@@ -152,7 +152,6 @@ testing = [
     "matplotlib >= 3.6.1",
     "pooch>=1.6.0",
     "coverage>7",
-    "docstring_parser>=0.15",
     "pretend>=1.0.9",
     "pyautogui>=0.9.54",
     "pytest-qt >=4.4.0; python_version > '3.10'",
@@ -186,6 +185,7 @@ gallery = [
 # needed to build docs
 docs = [
     "napari[gallery]",
+    "numpydoc>=1.0.0",
     "sphinx<8",
     "sphinx-autobuild",
     "sphinx-tabs",
@@ -242,7 +242,6 @@ testing = [
     "matplotlib >= 3.6.1",
     "pooch>=1.6.0",
     "coverage>7",
-    "docstring_parser>=0.15",
     "pretend>=1.0.9",
     "pyautogui>=0.9.54",
     "pytest-qt >=4.4.0; python_version > '3.10'",
@@ -276,6 +275,7 @@ gallery = [
 # needed to build docs
 docs = [
     {include-group = "gallery"},
+    "numpydoc>=1.0.0",
     "sphinx<8",
     "sphinx-autobuild",
     "sphinx-tabs",

--- a/src/napari/_tests/test_view_layers.py
+++ b/src/napari/_tests/test_view_layers.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, call
 
 import numpy as np
 import pytest
-from numpydoc.docscrape import ClassDoc, FunctionDoc
+from docstring_parser import parse as parse_docstring
 
 import napari
 from napari import Viewer, layers as module
@@ -36,11 +36,11 @@ def test_docstring(layer):
     method_name = f'add_{camel_to_snake(name)}'
     method = getattr(Viewer, method_name)
 
-    method_doc = FunctionDoc(method)
-    layer_doc = ClassDoc(layer)
+    method_doc = parse_docstring(method.__doc__ or '')
+    layer_doc = parse_docstring(layer.__doc__ or '')
 
     # check summary section
-    method_summary = ' '.join(method_doc['Summary'])  # join multi-line summary
+    method_summary = method_doc.short_description or ''
 
     if name == 'Image':
         summary_format = 'Add one or more Image layers to the layer list.'
@@ -52,31 +52,30 @@ def test_docstring(layer):
     )
 
     # check parameters section
-    method_params = method_doc['Parameters']
-    layer_params = layer_doc['Parameters']
+    method_params = method_doc.params
+    layer_params = layer_doc.params
 
     # Remove path parameter from viewer method if it exists
-    method_params = [m for m in method_params if m.name != 'path']
+    method_params = [m for m in method_params if m.arg_name != 'path']
 
     if name == 'Image':
         # For Image just test arguments that are in layer are in method
-        named_method_params = [m.name for m in method_params]
+        named_method_params = [m.arg_name for m in method_params]
         for layer_param in layer_params:
-            l_name, l_type, l_description = layer_param
-            assert l_name in named_method_params
+            assert layer_param.arg_name in named_method_params
     else:
         try:
             assert len(method_params) == len(layer_params)
             for method_param, layer_param in zip(
                 method_params, layer_params, strict=False
             ):
-                m_name, m_type, m_description = method_param
-                l_name, l_type, l_description = layer_param
+                m_name = method_param.arg_name
+                m_type = method_param.type_name or ''
+                m_description = (method_param.description or '').strip()
 
-                # descriptions are treated as lists where each line is an
-                # element
-                m_description = ' '.join(m_description)
-                l_description = ' '.join(l_description)
+                l_name = layer_param.arg_name
+                l_type = layer_param.type_name or ''
+                l_description = (layer_param.description or '').strip()
 
                 assert m_name == l_name, 'different parameter names or order'
                 assert m_type == l_type, (
@@ -91,24 +90,29 @@ def test_docstring(layer):
             ) from e
 
     # check returns section
-    (method_returns,) = method_doc[
-        'Returns'
-    ]  # only one thing should be returned
-    description = ' '.join(method_returns[-1])  # join multi-line description
-    method_returns = *method_returns[:-1], description
+    method_returns = method_doc.returns
 
-    if name == 'Image':
-        assert method_returns == (
-            'layer',
-            f':class:`napari.layers.{name}` or list',
-            f'The newly-created {name.lower()} layer or list of {name.lower()} layers.',
-        ), f"improper 'Returns' section of '{method_name}'"
-    else:
-        assert method_returns == (
-            'layer',
-            f':class:`napari.layers.{name}`',
-            f'The newly-created {name.lower()} layer.',
-        ), f"improper 'Returns' section of '{method_name}'"
+    if method_returns:
+        return_name = method_returns.return_name or 'layer'
+        return_type = method_returns.type_name or ''
+        return_description = (method_returns.description or '').strip()
+
+        if name == 'Image':
+            expected_type = f':class:`napari.layers.{name}` or list'
+            expected_desc = f'The newly-created {name.lower()} layer or list of {name.lower()} layers.'
+        else:
+            expected_type = f':class:`napari.layers.{name}`'
+            expected_desc = f'The newly-created {name.lower()} layer.'
+
+        assert return_name == 'layer', (
+            f"improper return name in '{method_name}'"
+        )
+        assert return_type == expected_type, (
+            f"improper return type in '{method_name}'"
+        )
+        assert return_description == expected_desc, (
+            f"improper return description in '{method_name}'"
+        )
 
 
 @pytest.mark.parametrize('layer', layers, ids=lambda layer: layer.__name__)

--- a/src/napari/_tests/test_view_layers.py
+++ b/src/napari/_tests/test_view_layers.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, call
 
 import numpy as np
 import pytest
-from docstring_parser import parse as parse_docstring
+from docstring_parser.numpydoc import parse as parse_docstring
 
 import napari
 from napari import Viewer, layers as module

--- a/src/napari/plugins/_tests/test_hook_specifications.py
+++ b/src/napari/plugins/_tests/test_hook_specifications.py
@@ -1,7 +1,7 @@
 import inspect
 
 import pytest
-from numpydoc.docscrape import FunctionDoc
+from docstring_parser import parse as parse_docstring
 
 from napari.plugins import hook_specifications
 
@@ -71,9 +71,9 @@ def test_annotation_on_hook_specification(name, func):
 @pytest.mark.parametrize(('name', 'func'), HOOK_SPECIFICATIONS)
 def test_docs_match_signature(name, func):
     sig = inspect.signature(func)
-    docs = FunctionDoc(func)
+    docs = parse_docstring(func.__doc__ or '')
     sig_params = set(sig.parameters)
-    doc_params = {p.name for p in docs.get('Parameters')}
+    doc_params = {p.arg_name for p in docs.params}
     assert sig_params == doc_params, (
         f"Signature parameters for hook specification '{name}' do "
         'not match the parameters listed in the docstring:\n'

--- a/src/napari/plugins/_tests/test_hook_specifications.py
+++ b/src/napari/plugins/_tests/test_hook_specifications.py
@@ -1,7 +1,7 @@
 import inspect
 
 import pytest
-from docstring_parser import parse as parse_docstring
+from docstring_parser.numpydoc import parse as parse_docstring
 
 from napari.plugins import hook_specifications
 

--- a/src/napari/utils/interactions.py
+++ b/src/napari/utils/interactions.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from typing import TYPE_CHECKING
 
-from docstring_parser import parse as parse_docstring
+from docstring_parser.numpydoc import parse as parse_docstring
 
 from napari.utils.key_bindings import (
     KeyBindingLike,

--- a/src/napari/utils/interactions.py
+++ b/src/napari/utils/interactions.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from typing import TYPE_CHECKING
 
-from numpydoc.docscrape import FunctionDoc
+from docstring_parser import parse as parse_docstring
 
 from napari.utils.key_bindings import (
     KeyBindingLike,
@@ -373,8 +373,6 @@ def get_key_bindings_summary(keymap, col='rgb(134, 142, 147)'):
 
 def get_function_summary(func):
     """Get summary of doc string of function."""
-    doc = FunctionDoc(func)
-    summary = ''
-    for s in doc['Summary']:
-        summary += s
+    doc = parse_docstring(func.__doc__ or '')
+    summary = doc.short_description or ''
     return summary.rstrip('.')


### PR DESCRIPTION
# References and relevant issues

Closes #8322

# Description

Replace numpydoc (with sphinx dependencies) with the very lightweight (50kb) `docstring_parser`. We can use `docstring_parser.numpydoc.parse()` to grab out the docstrings. I also like the API of the object returned from parse, cleaner to work with IMO. 

`uv pip install napari`
Main: 116 packages, 395MB size, 434MB size on disk
This PR: 100 packages, 340MB size, 371MB size on disk

1. Refactors `interactions:get_function_summary()` to use parser
2. Refactors `view_*` methods to use `docstring_parser` (due to be deprecated #7047, so maybe more motivation to remove these crufty methods)
3. Used copilot to refactor tests, so can't say I put too much thought in it, but the `test_hook_specifications` looks ok to me (test_view_* is going to be deprecated so I turned brain off)

Uhm yeah just for install size alone we should figure out how to remove numpydoc if its really this simple. 