### PR TITLE
Fix type annotation in viewer keybindings, use QtViewer for console

### DIFF
--- a/src/napari/_qt/_qapp_model/injection/_qproviders.py
+++ b/src/napari/_qt/_qapp_model/injection/_qproviders.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from napari import components, layers, viewer
+from napari._app_model import get_app_model
 from napari.utils._proxies import PublicOnlyProxy
 from napari.utils.translations import trans
 from napari.viewer import ViewerModel
@@ -100,6 +101,17 @@ def _provide_active_layer() -> layers.Layer | None:
 
 def _provide_active_layer_list() -> components.LayerList | None:
     return v.layers if (v := _provide_viewer()) else None
+
+
+def register_qt_types() -> None:
+    from napari._qt.qt_viewer import QtViewer
+
+    app = get_app_model()
+    if 'QtViewer' not in app.injection_store.namespace:
+        app.injection_store.namespace = {
+            **app.injection_store.namespace,
+            'QtViewer': QtViewer,
+        }
 
 
 # syntax could be simplified after

--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -14,6 +14,7 @@ from qtpy.QtSvg import QSvgRenderer
 from qtpy.QtWidgets import QApplication, QWidget
 
 from napari import Viewer, __version__
+from napari._qt._qapp_model.injection._qproviders import register_qt_types
 from napari._qt.dialogs.qt_notification import NapariQtNotification
 from napari._qt.qt_event_filters import QtToolTipEventFilter
 from napari._qt.qthreading import (
@@ -265,6 +266,7 @@ def get_qapp(
             QDir.addSearchPath(f'theme_{name}', str(_theme_path(name)))
 
         register_threadworker_processors()
+        register_qt_types()
 
         notification_manager.notification_ready.connect(
             NapariQtNotification.show_notification

--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -277,6 +277,7 @@ def test_toggle_ndisplay(mock_app_model, qt_viewer_buttons, qtbot):
     with app.injection_store.register(
         providers=[
             (lambda: viewer, Viewer, 100),
+            (lambda: viewer, ViewerModel, 100),
         ]
     ):
         qtbot.mouseClick(viewer_buttons.ndisplayButton, Qt.LeftButton)

--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -223,7 +223,12 @@ def show_only_layer_below(viewer: ViewerModel) -> None:
     )
 )
 def toggle_console_visibility(qt_viewer: QtViewer) -> None:
-    qt_viewer.toggle_console_visibility()
+    if hasattr(qt_viewer, 'toggle_console_visibility'):
+        qt_viewer.toggle_console_visibility()
+    else:
+        # old action_manager path :( :(, where
+        # toggle_console_visibility is treated as bound method...
+        qt_viewer.window._qt_viewer.toggle_console_visibility()
 
 
 @register_viewer_action(trans._('Press and hold for move camera mode'))

--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Generator
 
 import numpy as np
 from app_model.types import KeyCode, KeyMod
 
-from napari.components.viewer_model import ViewerModel
 from napari.utils.action_manager import action_manager
 from napari.utils.notifications import show_info, show_warning
 from napari.utils.theme import available_themes, get_system_theme
@@ -14,9 +13,11 @@ from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from napari.viewer import Viewer
+    from napari.components.viewer_model import ViewerModel
+    from napari._qt.qt_viewer import QtViewer
 
 
-def register_viewer_action(description, repeatable=False):
+def register_viewer_action(description: str, repeatable: bool=False) -> Callable[[Callable], Callable]:
     """
     Convenient decorator to register an action with the current ViewerModel
 
@@ -24,7 +25,7 @@ def register_viewer_action(description, repeatable=False):
     to be given instead of function docstring for translation purpose.
     """
 
-    def _inner(func):
+    def _inner(func: Callable) -> Callable:
         action_manager.register_action(
             name=f'napari:{func.__name__}',
             command=func,
@@ -38,17 +39,17 @@ def register_viewer_action(description, repeatable=False):
 
 
 @ViewerModel.bind_key(KeyMod.Shift | KeyCode.UpArrow, overwrite=True)
-def extend_selection_to_layer_above(viewer: Viewer):
+def extend_selection_to_layer_above(viewer: ViewerModel) -> None:
     viewer.layers.select_next(shift=True)
 
 
 @ViewerModel.bind_key(KeyMod.Shift | KeyCode.DownArrow, overwrite=True)
-def extend_selection_to_layer_below(viewer: Viewer):
+def extend_selection_to_layer_below(viewer: ViewerModel) -> None:
     viewer.layers.select_previous(shift=True)
 
 
 @register_viewer_action(trans._('Toggle 2D/3D view'))
-def toggle_ndisplay(viewer: Viewer):
+def toggle_ndisplay(viewer: ViewerModel) -> None:
     if viewer.dims.ndisplay == 2:
         viewer.dims.ndisplay = 3
     else:
@@ -61,7 +62,7 @@ def toggle_ndisplay(viewer: Viewer):
 # RuntimeError: wrapped C/C++ object of type CanvasBackendDesktop has been deleted
 # ```
 @register_viewer_action(trans._('Toggle current viewer theme'))
-def toggle_theme(viewer: ViewerModel):
+def toggle_theme(viewer: ViewerModel) -> None:
     """Toggle theme for current viewer"""
     themes = available_themes()
     current_theme = viewer.theme
@@ -78,36 +79,36 @@ def toggle_theme(viewer: ViewerModel):
 
 
 @register_viewer_action(trans._('Reset view to original state'))
-def reset_view(viewer: Viewer):
+def reset_view(viewer: ViewerModel) -> None:
     viewer.reset_view()
 
 
 @register_viewer_action(trans._('Delete selected layers'))
-def delete_selected_layers(viewer: Viewer):
+def delete_selected_layers(viewer: ViewerModel) -> None:
     viewer.layers.remove_selected()
 
 
 @register_viewer_action(
     trans._('Increment dimensions slider to the left'), repeatable=True
 )
-def increment_dims_left(viewer: Viewer):
+def increment_dims_left(viewer: ViewerModel) -> None:
     viewer.dims._increment_dims_left()
 
 
 @register_viewer_action(
     trans._('Increment dimensions slider to the right'), repeatable=True
 )
-def increment_dims_right(viewer: Viewer):
+def increment_dims_right(viewer: ViewerModel) -> None:
     viewer.dims._increment_dims_right()
 
 
 @register_viewer_action(trans._('Move focus of dimensions slider up'))
-def focus_axes_up(viewer: Viewer):
+def focus_axes_up(viewer: ViewerModel) -> None:
     viewer.dims._focus_up()
 
 
 @register_viewer_action(trans._('Move focus of dimensions slider down'))
-def focus_axes_down(viewer: Viewer):
+def focus_axes_down(viewer: ViewerModel) -> None:
     viewer.dims._focus_down()
 
 
@@ -117,7 +118,7 @@ def focus_axes_down(viewer: Viewer):
         'Change order of the visible axes, e.g.\u00a0[-3,\u00a0-2,\u00a0-1]\u00a0\u2011>\u00a0[-1,\u00a0-3,\u00a0-2]'
     ),
 )
-def roll_axes(viewer: Viewer):
+def roll_axes(viewer: ViewerModel) -> None:
     viewer.dims.roll()
 
 
@@ -127,12 +128,12 @@ def roll_axes(viewer: Viewer):
         'Transpose order of the last two visible axes, e.g.\u00a0[-2,\u00a0-1]\u00a0\u2011>\u00a0[-1,\u00a0-2]'
     ),
 )
-def transpose_axes(viewer: Viewer):
+def transpose_axes(viewer: ViewerModel) -> None:
     viewer.dims.transpose()
 
 
 @register_viewer_action(trans._('Rotate layers 90 degrees counter-clockwise'))
-def rotate_layers(viewer: Viewer):
+def rotate_layers(viewer: ViewerModel) -> None:
     if viewer.dims.ndisplay == 3:
         show_info(trans._('Rotating layers only works in 2D'))
         return
@@ -168,7 +169,7 @@ def rotate_layers(viewer: Viewer):
 
 
 @register_viewer_action(trans._('Toggle grid mode'))
-def toggle_grid(viewer: Viewer):
+def toggle_grid(viewer: ViewerModel) -> None:
     if (
         1 < len(viewer.layers) <= abs(viewer.grid.stride)
         and not viewer.grid.enabled
@@ -180,35 +181,35 @@ def toggle_grid(viewer: Viewer):
 
 
 @register_viewer_action(trans._('Toggle visibility of selected layers'))
-def toggle_selected_visibility(viewer: Viewer):
+def toggle_selected_visibility(viewer: ViewerModel) -> None:
     viewer.layers.toggle_selected_visibility()
 
 
 @register_viewer_action(trans._('Toggle visibility of unselected layers'))
-def toggle_unselected_visibility(viewer: Viewer):
+def toggle_unselected_visibility(viewer: ViewerModel) -> None:
     for layer in viewer.layers:
         if layer not in viewer.layers.selection:
             layer.visible = not layer.visible
 
 
 @register_viewer_action(trans._('Select layer above'))
-def select_layer_above(viewer):
+def select_layer_above(viewer: ViewerModel) -> None:
     viewer.layers.select_next()
 
 
 @register_viewer_action(trans._('Select layer below'))
-def select_layer_below(viewer):
+def select_layer_below(viewer: ViewerModel) -> None:
     viewer.layers.select_previous()
 
 
 @register_viewer_action(trans._('Select and show only layer above'))
-def show_only_layer_above(viewer):
+def show_only_layer_above(viewer: ViewerModel) -> None:
     viewer.layers.select_next()
     _show_only_selected_layer(viewer)
 
 
 @register_viewer_action(trans._('Select and show only layer below'))
-def show_only_layer_below(viewer):
+def show_only_layer_below(viewer: ViewerModel) -> None:
     viewer.layers.select_previous()
     _show_only_selected_layer(viewer)
 
@@ -218,12 +219,12 @@ def show_only_layer_below(viewer):
         'Show/Hide IPython console (only available when napari started as standalone application)'
     )
 )
-def toggle_console_visibility(viewer: Viewer):
-    viewer.window._qt_viewer.toggle_console_visibility()
+def toggle_console_visibility(qt_viewer: QtViewer) -> None:
+    qt_viewer.toggle_console_visibility()
 
 
 @register_viewer_action(trans._('Press and hold for move camera mode'))
-def hold_for_pan_zoom(viewer: ViewerModel):
+def hold_for_pan_zoom(viewer: ViewerModel) -> Generator[None, None, None]:
     selected_layer = viewer.layers.selection.active
     if selected_layer is None:
         yield
@@ -242,14 +243,14 @@ def hold_for_pan_zoom(viewer: ViewerModel):
 
 
 @register_viewer_action(trans._('Show all key bindings'))
-def show_shortcuts(viewer: Viewer):
+def show_shortcuts(viewer: Viewer) -> None:
     pref_list = viewer.window._open_preferences_dialog()._list
     for i in range(pref_list.count()):
         if (item := pref_list.item(i)) and item.text() == 'Shortcuts':
             pref_list.setCurrentRow(i)
 
 
-def _show_only_selected_layer(viewer):
+def _show_only_selected_layer(viewer: ViewerModel) -> None:
     """Helper function to show only selected layer"""
     for layer in viewer.layers:
         if layer not in viewer.layers.selection:

--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -228,7 +228,7 @@ def toggle_console_visibility(qt_viewer: QtViewer) -> None:
     else:
         # old action_manager path :( :(, where
         # toggle_console_visibility is treated as bound method...
-        qt_viewer.window._qt_viewer.toggle_console_visibility()
+        qt_viewer.window._qt_viewer.toggle_console_visibility()  # type: ignore[attr-defined]
 
 
 @register_viewer_action(trans._('Press and hold for move camera mode'))

--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Generator
+from collections.abc import Callable, Generator
+from typing import TYPE_CHECKING
 
 import numpy as np
 from app_model.types import KeyCode, KeyMod
 
+from napari.components.viewer_model import ViewerModel
 from napari.utils.action_manager import action_manager
 from napari.utils.notifications import show_info, show_warning
 from napari.utils.theme import available_themes, get_system_theme
@@ -12,12 +14,13 @@ from napari.utils.transforms import Affine
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
-    from napari.viewer import Viewer
-    from napari.components.viewer_model import ViewerModel
     from napari._qt.qt_viewer import QtViewer
+    from napari.viewer import Viewer
 
 
-def register_viewer_action(description: str, repeatable: bool=False) -> Callable[[Callable], Callable]:
+def register_viewer_action(
+    description: str, repeatable: bool = False
+) -> Callable[[Callable], Callable]:
     """
     Convenient decorator to register an action with the current ViewerModel
 

--- a/src/napari/utils/action_manager.py
+++ b/src/napari/utils/action_manager.py
@@ -105,7 +105,7 @@ class ActionManager:
         name: str,
         command: Callable,
         description: str,
-        keymapprovider: KeymapProvider | None,
+        keymapprovider: type[KeymapProvider] | None,
         repeatable: bool = False,
     ):
         """


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/channel/212875-general/topic/adding.20viewer.20buttons/near/575287347

# Description

This PR was inspired to allow use toogle console actions when embedding Qt Viewer in other applications. 

Even if `toggle_console_visibility` require only `QtViewer` we expect the `Viewer`, but we provide `QtViewer` provider, so we could change type annotation and implementation. 

Then someone who embed console might provide own providers to allow it working. 

Rest of changes is improvement of type annotation in file. 
