### PR TITLE
Fix invisible zoom box

### DIFF
--- a/src/napari/_qt/_tests/test_qt_viewer.py
+++ b/src/napari/_qt/_tests/test_qt_viewer.py
@@ -1227,7 +1227,7 @@ def test_viewer_drag_to_zoom(
     assert viewer_model._zoom_box.visible is True, (
         'Zoom box should remain visible during drag'
     )
-    assert viewer_model._zoom_box.canvas_positions == ((0, 0), (100, 100)), (
+    assert viewer_model._zoom_box.position == ((0, 0), (100, 100)), (
         'Zoom box canvas positions should match the drag coordinates'
     )
 
@@ -1287,6 +1287,6 @@ def test_viewer_drag_to_zoom_with_cancel(
     assert viewer_model._zoom_box.visible is False, (
         'Zoom box should remain visible during drag'
     )
-    assert viewer_model._zoom_box.canvas_positions == ((0, 0), (0, 0)), (
+    assert viewer_model._zoom_box.position == ((0, 0), (0, 0)), (
         'Zoom box canvas positions should match the drag coordinates'
     )

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -374,7 +374,7 @@ class VispyCanvas:
     def _on_boxzoom(self, event):
         """Update zoom level."""
         box_size_canvas = np.abs(
-            np.diff(self.viewer._zoom_box.canvas_positions, axis=0)
+            np.diff(self.viewer._zoom_box.position, axis=0)
         )
         box_center_world = np.mean(event.value, axis=0)
         ratio = np.min(self._current_viewbox_size / box_size_canvas)

--- a/src/napari/_vispy/overlays/base.py
+++ b/src/napari/_vispy/overlays/base.py
@@ -59,8 +59,13 @@ class VispyCanvasOverlay(VispyBaseOverlay):
     """
     Vispy overlay backend for overlays that live in canvas space.
 
-    NOTE: Subclasses should make sure to properly set their x_size and y_size
-    attribute when their size changes for proper tiling.
+    NOTE: Subclasses must follow some rules:
+    - ensure that when `_on_position_change` is called, the x_size and y_size
+      attributes are already updated depending on the overlay size, to ensure
+      proper tiling. Alternatively, override this method if the overlay is
+      *not* supposed to be tiled
+    - ensure that the napari Overlay model uses the `position` field correctly
+      (must be a CanvasPosition enum if tileable, or anything else if "free")
 
     canvas_position_callback is set by the VispyCanvas object, and is responsible
     to update the position of all canvas overlays whenever necessary

--- a/src/napari/_vispy/overlays/zoom.py
+++ b/src/napari/_vispy/overlays/zoom.py
@@ -30,11 +30,11 @@ class VispyZoomOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             parent=parent,
         )
 
-        self.overlay.events.canvas_positions.connect(self._on_positions_change)
+        self.overlay.events.position.connect(self._on_position_change)
 
         self._on_visible_change()
 
-    def _on_positions_change(self, _evt: Optional[Event] = None) -> None:
+    def _on_position_change(self, _evt: Optional[Event] = None) -> None:
         """Change position."""
         settings = get_settings()
         self.node._highlight_width = (
@@ -42,7 +42,7 @@ class VispyZoomOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         )
         self.node._edge_color = settings.appearance.highlight.highlight_color
 
-        top_left, bot_right = self.overlay.canvas_positions
+        top_left, bot_right = self.overlay.position
         self.node.set_data(
             # invert axes for vispy
             top_left[::-1],

--- a/src/napari/components/_tests/test_zoom.py
+++ b/src/napari/components/_tests/test_zoom.py
@@ -15,9 +15,9 @@ def test_zoom():
 def test_zoom_values():
     """Test creating zoom object"""
     zoom = ZoomOverlay()
-    # validate canvas_positions
-    zoom.canvas_positions = ((0, 0), (300, 200))
+    # validate position
+    zoom.position = ((0, 0), (300, 200))
 
     # data_positions must be 2-D
     with pytest.raises(ValidationError):
-        zoom.canvas_positions = ((0, 0, 0), (300, 200, 100))
+        zoom.position = ((0, 0, 0), (300, 200, 100))

--- a/src/napari/components/_viewer_mouse_bindings.py
+++ b/src/napari/components/_viewer_mouse_bindings.py
@@ -60,7 +60,7 @@ def drag_to_zoom(viewer, event):
         viewer._zoom_box.visible = True
         press_pos = event.pos[::-1]
         press_position = event.position
-        viewer._zoom_box.canvas_positions = (press_pos, press_pos)
+        viewer._zoom_box.position = (press_pos, press_pos)
         yield
         event.handled = True
 
@@ -73,7 +73,7 @@ def drag_to_zoom(viewer, event):
             continue
         if 'Alt' in event.modifiers:
             move_pos = event.pos[::-1]
-            viewer._zoom_box.canvas_positions = (press_pos, move_pos)
+            viewer._zoom_box.position = (press_pos, move_pos)
             move_position = event.position
         else:
             # if Alt is released, cancel the zoom box

--- a/src/napari/components/overlays/base.py
+++ b/src/napari/components/overlays/base.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from napari.components._viewer_constants import CanvasPosition
 from napari.layers.base._base_constants import Blending
 from napari.utils.events import EventedModel
@@ -51,7 +53,7 @@ class CanvasOverlay(Overlay):
         The overlay will be duplicated across all grid cells in gridded mode.
     """
 
-    position: CanvasPosition | tuple[int, int] = CanvasPosition.BOTTOM_RIGHT
+    position: CanvasPosition | Any = CanvasPosition.BOTTOM_RIGHT
     blending: Blending = Blending.TRANSLUCENT_NO_DEPTH
     gridded: bool = False
 

--- a/src/napari/components/overlays/zoom.py
+++ b/src/napari/components/overlays/zoom.py
@@ -14,7 +14,7 @@ class ZoomOverlay(CanvasOverlay):
 
     Attributes
     ----------
-    canvas_positions : 2-tuple of 2-tuples
+    position : 2-tuple of 2-tuples
         Corners at the top left and bottom right in canvas coordinates.
     visible : bool
         If the overlay is visible or not.
@@ -24,7 +24,7 @@ class ZoomOverlay(CanvasOverlay):
         The rendering order of the overlay: lower numbers get rendered first.
     """
 
-    canvas_positions: tuple[tuple[float, float], tuple[float, float]] = (
+    position: tuple[tuple[float, float], tuple[float, float]] = (
         (0, 0),
         (0, 0),
     )
@@ -33,7 +33,7 @@ class ZoomOverlay(CanvasOverlay):
         super().__init__(**kwargs)
         self.events.add(zoom=Event)
 
-    @validator('canvas_positions', pre=True, always=True, allow_reuse=True)
+    @validator('position', pre=True, always=True, allow_reuse=True)
     def _validate_bounds(
         cls, v: tuple[tuple[float, ...], tuple[float, ...]]
     ) -> tuple[tuple[float, float], tuple[float, float]]:


### PR DESCRIPTION
# References and relevant issues
- closes https://github.com/napari/napari/issues/8342

# Description
This slipped through when refactoring in #7836. The root of the problem is:
- canvas overlays can have "locked" position (top_left, bottom_right, etc), or "free" positions (whatever the overlay wants)
- overlays need to opt out of the "locked" mode, which takes care of tiling and auto-sets the position
- to opt out you need to specifically set `overlaymodel.position` to a value that *isn't* a `CanvasPosition` enum
- you also should override the method `_on_position_change` in the `VispyOverlay` class in order to avoid unnecessarily updating the tiling

I changed the naming scheme to adapt to this, and now everything works. Basically what was happening is that the overlay was being shifted to `bottom_right` automatically, which meant it was outside of the canvas :P

