### PR TITLE
Fix labels of angle order of camera widget

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -213,18 +213,18 @@ def test_ndisplay_button_popup(qt_viewer_buttons, qtbot):
     assert viewer.camera.zoom == viewer_buttons.zoom.value() == 5
 
     # check viewer camera rotation value affects camera angles
-    assert viewer_buttons.rx
+    assert viewer_buttons.rz
     assert viewer_buttons.ry
     assert viewer_buttons.rz
-    viewer_buttons.rx.setValue(90)
+    viewer_buttons.rz.setValue(90)
     viewer_buttons.ry.setValue(45)
-    viewer_buttons.rz.setValue(0)
+    viewer_buttons.rx.setValue(0)
     assert (
         viewer.camera.angles
         == (
-            viewer_buttons.rx.value(),
-            viewer_buttons.ry.value(),
             viewer_buttons.rz.value(),
+            viewer_buttons.ry.value(),
+            viewer_buttons.rx.value(),
         )
         == (90, 45, 0)
     )
@@ -249,15 +249,15 @@ def test_ndisplay_button_popup(qt_viewer_buttons, qtbot):
     )
     assert viewer_buttons.zoom
     assert viewer.camera.zoom == viewer_buttons.zoom.value() == 2
-    assert viewer_buttons.rx
-    assert viewer_buttons.ry
     assert viewer_buttons.rz
+    assert viewer_buttons.ry
+    assert viewer_buttons.rx
     assert (
         viewer.camera.angles
         == (
-            viewer_buttons.rx.value(),
-            viewer_buttons.ry.value(),
             viewer_buttons.rz.value(),
+            viewer_buttons.ry.value(),
+            viewer_buttons.rx.value(),
         )
         == (0, 0, 90)
     )

--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -215,7 +215,7 @@ def test_ndisplay_button_popup(qt_viewer_buttons, qtbot):
     # check viewer camera rotation value affects camera angles
     assert viewer_buttons.rz
     assert viewer_buttons.ry
-    assert viewer_buttons.rz
+    assert viewer_buttons.rx
     viewer_buttons.rz.setValue(90)
     viewer_buttons.ry.setValue(45)
     viewer_buttons.rx.setValue(0)

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -285,13 +285,15 @@ class QtViewerButtons(QFrame):
             text='Controls perspective projection strength. 0 is orthographic, larger values increase perspective effect.',
         )
 
-        self.rx = labeled_double_slider(
+        self.rz = labeled_double_slider(
             parent=popup,
             value=self.viewer.camera.angles[0],
             value_range=(-180, 180),
             callback=partial(self._update_camera_angles, 0),
         )
 
+        # value_range is [-89, 89] because at >=+/-90 gimbal locks the camera.
+        # this is a known complication of calculation with Euler angles
         self.ry = labeled_double_slider(
             parent=popup,
             value=self.viewer.camera.angles[1],
@@ -299,7 +301,7 @@ class QtViewerButtons(QFrame):
             callback=partial(self._update_camera_angles, 1),
         )
 
-        self.rz = labeled_double_slider(
+        self.rx = labeled_double_slider(
             parent=popup,
             value=self.viewer.camera.angles[2],
             value_range=(-180, 180),
@@ -315,15 +317,15 @@ class QtViewerButtons(QFrame):
         grid_layout.addWidget(self.perspective, 2, 1)
         grid_layout.addWidget(perspective_help_symbol, 2, 2)
 
-        grid_layout.addWidget(QLabel(trans._('Angles    X:')), 3, 0)
-        grid_layout.addWidget(self.rx, 3, 1)
+        grid_layout.addWidget(QLabel(trans._('Angles    Z:')), 3, 0)
+        grid_layout.addWidget(self.rz, 3, 1)
         grid_layout.addWidget(angle_help_symbol, 3, 2)
 
-        grid_layout.addWidget(QLabel(trans._('             Y:')), 4, 0)
+        grid_layout.addWidget(QLabel(trans._('               Y:')), 4, 0)
         grid_layout.addWidget(self.ry, 4, 1)
 
-        grid_layout.addWidget(QLabel(trans._('             Z:')), 5, 0)
-        grid_layout.addWidget(self.rz, 5, 1)
+        grid_layout.addWidget(QLabel(trans._('               X:')), 5, 0)
+        grid_layout.addWidget(self.rx, 5, 1)
 
     def _add_shared_camera_controls(
         self,
@@ -488,7 +490,7 @@ class QtViewerButtons(QFrame):
         Parameters
         ----------
         idx : int
-            Index of the angle to update. In the order of (rx, ry, rz).
+            Index of the angle to update. In the euler order of (rz, ry, rx).
         value : float
             New angle value.
         """


### PR DESCRIPTION
# References and relevant issues

Closes #8643 

# Description

In #7626 I incorrectly thought the Euler ordered was XYZ, but now know that it is ZYX after all our recent discussions like in #8281 

