### PR TITLE
Fix cff check for bots

### DIFF
--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -82,7 +82,7 @@ jobs:
           PR_AFFILIATION: ${{ github.event.pull_request.user.company }}
         run: |
           echo "PR author: $PR_AUTHOR"
-          if [[ "$PR_AUTHOR" == *"[bot]" ]]; then
+          if [[ "$PR_AUTHOR" == *"svag" ]]; then
             echo "Bot author '$PR_AUTHOR' detected. Skipping CITATION.cff check."
             exit 0
           fi

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -82,7 +82,7 @@ jobs:
           PR_AFFILIATION: ${{ github.event.pull_request.user.company }}
         run: |
           echo "PR author: $PR_AUTHOR"
-          if [[ "$PR_AUTHOR" == *"[bot]" ]]; then
+          if [[ "$PR_AUTHOR" == *"[bot]" || "$PR_AUTHOR" == "napari-bot" ]]; then
             echo "Bot author '$PR_AUTHOR' detected. Skipping CITATION.cff check."
             exit 0
           fi

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -82,7 +82,7 @@ jobs:
           PR_AFFILIATION: ${{ github.event.pull_request.user.company }}
         run: |
           echo "PR author: $PR_AUTHOR"
-          if [[ "$PR_AUTHOR" == *"svag" ]]; then
+          if [[ "$PR_AUTHOR" == *"[bot]" ]]; then
             echo "Bot author '$PR_AUTHOR' detected. Skipping CITATION.cff check."
             exit 0
           fi

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -82,7 +82,7 @@ jobs:
           PR_AFFILIATION: ${{ github.event.pull_request.user.company }}
         run: |
           echo "PR author: $PR_AUTHOR"
-          if [ "$PR_AUTHOR" = "napari-bot" ] || [ "$PR_AUTHOR" = "pre-commit-ci" ] || [ "$PR_AUTHOR" = "dependabot" ]; then
+          if [[ "$PR_AUTHOR" == *"[bot]" ]]; then
             echo "Bot author '$PR_AUTHOR' detected. Skipping CITATION.cff check."
             exit 0
           fi


### PR DESCRIPTION
# References and relevant issues
See the following failures:
- https://github.com/napari/napari/actions/runs/19234061465/job/54979237688?pr=8400
- https://github.com/napari/napari/actions/runs/19241056313/job/55003545620?pr=8386

# Description
Bot authors always append `[bot]` to their username, so the existing check from https://github.com/napari/napari/pull/8392 is failing. This fixes it and makes it more general by checking for this suffix instead of a blacklist of names.
