### PR TITLE
Move `project.scripts.napari` to `napari_builtins`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,7 +345,7 @@ napari = "napari.utils._testsupport"
 napari_builtins = "napari_builtins:builtins.yaml"
 
 [project.scripts]
-napari = "napari.__main__:main"
+napari = "napari_builtins._main:main"
 
 [tool.setuptools]
 zip-safe = false

--- a/src/napari_builtins/_main.py
+++ b/src/napari_builtins/_main.py
@@ -1,0 +1,27 @@
+"""The entrypoint for napari program.
+
+This Is workaround for a problem of import path pollution
+(ex. napari.py file in CDW)
+
+The purpose of this file is to import napari.__main__ and call it.
+But if it fail, try to determine if
+
+"""
+
+import importlib.util
+
+
+def check_napari_import():
+    spec = importlib.util.find_spec('napari')
+    if spec is None:
+        raise ImportError('napari is not installed')
+    # real code here
+
+
+def main():
+    try:
+        from napari.__main__ import main
+
+        main()
+    except ImportError:
+        check_napari_import()


### PR DESCRIPTION
# References and relevant issues

inspired by #8696

# Description

The idea of this PR is to move startup script for napari triggered form console to `napari_builtins`.

As we meet multiple times a problem that user create `napari.py` file or `napari` directory in his data. And such end with some hard to understand errors. 

I think that there is a lower probability that a user might have `napari_builtins` named stuff. 

We might add `_napari` package as other solution (following `pytest` pattern)

If my assumptions are correct, then we could put proper code for checking various variants. 

Did you think it is wort to work on it?