### PR TITLE
Avoid materializing property views when updating points highlight

### DIFF
--- a/src/napari/_vispy/layers/points.py
+++ b/src/napari/_vispy/layers/points.py
@@ -92,19 +92,23 @@ class VispyPointsLayer(VispyBaseLayer):
         settings = get_settings()
         if len(self.layer._highlight_index) > 0:
             # Color the hovered or selected points
-            data = self.layer._view_data[self.layer._highlight_index]
-            if data.ndim == 1:
-                data = np.expand_dims(data, axis=0)
-            size = self.layer._view_size[self.layer._highlight_index]
-            border_width = self.layer._view_border_width[
+
+            # _highlight_index contains indices into the view arrays, but we can get the
+            # actual data indices once to avoid materializing the entire view for each property
+            data_indices = self.layer._indices_view[
                 self.layer._highlight_index
             ]
+
+            data = self.layer.data[
+                np.ix_(data_indices, self.layer._slice_input.displayed)
+            ]
+            if data.ndim == 1:
+                data = np.expand_dims(data, axis=0)
+            size = self.layer.size[data_indices] * self.layer._view_size_scale
+            border_width = self.layer.border_width[data_indices]
             if self.layer.border_width_is_relative:
-                border_width = (
-                    border_width
-                    * self.layer._view_size[self.layer._highlight_index][-1]
-                )
-            symbol = self.layer._view_symbol[self.layer._highlight_index]
+                border_width = border_width * size
+            symbol = self.layer.symbol[data_indices]
         else:
             data = np.empty((0, self.layer._slice_input.ndisplay))
             size = 0


### PR DESCRIPTION
# References and relevant issues
Working on some updates to the points layer (vispy Markers visual) @psobolewskiPhD [reported some issues](https://github.com/napari/napari/pull/8501#issuecomment-3662876070) and I started digging into the performance.

# Description
When updating highlighted points during zoom, the fancy indexing is materializing entire view arrays (`_view_data`, `_view_size`, `_view_border_width`, `_view_symbol`) for all visible points before extracting just the selected indices.

Convert `_highlight_index` to actual data indices once, and reuse to index directly into the original data arrays.

Sorry this is not a proper benchmark, but here is some approximate timing (just print logging with perf_timer) for `_on_highlight_change` with 10M points. The speedup is huge when few points are selected, less impressive but still meaningful when more are selected.

This PR 
-------
```
_on_highlight_change: 0.106ms | n_highlighted=0
_on_highlight_change: 0.097ms | n_highlighted=0
_on_highlight_change: 0.132ms | n_highlighted=0
Selecting a single point...
_on_highlight_change: 0.214ms | n_highlighted=1
Selecting 1,000,000 points...
_on_highlight_change: 434.063ms | n_highlighted=1000000
```

`main`
-----
```
Running test (close the viewer when done)...
_on_highlight_change: 0.105ms | n_highlighted=0
_on_highlight_change: 0.106ms | n_highlighted=0
_on_highlight_change: 0.137ms | n_highlighted=0
Selecting a single point...
 _on_highlight_change: 237.952ms | n_highlighted=1
Selecting 1,000,000 points...
_on_highlight_change: 732.469ms | n_highlighted=1000000
```