### PR TITLE
Upload triangulation artifacts if benchmarks fails

### DIFF
--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -261,3 +261,10 @@ jobs:
         env:
           PR: 1  # prevents asv from running very compute-intensive benchmarks
           PIP_CONSTRAINT: ${{ github.workspace }}/resources/constraints/benchmark.txt
+
+      - name: Upload triangulation artifacts
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: triangulation-benchmarks
+          path: /tmp/napari*


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/8509#issuecomment-3889661451

# Description

We recently observed failing benchmarks using `bermuda` backend. To be able to reproduce an error and debug it, there is a need to get source data. 

This PR gives this. 