### PR TITLE
Fix dim order of rendering of 2D rgb data in 3D mode

### DIFF
--- a/src/napari/_vispy/layers/scalar_field.py
+++ b/src/napari/_vispy/layers/scalar_field.py
@@ -101,9 +101,10 @@ class VispyScalarFieldBaseLayer(VispyBaseLayer[ScalarFieldBase]):
         node = self._layer_node.get_node(
             ndisplay, getattr(data, 'dtype', None)
         )
-
-        if ndisplay > data.ndim:
-            data = data.reshape((1,) * (ndisplay - data.ndim) + data.shape)
+        if ndisplay > self.layer.ndim:
+            data = data.reshape(
+                (1,) * (ndisplay - self.layer.ndim) + data.shape
+            )
 
         # Check if data exceeds MAX_TEXTURE_SIZE and downsample
         if self.MAX_TEXTURE_SIZE_2D is not None and ndisplay == 2:


### PR DESCRIPTION
# References and relevant issues

closes #8521

# Description

It looks like a bug is introduced in #7150. There was a wrong assumption that for `ScalarField` the `data.ndim` is equal to `layer.ndim`. 

This PR comes back to using `layer.ndim` to properly expand data dimensionality. 
