### PR TITLE
Modify sphinx-external-toc version constraint to eliminate warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ docs = [
     "sphinx-tabs",
     "sphinx-tags",
     "sphinx-design",
-    "sphinx-external-toc",
+    "sphinx-external-toc<1.1.0", # parallel build issue
     "sphinx-favicon>=1.0",
     "sphinx-copybutton",
     "sphinx-gallery",
@@ -289,7 +289,7 @@ docs = [
     "sphinx-tabs",
     "sphinx-tags",
     "sphinx-design",
-    "sphinx-external-toc",
+    "sphinx-external-toc<1.1.0", # parallel build issue
     "sphinx-favicon>=1.0",
     "sphinx-copybutton",
     "sphinx-gallery",

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -817,14 +817,12 @@ sphinx-copybutton==0.5.2
     # via napari (pyproject.toml:docs)
 sphinx-design==0.7.0
     # via napari (pyproject.toml:docs)
-sphinx-external-toc==1.1.0
+sphinx-external-toc==1.0.1
     # via napari (pyproject.toml:docs)
 sphinx-favicon==1.0.1
     # via napari (pyproject.toml:docs)
 sphinx-gallery==0.20.0
     # via napari (pyproject.toml:docs)
-sphinx-multitoc-numbering==0.1.3
-    # via sphinx-external-toc
 sphinx-tabs==3.4.7
     # via napari (pyproject.toml:docs)
 sphinx-tags==0.4


### PR DESCRIPTION
# References and relevant issues
See: https://github.com/napari/docs/pull/907#issuecomment-3795930363

# Description
sphinx-external-toc was updated, it now depends on sphinx-multitoc-numbering, which doesn't explicitly support parallel builds, which triggers a warning, which is a fail.
But, our napari prs for constraints don't do a parallel build because they build examples, so the warnings didn't occur, so we didn't catch it.

I tried to look into supressing that warning, but it wasn't really working.
I made issues with the two repos:

https://github.com/executablebooks/sphinx-external-toc/issues/115
https://github.com/executablebooks/sphinx-multitoc-numbering/issues/27

So I think for now it's best to just set upper pin on sphinx-external-toc.
