### PR TITLE
Reordering default colormap to split channels 

### DIFF
--- a/src/napari/_tests/test_with_screenshot.py
+++ b/src/napari/_tests/test_with_screenshot.py
@@ -237,7 +237,7 @@ def test_grid_mode(make_napari_viewer):
         [0, 255, 0, 255],
         [255, 0, 0, 255],
     ]
-    
+
     viewer = make_napari_viewer(show=True)
 
     # Add images

--- a/src/napari/_tests/test_with_screenshot.py
+++ b/src/napari/_tests/test_with_screenshot.py
@@ -227,6 +227,17 @@ def test_changing_image_gamma(make_napari_viewer):
 @skip_on_win_ci
 @skip_local_popups
 def test_grid_mode(make_napari_viewer):
+    # CMYBGR is the default color order when adding multichannel images.
+    # See `napari.layers.utils.stack_utils.split_channels`.
+    color = [
+        [0, 255, 255, 255],
+        [255, 0, 255, 255],
+        [255, 255, 0, 255],
+        [0, 0, 255, 255],
+        [0, 255, 0, 255],
+        [255, 0, 0, 255],
+    ]
+    
     viewer = make_napari_viewer(show=True)
 
     # Add images
@@ -240,7 +251,7 @@ def test_grid_mode(make_napari_viewer):
     # check screenshot
     screenshot = viewer.screenshot(canvas_only=True, flash=False)
     center = tuple(np.round(np.divide(screenshot.shape[:2], 2)).astype(int))
-    np.testing.assert_almost_equal(screenshot[center], [0, 0, 255, 255])
+    np.testing.assert_almost_equal(screenshot[center], color[-1])
 
     # enter grid view
     viewer.grid.enabled = True
@@ -259,15 +270,6 @@ def test_grid_mode(make_napari_viewer):
         (3 / 4, 3 / 6),
         (3 / 4, 5 / 6),
     ]
-    # CYMRGB color order
-    color = [
-        [0, 255, 255, 255],
-        [255, 255, 0, 255],
-        [255, 0, 255, 255],
-        [255, 0, 0, 255],
-        [0, 255, 0, 255],
-        [0, 0, 255, 255],
-    ]
     for c, p in zip(color, pos, strict=False):
         coord = tuple(
             np.round(np.multiply(screenshot.shape[:2], p)).astype(int)
@@ -277,18 +279,11 @@ def test_grid_mode(make_napari_viewer):
     # reorder layers, swapping 0 and 5
     viewer.layers.move(5, 0)
     viewer.layers.move(1, 6)
+    # swapping the expected colors
+    color = np.array(color)[[5, 1, 2, 3, 4, 0]]
 
     # check screenshot
     screenshot = viewer.screenshot(canvas_only=True, flash=False)
-    # CGRMYB color order
-    color = [
-        [0, 0, 255, 255],
-        [255, 255, 0, 255],
-        [255, 0, 255, 255],
-        [255, 0, 0, 255],
-        [0, 255, 0, 255],
-        [0, 255, 255, 255],
-    ]
     for c, p in zip(color, pos, strict=False):
         coord = tuple(
             np.round(np.multiply(screenshot.shape[:2], p)).astype(int)

--- a/src/napari/components/_tests/test_multichannel.py
+++ b/src/napari/components/_tests/test_multichannel.py
@@ -5,7 +5,7 @@ import pytest
 from napari.components import ViewerModel
 from napari.utils.colormaps import (
     AVAILABLE_COLORMAPS,
-    CYMRGB,
+    CMYBGR,
     MAGENTA_GREEN,
     SIMPLE_COLORMAPS,
     Colormap,
@@ -13,7 +13,7 @@ from napari.utils.colormaps import (
 )
 from napari.utils.misc import ensure_iterable, ensure_sequence_of_iterables
 
-base_colormaps = CYMRGB
+base_colormaps = CMYBGR
 two_colormaps = MAGENTA_GREEN
 green_cmap = SIMPLE_COLORMAPS['green']
 red_cmap = SIMPLE_COLORMAPS['red']

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -9,7 +9,7 @@ import pint
 
 from napari.layers import Image
 from napari.layers.image._image_utils import guess_multiscale
-from napari.utils.colormaps import CYMRGB, MAGENTA_GREEN, Colormap
+from napari.utils.colormaps import CMYBGR, MAGENTA_GREEN, Colormap
 from napari.utils.misc import ensure_iterable, ensure_sequence_of_iterables
 from napari.utils.translations import trans
 
@@ -122,7 +122,7 @@ def split_channels(
             elif n_channels == 2:
                 kwargs[key] = iter(MAGENTA_GREEN)
             else:
-                kwargs[key] = itertools.cycle(CYMRGB)
+                kwargs[key] = itertools.cycle(CMYBGR)
 
         # make sure that iterable_kwargs are a *sequence* of iterables
         # for the multichannel case.  For example: if scale == (1, 2) &

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -65,7 +65,7 @@ def split_channels(
     Keyword arguments will override any parameters altered or set in this
     function. Colormap, blending, or multiscale are set as follows if not
     overridden by a keyword:
-    - colormap : (magenta, green) for 2 channels, (CYMRGB) for more than 2
+    - colormap : (magenta, green) for 2 channels, (CMYBGR) for more than 2
     - blending : translucent for first channel, additive for others
     - multiscale : determined by layers.image._image_utils.guess_multiscale.
 

--- a/src/napari/utils/colormaps/__init__.py
+++ b/src/napari/utils/colormaps/__init__.py
@@ -8,8 +8,8 @@ from napari.utils.colormaps.colormap import (
 from napari.utils.colormaps.colormap_utils import (
     ALL_COLORMAPS,
     AVAILABLE_COLORMAPS,
-    CYMRGB,
     CMYBGR,
+    CYMRGB,
     INVERSE_COLORMAPS,
     MAGENTA_GREEN,
     RGB,

--- a/src/napari/utils/colormaps/__init__.py
+++ b/src/napari/utils/colormaps/__init__.py
@@ -8,6 +8,7 @@ from napari.utils.colormaps.colormap import (
 from napari.utils.colormaps.colormap_utils import (
     ALL_COLORMAPS,
     AVAILABLE_COLORMAPS,
+    CYMRGB,
     CMYBGR,
     INVERSE_COLORMAPS,
     MAGENTA_GREEN,
@@ -27,6 +28,7 @@ __all__ = (
     'ALL_COLORMAPS',
     'AVAILABLE_COLORMAPS',
     'CMYBGR',
+    'CYMRGB',
     'INVERSE_COLORMAPS',
     'MAGENTA_GREEN',
     'RGB',

--- a/src/napari/utils/colormaps/__init__.py
+++ b/src/napari/utils/colormaps/__init__.py
@@ -8,7 +8,7 @@ from napari.utils.colormaps.colormap import (
 from napari.utils.colormaps.colormap_utils import (
     ALL_COLORMAPS,
     AVAILABLE_COLORMAPS,
-    CYMRGB,
+    CMYBGR,
     INVERSE_COLORMAPS,
     MAGENTA_GREEN,
     RGB,
@@ -26,7 +26,7 @@ from napari.utils.colormaps.colormap_utils import (
 __all__ = (
     'ALL_COLORMAPS',
     'AVAILABLE_COLORMAPS',
-    'CYMRGB',
+    'CMYBGR',
     'INVERSE_COLORMAPS',
     'MAGENTA_GREEN',
     'RGB',

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -718,7 +718,7 @@ AVAILABLE_COLORMAPS_LOCK = Lock()
 # blending of multiple channels.
 MAGENTA_GREEN = ['magenta', 'green']
 RGB = ['red', 'green', 'blue']
-CYMRGB = ['cyan', 'yellow', 'magenta', 'red', 'green', 'blue']
+CMYBGR = ['cyan', 'magenta', 'yellow', 'blue', 'green', 'red']
 
 
 AVAILABLE_LABELS_COLORMAPS = {

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -719,7 +719,7 @@ AVAILABLE_COLORMAPS_LOCK = Lock()
 MAGENTA_GREEN = ['magenta', 'green']
 RGB = ['red', 'green', 'blue']
 CMYBGR = ['cyan', 'magenta', 'yellow', 'blue', 'green', 'red']
-
+CYMRGB = ['cyan', 'yellow', 'magenta', 'red', 'green', 'blue']
 
 AVAILABLE_LABELS_COLORMAPS = {
     'lodisc-50': label_colormap(50),


### PR DESCRIPTION
# References and relevant issues
Closes #8116, related to #8090.

# Description
I updated the default colormap for `napari.layers.utils.stack_utils.split_channels` from `CYMRGB` to `CMYBGR`.
I'm not sure if I should add `.. versionchanged::` but please ping me if that is the case.