### PR TITLE
Increase minimum version of pyopengl to allow start napari

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "pygments>=2.13.0",
     "pydantic-extra-types",
     "pydantic-settings",
-    "PyOpenGL>=3.1.5",
+    "PyOpenGL>=3.1.10",
     "pywin32 ; platform_system == 'Windows'",
     "PyYAML>=6.0",
     "qtpy>=2.4.0",


### PR DESCRIPTION
# References and relevant issues

https://github.com/mcfletch/pyopengl/commit/594dc6461228fdbcdfb5ce658618f4515e1a5dfd

# Description

With #8552 new NumPy version and PyOpenGL below 3.1.10 napari fails to start 

```python
Traceback (most recent call last):
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/app/backends/_qt.py", line 1000, in paintGL
    self._vispy_canvas.events.draw(region=None)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/util/event.py", line 453, in __call__
    self._invoke_callback(cb, event)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/util/event.py", line 471, in _invoke_callback
    _handle_exception(self.ignore_callback_errors,
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/util/event.py", line 469, in _invoke_callback
    cb(event)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/scene/canvas.py", line 226, in on_draw
    self._draw_scene()
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/scene/canvas.py", line 285, in _draw_scene
    self.draw_visual(self.scene)
  File "/home/czaki/Projekty/napari/src/napari/_vispy/canvas.py", line 94, in draw_visual
    super().draw_visual(visual, event=event)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/scene/canvas.py", line 323, in draw_visual
    node.draw()
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/scene/visuals.py", line 106, in draw
    self._visual_superclass.draw(self)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/visuals/visual.py", line 668, in draw
    v.draw()
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/visuals/visual.py", line 514, in draw
    self._program.draw(self._vshare.draw_mode,
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/visuals/shaders/program.py", line 102, in draw
    Program.draw(self, *args, **kwargs)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/program.py", line 544, in draw
    canvas.context.flush_commands()
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/context.py", line 172, in flush_commands
    self.glir.flush(self.shared.parser)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/glir.py", line 584, in flush
    self._shared.flush(parser)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/glir.py", line 506, in flush
    parser.parse(self._filter(self.clear(), parser))
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/glir.py", line 824, in parse
    self._parse(command)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/glir.py", line 804, in _parse
    ob.link_program(*args)
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/glir.py", line 1127, in link_program
    self._unset_variables = self._get_active_attributes_and_uniforms()
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/glir.py", line 1153, in _get_active_attributes_and_uniforms
    name, size, gtype = func(self._handle, i)
                        ^^^^^^^^^^^^^^^^^^^^^
  File "/home/czaki/.pyenv/versions/3.12.9/envs/napari_3.12/lib/python3.12/site-packages/vispy/gloo/gl/_pyopengl2.py", line 91, in glGetActiveAttrib
    return name.decode('utf-8'), size, type
           ^^^^^^^^^^^
AttributeError: 'numpy.ndarray' object has no attribute 'decode'
``` 
