### PR TITLE
Reduce noise in benchmark logs

### DIFF
--- a/.github/workflows/benchmark_labels_trigger.yml
+++ b/.github/workflows/benchmark_labels_trigger.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   trigger-benchmarks:
     if: github.event.label.name == 'run-benchmarks'

--- a/.github/workflows/benchmark_labels_trigger.yml
+++ b/.github/workflows/benchmark_labels_trigger.yml
@@ -1,0 +1,11 @@
+name: Benchmark Trigger by Label
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  trigger-benchmarks:
+    if: github.event.label.name == 'run-benchmarks'
+    uses: ./.github/workflows/benchmarks.yml
+    secrets: inherit

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,10 +6,9 @@
 name: Benchmarks
 
 on:
-  pull_request:
-    types: [labeled]
+  workflow_call:
   schedule:
-    - cron: "6 6 * * 0" # every sunday
+    - cron: "6 6 * * 0" # every sunday
   workflow_dispatch:
     inputs:
       base_ref:
@@ -20,7 +19,7 @@ on:
         required: true
 
 # This is the main configuration section that needs to be fine tuned to napari's needs
-# All the *_THREADS options is just to make the benchmarks more robust by not using parallelism
+# All the *_THREADS options is just to make the benchmarks more robust by not using parallelism
 env:
   OPENBLAS_NUM_THREADS: "1"
   MKL_NUM_THREADS: "1"
@@ -30,11 +29,10 @@ env:
   # --show-stderr -> print tracebacks if errors occur
   # --factor 1.5 -> report anomaly if tested timings are beyond 1.5x base timings
   # --attribute timeout=300 -> override timeout attribute (default=60s) to allow slow tests to run
-  # see https://asv.readthedocs.io/en/stable/commands.html#asv-continuous for more details!
+  # see https://asv.readthedocs.io/en/stable/commands.html#asv-continuous for more details!
 
 jobs:
   benchmark:
-    if: ${{ github.event.label.name == 'run-benchmarks' && github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     name: ${{ matrix.benchmark-name }}
     runs-on: ${{ matrix.runs-on }}
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -106,7 +106,7 @@ jobs:
           # ID this runner
           asv machine --yes
 
-          if [[ $GITHUB_EVENT_NAME == pull_request ]]; then
+          if [[ $GITHUB_EVENT_NAME == workflow_call ]]; then
             EVENT_NAME="PR #${{ github.event.pull_request.number }}"
             BASE_REF=${{ github.event.pull_request.base.sha }}
             CONTENDER_REF=${GITHUB_SHA}
@@ -176,7 +176,7 @@ jobs:
           # Add the message that might be posted as a comment on the PR
           # We delegate the actual comment to `benchmarks_report.yml` due to
           # potential token permissions issues
-          if [[ $GITHUB_EVENT_NAME == pull_request ]]; then
+          if [[ $GITHUB_EVENT_NAME == workflow_call ]]; then
 
           echo "${{ github.event.pull_request.number }}" > .asv/results/pr_number
           echo \

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -11,7 +11,7 @@ name: "Benchmarks - Report"
 
 on:
   workflow_run:
-    workflows: [Benchmarks]
+    workflows: [Benchmarks, "Benchmark Trigger by Label"]
     types:
       - completed
 


### PR DESCRIPTION
# Description

Currently, adding a label triggers the benchmark workflow. It is then skipped conditionally, but add an entry to the list of actions in the GitHub interface. 

<img width="1382" height="931" alt="obraz" src="https://github.com/user-attachments/assets/0dc3320b-a060-4261-8be7-f1ed0d3346b7" />

This PR moves label trigger to a separate workflow that will contain all skipped  
