### PR TITLE
Add sphinxext-rediraffe to docs requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ docs = [
     "sphinx_autodoc_typehints==1.12.0",
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxext-opengraph[social-cards]",
+    "sphinxext-rediraffe",
     "myst-nb",
     "napari-sphinx-theme>=1.0.0",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,6 +304,7 @@ docs = [
     "sphinx_autodoc_typehints==1.12.0",
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxext-opengraph[social-cards]",
+    "sphinxext-rediraffe",
     "myst-nb",
     "napari-sphinx-theme>=1.0.0",
     "matplotlib",

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -898,6 +898,8 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxext-opengraph==0.13.0
     # via napari (pyproject.toml:docs)
+sphinxext-rediraffe==0.3.0
+    # via napari (pyproject.toml:docs)
 sqlalchemy==2.0.46
     # via jupyter-cache
 stack-data==0.6.3


### PR DESCRIPTION
# References and relevant issues
Follow-up to #881

# Description
Adds the sphinx-rediraffe extension to manage redirects of the old pages, so the reader flow is not broken between versions (i.e. if you click on docs/fundamentals/installation, it will redirect you to docs/getting_started/installation
