### PR TITLE
Add caching of outlines to reduce delay on Shapes zoom

### DIFF
--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -581,6 +581,7 @@ class Shapes(Layer):
         self._selected_data.events.items_changed.connect(
             self._clean_outline_cache
         )
+        self.events.set_data.connect(self._clean_outline_cache)
 
         self._status = self.mode
 

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -581,7 +581,6 @@ class Shapes(Layer):
         self._selected_data.events.items_changed.connect(
             self._clean_outline_cache
         )
-        self.events.set_data.connect(self._clean_outline_cache)
 
         self._status = self.mode
 
@@ -2500,6 +2499,27 @@ class Shapes(Layer):
             box = np.append(box, [rot], axis=0)
 
         return box
+
+    def refresh(
+        self,
+        event: Event | None = None,
+        *,
+        thumbnail: bool = True,
+        data_displayed: bool = True,
+        highlight: bool = True,
+        extent: bool = True,
+        force: bool = False,
+    ) -> None:
+        if data_displayed:
+            self._clean_outline_cache()
+        super().refresh(
+            event,
+            thumbnail=thumbnail,
+            data_displayed=data_displayed,
+            highlight=highlight,
+            extent=extent,
+            force=force,
+        )
 
     def _clean_outline_cache(self):
         self._outlines_cache.clear()

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2543,6 +2543,7 @@ class Shapes(Layer):
             value = self._value[0]
             if value in self.selected_data:
                 value = None
+
             if value in self._outlines_cache:
                 centers, offsets, triangles = self._outlines_cache[value]
             else:

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -576,6 +576,12 @@ class Shapes(Layer):
         self._drag_box_stored = None
         self._is_creating = False
         self._clipboard: dict[str, Shapes] = {}
+        self._outlines_cache: dict[
+            int | None, tuple[np.ndarray, np.ndarray, np.ndarray]
+        ] = {}
+        self._selected_data.events.items_changed.connect(
+            self._clean_outline_cache
+        )
 
         self._status = self.mode
 
@@ -2498,6 +2504,9 @@ class Shapes(Layer):
 
         return box
 
+    def _clean_outline_cache(self):
+        self._outlines_cache.clear()
+
     def _outline_shapes(self):
         """Find outlines of any selected or hovered shapes.
 
@@ -2514,18 +2523,26 @@ class Shapes(Layer):
             and self._value is not None
             and (self._value[0] is not None or len(self.selected_data) > 0)
         ):
-            if len(self.selected_data) > 0:
-                index = list(self.selected_data)
-                if self._value[0] is not None:
-                    if self._value[0] in index:
-                        pass
-                    else:
-                        index.append(self._value[0])
-                index.sort()
+            value = self._value[0]
+            if value in self.selected_data:
+                value = None
+            if value in self._outlines_cache:
+                centers, offsets, triangles = self._outlines_cache[value]
             else:
-                index = self._value[0]
+                if len(self.selected_data) > 0:
+                    index = list(self.selected_data)
+                    if value is not None:
+                        index.append(value)
+                    index.sort()
+                else:
+                    index = value
 
-            centers, offsets, triangles = self._data_view.outline(index)
+                centers, offsets, triangles = self._data_view.outline(index)
+                self._outlines_cache[self._value[0]] = (
+                    centers,
+                    offsets,
+                    triangles,
+                )
             vertices = centers + (
                 self._normalized_scale_factor * self._highlight_width * offsets
             )


### PR DESCRIPTION
# References and relevant issues
Similar to #8404

# Description

I perform profiling and spot that on zooming, most time is spent on `self._data_view.outline(index)`. And the output of this function is not changing if the list of selected indices is the same. So this PR adds caching. 

As far as I check, the cache needs to be cleaned when the selection is changed.

I'm not sure what to do on layer change, but the whole code does not look ready for selection outside the visible layer 


Output of profiling with 30x zoom changes. visible shapes_list(outline) is called only once:

<img width="1818" height="1005" alt="obraz" src="https://github.com/user-attachments/assets/6f1e5bbe-cdca-41c9-a442-3dbbbc8f3d7e" />


The long `get_bounds` method is this:
https://github.com/vispy/vispy/blob/422f2b81404d147295af431b878c97314225c94a/vispy/geometry/meshdata.py#L246-L261

WE might speed it up in vispy, or precalculate bounds and provide a custom class as MeshData. 