### PR TITLE
Fix empty points tiny point

### DIFF
--- a/src/napari/_vispy/layers/points.py
+++ b/src/napari/_vispy/layers/points.py
@@ -199,13 +199,15 @@ class VispyPointsLayer(VispyBaseLayer):
         self.node.spherical = shading == 'spherical'
 
     def _on_canvas_size_limits_change(self):
-        self.node.points_markers.canvas_size_limits = (
-            self.layer.canvas_size_limits
-        )
+        if len(self.layer.data) == 0:
+            canvas_limits = 0, 0
+        else:
+            canvas_limits = self.layer.canvas_size_limits
+        self.node.points_markers.canvas_size_limits = canvas_limits
         highlight_thickness = (
             get_settings().appearance.highlight.highlight_thickness
         )
-        low, high = self.layer.canvas_size_limits
+        low, high = canvas_limits
         self.node.selection_markers.canvas_size_limits = (
             low + highlight_thickness,
             high + highlight_thickness,


### PR DESCRIPTION
# References and relevant issues
- bug introduced in #8501

# Description
Due to the new canvas_size_limits machinery from vispy 0.16, we now can see the normally invisible placeholder marker we use when points layers are empty. This PR fixes it by overriding the limits when the layer is empty.


Before (note the tiny white spec at the top left):

<img width="626" height="352" alt="image" src="https://github.com/user-attachments/assets/8a8e7299-701a-4961-b3e2-a8f1b11c00a5" />



After:


<img width="626" height="352" alt="image" src="https://github.com/user-attachments/assets/e05f4ccc-198b-4ff2-8e17-3561033a60d6" />
