### PR TITLE
Use 10x10 pixels rect around mouse position to invalidate tooltip

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -288,7 +288,10 @@ class _QtMainWindow(QMainWindow):
                 if hasattr(e, 'globalPosition')
                 else e.globalPos()
             )
-            QToolTip.showText(pnt, self._qt_viewer.viewer.tooltip.text, self)
+            rect = QRect(pnt.x() - 5, pnt.y() - 5, 10, 10)
+            QToolTip.showText(
+                pnt, self._qt_viewer.viewer.tooltip.text, self, rect=rect
+            )
         if e.type() in {QEvent.Type.WindowActivate, QEvent.Type.ZOrderChange}:
             # upon activation or raise_, put window at the end of _instances
             with contextlib.suppress(ValueError):


### PR DESCRIPTION
# References and relevant issues

Closes: https://github.com/napari/napari/issues/8381
Alternative to #8495

https://doc.qt.io/qt-6/qtooltip.html#showText

> If you specify a non-empty rect the tip will be hidden as soon as you move your cursor out of this area.
> 
> The rect is in the coordinates of the widget you specify with w. If the rect is not empty you must specify a widget. Otherwise this argument can be nullptr but it is used to determine the appropriate screen on multi-head systems.

> If text is empty the tool tip is hidden. If the text is the same as the currently shown tooltip, the tip will not move. You can force moving by first hiding the tip with an empty text, and then showing the new tip at the new position. 

# Description

This PR uses the `rect` argument of `QToolTip::showText` to invalidate the tooltip when moving the mouse over 5 pixels from the position that triggered showing the tooltip. 

The idea of showing value used in #8495 still might be a valid change to contain more information, but for me, rect is better for invalidation. 

