### PR TITLE
initialize label selection spinbox to a correct value

### DIFF
--- a/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -160,6 +160,14 @@ def test_change_label_selector_range(make_labels_controls):
     assert qtctrl._label_control.selection_spinbox.maximum() == 127
 
 
+def test_initial_label_selector_value(make_labels_controls):
+    """Initializing the label selector spinbox to an initial value."""
+    layer, qtctrl = make_labels_controls()
+    assert (
+        qtctrl._label_control.selection_spinbox.value() == layer.selected_label
+    )
+
+
 def test_change_iso_gradient_mode(make_labels_controls):
     """Changing the iso gradient mode should update the layer and vice versa."""
     layer, qtctrl = make_labels_controls()

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -135,6 +135,7 @@ class QtLabelControl(QtWidgetControlsBase):
         self.selection_spinbox = QLargeIntSpinBox()
         dtype_lims = get_dtype_limits(get_dtype(layer))
         self.selection_spinbox.setRange(*dtype_lims)
+        self.selection_spinbox.setValue(self._layer.selected_label)
         self.selection_spinbox.setKeyboardTracking(False)
         self.selection_spinbox.valueChanged.connect(self.change_selection)
         self.selection_spinbox.setAlignment(Qt.AlignmentFlag.AlignCenter)


### PR DESCRIPTION
# References and relevant issues
closes #8380 

# Description
Before #8274 we called the callback to initialize the label spinbox to the current label value, but after #8274 the spinbox was left to a default state. This PR updates the current label value before the callback is called. 
@DragaDoncila and I checked the rest of the widgets, but we found no issues, as the current value is either initialized or 0 by default.
Added a test that fails on main but passes on this PR.


