### PR TITLE
Fix event triggering start of welcome screen

### DIFF
--- a/src/napari/_vispy/overlays/welcome.py
+++ b/src/napari/_vispy/overlays/welcome.py
@@ -28,7 +28,8 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             node=Welcome(), viewer=viewer, overlay=overlay, parent=parent
         )
         self.viewer.events.theme.connect(self._on_theme_change)
-        self.viewer.layers.events.connect(self._on_visible_change)
+        self.viewer.layers.events.inserted.connect(self._on_visible_change)
+        self.viewer.layers.events.removed.connect(self._on_visible_change)
 
         self.overlay.events.version.connect(self._on_version_change)
         self.overlay.events.shortcuts.connect(self._on_shortcuts_change)


### PR DESCRIPTION
# References and relevant issues

Follow-up #8652

# Description

Connect only to `inserted` and `deleted` events of layerlist.  
Previous ones are also triggered by the `inserting` event. When such an event is triggered when adding the first layer, the check for layerlist is returning that it's empty, and trigger start of timer.  