### PR TITLE
Block numba 0.62.0 for docs constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ docs = [
     "bermuda>=0.1.4",
     "pytest",
     "linkify-it-py",
-    "numba!=0.62.1",
+    "numba!=0.62.1,!=0.62.0",
 ]
 release = [
     "PyGithub>=1.46",
@@ -299,7 +299,7 @@ docs = [
     "bermuda>=0.1.4",
     "pytest",
     "linkify-it-py",
-    "numba!=0.62.1",
+    "numba!=0.62.1,!=0.62.0",
 ]
 release = [
     "PyGithub>=1.46",


### PR DESCRIPTION
# References and relevant issues

# Description

As CI crashes on both numba 0.62.0 and 0.62.1 then block also numba 0.62.0

