### PR TITLE
[UI, UX] Make dock widget title bar icons bigger and text more legible

### DIFF
--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -77,7 +77,7 @@ QMainWindow::separator:vertical {
 }
 
 #QtCustomTitleBar > QLabel {
-  color: {{ primary }};
+  color: {{ text }};
   font-size: {{ decrease(font_size, 1) }};
 }
 

--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -82,8 +82,8 @@ QMainWindow::separator:vertical {
 }
 
 #QTitleBarCloseButton{
-    width: 12px;
-    height: 12px;
+    width: 24px;
+    height: 24px;
     padding: 0;
     image: url("theme_{{ id }}:/delete_shape.svg");
 }
@@ -91,15 +91,15 @@ QMainWindow::separator:vertical {
 
 #QTitleBarFloatButton{
     image: url("theme_{{ id }}:/pop_out.svg");
-    width: 10px;
-    height: 8px;
+    width: 24px;
+    height: 24px;
     padding: 2 1 2 1;
 }
 
 #QTitleBarHideButton{
     image: url("theme_{{ id }}:/visibility_off.svg");
-    width: 10px;
-    height: 8px;
+    width: 24px;
+    height: 24px;
     padding: 2 1 2 1;
 }
 


### PR DESCRIPTION
# References and relevant issues 
UI review with Harry Barng at SciPy 2025 sprints

# Description
This PR addresses two related accessibility issues raised by Harry at SciPy 2025 sprints regarding the dock widget title bars:
1. The dock widget icons are really small (layer controls, layer llist, etc.), so it's really hard to see the iconography for what they may do. Also their target click area is tiny.
   - in this PR I double their size, which still doesn't affect the overall height of the titlebar.

2. The dock widget title bar text is extremely low contrast, almost completely illegible
   - in this PR I make the dock widget title bar use the theme `text` color, so it has more reasonable contrast. This is particularly beneficial for Plugin widgets, where you can finally read the widget titles.

Screenshot: the napari window in the middle (on top) is this branch. the one in the background is main

<img width="1252" height="430" alt="image" src="https://github.com/user-attachments/assets/c30716d3-0e3e-4d26-84d0-8feb8b6c5fa8" />


Light mode (just this PR)
<img width="1165" height="758" alt="image" src="https://github.com/user-attachments/assets/9cb1155a-ac20-473b-ad69-ef21c0cfe8a2" />
