### PR TITLE
Fix empty thumbnail

### DIFF
--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -492,10 +492,9 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
 
     def _update_thumbnail(self) -> None:
         """Update thumbnail with current image data and colormap."""
-        # don't bother updating thumbnail if we don't have any data
-        # this also avoids possible dtype mismatch issues below
-        # for example np.clip may raise an OverflowError (in numpy 2.0)
+        # black thumbnail if there is no data in the slice
         if self._slice.empty:
+            self.thumbnail = np.zeros(self._thumbnail_shape, self.dtype)
             return
 
         image = self._slice.thumbnail.raw


### PR DESCRIPTION
# References and relevant issues
- closes #8618

# Description
Instead of not updating the thumbnail (which can result in no thumbnail at all), set it to black when nothing was found in the slice.

This also fixes the fact that when async is active, the thumbnail would remain to the last non-empty slice even if you moved into empty space.
