### PR TITLE
Fix overlay initialization and layer addition slowdown

### DIFF
--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -56,6 +56,8 @@ def test_layer_overlays(qt_viewer):
     layer_node = canvas.layer_to_visual[layer].node
 
     for overlay in layer._overlays.values():
+        # vispy overlays only exist if they are visible at least once
+        overlay.visible = True
         if isinstance(overlay, CanvasOverlay):
             assert (
                 canvas._layer_overlay_to_visual[layer][overlay].node
@@ -69,7 +71,7 @@ def test_layer_overlays(qt_viewer):
 
     old_vispy_overlays = {**canvas._layer_overlay_to_visual[layer]}
 
-    new_overlay = BoundingBoxOverlay()
+    new_overlay = BoundingBoxOverlay(visible=True)
     layer._overlays['test'] = new_overlay
 
     assert new_overlay in canvas._layer_overlay_to_visual[layer]

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1154,6 +1154,7 @@ class VispyCanvas:
                 napari_layer = self.viewer.layers[idx]
                 vispy_layer = self.layer_to_visual[napari_layer]
                 vispy_layer.node.parent = view.scene
+                self._update_layer_overlays(napari_layer)
 
     @property
     def _current_viewbox_size(self):

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -903,7 +903,7 @@ class VispyCanvas:
         overlay_to_visual = self._layer_overlay_to_visual.setdefault(layer, {})
 
         # delete outdated overlays
-        if layer not in self.layer_to_visual:
+        if layer not in self.viewer.layers:
             to_remove = layer._overlays
         else:
             to_remove = set(overlay_to_visual) - set(layer._overlays)
@@ -911,8 +911,12 @@ class VispyCanvas:
         for overlay in to_remove:
             if isinstance(overlay, CanvasOverlay):
                 self._disconnect_canvas_overlay_events(overlay)
-            vispy_overlay = overlay_to_visual.pop(overlay)
-            vispy_overlay.close()
+            if vispy_overlay := overlay_to_visual.pop(overlay, None):
+                vispy_overlay.close()
+
+        if layer not in self.viewer.layers:
+            # we're just removing all the overlays of this layer, so we're done here
+            return
 
         for overlay in layer._overlays.values():
             # only create overlays when they are visible. If not, we connect the visible

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1159,6 +1159,8 @@ class VispyCanvas:
 
     def _update_scenegraph(self, event=None):
         with self._scene_canvas.events.draw.blocker():
+            self._init_or_update_grid()
+
             if self.viewer.grid.enabled:
                 self._setup_layer_views_in_grid()
                 self._update_grid_spacing()

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -915,6 +915,13 @@ class VispyCanvas:
             vispy_overlay.close()
 
         for overlay in layer._overlays.values():
+            # only create overlays when they are visible. If not, we connect the visible
+            # event of this overlay to this method until it's finally visible
+            if not overlay.visible:
+                overlay.events.visible.connect(self._overlay_callbacks[layer])
+                continue
+            overlay.events.visible.disconnect(self._overlay_callbacks[layer])
+
             vispy_overlay = overlay_to_visual.get(overlay, None)
 
             if isinstance(overlay, CanvasOverlay):

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -740,8 +740,6 @@ class VispyCanvas:
         self._overlay_callbacks[napari_layer] = overlay_callback
         self.viewer.camera.events.angles.connect(vispy_layer._on_camera_move)
 
-        # create overlay visuals for this layer
-        self._update_layer_overlays(napari_layer)
         # we need to trigger _on_matrix_change once after adding the overlays so that
         # all children nodes are assigned the correct transforms
         vispy_layer._on_matrix_change()
@@ -892,7 +890,6 @@ class VispyCanvas:
                         )
 
                 else:
-                    # TODO: check if this is noop when parent is the same
                     vispy_overlay.node.parent = parent
 
         self._defer_overlay_position_update()
@@ -944,7 +941,6 @@ class VispyCanvas:
                         self._defer_overlay_position_update
                     )
             else:
-                # TODO: check if this is noop when parent is the same
                 vispy_overlay.node.parent = parent
 
         self._defer_overlay_position_update()

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1159,9 +1159,8 @@ class VispyCanvas:
 
     def _update_scenegraph(self, event=None):
         with self._scene_canvas.events.draw.blocker():
-            self._init_or_update_grid()
-
             if self.viewer.grid.enabled:
+                self._init_or_update_grid()
                 self._setup_layer_views_in_grid()
                 self._update_grid_spacing()
             else:

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -904,9 +904,11 @@ class VispyCanvas:
 
         # delete outdated overlays
         if layer not in self.viewer.layers:
-            to_remove = layer._overlays
+            to_remove = set(layer._overlays.values())
         else:
-            to_remove = set(overlay_to_visual) - set(layer._overlays)
+            to_remove = set(overlay_to_visual.keys()) - set(
+                layer._overlays.values()
+            )
 
         for overlay in to_remove:
             if isinstance(overlay, CanvasOverlay):

--- a/src/napari/_vispy/overlays/base.py
+++ b/src/napari/_vispy/overlays/base.py
@@ -88,6 +88,10 @@ class VispyCanvasOverlay(VispyBaseOverlay):
         super().reset()
         self._on_position_change()
 
+    def close(self) -> None:
+        super().close()
+        self.canvas_position_callback = lambda: None
+
 
 class VispySceneOverlay(VispyBaseOverlay):
     """

--- a/src/napari/_vispy/overlays/labels_polygon.py
+++ b/src/napari/_vispy/overlays/labels_polygon.py
@@ -86,8 +86,6 @@ class VispyLabelsPolygonOverlay(LayerOverlayMixin, VispySceneOverlay):
 
         self.reset()
         self._update_color()
-        # If there are no points, it won't be visible
-        self.overlay.visible = True
 
     def _on_completion_radius_settings_change(self, event=None):
         completion_radius_setting = (

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -392,7 +392,7 @@ class Labels(ScalarFieldBase):
             LabelsPolygonOverlay,
         )
 
-        self._overlays.update({'polygon': LabelsPolygonOverlay()})
+        self._overlays.update({'polygon': LabelsPolygonOverlay(visible=True)})
 
         self._feature_table = _FeatureTable.from_layer(
             features=features, properties=properties


### PR DESCRIPTION
# References and relevant issues
- follow up #8423
- fix #8434
- fix #8421

# Description
When trying to improve #8421, I caused #8434. This prompted me to finally rework the overlay initialization machinery to be less wasteful. This PR has 3 main changes compared to main:

1. Instead of deleting and recreating all overlays every time an scenegraph update is necessary, vispy overlays are reused and simply reparented (also their duplicates when working in gridded mode). I could not make this work in the past for some reason, but now it seems to work just fine.
2. VispyLayerOverlay initialization is deferred until the overlay becomes visible the first time. This removes the hidden cost of layer overlays which was causing extra slowdown when creating new layers.
3. Only regenerate the grid when necessary (when the grid size changes), which drastically speeds up layer addition for all cases where the grid does not change shape.

This results in the following profiles compared to #8421:

<img width="1374" height="653" alt="newplot2" src="https://github.com/user-attachments/assets/afbd2448-5e37-4693-8aec-ab4d12db5a31" />

Note how now in grid mode the baseline is much better, and there's those spikes corresponding to when the grid needs to be made bigger.