### PR TITLE
Fix unnecessary overlay initialization on scenegraph update

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1131,9 +1131,8 @@ class VispyCanvas:
         self.on_draw(None)
 
     def _setup_single_view(self):
-        for napari_layer, vispy_layer in self.layer_to_visual.items():
+        for vispy_layer in self.layer_to_visual.values():
             vispy_layer.node.parent = self.view.scene
-            self._update_layer_overlays(napari_layer)
 
     def _setup_layer_views_in_grid(self):
         for (row, col), layer_indices in self.viewer.grid.iter_viewboxes(
@@ -1155,7 +1154,6 @@ class VispyCanvas:
                 napari_layer = self.viewer.layers[idx]
                 vispy_layer = self.layer_to_visual[napari_layer]
                 vispy_layer.node.parent = view.scene
-                self._update_layer_overlays(napari_layer)
 
     @property
     def _current_viewbox_size(self):


### PR DESCRIPTION
# References and relevant issues
- fixes (partly) https://github.com/napari/napari/issues/8421 

# Description
This line must be a leftover from some previous version of this refactor: we were basically re-initializing all the overlays of each layer every time we were updating the scenegraph. I haven't found a case where this is necessary and tests seem to be passing, so I think this is safe to remove.

Running the benchmark from OP (with extra line to comment in/out for grid mode):

```py
import sys
import time

import napari
import numpy as np
from napari.layers import Image
from tqdm import tqdm

layers = []
for i in range(50):
    layers.append(Image(data=np.zeros(shape=(2, 2))))

viewer = napari.Viewer()
# enable grid to see how that affects it
# viewer.grid.enabled = True

times = []
for layer in tqdm(layers, file=sys.stdout, desc="Adding napari layers"):
    t0 = time.perf_counter()
    viewer.add_layer(layer)
    t1 = time.perf_counter()
    times.append(t1 - t0)

print("version", napari.__version__)
print(times)
```

I get:

<img width="1220" height="574" alt="newplot" src="https://github.com/user-attachments/assets/788ba99a-507a-442c-bf5b-fd4944ff1144" />


Note that there is no longer a slowdown for each layer added in single-view mode. However, there is still a slowdown in grid mode (due to the grid havign to be recreated each time the number of viewboxes changes) and our baseline is slower than 0.6.0 (due to the extra work in initializing).

I'm sure we can solve the other two issues with some work, but this is the biggest issue and the lowest hanging fruit!
