### PR TITLE
Do not expose legacy angle

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_camera.py
+++ b/src/napari/_vispy/_tests/test_vispy_camera.py
@@ -18,9 +18,6 @@ def test_camera(make_napari_viewer):
     assert viewer.dims.ndisplay == 2
 
     np.testing.assert_almost_equal(viewer.camera.angles, (0, 0, 0))
-    np.testing.assert_almost_equal(
-        viewer.camera.angles, viewer.camera.from_legacy_angles((0, 0, 90))
-    )
     np.testing.assert_almost_equal(viewer.camera.center, (0, 5.0, 5.0))
     np.testing.assert_almost_equal(viewer.camera.angles, vispy_camera.angles)
     np.testing.assert_almost_equal(viewer.camera.center, vispy_camera.center)

--- a/src/napari/components/camera.py
+++ b/src/napari/components/camera.py
@@ -222,58 +222,6 @@ class Camera(EventedModel):
             return Handedness.LEFT
         return Handedness.RIGHT
 
-    def from_legacy_angles(
-        self, angles: tuple[float, float, float]
-    ) -> tuple[float, float, float]:
-        """Convert camera angles from vispy convention (legacy behaviour) to napari.
-
-        Vispy (and previously napari) uses YZX ordering, but in napari we use ZYX.
-        Rotations are extrinsic.
-
-        Prior to napari 0.7.0, we didn't account for Vispy's ZYX ordering, so our
-        camera angles updated the rotation around the wrong axes. See:
-
-        https://github.com/napari/napari/pull/8281
-        """
-        # see #8281 for why this is yzx. In short: longstanding vispy bug.
-        rot = R.from_euler('yzx', angles, degrees=True)
-        # rotate 90 degrees to get neutral position at 0, 0, 0
-        rot = rot * R.from_euler('x', -90, degrees=True)
-        angles = rot.as_euler('zyx', degrees=True)
-        # flip angles where orientation is flipped relative to default, so the
-        # resulting rotation is always right-handed (i.e: CCW when facing the plane)
-        flipped = angles * np.where(
-            self._vispy_flipped_axes(ndisplay=3), -1, 1
-        )
-        return cast(tuple[float, float, float], tuple(flipped))
-
-    def to_legacy_angles(
-        self, angles: tuple[float, float, float]
-    ) -> tuple[float, float, float]:
-        """Convert camera angles to napari convention to vispy (legacy behaviour).
-
-        Vispy (and previously napari) uses YZX ordering, but in napari we use ZYX.
-        Rotations are extrinsic.
-
-        Prior to napari 0.7.0, we didn't account for Vispy's ZYX ordering, so our
-        camera angles updated the rotation around the wrong axes. See:
-
-        https://github.com/napari/napari/pull/8281
-        """
-        # flip angles where orientation is flipped relative to default, so the
-        # resulting rotation is always right-handed (i.e: CCW when facing the plane)
-        flipped_angles = angles * np.where(
-            self._vispy_flipped_axes(ndisplay=3), -1, 1
-        )
-        # see #8281 for why this is yzx. In short: longstanding vispy bug.
-        rot = R.from_euler('zyx', flipped_angles, degrees=True)
-        # flip angles so handedness of rotation is always right
-        rot = rot * R.from_euler('x', 90, degrees=True)
-        return cast(
-            tuple[float, float, float],
-            tuple(rot.as_euler('yzx', degrees=True)),
-        )
-
     def _vispy_flipped_axes(
         self, ndisplay: Literal[2, 3] = 2
     ) -> tuple[int, int, int]:


### PR DESCRIPTION
# References and relevant issues
- supersedes #8537
- closes #8524

# Description
Trying to both fix the angles in napari and retain a way to use "old" angles without issues seems to be a fool's errand. In #8537 we sort of agreed that we should just drop support of the broken angles.

This PR does that, simplifying the public API and reducing the code complexity a bit.
