### PR TITLE
Low hanging Labels painting performance improvement

### DIFF
--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -1480,10 +1480,8 @@ class Labels(ScalarFieldBase):
             indices = [np.array(x).flatten() for x in indices]
 
         updated_slice = tuple(
-            [
-                slice(min(axis_indices), max(axis_indices) + 1)
-                for axis_indices in indices
-            ]
+            slice(int(axis_indices.min()), int(axis_indices.max()) + 1)
+            for axis_indices in indices
         )
 
         if self.contour > 0:

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -13,8 +13,8 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from PIL import Image, ImageDraw
 from scipy import ndimage as ndi
-from skimage.draw import polygon2mask
 
 from napari.layers._data_protocols import LayerDataProtocol
 from napari.layers._multiscale_data import MultiScaleData
@@ -1286,7 +1286,8 @@ class Labels(ScalarFieldBase):
         slice_coord = points[0].tolist()
         points2d = points[:, dims_to_paint]
 
-        polygon_mask = polygon2mask(shape, points2d)
+        polygon_mask = self._create_polygon_mask(points2d, shape)
+
         mask_indices = np.argwhere(polygon_mask)
         self._paint_indices(
             mask_indices,
@@ -1296,6 +1297,31 @@ class Labels(ScalarFieldBase):
             slice_coord,
             refresh=True,
         )
+
+    def _create_polygon_mask(
+        self, points2d: np.ndarray, shape: list[int]
+    ) -> np.ndarray:
+        """Create a boolean mask from polygon points using PIL rasterization.
+
+        Parameters
+        ----------
+        points2d : ndarray
+            2D polygon vertices in (row, col) format, relative to the mask
+            coordinate system.
+        shape : list of int
+            Shape of the mask to create [height, width].
+
+        Returns
+        -------
+        ndarray
+            Boolean mask with True inside polygon.
+        """
+        # PIL uses (x, y) = (col, row), so reverse the points
+        img = Image.new('L', (shape[1], shape[0]), 0)
+        draw = ImageDraw.Draw(img)
+        points_pil = [tuple(p[::-1]) for p in points2d]
+        draw.polygon(points_pil, outline=1, fill=1)
+        return np.array(img, dtype=bool)
 
     def _paint_indices(
         self,


### PR DESCRIPTION
# References and relevant issues
Stop-gap pulled from https://github.com/napari/napari/pull/8567
I think the approach in the PR of using bounding boxes and masking is much better for both paint and polygon, but the changes here are a quick fix that helps considerably, especially for mid-size things.

# Description
This PR does two small things:
1. towards polygon painting improvement, it switches to using PIL to rasterize instead of skimage, see: https://github.com/scikit-image/scikit-image/issues/5451
We already have PIL in the dependencies and it's at least 30x faster.
2. uses numpy.min and max in data_setitem -- this affects polygon, brush painting, and fill.

All tests pass for me locally.
Performance with this PR:
Polygon (~6X speedup)
```
Benchmarking size 500x500...
Size 500x500 took 0.0072 seconds
Benchmarking size 2500x2500...
Size 2500x2500 took 0.1690 seconds
Benchmarking size 5000x5000...
Size 5000x5000 took 0.7740 seconds
Benchmarking size 10000x10000...
Size 10000x10000 took 3.4357 seconds
```
Fill (~4x speedup)
```
Benchmarking size 500x500...
Size 500x500 took 0.0077 seconds
Benchmarking size 2500x2500...
Size 2500x2500 took 0.1827 seconds
Benchmarking size 5000x5000...
Size 5000x5000 took 0.7900 seconds
Benchmarking size 10000x10000...
Size 10000x10000 took 4.1392 seconds
```
Large brushes are also faster, feels like ~2X, so e.g. brush_size 2500 doesn't block anymore, and 1000 brush_size is fine?

MAIN:
Polygon:
```
Benchmarking size 500x500...
Size 500x500 took 0.0485 seconds
Benchmarking size 2500x2500...
Size 2500x2500 took 1.2613 seconds
Benchmarking size 5000x5000...
Size 5000x5000 took 5.0181 seconds
Benchmarking size 10000x10000...
Size 10000x10000 took 22.3280 seconds
```
Fill:
```
Benchmarking size 500x500...
Size 500x500 took 0.0386 seconds
Benchmarking size 2500x2500...
Size 2500x2500 took 0.9748 seconds
Benchmarking size 5000x5000...
Size 5000x5000 took 3.9077 seconds
Benchmarking size 10000x10000...
Size 10000x10000 took 16.2589 seconds
```
Brush: brush_size 2500 blocks, even 1000 isn't great, but can work