### PR TITLE
Fix numpy warning for pure python edge triangulation

### DIFF
--- a/src/napari/layers/shapes/_accelerated_triangulate_python.py
+++ b/src/napari/layers/shapes/_accelerated_triangulate_python.py
@@ -117,15 +117,15 @@ def generate_2D_edge_meshes_py(
     miters = 0.5 * (full_normals[:-1] + full_normals[1:])
 
     # scale miters such that their dot product with normals is 1
-    mf_dot_ = np.expand_dims(
+    mf_dot = np.expand_dims(
         np.einsum('ij,ij->i', miters, full_normals[:-1]), -1
     )
 
     miters = np.divide(
         miters,
-        mf_dot_,
+        mf_dot,
         out=np.zeros_like(miters),
-        where=np.abs(mf_dot_) > 1e-10,
+        where=np.abs(mf_dot) > 1e-10,
     )
 
     miter_lengths_squared = (miters**2).sum(axis=1)

--- a/src/napari/layers/shapes/_accelerated_triangulate_python.py
+++ b/src/napari/layers/shapes/_accelerated_triangulate_python.py
@@ -117,14 +117,15 @@ def generate_2D_edge_meshes_py(
     miters = 0.5 * (full_normals[:-1] + full_normals[1:])
 
     # scale miters such that their dot product with normals is 1
-    _mf_dot = np.expand_dims(
+    mf_dot_ = np.expand_dims(
         np.einsum('ij,ij->i', miters, full_normals[:-1]), -1
     )
 
     miters = np.divide(
         miters,
-        _mf_dot,
-        where=np.abs(_mf_dot) > 1e-10,
+        mf_dot_,
+        out=np.zeros_like(miters),
+        where=np.abs(mf_dot_) > 1e-10,
     )
 
     miter_lengths_squared = (miters**2).sum(axis=1)


### PR DESCRIPTION
# References and relevant issues

closes #8506

# Description

When calculating mitter vectors, initialize the output array for division with zeros to avoid random values.

This resolves the problem pointed out by the warning introduced in NumPy 2.4.