### PR TITLE
Add a viewer button for the command palette

### DIFF
--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -34,6 +34,10 @@ QtViewerPushButton[mode="console"] {
   image: url("theme_{{ id }}:/console.svg");
 }
 
+QtViewerPushButton[mode="command_palette"] {
+  image: url("theme_{{ id }}:/zoom.svg");
+}
+
 QtViewerPushButton[mode="roll"] {
   image: url("theme_{{ id }}:/roll.svg");
 }

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -154,6 +154,8 @@ class QtViewerButtons(QFrame):
     ----------
     consoleButton : QtViewerPushButton
         Button to open iPython console within napari.
+    commandPaletteButton : QtViewerPushButton
+        Button to toggle the command palette.
     rollDimsButton : QtViewerPushButton
         Button to roll orientation of spatial dimensions in the napari viewer.
     transposeDimsButton : QtViewerPushButton
@@ -179,6 +181,12 @@ class QtViewerButtons(QFrame):
         self.consoleButton.setProperty('expanded', False)
         if in_ipython() or in_jupyter() or in_python_repl():
             self.consoleButton.setEnabled(False)
+
+        self.commandPaletteButton = QtViewerPushButton(
+            'command_palette',
+            trans._('Command Palette'),
+            action='napari:toggle_command_palette',
+        )
 
         rdb = QtViewerPushButton('roll', action='napari:roll_axes')
         self.rollDimsButton = rdb
@@ -226,6 +234,7 @@ class QtViewerButtons(QFrame):
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.consoleButton)
+        layout.addWidget(self.commandPaletteButton)
         layout.addWidget(self.ndisplayButton)
         layout.addWidget(self.rollDimsButton)
         layout.addWidget(self.transposeDimsButton)

--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -222,6 +222,11 @@ def toggle_console_visibility(viewer: Viewer):
     viewer.window._qt_viewer.toggle_console_visibility()
 
 
+@register_viewer_action(trans._('Toggle command palette'))
+def toggle_command_palette(viewer: Viewer):
+    viewer.window._toggle_command_palette()
+
+
 @register_viewer_action(trans._('Press and hold for move camera mode'))
 def hold_for_pan_zoom(viewer: ViewerModel):
     selected_layer = viewer.layers.selection.active


### PR DESCRIPTION
# References and relevant issues

I think that the command palette should be more discoverable and is a key feature of napari (IMO), so this is a proposal for discussion about adding it to the viewer buttons row.

# Description

This adds a button to toggle the command palette to the lower left viewer buttons, using the pan/zoom icon because it looks like a "search" button. Note: I think this is important to consider what icon we use, because by residing in this row it implifies it could effect the canvas, which... does allow panning and zooming. 

I opted to add this next to the console button because the other alternative felt like being next to home button was the wrong implication.

<img width="618" height="911" alt="image" src="https://github.com/user-attachments/assets/1b6cc7d9-cae8-427c-a4f1-f543127257df" />


This was just a quick PR while I've been messing about in the button world and it came to me as a shower thought, basically. 
I can think of a few issues with it including:
1. it's in the lower left while the command palette launches from the top middle
2. it maximizes the amount of buttons we can put in the viewer row without breaching our current minimum width
3. it needs a really thoughtful icon for this to not be confusing