### PR TITLE
bugfix: Ensure that edge_width is accounted for when using polygon lasso

### DIFF
--- a/src/napari/layers/shapes/_shape_list.py
+++ b/src/napari/layers/shapes/_shape_list.py
@@ -1324,12 +1324,17 @@ class ShapeList:
             shape_slice = self._mesh_vertices_slice_available(index)
             current_range = shape_slice.stop - shape_slice.start
             if current_range < shape.vertices_count:
+                # account for edge width
+                edge_vertices_with_width = (
+                    shape._edge_vertices
+                    + shape.edge_width * shape._edge_offsets
+                )
                 # need to allocate_more space
                 self._mesh.vertices = np.concatenate(
                     [
                         self._mesh.vertices[: shape_slice.start],
                         shape._face_vertices,
-                        shape._edge_vertices,
+                        edge_vertices_with_width,
                         self._mesh.vertices[shape_slice.stop :],
                     ]
                 )


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8273

# Description
It looks like the case of `if edge and face:` and increasing number of vertexes does not account for edge_width when setting up the meshes. In this PR i account for it in that code block. An alternative is to remove the early return, letting the `if edge` code take care of it, but I suspect that would be much less performant.

Shapes tests pass for me locally and the behavior is fixed.
