### PR TITLE
Fix running benchmarks by label by fix condition

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -106,7 +106,7 @@ jobs:
           # ID this runner
           asv machine --yes
 
-          if [[ $GITHUB_EVENT_NAME == workflow_call ]]; then
+          if [[ $GITHUB_EVENT_NAME == pull_request ]]; then
             EVENT_NAME="PR #${{ github.event.pull_request.number }}"
             BASE_REF=${{ github.event.pull_request.base.sha }}
             CONTENDER_REF=${GITHUB_SHA}
@@ -176,7 +176,7 @@ jobs:
           # Add the message that might be posted as a comment on the PR
           # We delegate the actual comment to `benchmarks_report.yml` due to
           # potential token permissions issues
-          if [[ $GITHUB_EVENT_NAME == workflow_call ]]; then
+          if [[ $GITHUB_EVENT_NAME == pull_request ]]; then
 
           echo "${{ github.event.pull_request.number }}" > .asv/results/pr_number
           echo \


### PR DESCRIPTION
# References and relevant issues

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call

# Description

When creating #8525 I missed 

> When a workflow is triggered with the workflow_call event, the event payload in the called workflow is the same event payload from the calling workflow.

And it was impossible to test changes before the merge, so this PR is restoring usage of the old event name. 