### PR TITLE
Add `uv.lock` and leak graphs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+uv.lock
+*leak-backref-graph*
 docs
 tmp
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
# References and relevant issues

# Description

When debugging Pydantic 2 I found that `uv.lock` and pdf produced by the leak widget check are not ignored; that might lead to commits that need to be reverted. 

https://github.com/napari/napari/blob/78e9cfbeafc9c560c6cc99e8fc315d094d6a11c9/src/napari/utils/_testsupport.py#L64-L66

So I suggest adding it to gitignore to avoid mistakes. 