### PR TITLE
Try full record URLs for zenodo instead of DOIs

### DIFF
--- a/examples/3D_vectors_through_time.py
+++ b/examples/3D_vectors_through_time.py
@@ -28,7 +28,7 @@ import napari
 # Let's download it!
 
 grey_files = sorted(pooch.retrieve(
-    "doi:10.5281/zenodo.17668709/grey.zip",
+    "https://zenodo.org/records/17668709/files/grey.zip",
     known_hash="md5:760be2bad68366872111410776563760",
     processor=pooch.Unzip(),
     progressbar=True
@@ -40,7 +40,7 @@ greys = np.array([tifffile.imread(grey_file) for grey_file in grey_files[0:-1]])
 
 # load incremental TSV tracking files from spam-ddic, [::2] is to skip VTK files also in folder
 tracking_files = sorted(pooch.retrieve(
-    "doi:10.5281/zenodo.17668709/ddic.zip",
+    "https://zenodo.org/records/17668709/files/ddic.zip",
     known_hash="md5:2d7c6a052f53b4a827ff4e4585644fac",
     processor=pooch.Unzip(),
     progressbar=True

--- a/examples/surface_multi_texture.py
+++ b/examples/surface_multi_texture.py
@@ -54,8 +54,8 @@ import napari
 ###############################################################################
 # Download the model
 # ------------------
-download = pooch.DOIDownloader(progressbar=True)
-doi = '10.5281/zenodo.13380203'
+download = pooch.HTTPDownloader(progressbar=True)
+zenodo_record = 'https://zenodo.org/records/13380203/files'
 tmp_dir = pooch.os_cache('napari-surface-texture-example')
 os.makedirs(tmp_dir, exist_ok=True)
 data_files = {
@@ -69,7 +69,7 @@ for file_name in data_files.values():
     if not (tmp_dir / file_name).exists():
         print(f'downloading {file_name}')
         download(
-            f'doi:{doi}/{file_name}',
+            f'{zenodo_record}/{file_name}',
             output_file=tmp_dir / file_name,
             pooch=None,
         )


### PR DESCRIPTION
# References and relevant issues

# Description
Try using full zenodo record URLs instead of DOIs to see if we can get docs building and examples passing