### PR TITLE
Do not use keyword argument when creating tooltip

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -289,7 +289,7 @@ class _QtMainWindow(QMainWindow):
             )
             rect = QRect(pnt.x() - 5, pnt.y() - 5, 10, 10)
             QToolTip.showText(
-                pnt, self._qt_viewer.viewer.tooltip.text, self, rect=rect
+                pnt, self._qt_viewer.viewer.tooltip.text, self, rect
             )
         if e.type() in {QEvent.Type.WindowActivate, QEvent.Type.ZOrderChange}:
             # upon activation or raise_, put window at the end of _instances


### PR DESCRIPTION
# References and relevant issues

closes #8527

# Description

Qt5 does not accept keyword arguments; you need to provide tooltips activity rect as a positional one.