### PR TITLE
Add out of slice visualization for nD shapes in 2D view

### DIFF
--- a/examples/3D_paths.py
+++ b/examples/3D_paths.py
@@ -2,10 +2,12 @@
 3D Paths
 ========
 
-Display two vectors layers ontop of a 4-D image layer. One of the vectors
-layers is 3D and "sliced" with a different set of vectors appearing on
-different 3D slices. Another is 2D and "broadcast" with the same vectors
-appearing on each slice.
+Display two path shapes on top of a 3D image layer. One path spans multiple
+Z slices (red) and one is flat on the Z=0 plane (blue).
+
+With ``out_of_slice_display=True``, the 3D path is visible even in
+2D view — it is shown on every slice that falls within its Z range.
+Switch to 2D view and scroll through the Z slider to see both paths.
 
 .. tags:: visualization-advanced, layers
 """
@@ -16,8 +18,8 @@ from skimage import data
 import napari
 
 blobs = data.binary_blobs(
-            length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.05
-        )
+    length=128, blob_size_fraction=0.05, n_dim=3, volume_fraction=0.05
+)
 
 viewer = napari.Viewer(ndisplay=3)
 viewer.add_image(blobs.astype(float))
@@ -30,7 +32,11 @@ path = np.array([np.array([[0, 0, 0], [0, 10, 10], [0, 5, 15], [20, 5, 15],
 
 print('Path', path.shape)
 layer = viewer.add_shapes(
-    path, shape_type='path', edge_width=4, edge_color=['red', 'blue']
+    path,
+    shape_type='path',
+    edge_width=4,
+    edge_color=['red', 'blue'],
+    out_of_slice_display=True,
 )
 
 if __name__ == '__main__':

--- a/src/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/src/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from napari._qt.layer_controls.qt_layer_controls_base import QtLayerControls
 from napari._qt.layer_controls.widgets import (
     QtFaceColorControl,
+    QtOutSliceCheckBoxControl,
     QtTextVisibilityControl,
 )
 from napari._qt.layer_controls.widgets._shapes import (
@@ -35,6 +36,8 @@ class QtShapesControls(QtLayerControls):
         Widget that wraps a slider controlling line edge width of layer.
     _face_color_control : napari._qt.layer_controls.widgets.QtFaceColorControl
         Widget that wraps a ColorSwatchEdit controlling current face color of the layer.
+    _out_slice_checkbox_control : napari._qt.layer_controls.widgets.QtOutSliceCheckBoxControl
+        Widget that wraps a checkbox controlling out of slice display.
     _text_visibility_control : napari._qt.layer_controls.widgets.QtTextVisibilityControl
         WIdget that wraps a checkbox controlling if text on the layer is visible or not.
     delete_button : qtpy.QtWidgets.QtModePushButton
@@ -214,6 +217,10 @@ class QtShapesControls(QtLayerControls):
         self._add_widget_controls(self._face_color_control)
         self._text_visibility_control = QtTextVisibilityControl(self, layer)
         self._add_widget_controls(self._text_visibility_control)
+        self._out_slice_checkbox_control = QtOutSliceCheckBoxControl(
+            self, layer
+        )
+        self._add_widget_controls(self._out_slice_checkbox_control)
 
     def _on_mode_change(self, event):
         """Update ticks in checkbox widgets when shapes layer mode changed.

--- a/src/napari/layers/shapes/_shape_list.py
+++ b/src/napari/layers/shapes/_shape_list.py
@@ -434,6 +434,7 @@ class ShapeList:
         self.shapes: list[Shape] = []
         self._displayed = np.array([])
         self._slice_key = np.array([])
+        self.out_of_slice_display = False
         self.displayed_vertices = np.array([], dtype=CoordinateDtype)
         self.displayed_vertices_to_shape_num = np.array([], dtype=IndexDtype)
         self.displayed_indices = np.array([], dtype=IndexDtype)
@@ -772,12 +773,27 @@ class ShapeList:
         # max values stored in the shapes slice key.
         slice_key = np.array([self.slice_key, self.slice_key])
 
-        # Slice key must exactly match mins and maxs of shape as then the
-        # shape is entirely contained within the current slice.
         if len(self.shapes) > 0:
-            self._displayed = np.all(
-                np.abs(self.slice_keys - slice_key) < 0.5, axis=(1, 2)
-            )
+            if self.out_of_slice_display:
+                # Show shapes where the current slice falls within the
+                # shape's extent range in each non-displayed dimension.
+                # slice_keys shape: (N, 2, P) where [i, 0, :] = mins, [i, 1, :] = maxs
+                # slice_key[0] = current slice position for each non-displayed dim
+                mins = self.slice_keys[:, 0, :]  # (N, P)
+                maxs = self.slice_keys[:, 1, :]  # (N, P)
+                current = slice_key[0]  # (P,)
+                # Shape is displayed if current slice is within [min-0.5, max+0.5]
+                # for all non-displayed dimensions
+                self._displayed = np.all(
+                    (current >= mins - 0.5) & (current <= maxs + 0.5),
+                    axis=1,
+                )
+            else:
+                # Slice key must exactly match mins and maxs of shape as then the
+                # shape is entirely contained within the current slice.
+                self._displayed = np.all(
+                    np.abs(self.slice_keys - slice_key) < 0.5, axis=(1, 2)
+                )
         else:
             self._displayed = np.array([])
         disp_indices: IndexArray = np.nonzero(self._displayed)[0]  # type: ignore[assignment]

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -203,6 +203,11 @@ class Shapes(Layer):
         If not provided, the default units are assumed to be pixels.
     visible : bool
         Whether the layer visual is currently being displayed.
+    out_of_slice_display : bool
+        If True, renders shapes that are not entirely on the current slice.
+        Shapes will be visible in 2D view if the current slice falls within
+        the shape's extent range in the non-displayed dimensions. This is
+        especially useful for 3D paths and polygons that span multiple slices.
     z_index : int or list
         Specifier of z order priority. Shapes with higher z order are
         displayed ontop of others. If a list is supplied it must be the
@@ -238,6 +243,8 @@ class Shapes(Layer):
         Color of the shape face. Numeric color values should be RGB(A).
     edge_width : (N, ) list of float
         Edge width for each shape.
+    out_of_slice_display : bool
+        If True, renders shapes not entirely on the current slice.
     z_index : (N, ) list of int
         z-index for each shape.
     current_edge_width : float
@@ -458,6 +465,7 @@ class Shapes(Layer):
         metadata=None,
         name=None,
         opacity=0.7,
+        out_of_slice_display=False,
         projection_mode='none',
         properties=None,
         property_choices=None,
@@ -519,7 +527,10 @@ class Shapes(Layer):
             highlight=Event,
             features=Event,
             feature_defaults=Event,
+            out_of_slice_display=Event,
         )
+
+        self._out_of_slice_display = out_of_slice_display
 
         # Flag set to false to block thumbnail refresh
         self._allow_thumbnail_update = True
@@ -544,6 +555,7 @@ class Shapes(Layer):
             self._current_edge_width = 1
 
         self._data_view = ShapeList(ndisplay=self._slice_input.ndisplay)
+        self._data_view.out_of_slice_display = self._out_of_slice_display
         self._data_view.slice_key = np.array(self._data_slice.point)[
             self._slice_input.not_displayed
         ]
@@ -743,6 +755,7 @@ class Shapes(Layer):
 
         self.events.data(**kwargs)
         self._data_view = ShapeList(ndisplay=self._slice_input.ndisplay)
+        self._data_view.out_of_slice_display = self._out_of_slice_display
         self._data_view.slice_key = np.array(self._data_slice.point)[
             self._slice_input.not_displayed
         ]
@@ -861,6 +874,17 @@ class Shapes(Layer):
         """Determine number of dimensions of the layer."""
         ndim = self.ndim if self.nshapes == 0 else self.data[0].shape[1]
         return ndim
+
+    @property
+    def out_of_slice_display(self) -> bool:
+        """bool: renders shapes slightly out of slice."""
+        return self._out_of_slice_display
+
+    @out_of_slice_display.setter
+    def out_of_slice_display(self, out_of_slice_display: bool) -> None:
+        self._out_of_slice_display = bool(out_of_slice_display)
+        self.events.out_of_slice_display()
+        self.refresh(extent=False)
 
     @property
     def _extent_data(self) -> np.ndarray:
@@ -1649,6 +1673,7 @@ class Shapes(Layer):
                 'data': self.data,
                 'features': self.features,
                 'feature_defaults': self.feature_defaults,
+                'out_of_slice_display': self.out_of_slice_display,
             }
         )
         return state
@@ -2445,6 +2470,7 @@ class Shapes(Layer):
             ]
             if not np.array_equal(slice_key, self._data_view.slice_key):
                 self.selected_data = set()
+            self._data_view.out_of_slice_display = self._out_of_slice_display
             self._data_view.slice_key = slice_key
 
     def interaction_box(self, index: int | Iterable[int]) -> BoxArray | None:


### PR DESCRIPTION
# References and relevant issues

Inspired by #1334 
In 2D view, any nD shape will not render, unless the entirety of the shape is contained within the current slice.

# Description

This PR adds `out_of_slice_display` for the shapes layer, modeled after it's implementation in the points layer. The only business logic in this PR is in `_shapes_list.py` wherein if the current slice is contained within the range of the extent of an ndimensional shape, then _the entire shape_ will be rendered in 2D view.

Then, `out_of_slice_display` was exposed on the shapes layer and added to the shapes layer controls. 

I updated `examples/3D_paths.py` to demonstrate the out of slice display. But you can also see in `examples/add_points_on_nD_shapes.py` how visualization is just a nightmare in 2D without `out_of_slice_display`

3D_paths.py:

`out_of_slice_display` = True
<img width="1343" height="887" alt="image" src="https://github.com/user-attachments/assets/5bf905b3-2786-49e9-907e-94e5c72ebdff" />

`out_of_slice_display` = False
<img width="1343" height="887" alt="image" src="https://github.com/user-attachments/assets/10a0a384-52e1-4526-8f2a-7b701c206dd2" />

## To-do

When I wake up in the morning...

1. I forgot to add a callback,I think, because toggling the GUI display requires an independent canvas update before changing the rendering
2. I need to add some tests

## Follow-ups

Expose (potentially for points as well) the range from the current slice that should be visualized in the canvas.
@DragaDoncila mentioned to me briefly tonight that `out_of_slice_display` may be deprecated in favor of thick_slicing. However, I'm not sure this is the correct approach because thick_slicing is part of the dims model, and I may wish to render my "vector"-likes with out-of-slice (certainly this is true for paths and points, but _not_ change the visualization of my array-likes which would currently happen with thick slicing. However, thick slicing _would_ still be useful for this, and I think this sets precedence for the logic.