### PR TITLE
Bugfix: ensure triangle colors are updated properly when using polygon lasso

### DIFF
--- a/src/napari/layers/shapes/_shape_list.py
+++ b/src/napari/layers/shapes/_shape_list.py
@@ -1206,9 +1206,11 @@ class ShapeList:
             self._mesh.triangles[face_slice] = (
                 shape._face_triangles + triangle_shift
             )
+            self._mesh.triangles_colors[face_slice] = self._face_color[index]
             self._mesh.triangles[edge_slice] = shape._edge_triangles + (
                 triangle_shift + shape.face_vertices_count
             )
+            self._mesh.triangles_colors[edge_slice] = self._edge_color[index]
             if new_triangle_count < current_triangles_count:
                 padding_slice = slice(
                     triangles_slice.start + shape.triangles_count,


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8365
Closes: https://github.com/napari/napari/issues/8465

# Description
The key realization was that the `_data_view.face_color` was correct, but the displayed polygons had the wrong faces. This pointed me to the meshing code that I had looked at before.
Lasso draws as a Path which is then converted to Polygon in `_finish_drawing` by calling `_data_view.edit`, which calls `update` which calls `_update_mesh_triangles`. Here, we can see that for the case of not needing new triangles, triangle colors are not updated. So the fix is just to ensure that the colors are also updated.

Note: not sure how to test this on CI as it's purely a display issue. But i tested locally with a mess of different shapes including the ones from the two issues and everything was gucci.