### PR TITLE
Fix welcome screen timer

### DIFF
--- a/src/napari/components/overlays/welcome.py
+++ b/src/napari/components/overlays/welcome.py
@@ -7,7 +7,6 @@ from napari.components.overlays.base import CanvasOverlay
 class WelcomeOverlay(CanvasOverlay):
     """Welcome screen overlay."""
 
-    visible: bool = True
     # not settable in this specific overlay
     position: None = None
     gridded: Literal[False] = False


### PR DESCRIPTION
# References and relevant issues
- closes #8621

# Description
I initially changed the default for `visible` of the welcome screen to `True` to ensure it's shown on startup. But this logic is actually handled in `qt_viewer`, to allow hiding it if necessary, so we can remove it. This way the overlay won't be visible when initialized, and we won't start the timer if unnecessary.
