### PR TITLE
Add a opaque background Rectangle to Welcome overlay

### DIFF
--- a/src/napari/_tests/test_with_screenshot.py
+++ b/src/napari/_tests/test_with_screenshot.py
@@ -408,6 +408,25 @@ def test_welcome(make_napari_viewer):
 
 @skip_on_win_ci
 @skip_local_popups
+def test_welcome_overlay_covers_other_overlays(make_napari_viewer):
+    """Test that Welcome overlay covers scale_bar and axes when no layers.
+
+    Regression test for https://github.com/napari/napari/issues/8642
+    """
+    viewer = make_napari_viewer(show=True, show_welcome_screen=True)
+    launch_screenshot = viewer.screenshot(canvas_only=True, flash=False)
+
+    viewer.scale_bar.visible = True
+    viewer.axes.visible = True
+
+    screenshot_with_overlays = viewer.screenshot(canvas_only=True, flash=False)
+
+    np.testing.assert_array_equal(launch_screenshot, screenshot_with_overlays)
+    viewer.welcome_screen.visible = False  # to stop timer
+
+
+@skip_on_win_ci
+@skip_local_popups
 def test_axes_visible(make_napari_viewer):
     """Test that something appears when axes become visible."""
     viewer = make_napari_viewer(show=True)

--- a/src/napari/_vispy/overlays/welcome.py
+++ b/src/napari/_vispy/overlays/welcome.py
@@ -53,10 +53,14 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         else:
             background_color = get_theme(self.viewer.theme).canvas.as_hex()
             background_color = transform_color(background_color)[0]
+
+        # ensure background is opaque
+        background_color[-1] = 1.0
+
         color = np.subtract(1, background_color)
         color[-1] = background_color[-1]
         color *= 0.8  # dim a bit
-        self.node.set_color(color)
+        self.node.set_color(color, background_color)
 
     def _on_visible_change(self) -> None:
         show = self.overlay.visible and not self.viewer.layers

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from vispy.scene.node import Node
-from vispy.scene.visuals import Polygon
+from vispy.scene.visuals import Polygon, Rectangle
 from vispy.util.svg import Document
 from vispy.visuals.transforms import STTransform
 
@@ -46,6 +46,7 @@ class Welcome(Node):
         self.logo_coords[:, 1] -= 130  # magic number shifting up logo
         super().__init__()
 
+        self.bg = Rectangle(center=[0, 0], parent=self, border_width=0)
         self.logo = Polygon(
             self.logo_coords, border_method='agg', border_width=2, parent=self
         )
@@ -87,7 +88,8 @@ class Welcome(Node):
 
         self.transform = STTransform()
 
-    def set_color(self, color: ColorValue) -> None:
+    def set_color(self, color: ColorValue, bg_color: ColorValue) -> None:
+        self.bg.color = bg_color
         self.logo.color = color
         self.logo.border_color = color
         self.header.color = color
@@ -160,6 +162,9 @@ class Welcome(Node):
         self.transform.translate = (x / 2, y / 2, 0, 0)
         scale = min(x, y) * 0.002  # magic number
         self.transform.scale = (scale, scale, 0, 0)
+
+        self.bg.width = x / scale
+        self.bg.height = y / scale
 
         for text in (
             self.header,

--- a/src/napari/components/overlays/welcome.py
+++ b/src/napari/components/overlays/welcome.py
@@ -9,6 +9,8 @@ class WelcomeOverlay(CanvasOverlay):
 
     # not settable in this specific overlay
     position: None = None
+    # ensure it's on top of overlays with default value
+    order: int = 10**6 + 1
     gridded: Literal[False] = False
     version: str = __version__
     shortcuts: tuple[str, ...] = (


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8642

# Description
This PR restores the behavior with the old widget welcome screen, where it was over the top of any overlays.
I thought order alone would work, but it didn't.
I tried setting the overlay opacity and blending, but it didn't work.
Adding a Rectangle did though.

Added a regression test and tested locally to ensure it works as expected.