### PR TITLE
Fix conversion of vector images to coordinates of vectors

### DIFF
--- a/examples/vortex.py
+++ b/examples/vortex.py
@@ -46,10 +46,7 @@ offset = step // 2
 usub = u[offset::step, offset::step]
 vsub = v[offset::step, offset::step]
 
-vectors_field = np.transpose(  # transpose required — skimage bug?
-        np.stack([usub, vsub], axis=-1),
-        (1, 0, 2),
-        )
+vectors_field = np.stack([usub, vsub], axis=-1)
 
 #######################################################################
 # Finally, we create a viewer, and add the vortex frames, the flow

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -45,7 +45,7 @@ def test_random_vectors_image():
 
 def test_sparse_vectors_image_coordinates():
     """Test if vector images are correctly converted to coordinates.
-    
+
     Prior to [1]_, vector images were incorrectly converted to coordinates.
 
     This was due to an incorrect call to `np.meshgrid`.

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -43,6 +43,18 @@ def test_random_vectors_image():
     assert layer._view_data.shape[2] == 2
 
 
+def test_sparse_vectors_image_coordinates():
+    shape = (20, 10)
+    data = np.zeros(shape + (2,))
+    i, j = np.random.randint(shape)
+    data[i, j] = np.random.random((2,))
+    layer = Vectors(data)
+    coord_data = layer.data
+    non_zero_vectors = ~np.all(coord_data[:, 1] == 0, axis=-1)
+    non_zero_coords = coord_data[non_zero_vectors, 0, :][0]
+    np.testing.assert_equal(non_zero_coords, (i, j))
+
+
 def test_no_args_vectors():
     """Test instantiating Vectors layer with no arguments"""
     layer = Vectors()

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -44,6 +44,12 @@ def test_random_vectors_image():
 
 
 def test_sparse_vectors_image_coordinates():
+    """Prior to [1]_, vector images were incorrectly converted to coordinates.
+
+    This was due to an incorrect call to `np.meshgrid`.
+
+    [1]: https://forum.image.sc/t/missing-something-about-vectors-in-napari/117092
+    """
     shape = (20, 10)
     data = np.zeros(shape + (2,))
     i, j = np.random.randint(shape)

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -44,7 +44,9 @@ def test_random_vectors_image():
 
 
 def test_sparse_vectors_image_coordinates():
-    """Prior to [1]_, vector images were incorrectly converted to coordinates.
+    """Test if vector images are correctly converted to coordinates.
+    
+    Prior to [1]_, vector images were incorrectly converted to coordinates.
 
     This was due to an incorrect call to `np.meshgrid`.
 

--- a/src/napari/layers/vectors/_vector_utils.py
+++ b/src/napari/layers/vectors/_vector_utils.py
@@ -29,7 +29,11 @@ def convert_image_to_coordinates(vectors: npt.NDArray) -> npt.NDArray:
     grid = np.meshgrid(*spacing, indexing='ij')
     coordinates = np.stack([np.reshape(idx, -1) for idx in grid], axis=-1)
 
-    # the corresponding projections are just given by the data
+    # the corresponding projections come directly from the given vectors data
+    # TODO: consider whether it might be good to check for sparsity and
+    # only include nonzero vectors. This can have up-front performance cost but may
+    # lead to (significant) performance and memory savings
+    projections = np.reshape(vectors, (nvect, ndim))
     # TODO: consider whether it might be good to check for sparsity and
     # only include nonzero vectors. Up front performance cost but can
     # lead to (significant) performance and memory savings

--- a/src/napari/layers/vectors/_vector_utils.py
+++ b/src/napari/layers/vectors/_vector_utils.py
@@ -17,24 +17,28 @@ def convert_image_to_coordinates(vectors: npt.NDArray) -> npt.NDArray:
 
     Returns
     -------
-    coords : (N, 2, D) array
+    coord_vectors : (N, 2, D) array
         A list of N vectors with start point and projections of the vector
         in D dimensions.
     """
-    # create coordinate spacing for image
-    spacing = [list(range(r)) for r in vectors.shape[:-1]]
-    grid = np.meshgrid(*spacing)
-
-    # create empty vector of necessary shape
     nvect = np.prod(vectors.shape[:-1])
-    coords = np.empty((nvect, 2, vectors.ndim - 1), dtype=np.float32)
+    ndim = vectors.shape[-1]
 
-    # assign coordinates to all pixels
-    for i, g in enumerate(grid):
-        coords[:, 0, i] = g.flatten()
-    coords[:, 1, :] = np.reshape(vectors, (-1, vectors.ndim - 1))
+    # create coordinate spacing for image
+    spacing = [np.arange(r) for r in vectors.shape[:-1]]
+    grid = np.meshgrid(*spacing, indexing='ij')
+    coordinates = np.stack([np.reshape(idx, -1) for idx in grid], axis=-1)
 
-    return coords
+    # the corresponding projections are just given by the data
+    # TODO: consider whether it might be good to check for sparsity and
+    # only include nonzero vectors. Up front performance cost but can
+    # lead to (significant) performance and memory savings
+    projections = np.reshape(vectors, (nvect, ndim))
+
+    # stack them along axis 1
+    coord_vectors = np.stack([coordinates, projections], axis=1)
+
+    return coord_vectors
 
 
 def fix_data_vectors(


### PR DESCRIPTION
This fixes the bug reported in:

https://forum.image.sc/t/missing-something-about-vectors-in-napari/117092

which has been around since #343 😅

Reproducer copied from the forum:

```python
import numpy as np

import napari

# create the viewer and window
viewer = napari.Viewer()

# circle parameters
n = 400
m = 400
r = 50
cn = 300
cm = 250

image = np.zeros((n, m), dtype=np.float32)

# draw a circle
rr, cc = np.ogrid[:n, :m]
circle = ((rr - cn) ** 2 + (cc - cm) ** 2) < r ** 2
image[circle] = 1.0

layer = viewer.add_image(image, contrast_limits=[0, 1], name='background')

# create vectors only on the circle
pos = np.zeros(shape=(n, m, 2), dtype=np.float32)
pos[image==1, 0] = -1
pos[image==1, 1] = 1

#pos = np.transpose( pos, (1,0,2) )

# add the vectors
vect = viewer.add_vectors(pos, edge_width=0.3, length=0.8, vector_style ='line')

if __name__ == '__main__':
    napari.run()
```


I've included a test that fails before this PR and passes after.

The nice thing is we get rid of a weird transpose in the vortex example that
was compensating for this bug!

