### PR TITLE
Fix assign tuple of None to `layer.units`

### DIFF
--- a/src/napari/layers/base/_tests/test_base.py
+++ b/src/napari/layers/base/_tests/test_base.py
@@ -10,35 +10,48 @@ from napari.layers.base._test_util_sample_layer import SampleLayer
 REG = pint.get_application_registry()
 
 
-def test_assign_units():
+@pytest.mark.parametrize(
+    ('units', 'expected'),
+    [
+        (('nm', 'nm'), (REG.nm, REG.nm)),
+        ((REG.nm, REG.nm), (REG.nm, REG.nm)),
+        ('nm', (REG.nm, REG.nm)),
+        (None, (REG.pixel, REG.pixel)),
+        ((None, None), (REG.pixel, REG.pixel)),
+        ((None, 'nm'), (REG.pixel, REG.nm)),
+    ],
+)
+def test_assign_units(units, expected):
+    layer = SampleLayer(np.empty((10, 10)), units=['mm', 'mm'])
+    mock = Mock()
+    layer.events.units.connect(mock)
+    layer.units = units
+    assert layer.units == expected
+    mock.assert_called_once()
+
+
+def test_no_emmit_on_identical_units():
     layer = SampleLayer(np.empty((10, 10)))
     mock = Mock()
     layer.events.units.connect(mock)
-    assert layer.units == (REG.pixel, REG.pixel)
-
     layer.units = ('nm', 'nm')
-    mock.assert_called_once()
-    mock.reset_mock()
-
     assert layer.units == (REG.nm, REG.nm)
-
-    layer.units = (REG.mm, REG.mm)
     mock.assert_called_once()
-    mock.reset_mock()
 
-    assert layer.units == (REG.mm, REG.mm)
-
-    layer.units = ('mm', 'mm')
-    mock.assert_not_called()
-
-    layer.units = 'km'
+    layer.units = ('nm', REG.nm)
     mock.assert_called_once()
-    mock.reset_mock()
-    assert layer.units == (REG.km, REG.km)
 
-    layer.units = None
+    layer.units = (REG.nm, REG.nm)
     mock.assert_called_once()
-    assert layer.units == (REG.pixel, REG.pixel)
+
+
+def test_exception_on_invalid_units():
+    layer = SampleLayer(np.empty((10, 10)))
+    with pytest.raises(ValueError, match='Could not find unit'):
+        layer.units = ('ugh', 'ugh')
+
+    with pytest.raises(ValueError, match='Could not find unit'):
+        layer.units = (1, 1)
 
 
 def test_units_constructor():
@@ -203,3 +216,9 @@ def test_invalidate_extent_shear():
     with layer._block_refresh():
         layer.shear = [1]
     npt.assert_array_equal(layer.extent.world, [[0, 0], [28, 19]])
+
+
+def test_set_units_none(units, expected):
+    layer = SampleLayer(np.empty((10, 10)), units=('nm', 'nm'))
+    layer.units = None
+    assert layer.units == (REG.pixel, REG.pixel)

--- a/src/napari/layers/base/_tests/test_base.py
+++ b/src/napari/layers/base/_tests/test_base.py
@@ -53,6 +53,9 @@ def test_exception_on_invalid_units():
     with pytest.raises(ValueError, match='Could not find unit'):
         layer.units = (1, 1)
 
+    with pytest.raises(ValueError, match='Could not find unit'):
+        layer.units = 1
+
 
 def test_units_constructor():
     layer = SampleLayer(np.empty((10, 10)), units=('nm', 'nm'))
@@ -216,9 +219,3 @@ def test_invalidate_extent_shear():
     with layer._block_refresh():
         layer.shear = [1]
     npt.assert_array_equal(layer.extent.world, [[0, 0], [28, 19]])
-
-
-def test_set_units_none(units, expected):
-    layer = SampleLayer(np.empty((10, 10)), units=('nm', 'nm'))
-    layer.units = None
-    assert layer.units == (REG.pixel, REG.pixel)

--- a/src/napari/utils/transforms/_units.py
+++ b/src/napari/utils/transforms/_units.py
@@ -19,6 +19,16 @@ __all__ = (
 )
 
 
+def get_unit_from_name(unit: str | pint.Unit | None) -> pint.Unit:
+    if isinstance(unit, pint.Unit):
+        return unit
+    if unit is None:
+        return pint.get_application_registry().pixel
+    if isinstance(unit, str):
+        return pint.get_application_registry().parse_expression(unit).units
+    raise ValueError(f'Could not find unit {unit}')
+
+
 @overload
 def get_units_from_name(units: None) -> None: ...
 
@@ -37,16 +47,9 @@ def get_units_from_name(units: UnitsLike) -> UnitsInfo:
     """Convert a string or sequence of strings to pint units."""
     try:
         if isinstance(units, str):
-            return (
-                pint.get_application_registry().parse_expression(units).units
-            )
+            return get_unit_from_name(units)
         if isinstance(units, Sequence):
-            return tuple(
-                pint.get_application_registry().parse_expression(unit).units
-                if isinstance(unit, str)
-                else unit
-                for unit in units
-            )
+            return tuple(get_unit_from_name(u) for u in units)
     except AttributeError as e:
         raise ValueError(f'Could not find unit {units}') from e
     return units

--- a/src/napari/utils/transforms/_units.py
+++ b/src/napari/utils/transforms/_units.py
@@ -37,12 +37,12 @@ def get_units_from_name(units: None) -> None: ...
 
 
 @overload
-def get_units_from_name(units: str | pint.Unit) -> pint.Unit: ...
+def get_units_from_name(units: str | pint.Unit | None) -> pint.Unit: ...
 
 
 @overload
 def get_units_from_name(
-    units: Sequence[str | pint.Unit],
+    units: Sequence[str | pint.Unit | None],
 ) -> tuple[pint.Unit, ...]: ...
 
 

--- a/src/napari/utils/transforms/_units.py
+++ b/src/napari/utils/transforms/_units.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from contextlib import suppress
 from typing import (
     Union,
     overload,
@@ -25,7 +26,9 @@ def get_unit_from_name(unit: str | pint.Unit | None) -> pint.Unit:
     if unit is None:
         return pint.get_application_registry().pixel
     if isinstance(unit, str):
-        return pint.get_application_registry().parse_expression(unit).units
+        with suppress(pint.errors.UndefinedUnitError):
+            return pint.get_application_registry().parse_expression(unit).units
+
     raise ValueError(f'Could not find unit {unit}')
 
 
@@ -45,11 +48,8 @@ def get_units_from_name(
 
 def get_units_from_name(units: UnitsLike) -> UnitsInfo:
     """Convert a string or sequence of strings to pint units."""
-    try:
-        if isinstance(units, str):
-            return get_unit_from_name(units)
-        if isinstance(units, Sequence):
-            return tuple(get_unit_from_name(u) for u in units)
-    except AttributeError as e:
-        raise ValueError(f'Could not find unit {units}') from e
-    return units
+    if isinstance(units, str) or units is None:
+        return get_unit_from_name(units)
+    if isinstance(units, Sequence):
+        return tuple(get_unit_from_name(u) for u in units)
+    raise ValueError(f'Could not find unit {units}')

--- a/src/napari/utils/transforms/transforms.py
+++ b/src/napari/utils/transforms/transforms.py
@@ -522,8 +522,6 @@ class Affine(Transform):
     @units.setter
     def units(self, units: Sequence[pint.Unit] | None) -> None:
         units = get_units_from_name(units)
-        if units is None:
-            units = (pint.get_application_registry().pixel,) * self.ndim
         if isinstance(units, pint.Unit):
             units = (units,) * self.ndim
         if len(units) != self.ndim:


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari-metadata/issues/79#issuecomment-3952218295

# Description

This PR fix silent failing of assign not proper type for layer units. 

