### PR TITLE
Block LayerList.events.removed in the closeEvent, so we don't do expensive updates to the scenegraph when quitting

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -654,6 +654,10 @@ class _QtMainWindow(QMainWindow):
 
         self._qt_viewer.dims.stop()
 
+        # Block emitting layer removal events, which trigger
+        # expensive scenegraph updates
+        self._qt_viewer.viewer.layers.events.removed.block()
+
         if self._quit_app:
             quit_app_()
 


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8422

# Description
When napari is closed, layers are removed one by one, using https://github.com/napari/napari/blob/d629b4b5753a989aaf30d24474acb0606580f206/src/napari/_vispy/canvas.py#L749

This finishes with an expensive _update_scenegraph call.
In this PR I add `self._qt_viewer.viewer.layers.events.removed.block()` to prevent the vispy callbacks being triggered.
I mean after all, we're closing stuff, so who cares if we update the scenegraph? Let's just close!
Tests pass locally and for me this makes closing the viewer essentially instant, a real quality of life improvement. But I am concerned whether the events cleanup that `_remove_layers` does may also be important?

