### PR TITLE
Bugfix: update magicgui layer combobox if a layer is renamed

### DIFF
--- a/src/napari/_tests/test_magicgui.py
+++ b/src/napari/_tests/test_magicgui.py
@@ -620,3 +620,34 @@ def test_from_layer_data_tuple_accept_deprecating_dict(make_napari_viewer):
     assert len(viewer.layers) == 1
     assert isinstance(viewer.layers[0], Image)
     assert viewer.layers[0].name == 'test_image'
+
+
+@pytest.mark.parametrize(
+    ('annotation', 'name_suffix'),
+    [
+        (Image, ''),
+        (types.ImageData, ' (data)'),
+    ],
+)
+def test_layer_rename_updates_combobox(
+    make_napari_viewer, annotation, name_suffix
+):
+    """Test that renaming a layer updates magicgui combobox."""
+    viewer = make_napari_viewer()
+    viewer.add_image(np.zeros((10, 10)), name='Name')
+
+    @magicgui
+    def func(layer: annotation):
+        pass
+
+    viewer.window.add_dock_widget(func)
+
+    combo_widget = func.layer
+
+    assert len(combo_widget.choices) == 1
+    assert combo_widget.current_choice == f'Name{name_suffix}'
+
+    viewer.layers[0].name = 'New Name'
+
+    assert len(combo_widget.choices) == 1
+    assert combo_widget.current_choice == f'New Name{name_suffix}'

--- a/src/napari/utils/_magicgui.py
+++ b/src/napari/utils/_magicgui.py
@@ -432,7 +432,11 @@ def get_layers(gui: CategoricalWidget) -> list[Layer]:
 
     """
     if viewer := find_viewer_ancestor(gui.native):
-        return [x for x in viewer.layers if isinstance(x, gui.annotation)]
+        layers = [x for x in viewer.layers if isinstance(x, gui.annotation)]
+        for layer in layers:
+            layer.events.name.connect(gui.reset_choices)
+
+        return layers
     return []
 
 
@@ -467,7 +471,7 @@ def get_layers_data(gui: CategoricalWidget) -> list[tuple[str, Any]]:
     from napari import layers
 
     if not (viewer := find_viewer_ancestor(gui.native)):
-        return ()
+        return []
 
     layer_type_name = gui.annotation.__name__.replace('Data', '').title()
     layer_type = getattr(layers, layer_type_name)
@@ -476,6 +480,7 @@ def get_layers_data(gui: CategoricalWidget) -> list[tuple[str, Any]]:
         choice_key = f'{layer.name} (data)'
         choices.append((choice_key, layer.data))
         layer.events.data.connect(_make_choice_data_setter(gui, choice_key))
+        layer.events.name.connect(gui.reset_choices)
 
     return choices
 

--- a/src/napari/utils/_magicgui.py
+++ b/src/napari/utils/_magicgui.py
@@ -454,8 +454,8 @@ def get_layers_data(gui: CategoricalWidget) -> list[tuple[str, Any]]:
 
     Returns
     -------
-    tuple
-        Tuple of layer.data from layers of type ``gui.annotation``
+    list
+        list of tuples of name and layer.data from layers of type ``gui.annotation``
 
     Examples
     --------


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8406
Closes: https://github.com/napari/napari/issues/4331

# Description
In this PR I add callbacks to layer.name event, so that the magicgui combobox choices are reset/refreshed if a layer name is changed. I added a test that fails on main, but passes with this change. 

I also tested this locally with both Image and ImageData widgets (from napari/examples). Renaming works for existing layers, as well as if a new layer is added and then renamed. So I think this is working correctly.