### PR TITLE
change default blending mode of images on split RGB

### DIFF
--- a/src/napari/layers/utils/_tests/test_stack_utils.py
+++ b/src/napari/layers/utils/_tests/test_stack_utils.py
@@ -206,6 +206,33 @@ def test_split_and_merge_rgba():
     assert (rgb_image.data[3] == 4).all()
 
 
+def test_split_rgb_blending():
+    """Test blending settings on splitted RGB image."""
+    # Make an RGB
+    data = np.random.randint(0, 100, (10, 128, 128, 3))
+    stack = Image(data)
+    stack_blending = stack.blending
+
+    # split the RGB into 3 images
+    images = split_rgb(stack)
+    blendings = {image.blending for image in images}
+    assert blendings == {stack_blending, 'additive'}
+
+
+def test_split_rgba_blending():
+    """Test blending settings on splitted RGBA image."""
+    # Make an RGBA
+    data = np.random.randint(0, 100, (10, 128, 128, 4))
+    stack = Image(data)
+    stack_blending = stack.blending
+
+    # split the rgb into 4 images
+    images = split_rgb(stack, with_alpha=True)
+    blendings = {image.blending for image in images}
+    # multiplicative should be assigned to alpha channel
+    assert blendings == {stack_blending, 'additive', 'multiplicative'}
+
+
 @pytest.fixture(
     params=[
         {

--- a/src/napari/layers/utils/_tests/test_stack_utils.py
+++ b/src/napari/layers/utils/_tests/test_stack_utils.py
@@ -4,6 +4,7 @@ import pytest
 import zarr
 
 from napari.layers import Image
+from napari.layers.base._base_constants import Blending
 from napari.layers.utils.stack_utils import (
     images_to_stack,
     merge_rgb,
@@ -206,31 +207,42 @@ def test_split_and_merge_rgba():
     assert (rgb_image.data[3] == 4).all()
 
 
-def test_split_rgb_blending():
+@pytest.mark.parametrize(
+    'stack_blending', [blending.value for blending in Blending]
+)
+def test_split_rgb_blending(stack_blending):
     """Test blending settings on splitted RGB image."""
     # Make an RGB
     data = np.random.randint(0, 100, (10, 128, 128, 3))
     stack = Image(data)
-    stack_blending = stack.blending
+    stack.blending = stack_blending
 
     # split the RGB into 3 images
     images = split_rgb(stack)
-    blendings = {image.blending for image in images}
-    assert blendings == {stack_blending, 'additive'}
+    blendings = [image.blending for image in images]
+    assert blendings == [stack_blending, 'additive', 'additive']
 
 
-def test_split_rgba_blending():
+@pytest.mark.parametrize(
+    'stack_blending', [blending.value for blending in Blending]
+)
+def test_split_rgba_blending(stack_blending):
     """Test blending settings on splitted RGBA image."""
     # Make an RGBA
     data = np.random.randint(0, 100, (10, 128, 128, 4))
     stack = Image(data)
-    stack_blending = stack.blending
+    stack.blending = stack_blending
 
     # split the rgb into 4 images
     images = split_rgb(stack, with_alpha=True)
-    blendings = {image.blending for image in images}
+    blendings = [image.blending for image in images]
     # multiplicative should be assigned to alpha channel
-    assert blendings == {stack_blending, 'additive', 'multiplicative'}
+    assert blendings == [
+        stack_blending,
+        'additive',
+        'additive',
+        'multiplicative',
+    ]
 
 
 @pytest.fixture(

--- a/src/napari/layers/utils/_tests/test_stack_utils.py
+++ b/src/napari/layers/utils/_tests/test_stack_utils.py
@@ -211,7 +211,7 @@ def test_split_and_merge_rgba():
     'stack_blending', [blending.value for blending in Blending]
 )
 def test_split_rgb_blending(stack_blending):
-    """Test blending settings on splitted RGB image."""
+    """Test blending settings on a split RGB image."""
     # Make an RGB
     data = np.random.randint(0, 100, (10, 128, 128, 3))
     stack = Image(data)

--- a/src/napari/layers/utils/_tests/test_stack_utils.py
+++ b/src/napari/layers/utils/_tests/test_stack_utils.py
@@ -227,7 +227,7 @@ def test_split_rgb_blending(stack_blending):
     'stack_blending', [blending.value for blending in Blending]
 )
 def test_split_rgba_blending(stack_blending):
-    """Test blending settings on splitted RGBA image."""
+    """Test blending settings on a split RGBA image."""
     # Make an RGBA
     data = np.random.randint(0, 100, (10, 128, 128, 4))
     stack = Image(data)

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -285,10 +285,10 @@ def split_rgb(stack: Image, with_alpha=False) -> list[Image]:
     ]
 
     # first (red) channel blending is inherited from RGB stack
-    # others set to additive
+    # green and blue are set to additive to maintain appearance of unsplit RGB
+    # if rgba, set alpha channel blending to multiplicative
     for img in images[1:]:
         img.blending = 'additive'
-    # if rgba, set alpha channel blending to multiplicative
     if with_alpha:
         images[-1].blending = 'multiplicative'
 

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -283,6 +283,15 @@ def split_rgb(stack: Image, with_alpha=False) -> list[Image]:
     images = [
         Image(image, **i_kwargs) for image, i_kwargs, _ in layerdata_list
     ]
+
+    # first (blue) channel blending is inherited from RGB stack
+    # others set to additive
+    for img in images[1:]:
+        img.blending = 'additive'
+    # if rgba, set alpha channel blending to multiplicative
+    if with_alpha:
+        images[-1].blending = 'multiplicative'
+
     return images if with_alpha else images[:3]
 
 

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -284,7 +284,7 @@ def split_rgb(stack: Image, with_alpha=False) -> list[Image]:
         Image(image, **i_kwargs) for image, i_kwargs, _ in layerdata_list
     ]
 
-    # first (blue) channel blending is inherited from RGB stack
+    # first (red) channel blending is inherited from RGB stack
     # others set to additive
     for img in images[1:]:
         img.blending = 'additive'


### PR DESCRIPTION
# References and relevant issues
Closes #8379

# Description
This PR changes default rendering (blending mode) of images on split RGB(A) to:
1. red - inherit existing blending mode
2. green - additive
3. blue - additive 
4. gray (alpha) - multiplicative
Added simple tests that fail on main but passes on this PR.


