### PR TITLE
Switch PyPI downloads badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 [![License](https://img.shields.io/pypi/l/napari.svg)](https://github.com/napari/napari/raw/main/LICENSE)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/napari.svg)](https://python.org)
 [![Python package index](https://img.shields.io/pypi/v/napari.svg)](https://pypi.org/project/napari)
-[![Python package index download statistics](https://img.shields.io/pypi/dm/napari.svg)](https://pypistats.org/packages/napari)
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/napari-napari?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/napari-napari)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/napari.svg)](https://anaconda.org/conda-forge/napari)
 ![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/napari?label=Conda%20downloads)
 [![DOI](https://zenodo.org/badge/144513571.svg)](https://zenodo.org/badge/latestdoi/144513571)
+<!-- **note**: temporarily use pepy for pypi downloads as pypistats is rate-limited [![Python package index download statistics](https://img.shields.io/pypi/dm/napari.svg)](https://pypistats.org/packages/napari) -->
 
 <!-- Project standards and quality  -->
 [![Development Status](https://img.shields.io/pypi/status/napari.svg)](https://en.wikipedia.org/wiki/Software_release_life_cycle#Beta)


### PR DESCRIPTION
Change PyPI downloads badge source from pypistats, which is rate-limited and really isn't able to support API request load from all projects today. This PR uses pepy for data. Old badge is commented so we can easily change back of rate limitations change.
