### PR TITLE
`psygnal` migration and typing coverage: a PoC of what it would look like

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -707,7 +707,6 @@ module = [
     'napari.components.layerlist',
     'napari.layers._layer_actions',
     'napari.layers._multiscale_data',
-    'napari.layers.intensity_mixin',
     'napari.layers.points._points_key_bindings',
     'napari.layers.points._points_utils',
     'napari.layers.points.points',

--- a/src/napari/layers/_multiscale_data.py
+++ b/src/napari/layers/_multiscale_data.py
@@ -18,7 +18,7 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
 
     Parameters
     ----------
-    data : Sequence[LayerDataProtocol]
+    data : LayerDataProtocol | Sequence[LayerDataProtocol]
         Levels of multiscale data, from larger to smaller.
     max_size : Sequence[int], optional
         Maximum size of a displayed tile in pixels, by default`data[-1].shape`
@@ -31,15 +31,16 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
         If any of the items in `data` don't provide `LayerDataProtocol`.
     """
 
+    # TODO: max_size handling is missing
     def __init__(
         self,
-        data: Sequence[LayerDataProtocol],
+        data: LayerDataProtocol | Sequence[LayerDataProtocol] | list[LayerDataProtocol],
     ) -> None:
-        self._data: list[LayerDataProtocol] = list(data)
-        if not self._data:
+        if not data:
             raise ValueError(
                 trans._('Multiscale data must be a (non-empty) sequence')
             )
+        self._data: list[LayerDataProtocol] = list(data)
         for d in self._data:
             assert_protocol(d)
 

--- a/src/napari/layers/_multiscale_data.py
+++ b/src/napari/layers/_multiscale_data.py
@@ -34,7 +34,9 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
     # TODO: max_size handling is missing
     def __init__(
         self,
-        data: LayerDataProtocol | Sequence[LayerDataProtocol] | list[LayerDataProtocol],
+        data: LayerDataProtocol
+        | Sequence[LayerDataProtocol]
+        | list[LayerDataProtocol],
     ) -> None:
         if not data:
             raise ValueError(

--- a/src/napari/layers/_scalar_field/_slice.py
+++ b/src/napari/layers/_scalar_field/_slice.py
@@ -18,6 +18,7 @@ from napari.utils.transforms import Affine
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
 
+
 # TODO: this protocol shouldn't go in this module,
 # but somewhere more easily accessible to the rest of the code
 class ProjectionProtocol(Protocol):
@@ -30,17 +31,14 @@ class ProjectionProtocol(Protocol):
 
     NONE: str
 
-    def __call__(self, value: str | Self) -> Self:
-        ...
+    def __call__(self, value: str | Self) -> Self: ...
 
-    def __str__(self) -> str:
-        ...
+    def __str__(self) -> str: ...
 
-    def __eq__(self, other: object) -> bool:
-        ...
+    def __eq__(self, other: object) -> bool: ...
 
-    def __ne__(self, value: object) -> bool:
-        ...
+    def __ne__(self, value: object) -> bool: ...
+
 
 TProj = TypeVar('TProj', bound=ProjectionProtocol)
 

--- a/src/napari/layers/_scalar_field/scalar_field.py
+++ b/src/napari/layers/_scalar_field/scalar_field.py
@@ -66,15 +66,17 @@ if TYPE_CHECKING:
             but this is still an open question:
             https://github.com/pyapp-kit/psygnal/pull/304
         """
+
         attenuation: SignalInstance
         custom_interpolation_kernel_2d: SignalInstance
         depiction: SignalInstance
-        interpolation: SignalInstance # str
-        interpolation2d: SignalInstance # str
-        interpolation3d: SignalInstance # str
-        iso_threshold: SignalInstance # float
+        interpolation: SignalInstance  # str
+        interpolation2d: SignalInstance  # str
+        interpolation3d: SignalInstance  # str
+        iso_threshold: SignalInstance  # float
         plane: SignalInstance
         rendering: SignalInstance
+
 
 class ScalarFieldEventGroup(LayerEventGroup):
     """ScalarField layer events.
@@ -245,7 +247,7 @@ class ScalarFieldBase(Layer[TProj], ABC):
         blending: str | Blending = Blending.TRANSLUCENT,
         cache: bool = True,
         custom_interpolation_kernel_2d: npt.NDArray | None = None,
-        depiction: str ='volume',
+        depiction: str = 'volume',
         experimental_clipping_planes: ClippingPlaneList | None = None,
         metadata: dict[str, Any] | None = None,
         multiscale: bool | None = None,
@@ -253,7 +255,7 @@ class ScalarFieldBase(Layer[TProj], ABC):
         ndim: int | None = None,
         opacity: float = 1.0,
         plane: SlicingPlane | SlicingPlaneDict | None = None,
-        projection_mode: str | ImageProjectionMode = "none",
+        projection_mode: str | ImageProjectionMode = 'none',
         rendering: str = 'mip',
         rotate: float | tuple[float, float, float] | npt.NDArray | None = None,
         scale: tuple[float, ...] | None = None,

--- a/src/napari/layers/_scalar_field/scalar_field.py
+++ b/src/napari/layers/_scalar_field/scalar_field.py
@@ -16,7 +16,12 @@ from napari.layers._scalar_field._slice import (
     _ScalarFieldSliceRequest,
     _ScalarFieldSliceResponse,
 )
-from napari.layers.image._image_constants import Interpolation, VolumeDepiction
+from napari.layers.base._base_constants import Blending
+from napari.layers.image._image_constants import (
+    ImageProjectionMode,
+    Interpolation,
+    VolumeDepiction,
+)
 from napari.layers.image._image_mouse_bindings import (
     move_plane_along_normal as plane_drag_callback,
     set_plane_position as plane_double_click_callback,
@@ -35,7 +40,13 @@ from napari.utils.naming import magic_name
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
+    from typing import Any
+
+    import pint
+
     from napari.components import Dims
+    from napari.layers.utils.plane import ClippingPlaneList, SlicingPlaneDict
+    from napari.utils.transforms import Affine
 
 
 __all__ = ('ScalarFieldBase',)
@@ -180,30 +191,30 @@ class ScalarFieldBase(Layer, ABC):
 
     def __init__(
         self,
-        data,
+        data: npt.NDArray | list[npt.NDArray],
         *,
-        affine=None,
-        axis_labels=None,
-        blending='translucent',
-        cache=True,
-        custom_interpolation_kernel_2d=None,
-        depiction='volume',
-        experimental_clipping_planes=None,
-        metadata=None,
-        multiscale=None,
-        name=None,
-        ndim=None,
-        opacity=1.0,
-        plane=None,
-        projection_mode='none',
-        rendering='mip',
-        rotate=None,
-        scale=None,
-        shear=None,
-        translate=None,
-        units=None,
-        visible=True,
-    ):
+        affine: npt.NDArray | Affine | None = None,
+        axis_labels: tuple[str, ...] | None = None,
+        blending: str | Blending = Blending.TRANSLUCENT,
+        cache: bool = True,
+        custom_interpolation_kernel_2d: npt.NDArray | None = None,
+        depiction: str ='volume',
+        experimental_clipping_planes: ClippingPlaneList | None = None,
+        metadata: dict[str, Any] | None = None,
+        multiscale: bool | None = None,
+        name: str | None = None,
+        ndim: int | None = None,
+        opacity: float = 1.0,
+        plane: SlicingPlane | SlicingPlaneDict | None = None,
+        projection_mode: ImageProjectionMode | str = ImageProjectionMode.NONE,
+        rendering: str = 'mip',
+        rotate: float | tuple[float, float, float] | npt.NDArray | None = None,
+        scale: tuple[float, ...] | None = None,
+        shear: npt.NDArray | None = None,
+        translate: tuple[float, ...] | None = None,
+        units: pint.Unit | None = None,
+        visible: bool = True,
+    ) -> None:
         if name is None and data is not None:
             name = magic_name(data)
 

--- a/src/napari/layers/_scalar_field/scalar_field.py
+++ b/src/napari/layers/_scalar_field/scalar_field.py
@@ -7,7 +7,7 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
-from numpy import typing as npt
+from psygnal import Signal
 
 from napari.layers import Layer
 from napari.layers._data_protocols import LayerDataProtocol
@@ -17,8 +17,8 @@ from napari.layers._scalar_field._slice import (
     _ScalarFieldSliceResponse,
 )
 from napari.layers.base._base_constants import Blending
+from napari.layers.base.base import LayerEventGroup, TProj
 from napari.layers.image._image_constants import (
-    ImageProjectionMode,
     Interpolation,
     VolumeDepiction,
 )
@@ -40,13 +40,59 @@ from napari.utils.naming import magic_name
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Protocol
 
+    import numpy.typing as npt
     import pint
+    from psygnal import SignalInstance
 
     from napari.components import Dims
+    from napari.layers.base.base import LayerEventGroupProtocol
+    from napari.layers.image._image_constants import ImageProjectionMode
     from napari.layers.utils.plane import ClippingPlaneList, SlicingPlaneDict
     from napari.utils.transforms import Affine
+
+    class ScalarFieldEventsProtocol(LayerEventGroupProtocol, Protocol):
+        """Protocol for ScalarFieldBase signals.
+
+        These signals cannot be declared as `psygnal.Signal` as
+        this is simply the descriptor protocol implementation
+        of the actual signal. Instead, we want the instance type
+        that is created in the descriptor, which is `psygnal.SignalInstance`.
+
+        .. note::
+            The protocol is only for type-checking purposes; it should be type
+            hinted as a generic so to describe the actual data it transports
+            but this is still an open question:
+            https://github.com/pyapp-kit/psygnal/pull/304
+        """
+        attenuation: SignalInstance
+        custom_interpolation_kernel_2d: SignalInstance
+        depiction: SignalInstance
+        interpolation: SignalInstance # str
+        interpolation2d: SignalInstance # str
+        interpolation3d: SignalInstance # str
+        iso_threshold: SignalInstance # float
+        plane: SignalInstance
+        rendering: SignalInstance
+
+class ScalarFieldEventGroup(LayerEventGroup):
+    """ScalarField layer events.
+
+    The actual signals instances created by the descriptor.
+    These should be created in the final Layer class that
+    uses the ScalarFieldBase.
+    """
+
+    attenuation = Signal()
+    custom_interpolation_kernel_2d = Signal()
+    depiction = Signal()
+    interpolation = Signal(str)
+    interpolation2d = Signal(str)
+    interpolation3d = Signal(str)
+    iso_threshold = Signal(float)
+    plane = Signal()
+    rendering = Signal()
 
 
 __all__ = ('ScalarFieldBase',)
@@ -55,7 +101,7 @@ __all__ = ('ScalarFieldBase',)
 # It is important to contain at least one abstractmethod to properly exclude this class
 # in creating NAMES set inside of napari.layers.__init__
 # Mixin must come before Layer
-class ScalarFieldBase(Layer, ABC):
+class ScalarFieldBase(Layer[TProj], ABC):
     """Base class for volumetric layers.
 
     Parameters
@@ -188,10 +234,11 @@ class ScalarFieldBase(Layer, ABC):
     _colormaps = AVAILABLE_COLORMAPS
     _interpolation2d: Interpolation
     _interpolation3d: Interpolation
+    signals: ScalarFieldEventsProtocol
 
     def __init__(
         self,
-        data: npt.NDArray | list[npt.NDArray],
+        data: MultiScaleData | LayerDataProtocol | Sequence[LayerDataProtocol],
         *,
         affine: npt.NDArray | Affine | None = None,
         axis_labels: tuple[str, ...] | None = None,
@@ -206,39 +253,39 @@ class ScalarFieldBase(Layer, ABC):
         ndim: int | None = None,
         opacity: float = 1.0,
         plane: SlicingPlane | SlicingPlaneDict | None = None,
-        projection_mode: ImageProjectionMode | str = ImageProjectionMode.NONE,
+        projection_mode: str | ImageProjectionMode = "none",
         rendering: str = 'mip',
         rotate: float | tuple[float, float, float] | npt.NDArray | None = None,
         scale: tuple[float, ...] | None = None,
         shear: npt.NDArray | None = None,
         translate: tuple[float, ...] | None = None,
-        units: pint.Unit | None = None,
+        units: tuple[pint.Unit, ...] | None = None,
         visible: bool = True,
     ) -> None:
         if name is None and data is not None:
             name = magic_name(data)
 
         if isinstance(data, types.GeneratorType):
-            data = list(data)
+            data = MultiScaleData(list(data))
 
         if getattr(data, 'ndim', 2) < 2:
             raise ValueError(
                 trans._('Image data must have at least 2 dimensions.')
             )
 
+        self._data_raw: MultiScaleData
+
         # Determine if data is a multiscale
-        self._data_raw = data
         if multiscale is None:
-            multiscale, data = guess_multiscale(data)
+            multiscale, self._data_raw = guess_multiscale(data)
         elif multiscale and not isinstance(data, MultiScaleData):
-            data = MultiScaleData(data)
+            self._data_raw = MultiScaleData(data)
 
         # Determine dimensionality of the data
-        if ndim is None:
-            ndim = len(data.shape)
+        ndim = ndim or len(self._data_raw.shape)
 
         super().__init__(
-            data,
+            self._data_raw,
             ndim,
             affine=affine,
             axis_labels=axis_labels,
@@ -279,15 +326,15 @@ class ScalarFieldBase(Layer, ABC):
         self._array_like = True
 
         # Set data
-        self._data = data
-        if isinstance(data, MultiScaleData):
-            self._data_level = len(data) - 1
+        self._data = self._data_raw
+        if multiscale:
+            self._data_level = len(self._data) - 1
             # Determine which level of the multiscale to use for the thumbnail.
             # Pick the smallest level with at least one axis >= 64. This is
             # done to prevent the thumbnail from being from one of the very
             # low resolution layers and therefore being very blurred.
             big_enough_levels = [
-                np.any(np.greater_equal(p.shape, 64)) for p in data
+                np.any(np.greater_equal(p.shape, 64)) for p in self._data
             ]
             if np.any(big_enough_levels):
                 self._thumbnail_level = np.where(big_enough_levels)[0][-1]
@@ -303,7 +350,7 @@ class ScalarFieldBase(Layer, ABC):
 
         self._slice = _ScalarFieldSliceResponse.make_empty(
             slice_input=self._slice_input,
-            rgb=len(self.data.shape) != self.ndim,
+            rgb=len(self._data.shape) != self.ndim,
             dtype=self._slice_dtype(),
         )
 
@@ -317,8 +364,11 @@ class ScalarFieldBase(Layer, ABC):
         # triggered (self.refresh(), below).
         self.rendering = rendering
         self.depiction = depiction
-        if plane is not None:
-            self.plane = plane
+        if plane is not None or isinstance(plane, dict):
+            self.plane = SlicingPlane.parse_obj(plane)
+        # TODO: plane is a pydantic model; psygnal provides
+        # its own version of evented models. question is:
+        # how to replace this line?
         connect_no_arg(self.plane.events, self.events, 'plane')
         self.custom_interpolation_kernel_2d = custom_interpolation_kernel_2d
 
@@ -346,9 +396,9 @@ class ScalarFieldBase(Layer, ABC):
     @property
     def data_raw(
         self,
-    ) -> LayerDataProtocol | Sequence[LayerDataProtocol]:
+    ) -> list[LayerDataProtocol]:
         """Data, exactly as provided by the user."""
-        return self._data_raw
+        return self._data_raw._data
 
     def _get_ndim(self) -> int:
         """Determine number of dimensions of the layer."""
@@ -398,10 +448,10 @@ class ScalarFieldBase(Layer, ABC):
         self._data_level = level
         self.refresh(extent=False)
 
-    def _get_level_shapes(self):
+    def _get_level_shapes(self) -> list[tuple[int, ...]]:
         data = self.data
         if isinstance(data, MultiScaleData):
-            shapes = data.shapes
+            shapes = list(data.shapes)
         else:
             shapes = [self.data.shape]
         return shapes
@@ -434,6 +484,7 @@ class ScalarFieldBase(Layer, ABC):
         self._depiction = VolumeDepiction(depiction)
         self._update_plane_callbacks()
         self.events.depiction()
+        self.signals.depiction()
 
     def _reset_plane_parameters(self):
         """Set plane attributes to something valid."""
@@ -464,24 +515,28 @@ class ScalarFieldBase(Layer, ABC):
                 )
 
     @property
-    def plane(self):
+    def plane(self) -> SlicingPlane:
         return self._plane
 
     @plane.setter
-    def plane(self, value: dict | SlicingPlane) -> None:
+    def plane(self, value: SlicingPlane) -> None:
+        if isinstance(value, dict):
+            value = SlicingPlane.parse_obj(value)
         self._plane.update(value)
         self.events.plane()
+        self.signals.plane()
 
     @property
-    def custom_interpolation_kernel_2d(self):
+    def custom_interpolation_kernel_2d(self) -> npt.NDArray:
         return self._custom_interpolation_kernel_2d
 
     @custom_interpolation_kernel_2d.setter
-    def custom_interpolation_kernel_2d(self, value):
+    def custom_interpolation_kernel_2d(self, value: npt.NDArray) -> None:
         if value is None:
             value = [[1]]
         self._custom_interpolation_kernel_2d = np.array(value, np.float32)
         self.events.custom_interpolation_kernel_2d()
+        self.signals.custom_interpolation_kernel_2d()
 
     @abstractmethod
     def _raw_to_displayed(self, raw: np.ndarray) -> np.ndarray:
@@ -548,7 +603,7 @@ class ScalarFieldBase(Layer, ABC):
             data=self.data,
             dask_indexer=dask_indexer,
             data_slice=data_slice,
-            projection_mode=self.projection_mode,
+            projection_mode=self._projection_mode,
             multiscale=self.multiscale,
             corner_pixels=self.corner_pixels,
             rgb=len(self.data.shape) != self.ndim,

--- a/src/napari/layers/base/_base_constants.py
+++ b/src/napari/layers/base/_base_constants.py
@@ -1,11 +1,11 @@
 from collections import OrderedDict
 from enum import IntEnum, auto
 
-from napari.utils.misc import StringEnum
+from napari.utils.compat import StrEnum
 from napari.utils.translations import trans
 
 
-class Blending(StringEnum):
+class Blending(StrEnum):
     """BLENDING: Blending mode for the layer.
 
     Selects a preset blending mode in vispy that determines how
@@ -57,7 +57,7 @@ BLENDING_TRANSLATIONS = OrderedDict(
 )
 
 
-class Mode(StringEnum):
+class Mode(StrEnum):
     """
     Mode: Interactive mode. The normal, default mode is PAN_ZOOM, which
     allows for normal interactivity with the canvas.
@@ -129,7 +129,7 @@ class InteractionBoxHandle(IntEnum):
         )
 
 
-class ActionType(StringEnum):
+class ActionType(StrEnum):
     """
     Action types for layer.events.data of Shapes and Points layer.
     """
@@ -142,7 +142,7 @@ class ActionType(StringEnum):
     CHANGED = auto()
 
 
-class BaseProjectionMode(StringEnum):
+class BaseProjectionMode(StrEnum):
     """
     Projection mode for aggregating a thick nD slice onto displayed dimensions.
 

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -1939,7 +1939,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         click_position: npt.ArrayLike,
         view_direction: npt.ArrayLike,
         dims_displayed: list[int],
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[npt.NDArray, npt.NDArray]:
         """Calculate a (point, normal) plane parallel to the canvas in data
         coordinates, centered on the centre of rotation of the camera.
 
@@ -2025,10 +2025,13 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         """Adjust position for offset between viewer and data coordinates."""
         return np.asarray(position)
 
+    # TODO: bounding_box type should be
+    # specialized in its shape to (2, 3);
+    # how to do that?
     def _get_ray_intersections(
         self,
         position: npt.NDArray,
-        view_direction: np.ndarray,
+        view_direction: npt.NDArray,
         dims_displayed: list[int],
         bounding_box: npt.NDArray,
         world: bool = True,
@@ -2038,7 +2041,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
 
         Parameters
         ----------
-        position
+        position: np.ndarray
             the position of the point in nD coordinates. World vs. data
             is set by the world keyword argument.
         view_direction : np.ndarray

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
             but this is still an open question:
             https://github.com/pyapp-kit/psygnal/pull/304
         """
+
         axis_labels: SignalInstance
         data: SignalInstance
         metadata: SignalInstance
@@ -131,11 +132,14 @@ if TYPE_CHECKING:
         _extent_augmented: SignalInstance
         _overlays: SignalInstance
 
+
 class LayerEventGroup(SignalGroup):
     """Layer signals."""
 
     axis_labels = Signal()
-    data = Signal(object) # LayerDataProtocol | MultiScaleData; there should be only one type though...
+    data = Signal(
+        object
+    )  # LayerDataProtocol | MultiScaleData; there should be only one type though...
     metadata = Signal()
     affine = Signal()
     blending = Signal()
@@ -165,6 +169,7 @@ class LayerEventGroup(SignalGroup):
     visible = Signal()
     _extent_augmented = Signal()
     _overlays = Signal()
+
 
 logger = logging.getLogger('napari.layers.base.base')
 
@@ -207,6 +212,7 @@ class PostInit(ABCMeta):
         obj._post_init()
         return obj
 
+
 class ClippingPlaneDict(TypedDict):
     position: list[float]
     normal: list[float]
@@ -223,7 +229,9 @@ ClippingPlaneType: TypeAlias = (
 
 
 @mgui.register_type(choices=get_layers, return_callback=add_layer_to_viewer)
-class Layer(KeymapProvider, MousemapProvider, ABC, Generic[TProj], metaclass=PostInit):
+class Layer(
+    KeymapProvider, MousemapProvider, ABC, Generic[TProj], metaclass=PostInit
+):
     """Base layer class.
 
     Parameters

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -407,6 +407,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         # Needs to be imported here to avoid circular import in _source
         from napari.layers._source import current_source
 
+        # to trigger events at layer creation,
+        # we first define the internal private variables
+        # marked as `_<property name>` to dummy values;
+        # afterwards we compute the actual values
+        # and rely on the property setters to trigger events.
         self._highlight_visible = True
         self._unique_id = None
         self._source = current_source()

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -378,7 +378,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         ndim: int,
         *,
         affine: npt.ArrayLike | Affine | None = None,
-        axis_labels: tuple[str] | None = None,
+        axis_labels: tuple[str, ...] | None = None,
         blending: Blending = Blending.TRANSLUCENT,
         cache: bool = True,  # this should move to future "data source" object.
         experimental_clipping_planes: ClippingPlaneType | None = None,
@@ -395,6 +395,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         units: tuple[pint.Unit, ...] | None = None,
         visible: bool = True,
     ) -> None:
+        # TODO: is this needed?
+        # should it maybe be made explicit
+        # i.e. super(KeymapProvider, self).__init__()
         super().__init__()
 
         if name is None and data is not None:

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
 
     from napari.components.dims import Dims
     from napari.components.overlays.base import Overlay
+    from napari.layers._data_protocols import LayerDataProtocol
     from napari.layers._multiscale_data import MultiScaleData
     from napari.layers._source import Source
     from napari.layers.image._image_constants import ImageProjectionMode
@@ -134,7 +135,7 @@ class LayerEventGroup(SignalGroup):
     """Layer signals."""
 
     axis_labels = Signal()
-    data = Signal()
+    data = Signal(object) # LayerDataProtocol | MultiScaleData; there should be only one type though...
     metadata = Signal()
     affine = Signal()
     blending = Signal()
@@ -1083,7 +1084,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, Generic[TProj], metaclass=Pos
 
     @property
     @abstractmethod
-    def data(self) -> MultiScaleData:
+    def data(self) -> LayerDataProtocol:
         # user writes own docstring
         raise NotImplementedError
 
@@ -1092,7 +1093,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, Generic[TProj], metaclass=Pos
     # should be rethought
     @data.setter
     @abstractmethod
-    def data(self, data: MultiScaleData) -> None:
+    def data(self, data: LayerDataProtocol) -> None:
         raise NotImplementedError
 
     @property

--- a/src/napari/layers/image/_image_constants.py
+++ b/src/napari/layers/image/_image_constants.py
@@ -2,30 +2,12 @@ from collections import OrderedDict
 from enum import auto
 from typing import Literal
 
-from napari.utils.misc import StringEnum
+from napari.layers._scalar_field._slice import ProjectionProtocol
+from napari.utils.compat import StrEnum
 from napari.utils.translations import trans
 
-InterpolationStr = Literal[
-    'bessel',
-    'cubic',
-    'linear',
-    'blackman',
-    'catrom',
-    'gaussian',
-    'hamming',
-    'hanning',
-    'hermite',
-    'kaiser',
-    'lanczos',
-    'mitchell',
-    'nearest',
-    'spline16',
-    'spline36',
-    'custom',
-]
 
-
-class Interpolation(StringEnum):
+class Interpolation(StrEnum):
     """INTERPOLATION: Vispy interpolation mode.
 
     The spatial filters used for interpolation are from vispy's
@@ -51,8 +33,6 @@ class Interpolation(StringEnum):
     SPLINE36 = auto()
     CUSTOM = auto()
 
-    value: InterpolationStr
-
     @classmethod
     def view_subset(
         cls,
@@ -71,11 +51,8 @@ class Interpolation(StringEnum):
             cls.SPLINE36,
         )
 
-    def __str__(self) -> InterpolationStr:
-        return self.value
 
-
-class ImageRendering(StringEnum):
+class ImageRendering(StrEnum):
     """Rendering: Rendering mode for the layer.
 
     Selects a preset rendering mode in vispy
@@ -119,7 +96,7 @@ ImageRenderingStr = Literal[
 ]
 
 
-class VolumeDepiction(StringEnum):
+class VolumeDepiction(StrEnum):
     """Depiction: 3D depiction mode for images.
 
     Selects a preset depiction mode in vispy
@@ -139,7 +116,7 @@ VOLUME_DEPICTION_TRANSLATION = OrderedDict(
 )
 
 
-class ImageProjectionMode(StringEnum):
+class ImageProjectionMode(ProjectionProtocol, StrEnum):
     """
     Projection mode for aggregating a thick nD slice onto displayed dimensions.
 

--- a/src/napari/layers/image/_image_utils.py
+++ b/src/napari/layers/image/_image_utils.py
@@ -1,4 +1,5 @@
 """guess_rgb, guess_multiscale, guess_labels."""
+
 from __future__ import annotations
 
 import itertools
@@ -77,7 +78,11 @@ def guess_multiscale(
         # pyramid with only one level, unwrap
         return False, MultiScaleData(data[0])
 
-    sizes = [data.size] if isinstance(data, LayerDataProtocol) else [d.size for d in data]
+    sizes = (
+        [data.size]
+        if isinstance(data, LayerDataProtocol)
+        else [d.size for d in data]
+    )
     if len(sizes) <= 1:
         return False, MultiScaleData(data)
 
@@ -100,7 +105,11 @@ def guess_multiscale(
                 sizes=sizes,
             )
         )
-    ret = MultiScaleData([data]) if isinstance(data, LayerDataProtocol) else MultiScaleData(data)
+    ret = (
+        MultiScaleData([data])
+        if isinstance(data, LayerDataProtocol)
+        else MultiScaleData(data)
+    )
     return True, ret
 
 

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -457,19 +457,20 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase[ImageProjectionMode]):
         self.signals.attenuation()
 
     @property
-    def data(self) -> LayerDataProtocol | MultiScaleData:
+    def data(self) -> LayerDataProtocol:
         """Data, possibly in multiscale wrapper. Obeys LayerDataProtocol."""
         return self._data
 
     @data.setter
-    def data(self, data: LayerDataProtocol | MultiScaleData) -> None:
-        self._data_raw = data
+    def data(self, data: LayerDataProtocol) -> None:
+        self._data_raw = MultiScaleData(data)
         # note, we don't support changing multiscale in an Image instance
-        self._data = MultiScaleData(data) if self.multiscale else data  # type: ignore
+        self._data = MultiScaleData(data) if self.multiscale else data
         self._update_dims()
         if self._keep_auto_contrast:
             self.reset_contrast_limits()
-        self.events.data(value=self.data)
+        self.events.data(value=self._data)
+        self.signals.data(self._data)
         self._reset_editable()
 
     @property

--- a/src/napari/layers/intensity_mixin.py
+++ b/src/napari/layers/intensity_mixin.py
@@ -38,12 +38,15 @@ if TYPE_CHECKING:
             but this is still an open question:
             https://github.com/pyapp-kit/psygnal/pull/304
         """
+
         contrast_limits: SignalInstance
         contrast_limits_range: SignalInstance
         gamma: SignalInstance
         colormap: SignalInstance
 
+
 T = TypeVar('T')
+
 
 class IVMSignalGroup(SignalGroup):
     """IntensityVisualizationMixin signals.
@@ -52,6 +55,7 @@ class IVMSignalGroup(SignalGroup):
     These should be created in the final Layer class that
     uses the IntensityVisualizationMixin.
     """
+
     contrast_limits = Signal()
     contrast_limits_range = Signal()
     gamma = Signal()
@@ -70,6 +74,7 @@ class IntensityVisualizationMixin:
     Note: `contrast_limits_range` is range extent available on the widget,
     and `contrast_limits` is the visible range (the set values on the widget)
     """
+
     events: EmitterGroup
     _colormap: Colormap
     _overlays: EventedDict
@@ -91,7 +96,6 @@ class IntensityVisualizationMixin:
     # but mypy seems to be complaining if they are not present,
     # so we have to add them to "digest" any extra arguments
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-
         # this super().__init__() call
         # is necessary given the mixin nature of this class
         super().__init__()
@@ -115,7 +119,9 @@ class IntensityVisualizationMixin:
 
         self._overlays.update({'colorbar': ColorBarOverlay()})
 
-    def reset_contrast_limits(self, mode: Literal['data', 'slice'] | None = None) -> None:
+    def reset_contrast_limits(
+        self, mode: Literal['data', 'slice'] | None = None
+    ) -> None:
         """Scale contrast limits to data range"""
         mode = mode or self._auto_contrast_source
         self._contrast_limits = self._calc_data_range(mode)
@@ -126,7 +132,9 @@ class IntensityVisualizationMixin:
     ) -> tuple[float, float]:
         raise NotImplementedError
 
-    def reset_contrast_limits_range(self, mode: Literal['data', 'slice'] | None = None) -> None:
+    def reset_contrast_limits_range(
+        self, mode: Literal['data', 'slice'] | None = None
+    ) -> None:
         """Scale contrast limits range to data type if dtype is an integer,
         or use the current maximum data range otherwise.
         """
@@ -174,18 +182,16 @@ class IntensityVisualizationMixin:
     def contrast_limits(self, value: list[float | None]) -> None:
         if not check_list(value, 2):
             raise ValueError(
-            trans._(
-                'Sequence {sequence} must be of length {n} and contain no None values.',
-                deferred=True,
-                sequence=value,
-                n=2
+                trans._(
+                    'Sequence {sequence} must be of length {n} and contain no None values.',
+                    deferred=True,
+                    sequence=value,
+                    n=2,
+                )
             )
-        )
 
         self._contrast_limits_msg = (
-            format_float(value[0])
-            + ', '
-            + format_float(value[1])
+            format_float(value[0]) + ', ' + format_float(value[1])
         )
         self._contrast_limits = (value[0], value[1])
         # make sure range slider is big enough to fit range
@@ -220,13 +226,13 @@ class IntensityVisualizationMixin:
             # be made so that if one element is None,
             # it'll preserve the current range for that element
             raise ValueError(
-            trans._(
-                'Sequence {sequence} must be of length {n} and contain no None values.',
-                deferred=True,
-                sequence=value,
-                n=2
+                trans._(
+                    'Sequence {sequence} must be of length {n} and contain no None values.',
+                    deferred=True,
+                    sequence=value,
+                    n=2,
+                )
             )
-        )
         if list(value) == self.contrast_limits_range:
             return
 

--- a/src/napari/layers/intensity_mixin.py
+++ b/src/napari/layers/intensity_mixin.py
@@ -16,14 +16,14 @@ if TYPE_CHECKING:
     from typing import Literal, Protocol
 
     import numpy.typing as npt
-    from psygnal import Signal, SignalGroup
+    from psygnal import Signal
 
     from napari.components.overlays import ColorBarOverlay
     from napari.utils.colormaps.colormap import Colormap
     from napari.utils.colormaps.colormap_utils import ValidColormapArg
     from napari.utils.events import EmitterGroup, EventedDict
 
-    class IVMSignalGroup(SignalGroup, Protocol):
+    class IVMSignalGroup(Protocol):
         contrast_limits: Signal
         contrast_limits_range: Signal
         gamma: Signal

--- a/src/napari/layers/intensity_mixin.py
+++ b/src/napari/layers/intensity_mixin.py
@@ -49,6 +49,14 @@ class IntensityVisualizationMixin:
     _overlays: EventedDict
     dtype: npt.DTypeLike
     _colormaps: dict[str, Colormap]
+
+    # TODO: when declaring a protocol like this,
+    # mypy WILL complain because it does not understand that
+    # both the ScalarFieldBase, IntensityVisualizationMixin and
+    # Image classes will have this attribute which has to be extended
+    # with the appropriate signals... how to fix this? The nice thing
+    # about the current event system is that it relies on dynamic
+    # attributes setting, so we don't have to declare them all the time.
     signals: IVMSignalGroup
 
     def __init__(self) -> None:
@@ -159,6 +167,8 @@ class IntensityVisualizationMixin:
         self.events.contrast_limits()
         self.signals.contrast_limits()
 
+    # TODO: this kind of typing is confusing,
+    # although I understand the reasoining
     @property
     def contrast_limits_range(self) -> list[float | None]:
         """The current valid range of the contrast limits."""

--- a/src/napari/layers/utils/layer_utils.py
+++ b/src/napari/layers/utils/layer_utils.py
@@ -290,7 +290,11 @@ def calc_data_range(
     return (float(min_val), float(max_val))
 
 
-def segment_normal(a: npt.NDArray[Any], b: npt.NDArray[Any], p: tuple[int, int, int] = (0, 0, 1)) -> np.ndarray:
+def segment_normal(
+    a: npt.NDArray[Any],
+    b: npt.NDArray[Any],
+    p: tuple[int, int, int] = (0, 0, 1),
+) -> np.ndarray:
     """Determines the unit normal of the vector from a to b.
 
     Parameters

--- a/src/napari/layers/utils/layer_utils.py
+++ b/src/napari/layers/utils/layer_utils.py
@@ -329,7 +329,7 @@ def segment_normal(a, b, p=(0, 0, 1)) -> np.ndarray:
     return normal / norm
 
 
-def convert_to_uint8(data: np.ndarray) -> np.ndarray:
+def convert_to_uint8(data: npt.NDArray[Any]) -> npt.NDArray[np.uint8]:
     """
     Convert array content to uint8, always returning a copy.
 
@@ -603,7 +603,7 @@ def compute_multiscale_level_and_corners(
 
 
 def coerce_affine(
-    affine: npt.ArrayLike | Affine,
+    affine: npt.ArrayLike | Affine | None,
     *,
     ndim: int,
     name: str | None = None,
@@ -616,7 +616,7 @@ def coerce_affine(
 
     Parameters
     ----------
-    affine : array-like or napari.utils.transforms.Affine
+    affine : array-like or napari.utils.transforms.Affine, optional
         An existing affine transform object or an array-like that is its transform matrix.
     ndim : int
         The desired dimensionality of the transform. Ignored is affine is an Affine transform object.

--- a/src/napari/layers/utils/layer_utils.py
+++ b/src/napari/layers/utils/layer_utils.py
@@ -290,7 +290,7 @@ def calc_data_range(
     return (float(min_val), float(max_val))
 
 
-def segment_normal(a, b, p=(0, 0, 1)) -> np.ndarray:
+def segment_normal(a: npt.NDArray[Any], b: npt.NDArray[Any], p: tuple[int, int, int] = (0, 0, 1)) -> np.ndarray:
     """Determines the unit normal of the vector from a to b.
 
     Parameters

--- a/src/napari/layers/utils/plane.py
+++ b/src/napari/layers/utils/plane.py
@@ -15,9 +15,11 @@ if TYPE_CHECKING:
 
     class SlicingPlaneDict(TypedDict):
         """Typed dictionary equivalent of SlicingPlane."""
+
         position: tuple[float, float, float]
         normal: tuple[float, float, float]
         thickness: float
+
 
 Point3D: TypeAlias = tuple[float, float, float]
 

--- a/src/napari/layers/utils/plane.py
+++ b/src/napari/layers/utils/plane.py
@@ -1,4 +1,6 @@
-from typing import Any, TypeAlias, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -7,6 +9,15 @@ from napari._pydantic_compat import validator
 from napari.utils.events import EventedModel, SelectableEventedList
 from napari.utils.geometry import intersect_line_with_plane_3d
 from napari.utils.translations import trans
+
+if TYPE_CHECKING:
+    from typing import TypedDict
+
+    class SlicingPlaneDict(TypedDict):
+        """Typed dictionary equivalent of SlicingPlane."""
+        position: tuple[float, float, float]
+        normal: tuple[float, float, float]
+        thickness: float
 
 Point3D: TypeAlias = tuple[float, float, float]
 
@@ -64,7 +75,7 @@ class Plane(EventedModel):
         b: npt.NDArray,
         c: npt.NDArray,
         enabled: bool = True,
-    ) -> 'Plane':
+    ) -> Plane:
         """Derive a Plane from three points.
 
         Parameters
@@ -102,7 +113,7 @@ class Plane(EventedModel):
         return np.stack([self.position, self.normal])
 
     @classmethod
-    def from_array(cls, array: npt.NDArray, enabled: bool = True) -> 'Plane':
+    def from_array(cls, array: npt.NDArray, enabled: bool = True) -> Plane:
         """Construct a plane from a (2, 3) array.
 
         [0, :] : plane position
@@ -174,7 +185,7 @@ class ClippingPlaneList(SelectableEventedList[ClippingPlane]):
     @classmethod
     def from_array(
         cls, array: npt.NDArray, enabled: bool = True
-    ) -> 'ClippingPlaneList':
+    ) -> ClippingPlaneList:
         """Construct the PlaneList from an (N, 2, 3) array.
 
         [i, 0, :] : ith plane position
@@ -197,7 +208,7 @@ class ClippingPlaneList(SelectableEventedList[ClippingPlane]):
     @classmethod
     def from_bounding_box(
         cls, center: Point3D, dimensions: Point3D, enabled: bool = True
-    ) -> 'ClippingPlaneList':
+    ) -> ClippingPlaneList:
         """
         generate 6 planes positioned to form a bounding box, with normals towards the center
 

--- a/src/napari/layers/utils/plane.py
+++ b/src/napari/layers/utils/plane.py
@@ -154,7 +154,7 @@ class ClippingPlane(Plane):
     enabled: bool = True
 
 
-class ClippingPlaneList(SelectableEventedList):
+class ClippingPlaneList(SelectableEventedList[ClippingPlane]):
     """A list of planes with some utility methods."""
 
     def as_array(self) -> npt.NDArray:

--- a/src/napari/utils/_tests/test_validators.py
+++ b/src/napari/utils/_tests/test_validators.py
@@ -4,19 +4,17 @@ from napari.utils import validators
 
 
 def test_sequence_validator():
-    validate = validators.validate_n_seq(2, int)
+    correct_float_source = [1.0, 2.0]
+    correct_int_source = [1, 2]
+    incorrect_sources = [
+        [1, None],
+        [None, 2.0],
+    ]
 
-    # this should work
-    validate([4, 5])
-
-    with pytest.raises(TypeError):
-        validate(8)  # raises TypeError
-
-    with pytest.raises(ValueError, match='must have length'):
-        validate([1, 2, 3])  # raises ValueError
-
-    with pytest.raises(TypeError):
-        validate([1.4, 5])  # raises TypeError
+    assert validators.check_sequence(correct_float_source, 2)
+    assert validators.check_sequence(correct_int_source, 2)
+    for source in incorrect_sources:
+        assert not validators.check_sequence(source, 2)
 
 
 def test_pairwise():
@@ -27,11 +25,11 @@ def test_pairwise():
 
 def test_validate_increasing():
     valid_source = [1, 2, 3]
-    validators._validate_increasing(valid_source)
+    validators.validate_increasing(valid_source)
 
     invalid_sources = [[3, 2, 1], [1, 1, 2]]
     for source in invalid_sources:
         with pytest.raises(
             ValueError, match='must be monotonically increasing'
         ):
-            validators._validate_increasing(source)
+            validators.validate_increasing(source)

--- a/src/napari/utils/mouse_bindings.py
+++ b/src/napari/utils/mouse_bindings.py
@@ -1,24 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+if TYPE_CHECKING:
+    from napari.layers import Layer
+    from napari.utils.events import Event
+
+ModeCallable: TypeAlias = Callable[
+    ['Layer', 'Event'], None | Generator[None, None, None]
+]
+
+
 class MousemapProvider:
     """Mix-in to add mouse binding functionality.
 
+    Callbacks can be registered to respond to mouse events such as move,
+    drag, wheel, and double click.
+
+    Callbacks should provide the signature defined by `ModeCallable`, i.e.
+
+    def callback(layer: Layer, event: Event) -> None | Generator[None, None, None]:
+        ...
+
     Attributes
     ----------
-    mouse_move_callbacks : list
+    mouse_move_callbacks : list[ModeCallable]
         Callbacks from when mouse moves with nothing pressed.
-    mouse_drag_callbacks : list
+    mouse_drag_callbacks : list[ModeCallable]
         Callbacks from when mouse is pressed, dragged, and released.
-    mouse_wheel_callbacks : list
+    mouse_wheel_callbacks : list[ModeCallable]
         Callbacks from when mouse wheel is scrolled.
-    mouse_double_click_callbacks : list
+    mouse_double_click_callbacks : list[ModeCallable]
         Callbacks from when mouse wheel is scrolled.
     """
 
-    mouse_move_callbacks: list[callable]
-    mouse_wheel_callbacks: list[callable]
-    mouse_drag_callbacks: list[callable]
-    mouse_double_click_callbacks: list[callable]
+    mouse_move_callbacks: list[ModeCallable]
+    mouse_wheel_callbacks: list[ModeCallable]
+    mouse_drag_callbacks: list[ModeCallable]
+    mouse_double_click_callbacks: list[ModeCallable]
 
-    def __init__(self, *args, **kwargs) -> None:
+    # these args are required to preserve MRO call order,
+    # as this class is inherited as a mixin class
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # Hold callbacks for when mouse moves with nothing pressed
         self.mouse_move_callbacks = []

--- a/src/napari/utils/naming.py
+++ b/src/napari/utils/naming.py
@@ -1,4 +1,5 @@
 """Automatically generate names."""
+
 from __future__ import annotations
 
 import inspect

--- a/src/napari/utils/naming.py
+++ b/src/napari/utils/naming.py
@@ -1,4 +1,5 @@
 """Automatically generate names."""
+from __future__ import annotations
 
 import inspect
 import re
@@ -6,10 +7,14 @@ from collections import ChainMap, ChainMap as ChainMapType
 from collections.abc import Callable
 from types import FrameType, TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
 )
 
 from napari.utils.misc import ROOT_DIR, formatdoc
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 sep = ' '
 start = 1
@@ -98,7 +103,7 @@ class CallerFrame:
         self.namespace = ChainMap()
         self.names = ()
 
-    def __enter__(self) -> 'CallerFrame':
+    def __enter__(self) -> Self:
         frame = inspect.currentframe()
         try:
             # See issue #1635 regarding potential AttributeError

--- a/src/napari/utils/status_messages.py
+++ b/src/napari/utils/status_messages.py
@@ -1,15 +1,23 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
+if TYPE_CHECKING:
+    from typing import Any
 
-def format_float(value):
+    import numpy.typing as npt
+
+
+def format_float(value: float) -> str:
     """Nice float formatting into strings."""
     return f'{value:0.3g}'
 
 
-def status_format(value):
+def status_format(value: str | Iterable[Any] | float | np.ndarray) -> str:
     """Return a "nice" string representation of a value.
 
     Parameters

--- a/src/napari/utils/validators.py
+++ b/src/napari/utils/validators.py
@@ -8,7 +8,7 @@ from napari.utils.translations import trans
 if TYPE_CHECKING:
     from collections.abc import MutableSequence
 
-T = TypeVar('T', bound=int | float)
+T = TypeVar('T')
 
 
 # TODO: this should be generalizable to

--- a/src/napari/utils/validators.py
+++ b/src/napari/utils/validators.py
@@ -13,9 +13,7 @@ T = TypeVar('T')
 
 # TODO: this should be generalizable to
 # other mutable sequence types (e.g., tuple)
-def check_list(
-    values: list[T | None], n: int
-) -> TypeGuard[list[T]]:
+def check_list(values: list[T | None], n: int) -> TypeGuard[list[T]]:
     """
     Check that all elements in the list are not None,
     and that the length of the iterable is n.


### PR DESCRIPTION
# References and relevant issues
#8120 #3373 

# Description
> [!IMPORTANT]
> This PR is not intended for merging, it's a canvas for a more in-depth discussion about some typing mechanism and other stuff.

I originally started a discussion about migrating to [`psygnal`](https://github.com/pyapp-kit/psygnal) in zulip: [#general > migrating to psygnal](https://napari.zulipchat.com/#narrow/channel/212875-general/topic/migrating.20to.20psygnal/with/547218759).

> [!NOTE]
> Please have a look at #3373 because it lays the fundation of some discussion below.

I understand a lot of this (especially about `psygnal`) will be pretty established knowledge by core devs and others, but I wanted to be as exhaustive as possible for others who might not see the benefit.

## TL;DR

Correctly typing the currently ignored files requires an overhaul of the napari's event system, as this is too much embedded from GUI to model and finding alternative solutions would simply delay the inevitable migration that it is also (hopefully not by me) desired. I have tried a couple of times to try and bypass this but in the end I always encounter the `events.py` wall. Or maybe I'm just too stubborn to use `typing.Any`. This PR is intended as a discussion of how this should be done eventually in the future to highlight possible pitfalls. I covered some base classes and the `Image` layer as an incomplete example (I got tired of fighting a box match with `mypy` at some point, since it was winning).

## The problem
The current `events` are too dynamically typed to be able to correctly predict what a type of something will be; since the entire event mechanism is used from the top-down (from GUI to model), type hinting correctly the GUI parts currently uncovered becomes impossible. So instead the best approach is to go bottom-up and slowly adjust the types starting from the very basic, private classes up to the most exposed ones.

## The approach (a.k.a. I'm confused)
This is an example of that increased typing coverage; it is probably too strict for some tastes but it is intentionally extreme as it is what I would envision for napari in the future (but then again, it'll be up to the core devs to decide).

I started from the shared base classes of the `Image` layer; it's inheritance tree is:

```mermaid
graph TD
    Image[Image]
    IntensityVisualizationMixin[IntensityVisualizationMixin]
    ScalarFieldBase[ScalarFieldBase]
    Layer[Layer]
    KeymapProvider[KeymapProvider]
    MousemapProvider[MousemapProvider]
    ABC1[ABC]
    ABC2[ABC]
    
    Image --> IntensityVisualizationMixin
    Image --> ScalarFieldBase
    ScalarFieldBase --> Layer
    ScalarFieldBase --> ABC1
    Layer --> KeymapProvider
    Layer --> MousemapProvider
    Layer --> ABC2
```

### `LayerDataProtocol` vs `MultiScaleData`

One question it came to mind immediatly is: what's the expected type of the input `data` the user provides when initializing a `Image`? This should be propagated from top to bottom consistently, but I encountered the `LayerDataProtocol` and a `MultiScaleData` classes; while I understand the first, I do not entirely understand the second. Wouldn't it be better to have a single `MultiScaleDataProtocol` that unifies the two classes and an internal `multiscale` boolean flag would resolve whether it is multiscale or not?

### Redundant private attribute setting

Another point I encountered is the pre-emptive definition of private attributes that constitutes the **true** attributes of the `Layer` class (i.e. `self._visibile`) with dummy values that afterwards are immediatly updated by the respective property setters. So for example, [here](https://github.com/napari/napari/blob/6ee4f6ffb18ebe2d0ed876ea94de3447c1e1ba9c/src/napari/layers/base/base.py#L438) the `self._name` private attribute is declared as an empty list; then [this](https://github.com/napari/napari/blob/6ee4f6ffb18ebe2d0ed876ea94de3447c1e1ba9c/src/napari/layers/base/base.py#L484) calls the `name` setter which actually overwrites `self._name` and the first assignment is practically null.

The solution for this is simply defining in `__init__`: 

```
self._name: str
```

No runtime costs, and mypy will know that `self._name` is a `str`. And this will probably improve (even if slightly) performance.

For the purpose of this PR I kept the original implementation somewhat intact but I would simply do the above for all private attributes and trigger events when assigning values through setters.

### `TypedDict` to correctly infer types of dictionaries

There's a bunch of untyped `dict` inputs that are very non-explicit and sometimes they're simply a copy-paste visualization of a respective model. I honestly find this redundant: I would prefer to only provide the model as input, but I understand it would create the need of a bunch of non-exposed imports. As an alternative solution for internal typing I tried using `typing.TypedDict` to replicate the same patterns of some `pydantic` models. A big thanks to `pydantic` that apparently does not support the possibility to override the return type of `BaseModel.dict()` with its rispective typed dictionary, but maybe someone reading this PR has better knowledge of an alternative.

### Replacing `EmitterGroup` with `psygnal.SignalGroup`

> _The greates trick the developer ever pulled, is declaring a class that never existed._

`psygnal` has a nifty `SignalGroup` class that basically does the following:

```py
from psygnal import Signal, SignalGroup

class MyGroup(SignalGroup):
    # sig_a carries nothing
    sig_a = Signal()
    
    # sig_b carries an int
    sig_b = Signal(int)
    
    # sig_c can carry anything; 
    # the class should document 
    # what it "actually" carries
    sig_c = Signal(object)

obj = MyGroup()
obj.sig_b.emit(42) # callbacks will receive 42
```

There's also an alternative `SignalGroupDescriptor` for dataclass-like classes, whose usage is described [here](https://psygnal.readthedocs.io/en/latest/guides/dataclasses/#1-use-signalgroupdescriptor). For you `pydantic` lovers, all the currently existing `EventedModel`s can be entirely replaced by [`psygnal.EventedModel`](https://psygnal.readthedocs.io/en/latest/guides/model/). **In theory** it can even be done now, but we can't because of `events.py` - and because instead of carrying an `Event` object we're simply defining callbacks as:

```py
def my_callback(var: int) -> None:
    ...
```

So it's a pretty disruptive change.

Since `Layer` and related subclasses are dataclass-like classes, it is still possible to define custom `SignalGroup` classes (which is also what's returned from `SignalGroupDescriptor` anyway). The thing is that we have a mixin-like inheritance tree, and that doesn't play well when directly defining signal groups into each mixin class. Or rather, `mypy` whines.

While freaking around and finding out, I decided that the best course of action is to simply trick `mypy`: instead of defining `SignalGroups`, we make an expectation of what the signals in the mixin classes should look like by defining custom `typing.Protocol` classes for each of them. For example, for the `Layer` base class:

```py
from psygnal import Signal, SignalGroup
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from psygnal import SignalInstance
    from typing import Protocol
    
    # this is wrapped in TYPE_CHECKING because
    # it's not really needed at runtime; only by type checkers
    class LayerEventGroupProtocol(Protocol):
        """Protocol for IntensityVisualizationMixin signals.

        These signals cannot be declared as `psygnal.Signal` as
        this is simply the descriptor protocol implementation
        of the actual signal. Instead, we want the instance type
        that is created in the descriptor, which is `psygnal.SignalInstance`.

        .. note::
            The protocol is only for type-checking purposes; it should be type
            hinted as a generic so to describe the actual data it transports
            but this is still an open question:
            https://github.com/pyapp-kit/psygnal/pull/304
        """
        axis_labels: SignalInstance
        data: SignalInstance # LayerDataProtocol
        metadata: SignalInstance
        affine: SignalInstance
        blending: SignalInstance
        cursor: SignalInstance
        cursor_size: SignalInstance
        editable: SignalInstance
        # ... and so on and so forth

# ... but then we also have to define the true class with the appropriate signals; 
# but we don't use it yet
class LayerEventGroup(SignalGroup):
    """Layer signals (the actual ones)."""

    axis_labels = Signal()
    data = Signal(object) # LayerDataProtocol
    metadata = Signal()
    affine = Signal()
    blending = Signal()
    cursor = Signal()
    cursor_size = Signal()
    editable = Signal()
    # and so on and so forth

# ... then, in the layer class:
class Layer:
    signals: LayerEventGroupProtocol
```

This technically works, because `Layer` - being inherited from `abc.ABC`, can't be instantiated on its own. I did the same thing also for `ScalarFieldBase` and `IntensityVisualizationMixin` by extending the existing `SignalGroup` via inheritance. For example:

```py
# the protocol class...
class ScalarFieldEventsProtocol(LayerEventGroupProtocol, Protocol):
    ... # other signals defined here

# ... and the actual class
class ScalarFieldEventGroup(LayerEventGroup):
    ... # other signals defined here
```

Then, we actually need to declare these signals somewhere. We do this in the final class, `Image`:

```py
# combine the two groups together...
class ImageEventGroup(IVMSignalGroup, ScalarFieldEventGroup):
    """Image layer events."""

# ... and then create the object in Image.__init__()

class Image(IntensityVisualizationMixin, ScalarFieldBase):
    
    signals: ImageEventGroup
    
    def __init__(self, *args, **kwargs):
        self.signals = ImageEventGroup()
```

And that's pretty much it. The question is what kind of exposures should the base classes signal groups have: private or public? Given a possible future subclassing of `Layer`, I tend to think that they should be public, but you be the judge of that.

### More predictable typing of base classes `__init__`

There's also a whole bunch of other typing adjustments I tried to make to make the core have more sense. One thing I should note is that there's no point in the base classes like `Layer` or `ScalarFieldBase` to have `None` default values, but rather these should be parsed on a per-final layer basis, i.e. `Image.__init__()` should perform validation of the input values and raise exceptions or (if everything is correct) pass default values to the parent classes.

### More strict input/output types of setters

I honestly believe that the setters are a mess and a little bit too broad, but I understand that a lot of users are used to this at this time so I guess it requires a bit more discussion.

---

That's pretty much it. Since I'm sure I forgot to cover some other changes I made, please ask as many questions as you can. I'd be happy for some feedback.