### PR TITLE
Maint: Update test_prereleases.yml to bump retries to 3

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Test with tox (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
-          attempt_limit: 2
+          attempt_limit: 3
           attempt_delay: 30000 # 30s
           retry_condition: github.ref_name == 'main'  # avoid restart in PR
           command: python -m tox -v --pre  --recreate


### PR DESCRIPTION
# References and relevant issues
regular --pre fails resolved with rerun: https://github.com/napari/napari/issues?q=is%3Aissue%20state%3Aclosed%20--pre

# Description
This PR bumps the retries within the action from 2 to 3. The idea being that maybe I won't have to manually re-run the failed CI run and then close the issue.
