### PR TITLE
Fix calculation of camera angles in legacy conversion functions

### DIFF
--- a/src/napari/_vispy/camera.py
+++ b/src/napari/_vispy/camera.py
@@ -54,7 +54,7 @@ class VispyCamera:
             # Do conversion from quaternion representation to euler angles
             q = self._view.camera._quaternion
             rotation = Rotation.from_quat([q.x, q.y, q.z, q.w])
-            # vispy's create_from_euler_angles uses ZYX extrinsic convention
+            # vispy's equivalent quaternion creation uses ZYX extrinsic convention
             angles = rotation.as_euler('ZYX', degrees=True)
             return self._camera.from_legacy_angles(tuple(angles))
 
@@ -68,7 +68,7 @@ class VispyCamera:
         # Only update angles if current camera is 3D camera
         if isinstance(self._view.camera, MouseToggledArcballCamera):
             angles = self._camera.to_legacy_angles(angles)
-            # vispy's create_from_euler_angles uses ZYX extrinsic convention
+            # vispy's equivalent quaternion creation uses ZYX extrinsic convention
             rotation = Rotation.from_euler('ZYX', angles, degrees=True)
             # Create and set quaternion
             q = Quaternion(*rotation.as_quat(scalar_first=True))

--- a/src/napari/_vispy/camera.py
+++ b/src/napari/_vispy/camera.py
@@ -54,8 +54,8 @@ class VispyCamera:
             # Do conversion from quaternion representation to euler angles
             q = self._view.camera._quaternion
             rotation = Rotation.from_quat([q.x, q.y, q.z, q.w])
-            # see #8281 for why this is yzx. In short: longstanding vispy bug.
-            angles = rotation.as_euler('yzx', degrees=True)
+            # vispy's create_from_euler_angles uses ZYX extrinsic convention
+            angles = rotation.as_euler('ZYX', degrees=True)
             return self._camera.from_legacy_angles(tuple(angles))
 
         return (0, 0, 0)
@@ -68,8 +68,8 @@ class VispyCamera:
         # Only update angles if current camera is 3D camera
         if isinstance(self._view.camera, MouseToggledArcballCamera):
             angles = self._camera.to_legacy_angles(angles)
-            # see #8281 for why this is yzx. In short: longstanding vispy bug.
-            rotation = Rotation.from_euler('yzx', angles, degrees=True)
+            # vispy's create_from_euler_angles uses ZYX extrinsic convention
+            rotation = Rotation.from_euler('ZYX', angles, degrees=True)
             # Create and set quaternion
             q = Quaternion(*rotation.as_quat(scalar_first=True))
             self._view.camera._quaternion = q

--- a/src/napari/components/camera.py
+++ b/src/napari/components/camera.py
@@ -227,8 +227,8 @@ class Camera(EventedModel):
     ) -> tuple[float, float, float]:
         """Convert camera angles from vispy convention (legacy behaviour) to napari.
 
-        Vispy's create_from_euler_angles uses ZYX extrinsic ordering (note: capital
-        letters indicate extrinsic rotations). In napari 0.7.0+ we use xyz intrinsic.
+        Vispy's quaternion representation uses ZYX extrinsic ordering.
+        In napari 0.7.0+ we use xyz intrinsic.
 
         Prior to napari 0.7.0, we didn't account for Vispy's ZYX ordering, so our
         camera angles updated the rotation around the wrong axes. See:
@@ -253,8 +253,8 @@ class Camera(EventedModel):
     ) -> tuple[float, float, float]:
         """Convert camera angles from napari convention to vispy (legacy behaviour).
 
-        Vispy's create_from_euler_angles uses ZYX extrinsic ordering (note: capital
-        letters indicate extrinsic rotations). In napari 0.7.0+ we use xyz intrinsic.
+        Vispy's quaternion representation uses ZYX extrinsic ordering.
+        In napari 0.7.0+ we use xyz intrinsic.
 
         Prior to napari 0.7.0, we didn't account for Vispy's ZYX ordering, so our
         camera angles updated the rotation around the wrong axes. See:


### PR DESCRIPTION
# References and relevant issues

Closes #8524 

# Description

tl;dr I think ultimately our goal is to convert from napari euler angles to vispy quaternion, not napari euler angles to an incorrect vispy euler representation. To be fair, all of this is entirely new to me, so I could again be barking up the wrong tree.

#8281 introduces a new calculation of the camera angles. ~~We now use an `xyz` ordering rather than `yzx`. However, there was a discrepancy between `set_view_direction` (and its `view_direction` and `up_direction`)--which use `xyz`--and the conversion functions which are using `zyx` for the calculation. This updates the conversion functions to use `xyz` for euler angle ordering.~~

I think we were led astray in https://github.com/napari/napari/pull/8281#issuecomment-3325190919 where the transform is done. However, this was a red herring because in napari we only ever pass the quaternion to vispy, and vispy only ever handles quaternions, not Euler angles. (and I'm also not quite sure about the midi code that @jni brings up here: https://github.com/napari/napari/pull/8281#issuecomment-3324100787)

 Therefore, we want to match the Euler convention that the vispy quaternion "assumes".  I'm fairly certain this actually matches our `xyz` ordering now. BUT, when I tried to use this in the conversion function it would not be possible to round trip, I _think_ this is because intrinsic rotations are sensitive to adjustments, like our swap between (0,0,90) -> (0,0,0) as the home, _so_ I have found the the `xyz` extrinsic equivalent, `ZYX` produces matching behavior in 0.7.0 to legacy behavior. This makes sense in my learning because extrinsic rotations are not sensitive to the state of the axes at rotation time.

The good news about this, is that it makes things seem way easier to reason about, and I wonder now if we've overcomplicated things, the bad news is I don't have confidence enough to say that this is correct, nor how we came to this `yzx` conclusion from the Vispy code. I fell upon this solution quite early on, but wasn't convinced, went in circles for another two hours, and arrived back at the same conclusion. 🤦 

My learning materials were mostly the following:
1. https://en.wikipedia.org/wiki/Euler_angles (actually the most helpful as a start for me!)
2. https://www.youtube.com/watch?v=zjMuIxRvygQ
3. https://eater.net/quaternions

This PR on left, 0.6.6 on right:
`to_legacy_angles`
<img width="3055" height="1268" alt="image" src="https://github.com/user-attachments/assets/34f2a138-f415-4223-815e-7635a7e93f81" />

`from_legacy_angles`
<img width="3058" height="1264" alt="image" src="https://github.com/user-attachments/assets/1ef6612e-8746-4f28-917c-6b6cbc96ee4a" />

