### PR TITLE
Split out implementation details into classes

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1042,14 +1042,10 @@ class VispyCanvas:
                 parent = self.layer_to_visual[layer].node
 
             if vispy_overlay is None:
-                color_manager = (
-                    None if not getattr(layer, '_face', None) else layer._face
-                )
                 vispy_overlay = create_vispy_overlay(
                     overlay=overlay,
                     layer=layer,
                     parent=parent,
-                    color_manager=color_manager,
                 )
                 overlay_to_visual[overlay] = vispy_overlay
                 if isinstance(overlay, CanvasOverlay):

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1042,8 +1042,14 @@ class VispyCanvas:
                 parent = self.layer_to_visual[layer].node
 
             if vispy_overlay is None:
+                color_manager = (
+                    None if not getattr(layer, '_face', None) else layer._face
+                )
                 vispy_overlay = create_vispy_overlay(
-                    overlay=overlay, layer=layer, parent=parent
+                    overlay=overlay,
+                    layer=layer,
+                    parent=parent,
+                    color_manager=color_manager,
                 )
                 overlay_to_visual[overlay] = vispy_overlay
                 if isinstance(overlay, CanvasOverlay):

--- a/src/napari/_vispy/overlays/colorbar.py
+++ b/src/napari/_vispy/overlays/colorbar.py
@@ -52,7 +52,9 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
             )
             self.layer.events.face_colormap.connect(self._on_colormap_change)
 
-        self.overlay.events.visible.connect(self._on_visible_change)
+        self.overlay.events.visible.connect(
+            self._check_contrast_limits_colorbar
+        )
         self.overlay.events.size.connect(self._on_size_change)
         self.overlay.events.tick_length.connect(self._on_ticks_change)
         self.overlay.events.font_size.connect(self._on_ticks_change)
@@ -62,7 +64,7 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
 
         self.reset()
 
-    def _on_visible_change(self) -> None:
+    def _check_contrast_limits_colorbar(self) -> None:
         if not (
             getattr(self.layer, 'contrast_limits', None)
             or self.layer.face_contrast_limits

--- a/src/napari/_vispy/overlays/colorbar.py
+++ b/src/napari/_vispy/overlays/colorbar.py
@@ -65,12 +65,17 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
             getattr(self.layer, 'contrast_limits', None)
             or self.layer.face_contrast_limits
         ):
+            # TODO: for initial implementation only focus on face_color of points layer and not border.
+            dtype = (
+                getattr(self.layer, 'dtype', None)
+                or self.layer.face_color.dtype
+            )
             self.node.set_data_and_clim(
                 clim=_coerce_contrast_limits(
                     getattr(self.layer, 'contrast_limits', None)
                     or self.layer.face_contrast_limits
                 ).contrast_limits,
-                dtype=self.layer.dtype,
+                dtype=dtype,
             )
             self._on_colormap_change()
             if getattr(self.layer, 'contrast_limits', None):
@@ -78,7 +83,10 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
             self._on_ticks_change()
 
     def _on_colormap_change(self) -> None:
-        self.node.set_cmap(_napari_cmap_to_vispy(self.layer.colormap))
+        colormap = (
+            getattr(self.layer, 'colormap', None) or self.layer.face_colormap
+        )
+        self.node.set_cmap(_napari_cmap_to_vispy(colormap))
 
     def _on_gamma_change(self) -> None:
         self.node.set_gamma(self.layer.gamma)

--- a/src/napari/_vispy/overlays/colorbar.py
+++ b/src/napari/_vispy/overlays/colorbar.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -51,6 +52,7 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
             )
             self.layer.events.face_colormap.connect(self._on_colormap_change)
 
+        self.overlay.events.visible.connect(self._on_visible_change)
         self.overlay.events.size.connect(self._on_size_change)
         self.overlay.events.tick_length.connect(self._on_ticks_change)
         self.overlay.events.font_size.connect(self._on_ticks_change)
@@ -59,6 +61,18 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
         get_settings().appearance.events.theme.connect(self._on_data_change)
 
         self.reset()
+
+    def _on_visible_change(self) -> None:
+        if not (
+            getattr(self.layer, 'contrast_limits', None)
+            or self.layer.face_contrast_limits
+        ):
+            warnings.warn(
+                'Colorbar overlay is set to visible but the layer has no '
+                'contrast limits set. Hiding colorbar overlay.',
+                UserWarning,
+            )
+            self.layer.colorbar.visible = False
 
     def _on_data_change(self) -> None:
         if (
@@ -81,6 +95,13 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
             if getattr(self.layer, 'contrast_limits', None):
                 self._on_gamma_change()
             self._on_ticks_change()
+        else:
+            warnings.warn(
+                'Colorbar overlay is set to visible but the layer has no '
+                'contrast limits set. Hiding colorbar overlay.',
+                UserWarning,
+            )
+            self.layer.colorbar.visible = False
 
     def _on_colormap_change(self) -> None:
         colormap = (

--- a/src/napari/components/overlays/colorbar.py
+++ b/src/napari/components/overlays/colorbar.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from napari.components._viewer_constants import CanvasPosition
 from napari.components.overlays.base import CanvasOverlay
 from napari.utils.color import ColorValue
@@ -36,3 +38,6 @@ class ColorBarOverlay(CanvasOverlay):
     tick_length: float = 5
     font_size: float = 10
     position: CanvasPosition = CanvasPosition.TOP_RIGHT
+    colormanager_attribute: str | None = Field(
+        default=None, frozen=True, repr=False
+    )

--- a/src/napari/components/overlays/colorbar.py
+++ b/src/napari/components/overlays/colorbar.py
@@ -11,11 +11,24 @@ class ColorBarOverlay(CanvasOverlay):
     position : CanvasPosition
         The position of the overlay in the canvas.
     visible : bool
-        If the overlay is visible or not.
+        If the overlay is visible or not. Inherited from Overlay.
     opacity : float
-        The opacity of the overlay. 0 is fully transparent.
+        The opacity of the overlay. 0 is fully transparent. Inherited from Overlay.
     order : int
-        The rendering order of the overlay: lower numbers get rendered first.
+        The rendering order of the overlay: lower numbers get rendered first. Inherited from Overlay.
+    color : ColorValue | None
+        The color of the outline and ticks of the colorbar.
+    size : tuple[float, float]
+        The size of the colorbar in pixels (width, height).
+    tick_length : float
+        The length of the ticks in pixels.
+    font_size : float
+        The font size of the tick labels.
+    blending : str
+        One of a list of preset blending modes that determines how RGB and
+        alpha values of the colorbar visual get mixed with other visuals. Defaults to 'translucent_no_depth'. Inherited from CanvasOverlay.
+    gridded : bool
+        The overlay will be duplicated across all grid cells in gridded mode. Inherited from CanvasOverlay.
     """
 
     color: ColorValue | None = None

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -461,6 +461,8 @@ class Points(Layer):
             border_width_is_relative=Event,
             face_color=Event,
             current_face_color=Event,
+            face_contrast_limits=Event,
+            face_colormap=Event,
             border_color=Event,
             current_border_color=Event,
             properties=Event,
@@ -549,6 +551,10 @@ class Points(Layer):
         # Trigger generation of view slice and thumbnail
         self.refresh(extent=False)
         self._slicing_state.slice_done.connect(self._refresh_highlight)
+
+        from napari.components.overlays import ColorBarOverlay
+
+        self._overlays.update({'colorbar': ColorBarOverlay()})
 
     @property
     def data(self) -> np.ndarray:
@@ -714,6 +720,11 @@ class Points(Layer):
         self._face._update_current_properties(current_properties)
         self.events.current_properties()
         self.events.feature_defaults()
+
+    @property
+    def colorbar(self):
+        """The colorbar associated with this layer's color manager."""
+        return self._overlays['colorbar']
 
     @property
     def property_choices(self) -> dict[str, np.ndarray]:

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -554,7 +554,16 @@ class Points(Layer):
 
         from napari.components.overlays import ColorBarOverlay
 
-        self._overlays.update({'colorbar': ColorBarOverlay()})
+        self._overlays.update(
+            {
+                'face_colorbar': ColorBarOverlay(
+                    colormanager_attribute='_face'
+                ),
+                'border_colorbar': ColorBarOverlay(
+                    colormanager_attribute='_border'
+                ),
+            }
+        )
 
     @property
     def data(self) -> np.ndarray:


### PR DESCRIPTION
Initial implementation of what we discussed, with some changes:

- Ultimately, I realized that we can simply create wrappers (renamed from "handlers") for the manager and the layer with a common interface. This should be even simpler than having two different methods for setting the visuals's attributes, as we instead have very basic property wrappers around the respective modes. For now I just wrote it for `contrast_limits` and `gamma`, but the same should be done for the other relevant fields.
- found a way to hide the `ColorBar.colormanager_attribute` field by passing `repr=False`