### PR TITLE
Fix angle label values in ndim popup widget

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -211,13 +211,13 @@ def test_ndisplay_button_popup(qt_viewer_buttons, qtbot):
     viewer_buttons.zoom.setValue(5)
     assert viewer.camera.zoom == viewer_buttons.zoom.value() == 5
 
-    # check viewer camera rotation value affects camera angles
+    # check viewer camera rotation with widget values affects camera angles
     assert viewer_buttons.rx
     assert viewer_buttons.ry
     assert viewer_buttons.rz
-    viewer_buttons.rx.setValue(90)
+    viewer_buttons.rx.setValue(150)
     viewer_buttons.ry.setValue(45)
-    viewer_buttons.rz.setValue(0)
+    viewer_buttons.rz.setValue(-50)
     assert (
         viewer.camera.angles
         == (
@@ -225,7 +225,40 @@ def test_ndisplay_button_popup(qt_viewer_buttons, qtbot):
             viewer_buttons.ry.value(),
             viewer_buttons.rz.value(),
         )
-        == (90, 45, 0)
+        == (
+            viewer_buttons.rx._label.value(),
+            viewer_buttons.ry._label.value(),
+            viewer_buttons.rz._label.value(),
+        )
+        == (150, 45, -50)
+    )
+
+    # popup needs to be relaunched to get widget controls with the new values
+    perspective_popup.close()
+    perspective_popup = None
+
+    # check that changing angles outside widget properly updates the widget values
+    viewer.camera.angles = (125, 15, -45)
+
+    # relaunch popup to check values
+    viewer_buttons.ndisplayButton.customContextMenuRequested.emit(QPoint())
+    for widget in QApplication.topLevelWidgets():
+        if isinstance(widget, QtPopup):
+            perspective_popup = widget
+    assert perspective_popup
+    assert (
+        viewer.camera.angles
+        == (
+            viewer_buttons.rx.value(),
+            viewer_buttons.ry.value(),
+            viewer_buttons.rz.value(),
+        )
+        == (
+            viewer_buttons.rx._label.value(),
+            viewer_buttons.ry._label.value(),
+            viewer_buttons.rz._label.value(),
+        )
+        == (125, 15, -45)
     )
 
     # popup needs to be relaunched to get widget controls with the new values

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -109,8 +109,8 @@ def labeled_double_slider(
     """Create a labeled double slider widget."""
     slider = QLabeledDoubleSlider(parent)
     slider.setRange(*value_range)
-    slider.setValue(value)
     slider.setDecimals(decimals)
+    slider.setValue(value)
     slider.valueChanged.connect(callback)
     return slider
 


### PR DESCRIPTION
# References and Relevant Issues

Closes #8534 
Depends on https://github.com/pyapp-kit/superqt/pull/320

# Description

Sets decimal places prior to setting the value properly updates the number of decimal places in the label, but the raw values are unchanged (so 125.10 will display as 125, but still be 125.10).

Also adds tests which will fail until either we depend on a new release of superqt with the upstream fix or incorporate the suggested change. Not sure the best way to go about it. 🤷 

<img width="637" height="551" alt="image" src="https://github.com/user-attachments/assets/522086e1-29e3-4e9b-bbdf-dc3f818e2c2e" />

