### PR TITLE
skip check if author in citation.cff if bot created  PR

### DIFF
--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -82,6 +82,10 @@ jobs:
           PR_AFFILIATION: ${{ github.event.pull_request.user.company }}
         run: |
           echo "PR author: $PR_AUTHOR"
+          if [ "$PR_AUTHOR" = "napari-bot" ] || [ "$PR_AUTHOR" = "pre-commit-ci" ] || [ "$PR_AUTHOR" = "dependabot" ]; then
+            echo "Bot author '$PR_AUTHOR' detected. Skipping CITATION.cff check."
+            exit 0
+          fi
           if grep -Ei "^[[:space:]]*alias:[[:space:]]*${PR_AUTHOR}[[:space:]]*$" CITATION.cff; then
             echo "Found alias '$PR_AUTHOR' in CITATION.cff."
           else


### PR DESCRIPTION
# References and relevant issues


# Description

The #8310 and #8386 are failing because they are bot were creating PR. We do not want bot in CITATION.cff. 
