### PR TITLE
Don't warn user when a Zarr array with channel axis is passed

### DIFF
--- a/src/napari/layers/utils/_tests/test_stack_utils.py
+++ b/src/napari/layers/utils/_tests/test_stack_utils.py
@@ -395,15 +395,7 @@ def test_images_to_stack_lazy_arrays(input_array, expected_type):
     """Test that images_to_stack handles numpy, dask, and zarr arrays correctly."""
     data = input_array
     images = [Image(data) for _ in range(3)]
-
-    if isinstance(input_array, zarr.Array):
-        with pytest.warns(
-            UserWarning,
-            match='zarr array cannot be stacked lazily, using dask array to stack.',
-        ):
-            stack = images_to_stack(images)
-    else:
-        stack = images_to_stack(images)
+    stack = images_to_stack(images)
 
     assert not stack.multiscale
     assert isinstance(stack.data, expected_type)
@@ -428,15 +420,7 @@ def test_images_to_stack_lazy_multiscale_arrays(input_array, expected_type):
         data = [input_array, input_array[::2, ::2]]
 
     images = [Image(data) for _ in range(3)]
-
-    if isinstance(input_array, zarr.Array):
-        with pytest.warns(
-            UserWarning,
-            match='zarr array cannot be stacked lazily, using dask array to stack.',
-        ):
-            stack = images_to_stack(images)
-    else:
-        stack = images_to_stack(images)
+    stack = images_to_stack(images)
 
     assert stack.multiscale
     assert isinstance(stack.data[0], expected_type)
@@ -465,14 +449,7 @@ def test_slice_from_axis_different_array_types(
 
     axis, element = 1, 2
     expected_shape = (3, 4)
-
-    if array_type == 'zarr':
-        with pytest.warns(
-            UserWarning, match='zarr array cannot be sliced lazily'
-        ):
-            result = slice_from_axis(data, axis=axis, element=element)
-    else:
-        result = slice_from_axis(data, axis=axis, element=element)
+    result = slice_from_axis(data, axis=axis, element=element)
 
     # Check result type and shape
     assert isinstance(result, expected_result_type)

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -45,7 +45,7 @@ def slice_from_axis(array, *, axis, element):
         import dask.array as da
 
         array = da.from_zarr(array)
-        logger.warning(
+        logger.info(
             trans._(
                 'zarr array cannot be sliced lazily, converted to dask array.',
                 deferred=True,
@@ -384,7 +384,7 @@ def images_to_stack(images: list[Image], axis: int = 0, **kwargs) -> Image:
         import dask.array as da
 
         stacker = da.stack
-        logger.warning(
+        logger.info(
             trans._(
                 'zarr array cannot be sliced lazily, converted to dask array.',
                 deferred=True,

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -43,12 +42,6 @@ def slice_from_axis(array, *, axis, element):
         import dask.array as da
 
         array = da.from_zarr(array)
-        warnings.warn(
-            trans._(
-                'zarr array cannot be sliced lazily, converted to dask array.',
-                deferred=True,
-            )
-        )
 
     slices = [slice(None) for i in range(array.ndim)]
     slices[axis] = element
@@ -382,12 +375,6 @@ def images_to_stack(images: list[Image], axis: int = 0, **kwargs) -> Image:
         import dask.array as da
 
         stacker = da.stack
-        warnings.warn(
-            trans._(
-                'zarr array cannot be stacked lazily, using dask array to stack.',
-                deferred=True,
-            )
-        )
     else:
         stacker = np.stack
 

--- a/src/napari/layers/utils/stack_utils.py
+++ b/src/napari/layers/utils/stack_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -14,6 +15,8 @@ from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from napari.types import FullLayerData
+
+logger = logging.getLogger(__name__)
 
 
 def slice_from_axis(array, *, axis, element):
@@ -42,6 +45,12 @@ def slice_from_axis(array, *, axis, element):
         import dask.array as da
 
         array = da.from_zarr(array)
+        logger.warning(
+            trans._(
+                'zarr array cannot be sliced lazily, converted to dask array.',
+                deferred=True,
+            )
+        )
 
     slices = [slice(None) for i in range(array.ndim)]
     slices[axis] = element
@@ -375,6 +384,12 @@ def images_to_stack(images: list[Image], axis: int = 0, **kwargs) -> Image:
         import dask.array as da
 
         stacker = da.stack
+        logger.warning(
+            trans._(
+                'zarr array cannot be sliced lazily, converted to dask array.',
+                deferred=True,
+            )
+        )
     else:
         stacker = np.stack
 


### PR DESCRIPTION
# References and relevant issues

# Description
When a user passes a Zarr array that has a channel axis, a warning gets raised that the Zarr array is being put inside a dask array because Zarr arrays don't support lazy loading. As a user, this is not very helpful, as there is no action I can take to avoid the warning.

In this PR I want to suggest that using dask here is an implementation detail of `napari` that the user doesn't need to be aware of, and therefore I've removed the warnings.

For reference, these were originally introduced in https://github.com/napari/napari/pull/8260


