### PR TITLE
Remove string translation from PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,6 @@ a screenshot or a screen capture: "An image is worth a thousand words!" -->
 - I have made corresponding changes to docstrings and documentation
   (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
 - I have added tests that prove my fix is effective or that my feature works
-- If I included new strings, I have used `trans._("some string")` to make them localizable.
-  (For more information see our [translations guide](https://napari.org/stable/developers/contributing/translations.html)).
 - If an API has been modified, I have added a `.. versionadded::` or `.. versionchanged::`
   directive to the appropriate docstring (For more information see
   [the Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions)).


### PR DESCRIPTION
# Description

The PR checklist asks contributors to use our old `trans._()` machinery, which we now (for a long time) decided we should get rid of because it's causing only problems and never actually moved along. I'm removing this from the checklist.
