### PR TITLE
Limit `self.events` callbacks trigger to only once per assignment

### DIFF
--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install setuptools tox!=4.42 tox-gh-actions tox-min-req tox-uv
+          pip install setuptools tox tox-gh-actions tox-min-req tox-uv
         env:
           PIP_CONSTRAINT: ""
 

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install setuptools tox tox-gh-actions tox-min-req tox-uv
+          pip install setuptools tox!=4.42 tox-gh-actions tox-min-req tox-uv
         env:
           PIP_CONSTRAINT: ""
 

--- a/src/napari/utils/events/_tests/test_evented_model.py
+++ b/src/napari/utils/events/_tests/test_evented_model.py
@@ -789,7 +789,7 @@ def test_events_called_once(field):
     setattr(s, field, 4)
     a_m.assert_called_once()
     b_m.assert_called_once()
-    # prior #8672 th self.events will be called twice
+    # prior to #8672 the self.events will be called twice
     e_m.assert_called_once()
     assert e_m.call_args.args[0].value == 4
     assert e_m.call_args.args[0].type == field

--- a/src/napari/utils/events/_tests/test_evented_model.py
+++ b/src/napari/utils/events/_tests/test_evented_model.py
@@ -762,3 +762,26 @@ def test_single_emit():
     c_m.assert_called_once()
     d_m.assert_called_once()
     e_m.assert_called_once()
+
+
+def test_events_called_once():
+    class SampleClass(EventedModel):
+        a: int
+
+        @property
+        def b(self):
+            return self.a * 2
+
+    s = SampleClass(a=1)
+    a_m = Mock()
+    b_m = Mock()
+    e_m = Mock()
+
+    s.events.a.connect(a_m)
+    s.events.b.connect(b_m)
+    s.events.connect(e_m)
+
+    s.a = 2
+    a_m.assert_called_once()
+    b_m.assert_called_once()
+    e_m.assert_called_once()

--- a/src/napari/utils/events/_tests/test_evented_model.py
+++ b/src/napari/utils/events/_tests/test_evented_model.py
@@ -785,3 +785,17 @@ def test_events_called_once():
     a_m.assert_called_once()
     b_m.assert_called_once()
     e_m.assert_called_once()
+
+
+def test_events_called():
+    class SampleClass(EventedModel):
+        a: int
+
+    s = SampleClass(a=1)
+
+    e_m = Mock()
+    s.events.connect(e_m)
+
+    s.a = 2
+
+    e_m.assert_called_once()

--- a/src/napari/utils/events/event.py
+++ b/src/napari/utils/events/event.py
@@ -951,11 +951,13 @@ class EmitterGroup(EventEmitter):
         self,
         source: Any = None,
         auto_connect: bool = False,
+        _connect_children: bool = True,
         **emitters: type[Event] | EventEmitter | None,
     ) -> None:
         EventEmitter.__init__(self, source)
 
         self.auto_connect = auto_connect
+        self._connect_children = _connect_children
         self.auto_connect_format = 'on_%s'
         self._emitters: dict[str, EventEmitter] = {}
         # whether the sub-emitters have been connected to the group:
@@ -1105,7 +1107,8 @@ class EmitterGroup(EventEmitter):
         See :func:`EventEmitter.connect() <vispy.event.EventEmitter.connect>`
         for arguments.
         """
-        self._connect_emitters(True)
+        if self._connect_children:
+            self._connect_emitters(True)
         return EventEmitter.connect(
             self, callback, ref, position, before, after
         )

--- a/src/napari/utils/events/evented_model.py
+++ b/src/napari/utils/events/evented_model.py
@@ -175,7 +175,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     """
 
     # add private attributes for event emission
-    _events: EmitterGroup = PrivateAttr(default_factory=EmitterGroup)
+    _events: EmitterGroup = PrivateAttr(
+        default_factory=lambda: EmitterGroup(_connect_children=False)
+    )
 
     # mapping of name -> property obj for methods that are properties
     __properties__: ClassVar[dict[str, property]]
@@ -302,6 +304,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             # Again delay comparison to avoid having events caused by callback functions
             for name, new_value in to_emit:
                 getattr(self.events, name)(value=new_value)
+
+            if len(self.events.callbacks):
+                self.events(type_name=to_emit[0])
 
     def _setattr_impl(self, name: str, value: Any) -> None:
         if name not in getattr(self, 'events', {}):

--- a/src/napari/utils/events/evented_model.py
+++ b/src/napari/utils/events/evented_model.py
@@ -306,6 +306,10 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
                 getattr(self.events, name)(value=new_value)
 
             if len(self.events.callbacks):
+                # If there are callbacks connected to the obj.events itself,
+                # To mimic previous behavior for an object without
+                # dependent properties, we set type to the first changed field
+                # and value to the new value of that field.
                 self.events(type_name=to_emit[0][0], value=to_emit[0][1])
 
     def _setattr_impl(self, name: str, value: Any) -> None:

--- a/src/napari/utils/events/evented_model.py
+++ b/src/napari/utils/events/evented_model.py
@@ -306,7 +306,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
                 getattr(self.events, name)(value=new_value)
 
             if len(self.events.callbacks):
-                self.events(type_name=to_emit[0])
+                self.events(type_name=to_emit[0][0], value=to_emit[0][1])
 
     def _setattr_impl(self, name: str, value: Any) -> None:
         if name not in getattr(self, 'events', {}):


### PR DESCRIPTION
# References and relevant issues

Inspired by problems in #8654

# Description

Currently, if there are properties or `__field_dependents__` used, then `self.events` is triggered multiple times. 

As far as I've seen, the whole connection to `self.events` is not checking `type_name`. As if someone wants to react specifically to different event types, then connect directly to proper events.

Keeping old behavior means that any deprecation/rename will lead to performance regressions as a single event is processed multiple times.

The next benefit from this is that there will be no callback on every property, so warnings will not be triggered until the user directly accesses it 