### PR TITLE
Bugfix: Fix error raised when highlighting multiple points in view

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from napari._vispy.layers.points import VispyPointsLayer
+from napari.components import Dims
 from napari.layers import Points
 
 
@@ -120,3 +121,36 @@ def test_change_antialiasing():
     vispy_layer = VispyPointsLayer(layer)
     layer.antialiasing = 5
     assert vispy_layer.node.antialias == layer.antialiasing
+
+
+def test_highlight_with_out_of_slice_display():
+    """Highlight should work when out_of_slice_display is enabled.
+
+    Regression test for a bug where _view_size_scale (array for all view
+    points) was multiplied with size indexed only by highlighted points,
+    causing a shape mismatch when more than one point was in view but only
+    a subset was highlighted.
+    """
+    # Place 5 points at known z positions, with a large size so all 5 spill
+    # into the z=50 slice and _view_size_scale becomes a (5,) array.
+    data = np.array(
+        [[0, 0, 0], [25, 0, 0], [50, 0, 0], [75, 0, 0], [100, 0, 0]],
+        dtype=float,
+    )
+    layer = Points(data, size=200)
+    vispy_layer = VispyPointsLayer(layer)
+
+    # Select point 0 BEFORE slicing so update_selected_view populates
+    # _selected_view and _set_highlight populates _highlight_index.
+    layer.selected_data = {0}
+    layer.out_of_slice_display = True
+    layer._slice_dims(Dims(ndim=3, point=(50, 0, 0)))
+
+    # Verify the preconditions that cause the bug:
+    # all 5 points in view, scale is a per-point array, only 1 highlighted
+    assert len(layer._indices_view) == 5
+    assert isinstance(layer._view_size_scale, np.ndarray)
+    assert len(layer._highlight_index) == 1
+
+    # Previously, raised ValueError: could not broadcast input array from shape (5,) into shape (1,)
+    vispy_layer._on_highlight_change()

--- a/src/napari/_vispy/layers/points.py
+++ b/src/napari/_vispy/layers/points.py
@@ -94,24 +94,14 @@ class VispyPointsLayer(VispyBaseLayer):
     def _on_highlight_change(self):
         settings = get_settings()
         if len(self.layer._highlight_index) > 0:
-            # Color the hovered or selected points
-
-            # _highlight_index contains indices into the view arrays, but we can get the
-            # actual data indices once to avoid materializing the entire view for each property
-            data_indices = self.layer._indices_view[
-                self.layer._highlight_index
-            ]
-
-            data = self.layer.data[
-                np.ix_(data_indices, self.layer._slice_input.displayed)
-            ]
-            if data.ndim == 1:
-                data = np.expand_dims(data, axis=0)
-            size = self.layer.size[data_indices] * self.layer._view_size_scale
-            border_width = self.layer.border_width[data_indices]
+            # _highlight_index contains indices into the view arrays
+            hi = self.layer._highlight_index
+            data = self.layer._view_data[hi]
+            size = self.layer._view_size[hi]
+            border_width = self.layer._view_border_width[hi]
             if self.layer.border_width_is_relative:
                 border_width = border_width * size
-            symbol = self.layer.symbol[data_indices]
+            symbol = [str(x) for x in self.layer._view_symbol[hi]]
         else:
             data = np.empty((0, self.layer._slice_input.ndisplay))
             size = 0


### PR DESCRIPTION
# References and relevant issues

Closes #8707 . 

# Description

Before this PR, when `out_of_slice_display` was true AND multiple points were visible, a broadcast error would occur because multiple highlighted points would be multiplied against a single array. 

Now, this PR changes it so that the highlighted point properties are extracted from the `_view` which is an array containing the indices of all the highlighted points.

I added a regression test which fails on main and passes with this PR.

I used Claude Opus to understand the route of the problem, and then wrote the fix based off its explanation, because I wanted to try to figure out how to reason about it. I initially wrote the test by hand, but was having trouble get the error to trigger because I didn't realize `_slice_dims` would have to come after selecting the data; Sonnet helped me understand that. 