### PR TITLE
Fix scale bar padding

### DIFF
--- a/src/napari/_vispy/visuals/scale_bar.py
+++ b/src/napari/_vispy/visuals/scale_bar.py
@@ -54,7 +54,7 @@ class ScaleBar(Compound):
         # Text dimensions
         text_width, text_height = self.text.get_width_height()
         # add some extra padding between the scale bar and text
-        text_height *= 1.1
+        text_height *= 1.5
 
         # Box dimensions
         box_width = max(


### PR DESCRIPTION
# References and relevant issues
- caused by #8501

# Description
When we introduced the `line_height` text parameter in vispy 0.16, we also affected how the text height is calculated (it used to include the "spacing" below a line, but now it's just the text). This means we have to increase the padding ourselves. This looks more or less like what we had before!

before:

<img width="436" height="404" alt="image" src="https://github.com/user-attachments/assets/b0273295-5328-43d4-ba38-522a957d6cd9" />


after:

<img width="406" height="392" alt="image" src="https://github.com/user-attachments/assets/9ab29220-a2d8-49a7-a03d-2fefe89bf71c" />


Note that this was extra bad at bigger font sizes:

before:

<img width="436" height="404" alt="image" src="https://github.com/user-attachments/assets/b68ab2a0-329c-4cda-b3b9-bb267f185637" />

after:

<img width="436" height="404" alt="image" src="https://github.com/user-attachments/assets/0a72b48b-f3a3-4add-b61f-59a809d2b845" />
