### PR TITLE
Fix constraints upgrade scripts

### DIFF
--- a/tools/check_updated_packages.py
+++ b/tools/check_updated_packages.py
@@ -141,7 +141,6 @@ def calc_only_direct_updates(
         metadata['dependencies']
         + optional_dependencies['pyqt5']
         + optional_dependencies['pyqt6']
-        + optional_dependencies['pyside2']
         + optional_dependencies['pyside6']
         + optional_dependencies['testing']
         + optional_dependencies['all']

--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -187,12 +187,16 @@ def update_own_pr(pr_number: int, access_token: str, base_branch: str, repo):
             break
 
 
-def list_pr_for_branch(branch_name: str, access_token: str, repo=''):
+def list_pr_for_branch(
+    branch_name: str,
+    access_token: str,
+    repo: str = 'napari/napari',
+    user: str = 'napari-bot',
+):
     """
     check if PR for branch exists
     """
-    org_name = repo.split('/')[0]
-    url = f'{BASE_URL}/repos/{repo}/pulls?state=open&head={org_name}:{branch_name}'
+    url = f'{BASE_URL}/repos/{repo}/pulls?state=open&head={user}:{branch_name}'
     response = requests.get(url)
     response.raise_for_status()
     if response.json():


### PR DESCRIPTION
# References and relevant issues

# Description

Fix two bugs in update workflow scripts. 
First is dropping the `pyside2` group that should be removed in #8450 

Second is older and prevented from updating descriptions of PR. The wrong query led us to look for PR inside the repository, not from the @napari-bot repository. 