### PR TITLE
Enh: Add label value to the labels tooltip

### DIFF
--- a/src/napari/components/_tests/test_viewer_model.py
+++ b/src/napari/components/_tests/test_viewer_model.py
@@ -1049,7 +1049,7 @@ def test_get_status_text():
             'source_type': '',
             'value': '0; a: 1',
         },
-        'a: 1',
+        '0\na: 1',
     )
     viewer.update_status_from_cursor()
     assert viewer.status == {
@@ -1061,7 +1061,7 @@ def test_get_status_text():
         'source_type': '',
         'value': '0; a: 1',
     }
-    assert viewer.tooltip.text == 'a: 1'
+    assert viewer.tooltip.text == '0\na: 1'
 
 
 def test_reset_view():

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1816,6 +1816,35 @@ def test_get_status_with_custom_index():
     )
 
 
+def test_get_tooltip_text_with_same_features():
+    """
+    Test that tooltip text for different labels is different, even with
+    identical features.
+    """
+    data = np.array([[0, 1], [2, 0]])
+    features = {
+        'class': ['none', 'A', 'A'],
+        'value': ['none', 100, 100],
+    }
+    layer = Labels(data, features=features)
+
+    value1 = layer.get_value(position=(0, 1))
+    assert value1 == 1
+    tooltip1 = layer._get_tooltip_text(position=(0, 1))
+    features1 = layer._get_properties(position=(0, 1))
+
+    value2 = layer.get_value(position=(1, 0))
+    assert value2 == 2
+    tooltip2 = layer._get_tooltip_text(position=(1, 0))
+    features2 = layer._get_properties(position=(1, 0))
+
+    assert features1 == features2
+    assert tooltip1 != tooltip2
+
+    assert tooltip1 == f'{value1}\n' + '\n'.join(features1)
+    assert tooltip2 == f'{value2}\n' + '\n'.join(features2)
+
+
 def test_labels_features_event():
     event_emitted = False
 

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -1573,14 +1573,26 @@ class Labels(ScalarFieldBase):
         msg : string
             String containing a message that can be used as a tooltip.
         """
-        return '\n'.join(
-            self._get_properties(
-                position,
-                view_direction=view_direction,
-                dims_displayed=dims_displayed,
-                world=world,
-            )
+        value = self.get_value(
+            position,
+            view_direction=view_direction,
+            dims_displayed=dims_displayed,
+            world=world,
         )
+        if value is None:
+            return ''
+
+        properties = self._get_properties(
+            position,
+            view_direction=view_direction,
+            dims_displayed=dims_displayed,
+            world=world,
+        )
+
+        if not properties:
+            return f'{value}'
+
+        return f'{value}\n' + '\n'.join(properties)
 
     def _get_properties(
         self,


### PR DESCRIPTION
# References and relevant issues
Motivated by: https://github.com/napari/napari/issues/8381
#8500 does a better job of closing that one though

# Description
This PR extends the tooltips displayed when mousing over a label in a `Labels` layer by including both the label value, as well as any features associated with that label. 

<img width="1022" height="741" alt="image" src="https://github.com/user-attachments/assets/e7e3267d-76e7-4284-8c72-d89f6f1b2c1a" />
