### PR TITLE
Bugfix: recurse through sub-fields when making connections in EventedSettings Config

### DIFF
--- a/src/napari/_qt/dialogs/preferences_dialog.py
+++ b/src/napari/_qt/dialogs/preferences_dialog.py
@@ -257,6 +257,10 @@ class PreferencesDialog(QDialog):
         event.accept()
         self.accept()
 
+    def accept(self):
+        self._settings.save()
+        super().accept()
+
     def reject(self):
         """Restores the settings in place when dialog was launched."""
         self._settings.update(self._starting_values)

--- a/src/napari/settings/_tests/test_settings.py
+++ b/src/napari/settings/_tests/test_settings.py
@@ -38,6 +38,14 @@ def test_settings_autosave(test_settings):
     assert Path(test_settings.config_path).exists()
 
 
+def test_settings_autosave_recursive(test_settings):
+    """Test that changing a deeply nested field triggers autosave."""
+    assert not Path(test_settings.config_path).exists()
+    # 'highlight' is a nested model inside 'appearance'
+    test_settings.appearance.highlight.highlight_thickness = 5
+    assert Path(test_settings.config_path).exists()
+
+
 def test_settings_file_not_created(test_settings):
     assert not Path(test_settings.config_path).exists()
     test_settings._save_on_change = False


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8507

# Description
This fixes the issue by recursing through subfields. For example, in the case of Appearance, the `highlight_thickness` is in a sub-field `HighlightSettings`. So on main, editing the top level `them`, which is directly in AppearanceSettings works and is saved. But the nested settings in HIghlightSettings don't autosave.

I added an explicit test for the behavior that fails on main and passes with this and I also tested locally with various settings to ensure behavior wasn't changed.
