### PR TITLE
Change `exclude` to `extend-exclude` in ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,24 +373,7 @@ ignore = [
 
 [tool.ruff]
 line-length = 79
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".mypy_cache",
-    ".pants.d",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
+extend-exclude = [
     "*vendored*",
     "*_vendor*",
 ]


### PR DESCRIPTION
# References and relevant issues

# Description

To not keep a long, repetitive list of excluded configurations, use extend-exclude instead with only napari specific excludes. 

List of `extend` defaults that this cleans up: https://docs.astral.sh/ruff/settings/#exclude