### PR TITLE
Fix and improve `dock_widgets` docstrings

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -383,6 +383,11 @@ authors:
   family-names: Winston
   affiliation: Tobeva Software
   alias: pwinston
+- given-names: Qin
+  family-names: Yu
+  affiliation: European Molecular Biology Laboratory (EMBL)
+  orcid: https://orcid.org/0000-0002-4652-0795
+  alias: qin-yu
 - given-names: Rubin
   family-names: Zhao
   affiliation: Chinese Academy of Sciences - SIAT, Shenzhen, China

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -1303,7 +1303,8 @@ class Window:
         # other widget we should keep this name for a longer period
         warnings.warn(
             'The `_dock_widgets` property is private and should not be used in any plugin code. '
-            'Please use the `dock_widgets` property instead.',
+            'Use the `dock_widgets` property instead. If you need the dock wrapper, get it '
+            'via `dock_widgets[name].parent()` (or `.native.parent()` for magicgui widgets).',
             FutureWarning,
             stacklevel=2,
         )
@@ -1311,9 +1312,23 @@ class Window:
 
     @property
     def dock_widgets(self) -> Mapping[str, 'QWidget | Widget']:
-        """Read only mapping of widgets docked in napari window.
+        """Read-only mapping of widgets docked in napari window.
 
-        For wrapping QtViewerDockWidget use `dock_widgets` property.
+        Notes
+        -----
+        This mapping returns the *inner* widget contained in each dock widget
+        (a Qt ``QWidget`` or a ``magicgui.widgets.Widget``), not the
+        :class:`~napari._qt.widgets.qt_viewer_dock_widget.QtViewerDockWidget`
+        wrapper.
+
+        If you need to control the dock widget itself (for example, to show or
+        raise a docked widget tab), access the wrapper via the Qt parent:
+
+        >>> name = "My widget (my_plugin)"
+        >>> widget = viewer.window.dock_widgets[name]
+        >>> qt_widget = widget.native if hasattr(widget, "native") else widget
+        >>> dock_widget = qt_widget.parent()  # QtViewerDockWidget / QDockWidget
+        >>> dock_widget.show(); dock_widget.raise_()
         """
         return InnerWidgetMappingProxy(self._wrapped_dock_widgets)
 

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -1325,7 +1325,7 @@ class Window:
         If you need to control the dock widget itself (for example, to show or
         raise a docked widget tab), access the wrapper via the Qt parent:
 
-        >>> name = "My widget (my_plugin)"
+        >>> name = "My widget"
         >>> widget = viewer.window.dock_widgets[name]
         >>> qt_widget = widget.native if hasattr(widget, "native") else widget
         >>> dock_widget = qt_widget.parent()  # QtViewerDockWidget / QDockWidget

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -1303,8 +1303,9 @@ class Window:
         # other widget we should keep this name for a longer period
         warnings.warn(
             'The `_dock_widgets` property is private and should not be used in any plugin code. '
-            'Use the `dock_widgets` property instead. If you need the dock wrapper, get it '
-            'via `dock_widgets[name].parent()` (or `.native.parent()` for magicgui widgets).',
+            'To return the inner widget, use the `dock_widgets` property instead.'
+            'If you need the dock wrapper, return it via `dock_widgets[name].parent()`'
+            '(or `dock_widgets[name].native.parent()` for magicgui widgets).',
             FutureWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
## References and relevant issues

- Closes https://github.com/napari/napari/issues/8459  
- Napari Docs PR: https://github.com/napari/docs/pull/892  
- Image.sc discussion: https://forum.image.sc/t/napari-0-6-2-is-now-released/114029/5  

## Description

`viewer.window.dock_widgets` intentionally exposes the *inner* widget contained in each dock (a Qt `QWidget` or a `magicgui.widgets.Widget`), while the dock wrapper (`QtViewerDockWidget`/`QDockWidget`) remains private via `viewer.window._dock_widgets`.

The current docstring is ambiguous ("For wrapping QtViewerDockWidget use `dock_widgets` property"). This PR improves the docstrings and deprecation warning in `Window.dock_widgets` / `Window._dock_widgets` to clarify:

- `dock_widgets[name]` returns the inner widget (not the dock wrapper), and
- when callers need to show/raise/select a docked tab, they can obtain the wrapper via the Qt parent (`.parent()`, or `.native.parent()` for magicgui widgets).

This documents the supported pattern and helps plugin/app authors avoid relying on `_dock_widgets`, without changing any runtime behavior.