### PR TITLE
Move comment trigger of constraints update to a separate workflow

### DIFF
--- a/.github/workflows/constraints_comment_trigger.yml
+++ b/.github/workflows/constraints_comment_trigger.yml
@@ -1,0 +1,46 @@
+name: Upgrade test constraints trigger by comment
+
+on:
+  issue_comment:
+    types: [ created ]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  add_eyes:
+    name: Add eyes reaction
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add eyes reaction
+        run: |
+          COMMENT_ID=${{ github.event.comment.id }}
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
+            -d '{"content": "eyes"}'
+  trigger-benchmarks:
+    needs: add_eyes
+    uses: ./.github/workflows/upgrade_test_constraints.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+    secrets: inherit
+
+  add_rocket:
+    name: Add rocket reaction
+    needs: trigger-benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add rocket reaction
+        run: |
+          COMMENT_ID=${{ github.event.comment.id }}
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
+            -d '{"content": "rocket"}'

--- a/.github/workflows/constraints_comment_trigger.yml
+++ b/.github/workflows/constraints_comment_trigger.yml
@@ -26,8 +26,6 @@ jobs:
   trigger-benchmarks:
     needs: add_eyes
     uses: ./.github/workflows/upgrade_test_constraints.yml
-    with:
-      pr_number: ${{ github.event.issue.number }}
     secrets: inherit
 
   add_rocket:

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -52,11 +52,6 @@ on:
     - cron: '0 8 * * 1'
 
   workflow_call:
-    inputs:
-      pr_number:
-        description: Pull request number that triggered the comment workflow.
-        required: false
-        type: string
 
   pull_request:
     paths:
@@ -72,9 +67,9 @@ jobs:
     steps:
       - name: Get PR details
         # extract PR number and branch name from issue_comment event
-        if: github.event_name == 'workflow_call' && inputs.pr_number != ''
+        if: github.event_name == 'issue_comment' && inputs.pr_number != ''
         run: |
-          PR_number=${{ inputs.pr_number }}
+          PR_number=${{ github.event.issue.number }}
           PR_data=$(curl \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_number" \
@@ -91,7 +86,7 @@ jobs:
 
       - name: Get repo info
         # when schedule or workflow_dispatch triggers workflow, then we need to get info about which branch to use
-        if: github.event_name != 'workflow_call' && github.event_name != 'pull_request'
+        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
         run: |
           echo "FULL_NAME=${{ github.repository }}" >> "$GITHUB_ENV"
           echo "BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
@@ -102,7 +97,7 @@ jobs:
 
       - name: Clone target repo (remote)
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: github.event_name == 'workflow_call'
+        if: github.event_name == 'issue_comment'
         with:
           path: napari_repo  # place in a named directory
           repository: ${{ env.FULL_NAME }}
@@ -118,7 +113,7 @@ jobs:
 
       - name: Clone target repo (main)
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: github.event_name != 'workflow_call' && github.event_name != 'pull_request'
+        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
         with:
           path: napari_repo  # place in a named directory
           repository: ${{ env.FULL_NAME }}
@@ -162,5 +157,5 @@ jobs:
           uv run tools/create_pr_or_update_existing_one.py
         env:
             GHA_TOKEN_MAIN_REPO: ${{ secrets.GHA_TOKEN_NAPARI_BOT_MAIN_REPO }}
-            PR_NUMBER: ${{ inputs.pr_number }}
+            PR_NUMBER: ${{ github.event.issue.number }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -6,39 +6,42 @@
 #
 # The GitHub workflows have the following limitations:
 # - There is no pull request comment trigger for workflows.
-#   The `issue_comment` trigger is used instead, because it is used for pull requests too.
-# - If a workflow is triggered by pull_requests from forked repository,
+#   The `issue_comment` trigger is used instead because it is used for pull requests too.
+#   (See constraints_comment_trigger.yml)
+# - If a workflow is triggered by pull_requests from a forked repository,
 #   then it does not have access to secrets.
-#   So it is not possible to create PR from forked repository.
-# - If workflow is triggered by comment, then it is triggered on the main branch
-#   and not on the branch where the comment was created.
-# - In workflow triggers it is only possible to depend on created event, without any conditions.
+#   So it is not possible to create PR from a forked repository.
+# - If a comment triggers a workflow, then it is triggered on the main branch
+#   and not on the branch from PR where the comment was created.
+# - In workflow triggers it is only possible to depend on a created event, without any conditions.
 #   So it is not possible to trigger workflow only when the comment contains specific text.
 #   So we need to check it in the workflow.
-#   It will produce multiple empty runs that will create multiple empty entries in actions
-#   making it harder to find the right one.
-# - It is not possible to update pull request from forked repository using Fine grained personal token.
-# - It is not possible to create pull request to forked repository using Fine grained personal token.
+#   It will produce multiple empty runs that will create multiple empty entries in actions,
+#   making it harder to find the right one. Because of that, we move the comment triggering workflow
+#   to the separate file constraints_comment_trigger.yml.
+# - It is not possible to update a pull request from a forked repository using Fine grained personal token.
+# - It is not possible to create a pull request to forked repository using Fine grained personal token.
 # - There is no interface indicator that the workflow triggered by issue comment is running.
 #
-# Also, for safety reason, it is better to store automatically generated changes outside the main repository.
+# Also, for safety reasons, it is better to store automatically generated changes outside the main repository.
 #
 # Because of the above limitations, the following approach is used:
 # - We use `napari-bot/napari` repository to store automatically generated changes.
-# - We don't push changes to `napari-bot/napari` repository if PR contains changes in workflows.
-# - We use two checkouts of repository:
-#   * First into `.` directory from which we run the workflow.
-#   * Second into `napari_repo` directory from which we create pull request.
-#     If comment triggers the workflow, then this will contain the branch from which the PR was created.
-#     Changes will be pushed to `napari-bot/napari` repository.
-#     If schedule or workflow_dispatch triggers workflow, then this will contain the main branch.
-#     Changes will not be pushed to `napari/napari` repository.
-#     If pull_request triggers workflow, then this will contain PR branch.
+# - We don't push changes to the `napari-bot/napari` repository if PR contains changes in workflows.
+# - We use two checkouts of the repository:
+#   * First into the `.` directory from which we run the workflow.
+#   * Second into the `napari_repo` directory from which we create a pull request.
+#     If the comment triggers the workflow, then this will contain the branch from which the PR was created.
+#     Changes will be pushed to the `napari-bot/napari` repository.
+#     If schedule or workflow_dispatch triggers this workflow, then this will contain the main branch.
+#     Changes will not be pushed to the `napari/napari` repository.
+#     If pull_request triggers this workflow, then this will contain a PR branch.
 #     Changes will be only accessible as artifacts.
-# - If workflow is triggered by comment,
-#   then we add eyes reaction to the comment to show that workflow has started.
-#   After finishing calculation of new constraints, we add rocket reaction to the comment.
-#   Then pushing changes to `napari-bot/napari` repository and adding comment to the PR is
+# - If a comment triggers this workflow,
+#   then we add eyes reaction to the comment to show that the workflow has started.
+#   (add_eyes job in constraints_comment_trigger.yml)
+#   After finishing the calculation of new constraints, we add rocket reaction to the comment.
+#   Then pushing changes to the `napari-bot/napari` repository and adding comment to the PR is
 #   done by `tools/create_pr_or_update_existing_one.py`.
 name: Upgrade test constraints
 

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Get PR details
         # extract PR number and branch name from issue_comment event
-        if: github.event_name == 'issue_comment' && inputs.pr_number != ''
+        if: github.event_name == 'issue_comment'
         run: |
           PR_number=${{ github.event.issue.number }}
           PR_data=$(curl \

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -1,7 +1,7 @@
 # This is a workflow for upgrading test constraints. It is triggered by:
 # - On-demand workflow_dispatch
 # - weekly schedule (every Monday at 8:00 UTC)
-# - issue_comment with text "@napari-bot update constraints"
+# - workflow_call from constraints_comment_trigger.yml (comment text "@napari-bot update constraints")
 # - pull_request with changed .github/workflows/upgrade_test_constraints.yml
 #
 # The GitHub workflows have the following limitations:
@@ -10,7 +10,7 @@
 # - If a workflow is triggered by pull_requests from forked repository,
 #   then it does not have access to secrets.
 #   So it is not possible to create PR from forked repository.
-# - If workflow is triggered by issue comment, then it is triggered on the main branch
+# - If workflow is triggered by comment, then it is triggered on the main branch
 #   and not on the branch where the comment was created.
 # - In workflow triggers it is only possible to depend on created event, without any conditions.
 #   So it is not possible to trigger workflow only when the comment contains specific text.
@@ -35,7 +35,7 @@
 #     Changes will not be pushed to `napari/napari` repository.
 #     If pull_request triggers workflow, then this will contain PR branch.
 #     Changes will be only accessible as artifacts.
-# - If workflow is triggered by issue comment,
+# - If workflow is triggered by comment,
 #   then we add eyes reaction to the comment to show that workflow has started.
 #   After finishing calculation of new constraints, we add rocket reaction to the comment.
 #   Then pushing changes to `napari-bot/napari` repository and adding comment to the PR is
@@ -48,8 +48,12 @@ on:
     # Runs every Monday at 8:00 UTC (4:00 Eastern)
     - cron: '0 8 * * 1'
 
-  issue_comment:
-    types: [ created ]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: Pull request number that triggered the comment workflow.
+        required: false
+        type: string
 
   pull_request:
     paths:
@@ -61,26 +65,13 @@ jobs:
       pull-requests: write
       issues: write
     name: Upgrade & Open Pull Request
-    if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')) || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Add eyes reaction
-        # show that workflow has started
-        if: github.event_name == 'issue_comment'
-        run: |
-          COMMENT_ID=${{ github.event.comment.id }}
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
-            -d '{"content": "eyes"}'
-
       - name: Get PR details
         # extract PR number and branch name from issue_comment event
-        if: github.event_name == 'issue_comment'
+        if: github.event_name == 'workflow_call' && inputs.pr_number != ''
         run: |
-          PR_number=${{ github.event.issue.number }}
+          PR_number=${{ inputs.pr_number }}
           PR_data=$(curl \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_number" \
@@ -97,7 +88,7 @@ jobs:
 
       - name: Get repo info
         # when schedule or workflow_dispatch triggers workflow, then we need to get info about which branch to use
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
+        if: github.event_name != 'workflow_call' && github.event_name != 'pull_request'
         run: |
           echo "FULL_NAME=${{ github.repository }}" >> "$GITHUB_ENV"
           echo "BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
@@ -108,7 +99,7 @@ jobs:
 
       - name: Clone target repo (remote)
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: github.event_name == 'issue_comment'
+        if: github.event_name == 'workflow_call'
         with:
           path: napari_repo  # place in a named directory
           repository: ${{ env.FULL_NAME }}
@@ -124,7 +115,7 @@ jobs:
 
       - name: Clone target repo (main)
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
+        if: github.event_name != 'workflow_call' && github.event_name != 'pull_request'
         with:
           path: napari_repo  # place in a named directory
           repository: ${{ env.FULL_NAME }}
@@ -137,20 +128,15 @@ jobs:
           git remote -v
           git remote add napari-bot https://github.com/napari-bot/napari.git
           git remote -v
-
-      # START PYTHON DEPENDENCIES
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      - name: Set up Python 3.12
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: 'pyproject.toml'
 
       - name: Upgrade Python dependencies
         # ADD YOUR CUSTOM DEPENDENCY UPGRADE COMMANDS BELOW
         run: |
           set -x
-          pip install -U uv
-
           bash napari_repo/tools/compile_constraints.sh
 
       # END PYTHON DEPENDENCIES
@@ -168,23 +154,10 @@ jobs:
         env:
           UV_CONSTRAINT: napari_repo/resources/constraints/constraints_py3.12.txt
 
-      - name: Add rocket reaction
-        # inform that new constraints are available in artifacts
-        if: github.event_name == 'issue_comment'
-        run: |
-          COMMENT_ID=${{ github.event.comment.id }}
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions" \
-            -d '{"content": "rocket"}'
-
       - name: Create commit
         run: |
-          pip install requests
-          python tools/create_pr_or_update_existing_one.py
+          uv run tools/create_pr_or_update_existing_one.py
         env:
             GHA_TOKEN_MAIN_REPO: ${{ secrets.GHA_TOKEN_NAPARI_BOT_MAIN_REPO }}
-            PR_NUMBER: ${{ github.event.issue.number }}
+            PR_NUMBER: ${{ inputs.pr_number }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "requests>=2.32.5",
+# ]
+# ///
 """
 This file contains the code to create a PR or update an existing one based on the state of the current branch.
 """
@@ -348,7 +354,7 @@ def main():
     if event_name in {'schedule', 'workflow_dispatch'}:
         logging.info('Creating PR')
         create_pr_with_push(branch_name, access_token)
-    elif event_name == 'issue_comment':
+    elif event_name in {'issue_comment', 'workflow_call'}:
         logging.info('Updating PR')
         update_pr(branch_name)
     elif event_name == 'pull_request':


### PR DESCRIPTION
# References and relevant issues
similar to #8525

# Description

Same as in #8525. Move the comment trigger to a separate workflow to improve log readability

<img width="925" height="767" alt="obraz" src="https://github.com/user-attachments/assets/9e5fc1f6-4f61-44f2-b458-16dd50667267" />


