### PR TITLE
[multiscale] Only update/refresh when level has changed or view is outside current corner_pixels

### DIFF
--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -2125,8 +2125,18 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             )
             if any(s == 0 for s in display_shape):
                 return
-            if self.data_level != level or not np.array_equal(
-                self.corner_pixels, corners
+            # only update when level changes or
+            # when new view is outside current corner_pixels
+            if (
+                self.data_level != level
+                or np.any(
+                    corners[0, displayed_axes]
+                    < self.corner_pixels[0, displayed_axes]
+                )
+                or np.any(
+                    corners[1, displayed_axes]
+                    > self.corner_pixels[1, displayed_axes]
+                )
             ):
                 self._data_level = level
                 self.corner_pixels = corners


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/napari/issues/8677

# Description
This ended up being a pretty small change for a huge improvement for zooming in (super common) and panning around once zoomed in.
Basically, instead of refreshing on every pan/zoom, there is a guard now to only refresh if the level has actually changed or if the view is outside the current corner_pixels (the loaded data).
I used Gemini to review to convince myself that this was correct, since it seems like a pretty obvious thing to do.
I used copilot for the test.