### PR TITLE
Postpone QtViewer deprecation to 0.8.0

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -855,7 +855,7 @@ class Window:
         warnings.warn(
             trans._(
                 'Public access to Window.qt_viewer is deprecated and will be removed in\n'
-                'v0.7.0. It is considered an "implementation detail" of the napari\napplication, '
+                'v0.8.0. It is considered an "implementation detail" of the napari\napplication, '
                 'not part of the napari viewer model. If your use case\n'
                 'requires access to qt_viewer, please open an issue to discuss.',
                 deferred=True,


### PR DESCRIPTION
# References and relevant issues
See #6337 and #7724

# Description
More work needs to be done to deprecate QtViewer (see #6337), so postpone it for now.


