### PR TITLE
Correctly hide welcome screen when layers are present

### DIFF
--- a/src/napari/_vispy/overlays/base.py
+++ b/src/napari/_vispy/overlays/base.py
@@ -112,7 +112,7 @@ class VispyCanvasOverlay(VispyBaseOverlay):
         self._on_box_change()
 
     def _on_box_change(self) -> None:
-        if not self.overlay.box or not self.node.visible:
+        if not self.overlay.box or not self._should_be_visible():
             self.box.parent = None
             return
 

--- a/src/napari/_vispy/overlays/welcome.py
+++ b/src/napari/_vispy/overlays/welcome.py
@@ -53,6 +53,9 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
         self.reset()
 
+    def _should_be_visible(self) -> bool:
+        return bool(super()._should_be_visible() and not self.viewer.layers)
+
     def _on_position_change(self, event: Any = None) -> None:
         if self.node.canvas is not None:
             x, y = np.array(self.node.canvas.size)
@@ -79,7 +82,7 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.node.set_color(color)
 
     def _on_visible_change(self) -> None:
-        show = self.overlay.visible and not self.viewer.layers
+        show = self._should_be_visible()
         self.node.visible = show
         if show:
             self.tip_timer.start()


### PR DESCRIPTION
# References and relevant issues
- caused by #8654

# Description
The new overlay boxes visibility can sometimes be out of sync with the overlay itself. Try this *in two separate ipython cells*:

```py
import napari
import numpy as np
v = napari.Viewer()
```

```py
v.add_points(np.random.rand(10, 2) * 100)
```

You'll see a black screen instead of points, because the `welcome_screen`'s box remained visible. This PR just cleans up this by always using `_should_be_visible` when appropriate.
