### PR TITLE
Maint: Have triangle only on py313 and lower

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ optional-numba = [
 ]
 optional = [
     "napari[optional-base,optional-numba,bermuda]",
-    "triangle",
+    "triangle; python_version <= '3.13'",
 ]
 bermuda = [
     "bermuda>=0.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ optional-numba = [
 ]
 optional = [
     "napari[optional-base,optional-numba,bermuda]",
-    "triangle; python_version <= '3.13'",  # there is no wheel for triangle on python 3.14 at the time and build from source causes problems. 
+    "triangle; python_version <= '3.13'",  # there is no wheel for triangle on python 3.14 at the time and build from source causes problems.
 ]
 bermuda = [
     "bermuda>=0.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ optional-numba = [
 ]
 optional = [
     "napari[optional-base,optional-numba,bermuda]",
-    "triangle; python_version <= '3.13'",
+    "triangle; python_version <= '3.13'",  # there is no wheel for triangle on python 3.14 at the time and build from source causes problems. 
 ]
 bermuda = [
     "bermuda>=0.1.5",

--- a/resources/constraints/constraints_py3.14.txt
+++ b/resources/constraints/constraints_py3.14.txt
@@ -225,7 +225,6 @@ numpy==2.3.5
     #   scipy
     #   tensorstore
     #   tifffile
-    #   triangle
     #   vispy
     #   xarray
     #   zarr
@@ -536,8 +535,6 @@ traitlets==5.14.3
     #   jupyter-core
     #   matplotlib-inline
     #   qtconsole
-triangle==20200424
-    # via napari (pyproject.toml)
 triton==3.6.0
     # via torch
 typer==0.21.1


### PR DESCRIPTION
# References and relevant issues
https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E7.2E0/near/573597447

# Description
Minimal change to un-block `napari[all]` on py314.
triangle doesn't have wheels for 314.
Everything but 314 should work as currently.

Note: not having triangle (or any of the other backends) doesn't break anything, with regards to the Preference or actual Shapes. Things fall back.
