### PR TITLE
Allow selection in feature table widget with empty features

### DIFF
--- a/src/napari_builtins/_qt/features_table.py
+++ b/src/napari_builtins/_qt/features_table.py
@@ -1006,8 +1006,6 @@ class FeaturesTable(QWidget):
             return
 
         df = self.table.model().sourceModel().df
-        if df.empty:
-            return
 
         # Handle single layer case (no 'Layer' column)
         if len(self._selected_layers) == 1:


### PR DESCRIPTION
# References and relevant issues
- https://github.com/napari/napari/pull/8189

# Description
I noticed that after https://github.com/napari/napari/pull/8189 it was no longer possible to select points by clicking on their row in the features table widget, when there are no feature column present. While this is probably unlikely to be needed, it's a bit confusing for it not to work when AFAICT there is no reason to special case it. I removed the guard, and everything seems to work fine :P
