### PR TITLE
Bugfix: For FeatureTable `edit` test, check the QAbstractItemView.State and not isPersistentEditorOpen

### DIFF
--- a/src/napari_builtins/_qt/_tests/test_features_table.py
+++ b/src/napari_builtins/_qt/_tests/test_features_table.py
@@ -8,6 +8,7 @@ from qtpy.QtCore import QItemSelection, QItemSelectionModel, Qt
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import (
     QAbstractItemDelegate,
+    QAbstractItemView,
     QAbstractSpinBox,
     QComboBox,
     QDoubleSpinBox,
@@ -205,14 +206,14 @@ def test_features_table_edit(qtbot):
 
     idx = proxy.index(0, 1)
     w.table.edit(idx)
-    assert not w.table.isPersistentEditorOpen(idx)
+    assert w.table.state() != QAbstractItemView.State.EditingState
 
     w.toggle.click()
     assert proxy.sourceModel().editable
     w.table.edit(idx)
-    assert w.table.isPersistentEditorOpen(idx)
-
+    assert w.table.state() == QAbstractItemView.State.EditingState
     editor = w.table.findChild(QLineEdit)
+    assert editor
     qtbot.keyClicks(editor, 'hello')
     assert editor.text() == 'hello'
     w.table.commitData(editor)


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8451

# Description
In Qt 6.10.1, a bug was fixed with isPersistentEditorOpen(), where it improperly returned True:
-  https://codereview.qt-project.org/c/qt/qtbase/+/667643

In the failing test, `edit()` is used, which actually should not result in `isPersistentEditorOpen()` being True, because that is opened by `isPersistentEditorOpen()`. This test was passing previously due to the bug that was fixed in Qt 6.10.1, so now it fails. Importantly, it fails with Pyside 6.10.1 as well.

Process: Gemini clued me into the odd check of `isPersistentEditorOpen(idx)` when using `edit()` and then looking at the Qt6 docs (https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QAbstractItemView.html#PySide6.QtWidgets.QAbstractItemView.openPersistentEditor) and searching the release notes (https://www.qt.io/blog/qt-6.10.1-released) got me to the epiphany.

I tested locally *with Pyside6 6.10.1* which is also affected, but we don't run pre-tests with Pyside6 -- we should! I opened: https://github.com/napari/napari/issues/8464 .
With main the test with pyside6 6.10.1 fails and with this PR passes.
