### PR TITLE
Exclude dependabot from PR author check

### DIFF
--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -71,7 +71,7 @@ jobs:
 
   check_citation_cff_for_pr_author:
     name: Check PR author is in CITATION.cff
-    if: (github.event_name == 'pull_request')
+    if: (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This PR skips the author citation check if the PR's author is dependabot.