### PR TITLE
Fix error raised when `out_of_slice_display = True` and update highlight

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from napari._vispy.layers.points import VispyPointsLayer
+from napari.components import Dims
 from napari.layers import Points
 
 
@@ -120,3 +121,36 @@ def test_change_antialiasing():
     vispy_layer = VispyPointsLayer(layer)
     layer.antialiasing = 5
     assert vispy_layer.node.antialias == layer.antialiasing
+
+
+def test_highlight_with_out_of_slice_display():
+    """Highlight should work when out_of_slice_display is enabled.
+
+    Regression test for a bug where _view_size_scale (array for all view
+    points) was multiplied with size indexed only by highlighted points,
+    causing a shape mismatch when more than one point was in view but only
+    a subset was highlighted.
+    """
+    # Place 5 points at known z positions, with a large size so all 5 spill
+    # into the z=50 slice and _view_size_scale becomes a (5,) array.
+    data = np.array(
+        [[0, 0, 0], [25, 0, 0], [50, 0, 0], [75, 0, 0], [100, 0, 0]],
+        dtype=float,
+    )
+    layer = Points(data, size=200)
+    vispy_layer = VispyPointsLayer(layer)
+
+    # Select point 0 BEFORE slicing so update_selected_view populates
+    # _selected_view and _set_highlight populates _highlight_index.
+    layer.selected_data = {0}
+    layer.out_of_slice_display = True
+    layer._slice_dims(Dims(ndim=3, point=(50, 0, 0)))
+
+    # Verify the preconditions that cause the bug:
+    # all 5 points in view, scale is a per-point array, only 1 highlighted
+    assert len(layer._indices_view) == 5
+    assert isinstance(layer._view_size_scale, np.ndarray)
+    assert len(layer._highlight_index) == 1
+
+    # Previously, raised ValueError: could not broadcast input array from shape (5,) into shape (1,)
+    vispy_layer._on_highlight_change()

--- a/src/napari/_vispy/layers/points.py
+++ b/src/napari/_vispy/layers/points.py
@@ -107,7 +107,15 @@ class VispyPointsLayer(VispyBaseLayer):
             ]
             if data.ndim == 1:
                 data = np.expand_dims(data, axis=0)
-            size = self.layer.size[data_indices] * self.layer._view_size_scale
+            if isinstance(self.layer._view_size_scale, np.ndarray):
+                size = (
+                    self.layer.size[data_indices]
+                    * self.layer._view_size_scale[self.layer._highlight_index]
+                )
+            else:
+                size = (
+                    self.layer.size[data_indices] * self.layer._view_size_scale
+                )
             border_width = self.layer.border_width[data_indices]
             if self.layer.border_width_is_relative:
                 border_width = border_width * size

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -420,6 +420,7 @@ class Points(Layer):
         self._value = None
         self._value_stored = None
         self._highlight_index = []
+        # indices of highlighted points in current view
         self._highlight_box = None
         self._mode = Mode.PAN_ZOOM
         self._status = self.mode
@@ -1470,15 +1471,25 @@ class Points(Layer):
         return mode
 
     @property
-    def _indices_view(self):
+    def _indices_view(self) -> np.ndarray[tuple[int], np.dtype[np.int64]]:
+        """Indices of points in view."""
         return self._slicing_state._indices_view
 
     @property
-    def _selected_view(self):
+    def _selected_view(self) -> list[int]:
+        """Indices of selected points within the currently viewed slice"""
         return self._slicing_state._selected_view
 
     @property
-    def _view_size_scale(self):
+    def _view_size_scale(
+        self,
+    ) -> float | np.ndarray[tuple[int], np.dtype[np.float64]]:
+        """Scale factor for view size calculations
+
+        It is 1 if out_of_slice_display is False.
+        For out_of_slice_display=True, it is the scale factor for the
+        points to reduce size of visible points out of rendering slice
+        """
         return self._slicing_state._view_size_scale
 
     @property
@@ -2434,7 +2445,9 @@ class _PointsSlicingState(_LayerSlicingState):
         # Indices of selected points within the currently viewed slice
         self._selected_view = []
         # initialize view data
-        self._view_size_scale = []
+        self._view_size_scale: (
+            float | np.ndarray[tuple[int], np.dtype[np.float64]]
+        ) = 1.0
 
     def _set_view_slice(self) -> None:
         """Sets the view given the indices to slice with."""
@@ -2505,6 +2518,7 @@ class _PointsSlicingState(_LayerSlicingState):
 
     @property
     def _indices_view(self):
+        """Indices of the points in the currently viewed slice."""
         return self.__indices_view
 
     @_indices_view.setter


### PR DESCRIPTION
# References and relevant issues

closes #8707
Alternative to #8706

# Description

This PR fixes selection of `self.layer._view_size_scale` when `points.out_of_slice_display = True` 

Also add missing docstring and type annotation to allow better understand the data flow. 

Get test from #8706