### PR TITLE
Do not start welcome widget timer until QtViewer is visible

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -257,7 +257,7 @@ class QtViewer(QSplitter):
             self._add_layer(layer)
 
         # set up welcome screen
-        viewer.welcome_screen.visible = show_welcome_screen
+        viewer.welcome_screen.visible = False
         if tips is not None:
             viewer.welcome_screen.tips = tips
 


### PR DESCRIPTION
# References and relevant issues

Folloup for #8627

# Description

As setting `welcome_screen.visible = True` starts timer even if window is not visible. As we already set it to a proper value, then it still should be set to false 

https://github.com/napari/napari/blob/547724952a6f91328dbda88cc030ef4e3d3aee5c/src/napari/_qt/qt_viewer.py#L264-L266


Motivation are failing test in PartSeg:

```
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/PartSeg/common_gui/main_window.py:230: in napari_viewer_show
      viewer = Viewer(
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/PartSeg/common_gui/napari_viewer_wrap.py:221: in __init__
      super().__init__(**kwargs)
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/viewer.py:68: in __init__
      self._window = Window(
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/_qt/qt_main_window.py:714: in __init__
      self._qt_window = _QtMainWindow(
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/_qt/qt_main_window.py:136: in __init__
      self._qt_viewer = QtViewer(
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/_qt/qt_viewer.py:260: in __init__
      viewer.welcome_screen.visible = show_welcome_screen
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/utils/events/evented_model.py:259: in __setattr__
      with ComparisonDelayer(self):
           ^^^^^^^^^^^^^^^^^^^^^^^
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/utils/events/evented_model.py:472: in __exit__
      self._target._check_if_values_changed_and_emit_if_needed()
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/utils/events/evented_model.py:297: in _check_if_values_changed_and_emit_if_needed
      getattr(self.events, name)(value=new_value)
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/utils/events/event.py:752: in __call__
      self._invoke_callback(cb, event if pass_event else None)
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/utils/events/event.py:790: in _invoke_callback
      _handle_exception(
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/utils/events/event.py:779: in _invoke_callback
      cb()
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/napari/_vispy/overlays/welcome.py:65: in _on_visible_change
      self.tip_timer.start()
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/vispy/app/timer.py:118: in start
      self._backend._vispy_start(self.interval)
  /tmp/tox/py313-PyQt6-napari_repo/lib/python3.13/site-packages/vispy/app/backends/_qt.py:1034: in _vispy_start
      self.start(int(interval * 1000))
```