### PR TITLE
Fix pint warning about deprecation of getitem

### DIFF
--- a/src/napari/utils/transforms/_units.py
+++ b/src/napari/utils/transforms/_units.py
@@ -37,7 +37,9 @@ def get_units_from_name(units: UnitsLike) -> UnitsInfo:
     """Convert a string or sequence of strings to pint units."""
     try:
         if isinstance(units, str):
-            return pint.get_application_registry()[units].units
+            return (
+                pint.get_application_registry().parse_expression(units).units
+            )
         if isinstance(units, Sequence):
             return tuple(
                 pint.get_application_registry().parse_expression(unit).units


### PR DESCRIPTION
# References and relevant issues


# Description

Resolve this warning:

```
src/napari/layers/base/_tests/test_base.py::test_assign_units
  /tmp/.tox/py313-linux-pyqt5-no_cov/lib/python3.13/site-packages/pint/registry.py:264: DeprecationWarning: Calling the getitem method from a UnitRegistry will be removed in future versions of pint.
  use `parse_expression` method or use the registry as a callable.
    return self._registry[item]
```
