### PR TITLE
Change link to getting started in Help menu

### DIFF
--- a/src/napari/_qt/_qapp_model/qactions/_help.py
+++ b/src/napari/_qt/_qapp_model/qactions/_help.py
@@ -29,7 +29,7 @@ v = parse(__version__)
 VERSION = 'dev' if v.is_devrelease or v.is_prerelease else str(v.base_version)
 
 HELP_URLS: dict[str, str] = {
-    'getting_started': f'https://napari.org/{VERSION}/tutorials/start_index.html',
+    'getting_started': f'https://napari.org/{VERSION}/getting_started/start_index.html',
     'tutorials': f'https://napari.org/{VERSION}/tutorials/index.html',
     'layers_guide': f'https://napari.org/{VERSION}/howtos/layers/index.html',
     'examples_gallery': f'https://napari.org/{VERSION}/gallery.html',

--- a/tools/string_list.json
+++ b/tools/string_list.json
@@ -60,7 +60,7 @@
         "https://napari.org/{VERSION}/howtos/layers/index.html",
         "https://napari.org/{VERSION}/release/release_{VERSION.replace(\".\", \"_\")}.html",
         "https://napari.org/{VERSION}/tutorials/index.html",
-        "https://napari.org/{VERSION}/tutorials/start_index.html",
+        "https://napari.org/{VERSION}/getting_started/start_index.html",
         "id",
         "layers_guide",
         "release_notes",


### PR DESCRIPTION
# References and relevant issues
Depends on https://github.com/napari/docs/pull/881

# Description
Updates link to Getting Started guide in Help menu.

The other links in the Help menu did not change in that PR.