### PR TITLE
Improve language in Citation PR Author check

### DIFF
--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -79,7 +79,6 @@ jobs:
       - name: Verify PR author exists in CITATION.cff
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_AFFILIATION: ${{ github.event.pull_request.user.company }}
         run: |
           echo "PR author: $PR_AUTHOR"
           if [[ "$PR_AUTHOR" == *"[bot]" || "$PR_AUTHOR" == "napari-bot" ]]; then
@@ -97,7 +96,7 @@ jobs:
             '```yaml' \
             "- given-names: <first name>" \
             "  family-names: <last name>" \
-            "  affiliation: <required> (ex. ${PR_AFFILIATION})" \
+            "  affiliation: <required> (e.g. napari University)" \
             "  orcid: https://orcid.org/<ORCID> <optional>" \
             "  alias: ${PR_AUTHOR}" \
             '```'

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Verify PR author exists in CITATION.cff
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -90,13 +90,16 @@ jobs:
             echo "Found alias '$PR_AUTHOR' in CITATION.cff."
           else
             echo "ERROR: GitHub username '$PR_AUTHOR' not found as an alias in CITATION.cff under authors."
-            echo "You are welcome to modify this PR to include your authorship in CITATION.cff."
+            echo "You are welcome to modify this PR to include your authorship in CITATION.cff;"
+            echo "citations for community contributions are listed in alphabetical order by family-names."
             echo "Otherwise, a napari core team member will request this information from you."
             printf '%s\n' "Citation format example:" \
+            "```yaml" \
             "- given-names: <first name>" \
             "  family-names: <last name>" \
-            "  alias: ${PR_AUTHOR}" \
             "  affiliation: <required> (ex. ${PR_AFFILIATION})" \
-            "  orcid: <optional>"
+            "  orcid: https://orcid.org/<ORCID> <optional>" \
+            "  alias: ${PR_AUTHOR}" \
+            "```"
             exit 1
           fi

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -94,12 +94,12 @@ jobs:
             echo "citations for community contributors are listed in alphabetical order by family-names."
             echo "Otherwise, a napari core team member will request this information from you."
             printf '%s\n' "Citation format example:" \
-            "```yaml" \
+            '```yaml' \
             "- given-names: <first name>" \
             "  family-names: <last name>" \
             "  affiliation: <required> (ex. ${PR_AFFILIATION})" \
             "  orcid: https://orcid.org/<ORCID> <optional>" \
             "  alias: ${PR_AUTHOR}" \
-            "```"
+            '```'
             exit 1
           fi

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -91,7 +91,7 @@ jobs:
           else
             echo "ERROR: GitHub username '$PR_AUTHOR' not found as an alias in CITATION.cff under authors."
             echo "You are welcome to modify this PR to include your authorship in CITATION.cff;"
-            echo "citations for community contributions are listed in alphabetical order by family-names."
+            echo "citations for community contributors are listed in alphabetical order by family-names."
             echo "Otherwise, a napari core team member will request this information from you."
             printf '%s\n' "Citation format example:" \
             "```yaml" \


### PR DESCRIPTION
# Description

As I've been copying out the PR author citation check into PRs, I've found myself modifying it each time. This adds some clarifying language to the output statement and formatting:

1. adds code fencing so that doesn't need added when pasted (and prevents the extra space in the first line that sometimes happen due to quirky browser highlighting)
2. moves alias to the last line, which is what _most_ of our citations have
3. adds https: format to orcid, since so far everyone has just copied their ID numbers

**Question**: Should we drop the `(ex $PR_AFFILIATION)` because so far, no folks have had that in their github profile (though inevitably some will). currently, it prints out as `(ex. )` which looks a tad silly
