### PR TITLE
Bump napari plugin manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ optional-base = [
     "zarr>=2.12.0", # needed by `builtins` (dask.array.from_zarr) to open zarr
     "aiohttp", # needed to open remote files by zarr, replace by extras once https://github.com/zarr-developers/zarr-python/issues/3453 is done
     "napari-metadata>=0.1.0",
-    "napari-plugin-manager >=0.1.9, <0.2.0",
+    "napari-plugin-manager >=0.1.10, <0.2.0",
 ]
 optional-numba = [
     "numba>=0.57.1,<=0.62.1 ; platform_system == 'Darwin' and platform_machine == 'x86_64'",

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -197,7 +197,7 @@ napari-metadata==0.1.1
     # via napari (pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (pyproject.toml)
-napari-plugin-manager==0.1.9
+napari-plugin-manager==0.1.10
     # via napari (pyproject.toml)
 napari-svg==0.2.1
     # via napari (pyproject.toml)

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -190,7 +190,7 @@ napari-metadata==0.1.1
     # via napari (pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (pyproject.toml)
-napari-plugin-manager==0.1.9
+napari-plugin-manager==0.1.10
     # via napari (pyproject.toml)
 napari-svg==0.2.1
     # via napari (pyproject.toml)

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -188,7 +188,7 @@ napari-metadata==0.1.1
     # via napari (pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (pyproject.toml)
-napari-plugin-manager==0.1.9
+napari-plugin-manager==0.1.10
     # via napari (pyproject.toml)
 napari-svg==0.2.1
     # via napari (pyproject.toml)

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -372,7 +372,7 @@ napari-metadata==0.1.1
     # via napari (pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (pyproject.toml)
-napari-plugin-manager==0.1.9
+napari-plugin-manager==0.1.10
     # via
     #   napari (pyproject.toml)
     #   ndevio

--- a/resources/constraints/constraints_py3.12_examples.txt
+++ b/resources/constraints/constraints_py3.12_examples.txt
@@ -225,7 +225,7 @@ napari-metadata==0.1.1
     # via napari (pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (pyproject.toml)
-napari-plugin-manager==0.1.9
+napari-plugin-manager==0.1.10
     # via napari (pyproject.toml)
 napari-svg==0.2.1
     # via napari (pyproject.toml)

--- a/resources/constraints/constraints_py3.13.txt
+++ b/resources/constraints/constraints_py3.13.txt
@@ -188,7 +188,7 @@ napari-metadata==0.1.1
     # via napari (pyproject.toml)
 napari-plugin-engine==0.2.0
     # via napari (pyproject.toml)
-napari-plugin-manager==0.1.9
+napari-plugin-manager==0.1.10
     # via napari (pyproject.toml)
 napari-svg==0.2.1
     # via napari (pyproject.toml)


### PR DESCRIPTION
# References and relevant issues
Required by https://github.com/napari/napari/issues/8447

# Description
Bump the napari-plugin-manager version to 0.1.10 which is required by napari 0.7.0 (removal of plugin_manager)
