### PR TITLE
Reinitialize welcome screen shortcuts in a less ugly way

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -197,11 +197,10 @@ class _QtMainWindow(QMainWindow):
         # were defined somewhere in the `_qt` module and imported in init_qactions
         init_qactions()
 
-        # only after qaction are initialized we can get all shortcuts, so we have
-        # to force update the welcome screen here. TODO: UGLYYYY
-        self._qt_viewer.canvas._overlay_to_visual[
-            self._qt_viewer.viewer.welcome_screen
-        ][0].reset()
+        # only after qaction are initialized we can get all shortcuts and actions,
+        # so we have to force update the welcome screen here.
+        viewer.welcome_screen.events.shortcuts()
+        viewer.welcome_screen.events.tips()
 
         with contextlib.suppress(IndexError):
             viewer.cursor.events.position.disconnect(


### PR DESCRIPTION
# References and relevant issues
- sister PR to https://github.com/napari/napari/pull/8627

# Description
This should be a cleaner way to do the same thing, without reaching into the vispy side. I'm surprised this didn't break things for @Czaki in partseg nor in our tests in that PR, since the vispy overlay object might not exist in some cases... Anyways, this should cover those issues too.
