### PR TITLE
Proper cleanup and reuse of existing overlays

### DIFF
--- a/src/napari/_qt/_tests/test_qt_viewer.py
+++ b/src/napari/_qt/_tests/test_qt_viewer.py
@@ -803,6 +803,8 @@ def test_label_colors_matching_widget_direct(
 
 def test_axis_labels(viewer_model: ViewerModel, qt_viewer: QtViewer) -> None:
     viewer_model.dims.ndisplay = 3
+    viewer_model.axes.visible = True
+
     layer = viewer_model.add_image(np.zeros((2, 2, 2)), scale=(1, 2, 4))
 
     layer_visual = qt_viewer.layer_to_visual[layer]

--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -12,6 +12,8 @@ def test_viewer_overlays(qt_viewer):
     canvas = qt_viewer.canvas
 
     for overlay in viewer._overlays.values():
+        # vispy overlays only exist if they are visible at least once
+        overlay.visible = True
         if isinstance(overlay, CanvasOverlay):
             assert all(
                 visual.node in canvas.view.children
@@ -27,7 +29,7 @@ def test_viewer_overlays(qt_viewer):
         k: list(v) for k, v in canvas._overlay_to_visual.items()
     }
 
-    new_overlay = ScaleBarOverlay()
+    new_overlay = ScaleBarOverlay(visible=True)
     viewer._overlays['test'] = new_overlay
 
     assert new_overlay in canvas._overlay_to_visual
@@ -46,6 +48,8 @@ def test_viewer_overlays(qt_viewer):
     viewer._overlays.pop('test')
     assert new_overlay not in canvas._overlay_to_visual
     assert new_overlay_node not in canvas.view.children
+
+    viewer.welcome_screen.visible = False  # just for proper test cleanup
 
 
 def test_layer_overlays(qt_viewer):

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -872,12 +872,16 @@ class VispyCanvas:
         self._needs_overlay_position_update = True
 
     def _connect_canvas_overlay_events(self, overlay: Overlay) -> None:
-        overlay.events.position.connect(self._defer_overlay_position_update)
-        overlay.events.visible.connect(self._defer_overlay_position_update)
+        overlay.events.position.connect(self._update_overlay_canvas_positions)
+        overlay.events.visible.connect(self._update_overlay_canvas_positions)
 
     def _disconnect_canvas_overlay_events(self, overlay: Overlay) -> None:
-        overlay.events.position.disconnect(self._defer_overlay_position_update)
-        overlay.events.visible.disconnect(self._defer_overlay_position_update)
+        overlay.events.position.disconnect(
+            self._update_overlay_canvas_positions
+        )
+        overlay.events.visible.disconnect(
+            self._update_overlay_canvas_positions
+        )
 
     def _create_or_update_vispy_viewer_overlay(
         self, overlay, vispy_overlay, view
@@ -967,7 +971,7 @@ class VispyCanvas:
                 self._connect_canvas_overlay_events(overlay)
                 overlay.events.gridded.connect(self._update_viewer_overlays)
 
-        self._defer_overlay_position_update()
+        self._update_overlay_canvas_positions()
 
     def _update_layer_overlays(self, layer: Layer) -> None:
         """Update the overlay visuals for each layer in the canvas.
@@ -1031,7 +1035,7 @@ class VispyCanvas:
             else:
                 vispy_overlay.node.parent = parent
 
-        self._defer_overlay_position_update()
+        self._update_overlay_canvas_positions()
 
     def _get_ordered_visible_canvas_overlays(
         self,

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -879,6 +879,25 @@ class VispyCanvas:
         overlay.events.position.disconnect(self._defer_overlay_position_update)
         overlay.events.visible.disconnect(self._defer_overlay_position_update)
 
+    def _create_or_update_vispy_viewer_overlay(
+        self, overlay, vispy_overlay, view
+    ) -> None:
+        parent = view if isinstance(overlay, CanvasOverlay) else view.scene
+
+        if vispy_overlay is None:
+            vispy_overlay = create_vispy_overlay(
+                overlay=overlay, viewer=self.viewer, parent=parent
+            )
+            self._overlay_to_visual[overlay].append(vispy_overlay)
+
+            if isinstance(overlay, CanvasOverlay):
+                vispy_overlay.canvas_position_callback = (
+                    self._defer_overlay_position_update
+                )
+
+        else:
+            vispy_overlay.node.parent = parent
+
     def _update_viewer_overlays(self):
         """Update the viewer overlay visuals.
 
@@ -895,62 +914,51 @@ class VispyCanvas:
             for vispy_overlay in vispy_overlays:
                 vispy_overlay.close()
 
+        # go through all overlays and ensure there are the exact amount of
+        # corresponding visuals depending on number of views to display
         for overlay in self.viewer._overlays.values():
             vispy_overlays = self._overlay_to_visual.setdefault(overlay, [])
+
+            gridded = (
+                self.viewer.grid.enabled
+                and getattr(overlay, 'gridded', False)
+                and self.viewer.layers
+            )
+
+            # delete redundant vispy overlays (always keep 1)
+            n_views_to_populate = (
+                len(self.viewer.layers) // abs(self.viewer.grid.stride) or 1
+                if gridded
+                else 1
+            )
+            while len(vispy_overlays) > n_views_to_populate:
+                vispy_overlays.pop().close()
+
+            # create, or update parent if existing
+            if gridded:
+                for ((row, col), layer_indices), vispy_overlay in zip_longest(
+                    self.viewer.grid.iter_viewboxes(len(self.viewer.layers)),
+                    list(vispy_overlays),
+                ):
+                    if not layer_indices:
+                        # no overlays should be displayed in empty viewboxes
+                        continue
+
+                    view = self.grid[row, col]
+                    self._create_or_update_vispy_viewer_overlay(
+                        overlay, vispy_overlay, view
+                    )
+            else:
+                view = self.view
+                vispy_overlay = vispy_overlays[0] if vispy_overlays else None
+                self._create_or_update_vispy_viewer_overlay(
+                    overlay, vispy_overlay, view
+                )
 
             # connect position callbacks
             if isinstance(overlay, CanvasOverlay):
                 self._connect_canvas_overlay_events(overlay)
                 overlay.events.gridded.connect(self._update_viewer_overlays)
-
-            # this loop works for both gridded mode and nongridded, since grid.iter_viewboxes returns
-            # a single viewbox when the grid is disabled
-            for view_info, vispy_overlay in zip_longest(
-                self.viewer.grid.iter_viewboxes(len(self.viewer.layers)),
-                list(vispy_overlays),
-            ):
-                if view_info is None:
-                    # number of views decreased (grid resized); we should delete remaining orphan overlays
-                    vispy_overlays.pop().close()
-                    continue
-
-                (row, col), layer_indices = view_info
-
-                # Never hide the last remaining overlay (allows things like
-                # welcome screen, and to see any changes to overlays when the viewer is empty)
-                if len(vispy_overlays) > 1 and not layer_indices:
-                    if vispy_overlay is not None:
-                        # number of occupied views decreased (no grid resizing happened, just
-                        # some layers got deleted)
-                        # works "backwards" with pop() but it's ok cause we can't have empty views
-                        # followed by occupied ones.
-                        vispy_overlays.pop().close()
-                    # either way no new overlay should be created or there's not overlay to reparent
-                    continue
-
-                view = (
-                    self.grid[row, col]
-                    if self.viewer.grid.enabled
-                    else self.view
-                )
-
-                parent = (
-                    view if isinstance(overlay, CanvasOverlay) else view.scene
-                )
-
-                if vispy_overlay is None:
-                    vispy_overlay = create_vispy_overlay(
-                        overlay=overlay, viewer=self.viewer, parent=parent
-                    )
-                    vispy_overlays.append(vispy_overlay)
-
-                    if isinstance(overlay, CanvasOverlay):
-                        vispy_overlay.canvas_position_callback = (
-                            self._defer_overlay_position_update
-                        )
-
-                else:
-                    vispy_overlay.node.parent = parent
 
         self._defer_overlay_position_update()
 
@@ -1040,7 +1048,11 @@ class VispyCanvas:
             )
 
         def is_gridded(overlay):
-            return overlay.gridded and self.viewer.grid.enabled
+            return (
+                overlay.gridded
+                and self.viewer.grid.enabled
+                and self.viewer.layers
+            )
 
         # first the base view: non-gridded viewer overlays which appear
         # "on top of" the main canvas
@@ -1062,7 +1074,11 @@ class VispyCanvas:
 
             # if grid is disabled, this loop runs once and we put everything
             # in the base (None) viewbox
-            view = viewbox_idx if self.viewer.grid.enabled else None
+            view = (
+                viewbox_idx
+                if self.viewer.grid.enabled and self.viewer.layers
+                else None
+            )
 
             for overlay, vispy_overlays in self._overlay_to_visual.items():
                 if (

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -917,6 +917,13 @@ class VispyCanvas:
         # go through all overlays and ensure there are the exact amount of
         # corresponding visuals depending on number of views to display
         for overlay in self.viewer._overlays.values():
+            # only create overlays when they are visible. If not, we connect the visible
+            # event of this overlay to this method until it's finally visible
+            if not overlay.visible:
+                overlay.events.visible.connect(self._update_viewer_overlays)
+                continue
+            overlay.events.visible.disconnect(self._update_viewer_overlays)
+
             vispy_overlays = self._overlay_to_visual.setdefault(overlay, [])
 
             gridded = (

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -932,7 +932,9 @@ class VispyCanvas:
 
             gridded = (
                 self.viewer.grid.enabled
-                and getattr(overlay, 'gridded', False)
+                and getattr(
+                    overlay, 'gridded', True
+                )  # scene overlays always gridded
                 and self.viewer.layers
             )
 


### PR DESCRIPTION
# References and relevant issues
- closes #8606

# Description
I previously tried to hard to generalize between gridded and non-gridded overlays, resulting in hard-to-follow paths that ended up breaking. This should be a bit cleaner and easier to follow, and should fix the problem.

In short: some overlays were being parented to the wrong viewbox (the main view instead of a grid viewbox) because they were reported as "non-gridded" even though they were. Not all changes here are the actual solution (I think ultimately the problem was the part updating canvas positions), but they make it significantly easier to follow the flow, IMO.
