### PR TITLE
Test on macos-15-intel without numba

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -127,7 +127,7 @@ jobs:
             coverage: cov
           - python: "3.13"
             platform: macos-15-intel
-            backend: pyqt5
+            backend: pyqt5_no_numba
             coverage: no_cov
             timeout-minutes: 60
           - python: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,8 @@ optional-base = [
     "napari-plugin-manager >=0.1.3, <0.2.0",
 ]
 optional-numba = [
-    "numba>=0.57.1",
+    "numba>=0.57.1,<0.62.1 ; platform_system == 'Darwin' and platform_machine == 'x86_64'",
+    "numba>=0.57.1 ; platform_system != 'Darwin' or platform_machine != 'x86_64'",
 ]
 optional = [
     "napari[optional-base,optional-numba,bermuda]",
@@ -140,7 +141,6 @@ all_optional = [
 # they will be removed in napari 0.7.0
 
 testing = [
-    "napari[gallery]",
     "babel>=2.9.0",
     "docstring_parser>=0.15",
     "fsspec>=2023.10.0",
@@ -232,7 +232,6 @@ build = [
 # these need to be kept in sync with the equivalent optional-dependencies
 [dependency-groups]
 testing = [
-    {include-group = "gallery"},
     "babel>=2.9.0",
     "docstring_parser>=0.15",
     "fsspec>=2023.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ optional-base = [
     "napari-plugin-manager >=0.1.3, <0.2.0",
 ]
 optional-numba = [
-    "numba>=0.57.1,<0.62.1 ; platform_system == 'Darwin' and platform_machine == 'x86_64'",
+    "numba>=0.57.1,<=0.62.1 ; platform_system == 'Darwin' and platform_machine == 'x86_64'",
     "numba>=0.57.1 ; platform_system != 'Darwin' or platform_machine != 'x86_64'",
 ]
 optional = [

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@
 # "tox -e py38-macos-pyqt" will test python3.8 with pyqt on macos
 # (even if a combination of factors is not in the default envlist
 # you can run it manually... like py39-linux-pyside6)
-envlist = py{310,311,312,313}-{linux,macos,windows}-{pyqt5,pyqt6,pyside6,headless,pyqt6_no_numba}-{cov,no_cov},mypy
+envlist = py{310,311,312,313}-{linux,macos,windows}-{pyqt5,pyqt6,pyside6,headless,pyqt6_no_numba,pyqt5_no_numba}-{cov,no_cov},mypy
 isolated_build = true
 toxworkdir={env:TOX_WORK_DIR:/tmp/.tox}
 
@@ -42,6 +42,7 @@ BACKEND =
     pyqt6: pyqt6
     pyside6: pyside6
     pyqt6_no_numba: pyqt6_no_numba
+    pyqt5_no_numba: pyqt5_no_numba
     headless: headless
 COVERAGE =
     cov: cov
@@ -92,6 +93,7 @@ extras =
     pyqt5: pyqt5
     pyqt6: pyqt6
     pyqt6_no_numba: pyqt6
+    pyqt5_no_numba: pyqt5
     pyside6: pyside6
 allowlist_externals =
     mypy
@@ -132,6 +134,9 @@ commands =
         --save-leaked-object-graph --import-mode=importlib
 
 [testenv:py{310,311,312,313}-{linux,macos,windows}-{pyqt5,pyqt6,pyside6}-examples-{cov,no_cov}]
+extras =
+    {[testenv]extras}
+    gallery
 commands =
     cov: coverage run --parallel-mode \
     !cov: python \


### PR DESCRIPTION
# References and relevant issues

Extracted from #8456

# Description
The llvmlite dropped support for macOS with Intel processors (https://github.com/numba/llvmlite/pull/1298) and `llvmlite==0.46.0` is failing to build from source on macOS.

As llvmlite is for us, transition dependency of Numba and the latest Numba version that pins llvmlite below 0.46 is 0.62.1 then we pin Numba for Intel macOS. 

Also found that `numba` is a dependency of `glasbey` that was in `gallery` extras. But `gallery` is in `testing` extras when it is used only for testing examples. So remove `gallery` from `texing` extras and modify the tox file to include gallery when testing extras.

To not explode constraint files, the test on macos-intel will be executed without Numba. 
