### PR TITLE
Perf: add context manager to skip expensive parts of layer removal on quit

### DIFF
--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -258,7 +258,7 @@ def get_qapp(
 def quit_app():
     """Close all windows and quit the QApplication if napari started it."""
     for v in list(Viewer._instances):
-        v.close()
+        v.close(_is_quitting=True)
     QApplication.closeAllWindows()
     # if we started the application then the app will be named 'napari'.
     if (

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -396,11 +396,12 @@ class VispyCanvas:
         The `_is_quitting` attribute will be used by _remove_layer to
         skip expensive operations that are unneeded during shutdown.
         """
+        prev = self._is_quitting
         self._is_quitting = True
         try:
             yield
         finally:
-            self._is_quitting = False
+            self._is_quitting = prev
 
     def _on_interactive(self) -> None:
         """Link interactive attributes of view and viewer."""

--- a/src/napari/viewer.py
+++ b/src/napari/viewer.py
@@ -267,7 +267,9 @@ class Viewer(ViewerModel):
         # to avoid any unnecessary slicing.
         disconnect_events(self.dims.events, self)
         # Remove all the layers from the viewer
-        self.layers.clear()
+        # Use the quitting context manager to skip expensive operations
+        with self.window._qt_viewer.canvas.quitting():
+            self.layers.clear()
         # Close the main window
         self.window.close()
 


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8422

# Description
This PR adds a context manager that sets an attribute that if True, makes _remove_layer skip the expensive parts: gc, synchronizing the context queue, and updating the scene graph.
The idea is to allow the various event disconnections and cleanup to occur, but skip doing the expensive things that are typically used when removing a layer in a live viewer, because we're quitting!

To get this to work on quit only, I added _is_quitting kwarg to viewer.close().

Even after https://github.com/napari/napari/pull/8423 quitting with 50 layers is slow, nearly a minute. With this PR it's instant, as it should be.
