### PR TITLE
Fix `_disconnect_child_emitters` for `PsygnalModel` dict elements

### DIFF
--- a/src/napari/utils/events/containers/_evented_dict.py
+++ b/src/napari/utils/events/containers/_evented_dict.py
@@ -111,6 +111,8 @@ class EventedDict(TypedMutableMapping[_K, _T]):
 
     def _disconnect_child_emitters(self, child: _T) -> None:
         """Disconnect all events from the child from the re-emitter."""
+        if isinstance(child, PsygnalModel):
+            child.events.disconnect(self._reemit_child_event_psygnal)
         if isinstance(child, SupportsEvents):
             child.events.disconnect(self._reemit_child_event)
 


### PR DESCRIPTION
# References and relevant issues

# Description

Fix function `EventedDict._disconnect_child_emitters` to work also for `PsygnalModel`. Follow changes in `EventedDict._connect_child_emitters` 
