### PR TITLE
Fix vispy error traceback

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -81,8 +81,19 @@ class NapariSceneCanvas(SceneCanvas_):
                 # hiding the actual source of the problem. They are never really
                 # informative, so we can safely ignore them.
                 pass
-            else:
-                raise
+            elif 'Shader compilation error' in error_msg:
+                raise RuntimeError(
+                    'Shader compilation failed. Unless you are working with custom shader code,\n'
+                    'this is likely a bug in napari.\n'
+                    'Please open an issue on the repository and provide this *full* stack trace.'
+                ) from e
+            elif 'Cannot SIZE object' in error_msg:
+                raise RuntimeError(
+                    'The above error may be caused by a version mismatch between vispy and napari.\n'
+                    'Try recreating a fresh environment and reinstalling. If that does not work,\n'
+                    'please open an issue on the repository and provide this *full* stack trace.'
+                ) from e
+            raise
 
 
 class VispyCanvas:

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -80,14 +80,14 @@ class NapariSceneCanvas(SceneCanvas_):
                 # they flood the traceback because they are fired on each event,
                 # hiding the actual source of the problem. They are never really
                 # informative, so we can safely ignore them.
-                pass
-            elif 'Shader compilation error' in error_msg:
+                return
+            if 'Shader compilation error' in error_msg:
                 raise RuntimeError(
                     'Shader compilation failed. Unless you are working with custom shader code,\n'
                     'this is likely a bug in napari.\n'
                     'Please open an issue on the repository and provide this *full* stack trace.'
                 ) from e
-            elif 'Cannot SIZE object' in error_msg:
+            if 'Cannot SIZE object' in error_msg:
                 raise RuntimeError(
                     'The above error may be caused by a version mismatch between vispy and napari.\n'
                     'Try recreating a fresh environment and reinstalling. If that does not work,\n'

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -66,6 +66,24 @@ class NapariSceneCanvas(SceneCanvas_):
             return
         super()._process_mouse_event(event)
 
+    def draw_visual(self, visual, event=None):
+        try:
+            super().draw_visual(visual, event=event)
+        except RuntimeError as e:
+            error_msg = e.args[0] if e.args else ''
+            to_ignore = (
+                'Cannot draw program if code has not been set',
+                'Cannot set uniform when program has no code',
+            )
+            if any(msg in error_msg for msg in to_ignore):
+                # these always happens after another (real) error is raised, and
+                # they flood the traceback because they are fired on each event,
+                # hiding the actual source of the problem. They are never really
+                # informative, so we can safely ignore them.
+                pass
+            else:
+                raise
+
 
 class VispyCanvas:
     """Class for our QtViewer class to interact with Vispy SceneCanvas. Also


### PR DESCRIPTION
# References and relevant issues
- closes https://github.com/napari/napari/issues/4570 (and likely similar issues I missed)

# Description
When something goes wrong in vispy, the resulting traceback is usually very long and messy and full of info that's useless for users, to the point that when users ask for help, the relevant information from the traceback is often buried so far that they don't even copy it to the issue.

This PR attempts to mitigate this in 2 ways:
- ignoring "useless" errors, which have no useful info in the traceback and are always caused by another previous unresolved error, but end up burying it
- adding some extra info for known issues that are hard to decipher.

I'm tempted to add the `cannot size object` issue to the ignore list, but I'm not 100% sure that this won't hide actual useful information. I think it's better to be conservative here and if it shows up again we can update this ignore list as needed.
