### PR TITLE
Enforce unix line endings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,6 +383,7 @@ fix = true
 
 [tool.ruff.format]
 quote-style = "single"
+line-ending = "lf"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
# References and relevant issues
- Fixes issues like https://github.com/napari/napari/pull/8530?notification_referrer_id=NT_kwDOAWZPT7QyMTU4NDEyMzYxODoyMzQ4MjE5MQ#issuecomment-3706974790
- docs: https://docs.astral.sh/ruff/settings/#format_line-ending

# Description
We already have this in pre-commit, excepting all python files. It probably used to be enforced by black, then we forgot to enforce it in ruff. This should be faster than doing a second pass with the much slower builtin pre-commit hook.
