### PR TITLE
Fix shape selection in a single plane when shapes are on multiple planes

### DIFF
--- a/src/napari/layers/shapes/_shapes_key_bindings.py
+++ b/src/napari/layers/shapes/_shapes_key_bindings.py
@@ -162,23 +162,25 @@ def paste_shape(layer: Shapes) -> None:
 @register_shapes_action(
     trans._('Select/Deselect all shapes in the current view slice')
 )
-def select_all_shapes(layer: Shapes) -> None:
+def select_shapes_in_slice(layer: Shapes) -> None:
     """Select/Deselect all shapes in the current view slice."""
     new_selected = set(np.nonzero(layer._data_view._displayed)[0])
 
-    if new_selected & layer.selected_data == new_selected:
+    if new_selected.issubset(layer.selected_data):
         # If all visible shapes are already selected, deselect them
         layer.selected_data = layer.selected_data - new_selected
     else:
-        # If not all visible shapes are selected, select them
-        layer.selected_data = layer.selected_data | new_selected
-        show_info(
-            trans._(
-                'Selected {n_new} shapes in this slice.',
-                n_new=len(new_selected),
-                deferred=True,
+        # If not all visible shapes are selected, select them and replace
+        # any other selection.
+        layer.selected_data = new_selected
+        if new_selected:
+            show_info(
+                trans._(
+                    'Selected {n_new} shapes in this slice.',
+                    n_new=len(new_selected),
+                    deferred=True,
+                )
             )
-        )
     layer._set_highlight()
 
 

--- a/src/napari/layers/shapes/_tests/test_shapes_key_bindings.py
+++ b/src/napari/layers/shapes/_tests/test_shapes_key_bindings.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from napari.components import Dims
 from napari.layers import Shapes
 from napari.layers.shapes import _shapes_key_bindings as key_bindings
 
@@ -81,19 +82,61 @@ def test_copy_paste():
     assert len(layer._clipboard) > 0
 
 
-def test_select_all():
+def test_select_shapes_in_slice():
     # Test on three four corner rectangle
-    layer = Shapes(20 * np.random.random((3, 4, 2)))
+    data = np.array(
+        [
+            [[0, 0], [0, 10], [10, 10], [10, 0]],
+            [[20, 20], [20, 30], [30, 30], [30, 20]],
+            [[40, 40], [40, 50], [50, 50], [50, 40]],
+        ]
+    )
+    layer = Shapes(data)
     layer.mode = 'direct'
 
     assert len(layer.data) == 3
     assert len(layer.selected_data) == 0
 
-    key_bindings.select_all_shapes(layer)
+    key_bindings.select_shapes_in_slice(layer)
     assert len(layer.selected_data) == 3
 
-    key_bindings.select_all_shapes(layer)
+    # Calling it again should deselect all
+    key_bindings.select_shapes_in_slice(layer)
     assert len(layer.selected_data) == 0
+
+
+def test_select_shapes_in_slice_3d():
+    """Test select all shapes in a 3D slice."""
+    data = [
+        np.array([[0, 0, 0], [0, 10, 10]]),  # shape 0 on slice 0
+        np.array([[1, 5, 5], [1, 15, 15]]),  # shape 1 on slice 1
+        np.array([[0, 20, 20], [0, 30, 30]]),  # shape 2 on slice 0
+    ]
+    layer = Shapes(data, shape_type='line')
+    layer.mode = 'select'
+
+    # view slice 0
+    layer._slice_dims(
+        Dims(
+            ndim=3,
+            ndisplay=2,
+            range=((0, 2, 1), (0, 40, 1), (0, 40, 1)),
+            point=(0, 0, 0),
+        )
+    )
+
+    # select all shapes on slice 0
+    key_bindings.select_shapes_in_slice(layer)
+
+    # Check that shapes 0 and 2 are selected
+    assert layer.selected_data == {0, 2}
+
+    # Check that an interaction box is created
+    assert layer._selected_box is not None
+
+    # Check that get_status doesn't crash
+    status = layer.get_status(position=(0, 10, 10))
+    assert isinstance(status, dict)
 
 
 def test_delete():

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2468,15 +2468,15 @@ class Shapes(Layer):
                 displayed_shape_indices = [
                     i for i in index if self._data_view._displayed[i]
                 ]
-                vertices_range = np.r_[
-                    tuple(
-                        self._data_view._vertices_slice_available(i)
-                        for i in displayed_shape_indices
+                if not displayed_shape_indices:
+                    box = None
+                else:
+                    mask = np.isin(
+                        self._data_view.displayed_vertices_to_shape_num,
+                        displayed_shape_indices,
                     )
-                ]
-                box = create_box(
-                    self._data_view.displayed_vertices[vertices_range]
-                )
+                    verts = self._data_view.displayed_vertices[mask]
+                    box = create_box(verts)
         else:
             box = copy(self._data_view.shapes[index]._box)
 

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2556,7 +2556,7 @@ class Shapes(Layer):
             Width of the box edge
         """
         if self._highlight_visible and len(self.selected_data) > 0:
-            if self._mode == Mode.SELECT:
+            if self._mode == Mode.SELECT and self._selected_box is not None:
                 # If in select mode just show the interaction bounding box
                 # including its vertices and the rotation handle
                 box = self._selected_box[Box.WITH_HANDLE]
@@ -2975,7 +2975,7 @@ class Shapes(Layer):
             # - scale, because vertex sizes are not affected by scale (unlike in Points)
             # - 2, because the radius is what we need
 
-            if self._mode == Mode.SELECT:
+            if self._mode == Mode.SELECT and self._selected_box is not None:
                 # Check if inside vertex of interaction box or rotation handle
                 box = self._selected_box[Box.WITH_HANDLE]
                 distances = abs(box - coord)

--- a/src/napari/utils/shortcuts.py
+++ b/src/napari/utils/shortcuts.py
@@ -82,7 +82,7 @@ _default_shortcuts = {
     'napari:paste_shape': [KeyMod.CtrlCmd | KeyCode.KeyV],
     'napari:move_shapes_selection_to_front': [KeyCode.KeyF],
     'napari:move_shapes_selection_to_back': [KeyCode.KeyB],
-    'napari:select_all_shapes': [
+    'napari:select_shapes_in_slice': [
         KeyCode.KeyA,
         KeyMod.CtrlCmd | KeyCode.KeyA,
     ],


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/8293

# Description
In this PR I implement 3 main things to address the issue:
1. a guard to ensure _selected_box is not None before trying to index into it
2. use _data_view.displayed_vertices_to_shape_num as a mask on displayed_vertexes to get the vertexes of shapes in the view slice. The issue with the current  `self._data_view._vertices_slice_available(i)` is that it returns vertex indexes from all vertexes rather than just the subset of the displayed view slice.
3. rename the keybinding function from `select_all_shapes` to `select_shapes_in_slice`, which is what it does. Then I ensure that behavior, replacing the selection rather than appending. See related Points issue: https://github.com/napari/napari/issues/8333 This prevents trying to draw an interaction_box across slices.

Finally, I add a test (with help from gemini) for selecting within a slice of 3d shapes (also change from using random data, just in case). This test fails on main. 

Tests pass for me locally and selection of Shapes appears to work correctly when I play with it in napari, but it would be good to ensure someone pulls this down and checks in case I missed something!

Performance note: the issue was introduced in a performance-related PR (https://github.com/napari/napari/commit/2f666ca27f5e2735a826ebadf8a0788211c0037a). I tested this branch and main with a 150K shape layer and selection seems on par if not slightly faster with this PR.