### PR TITLE
Switch logo URL used for reader test

### DIFF
--- a/src/napari_builtins/_tests/test_reader.py
+++ b/src/napari_builtins/_tests/test_reader.py
@@ -55,7 +55,7 @@ def test_animated_gif_reader(save_image):
 def test_reader_plugin_url():
     layer_data = npe2.read(
         [
-            'https://github.com/napari/napari/raw/main/src/napari/resources/logo.png'
+            'https://github.com/napari/docs/raw/main/docs/_static/images/nf-logo.png'
         ],
         stack=False,
     )


### PR DESCRIPTION
# References and relevant issues
Closes #8595 

# Description
I've switched to using the numfocus logo from the docs repo since I figure that'll be around for a long time. Happy to consider some other wikipedia png or alternatively just delete the test?
