### PR TITLE
Change look of new layer buttons to mark that there are 3 modes

### DIFF
--- a/src/napari/_qt/containers/_base_item_view.py
+++ b/src/napari/_qt/containers/_base_item_view.py
@@ -17,7 +17,10 @@ if TYPE_CHECKING:
 
     from napari._qt.containers._base_item_model import _BaseEventedItemModel
     from napari.utils.events import Event
-    from napari.utils.events.containers import SelectableEventedList
+    from napari.utils.events.containers import (
+        Selectable,
+        SelectableEventedList,
+    )
 
 
 class _BaseEventedItemView(Generic[ItemType]):
@@ -47,6 +50,7 @@ class _BaseEventedItemView(Generic[ItemType]):
     """
 
     # ########## Reimplemented Public Qt Functions ##################
+    _root: Selectable
 
     def model(self) -> _BaseEventedItemModel[ItemType]:  # for type hints
         return super().model()
@@ -75,8 +79,7 @@ class _BaseEventedItemView(Generic[ItemType]):
         desel = {i.data(ItemRole) for i in deselected.indexes()}
 
         if not self._root.selection.events.changed._emitting:
-            self._root.selection.update(sel)
-            self._root.selection.difference_update(desel)
+            self._root.selection._add_and_remove(add=sel, remove=desel)
         return super().selectionChanged(selected, deselected)
 
     # ###### Non-Qt methods added for SelectableEventedList Model ############

--- a/src/napari/_qt/containers/_base_item_view.py
+++ b/src/napari/_qt/containers/_base_item_view.py
@@ -17,10 +17,7 @@ if TYPE_CHECKING:
 
     from napari._qt.containers._base_item_model import _BaseEventedItemModel
     from napari.utils.events import Event
-    from napari.utils.events.containers import (
-        Selectable,
-        SelectableEventedList,
-    )
+    from napari.utils.events.containers import SelectableEventedList
 
 
 class _BaseEventedItemView(Generic[ItemType]):
@@ -50,7 +47,7 @@ class _BaseEventedItemView(Generic[ItemType]):
     """
 
     # ########## Reimplemented Public Qt Functions ##################
-    _root: Selectable
+    _root: SelectableEventedList[ItemType]
 
     def model(self) -> _BaseEventedItemModel[ItemType]:  # for type hints
         return super().model()

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -18,11 +18,11 @@ QtViewerPushButton[mode="new_points"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_points"][selection_state="single"] {
+QtViewerPushButton[mode="new_points"][creation_state="full"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_points"][selection_state="multiple"] {
+QtViewerPushButton[mode="new_points"][creation_state="partial"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 
@@ -31,11 +31,11 @@ QtViewerPushButton[mode="new_shapes"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_shapes"][selection_state="single"] {
+QtViewerPushButton[mode="new_shapes"][creation_state="full"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_shapes"][selection_state="multiple"] {
+QtViewerPushButton[mode="new_shapes"][creation_state="partial"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 
@@ -48,11 +48,11 @@ QtViewerPushButton[mode="new_labels"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_labels"][selection_state="single"] {
+QtViewerPushButton[mode="new_labels"][creation_state="full"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_labels"][selection_state="multiple"] {
+QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -18,13 +18,11 @@ QtViewerPushButton[mode="new_points"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_points_one"] {
-  image: url("theme_{{ id }}:/new_points.svg");
+QtViewerPushButton[mode="new_points"][selection_state="single"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_points_multiple"] {
-  image: url("theme_{{ id }}:/new_points.svg");
+QtViewerPushButton[mode="new_points"][selection_state="multi"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 
@@ -33,13 +31,11 @@ QtViewerPushButton[mode="new_shapes"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_shapes_one"] {
-  image: url("theme_{{ id }}:/new_shapes.svg");
+QtViewerPushButton[mode="new_shapes"][selection_state="single"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_shapes_multiple"] {
-  image: url("theme_{{ id }}:/new_shapes.svg");
+QtViewerPushButton[mode="new_shapes"][selection_state="multi"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -20,14 +20,12 @@ QtViewerPushButton[mode="new_points"] {
 
 QtViewerPushButton[mode="new_points_one"] {
   image: url("theme_{{ id }}:/new_points.svg");
-  border: 3px solid {{ current }};
-  background-color: {{ foreground }};
+  border: 3px solid {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="new_points_multiple"] {
   image: url("theme_{{ id }}:/new_points.svg");
-  border: 3px solid {{ warning }};
-  background-color: {{ foreground }};
+  border: 3px solid {{ lighten(current, 20) }};
 }
 
 QtViewerPushButton[mode="new_shapes"] {
@@ -37,14 +35,12 @@ QtViewerPushButton[mode="new_shapes"] {
 
 QtViewerPushButton[mode="new_shapes_one"] {
   image: url("theme_{{ id }}:/new_shapes.svg");
-  border: 3px solid {{ current }};
-  background-color: {{ foreground }};
+  border: 3px solid {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="new_shapes_multiple"] {
   image: url("theme_{{ id }}:/new_shapes.svg");
-  border: 3px solid {{ warning }};
-  background-color: {{ foreground }};
+  border: 3px solid {{ lighten(current, 20) }};
 }
 
 QtViewerPushButton[mode="warning"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -48,9 +48,12 @@ QtViewerPushButton[mode="new_labels"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_labels"]:checked {
-  border: 3px solid {{ current }};
-  background-color: {{ foreground }};
+QtViewerPushButton[mode="new_labels"][selection_state="single"] {
+  border: 3px solid {{ darken(current, 5) }};
+}
+
+QtViewerPushButton[mode="new_labels"][selection_state="multi"] {
+  border: 3px solid {{ lighten(current, 20) }};
 }
 
 QtViewerPushButton[mode="console"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -18,8 +18,15 @@ QtViewerPushButton[mode="new_points"] {
   border: 3px solid {{ background }};
 }
 
- QtViewerPushButton[mode="new_points"]:checked {
+QtViewerPushButton[mode="new_points_one"] {
+  image: url("theme_{{ id }}:/new_points.svg");
   border: 3px solid {{ current }};
+  background-color: {{ foreground }};
+}
+
+QtViewerPushButton[mode="new_points_multiple"] {
+  image: url("theme_{{ id }}:/new_points.svg");
+  border: 3px solid {{ warning }};
   background-color: {{ foreground }};
 }
 
@@ -28,8 +35,15 @@ QtViewerPushButton[mode="new_shapes"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_shapes"]:checked {
+QtViewerPushButton[mode="new_shapes_one"] {
+  image: url("theme_{{ id }}:/new_shapes.svg");
   border: 3px solid {{ current }};
+  background-color: {{ foreground }};
+}
+
+QtViewerPushButton[mode="new_shapes_multiple"] {
+  image: url("theme_{{ id }}:/new_shapes.svg");
+  border: 3px solid {{ warning }};
   background-color: {{ foreground }};
 }
 

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -22,7 +22,7 @@ QtViewerPushButton[mode="new_points"][selection_state="single"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_points"][selection_state="multi"] {
+QtViewerPushButton[mode="new_points"][selection_state="multiple"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 
@@ -35,7 +35,7 @@ QtViewerPushButton[mode="new_shapes"][selection_state="single"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_shapes"][selection_state="multi"] {
+QtViewerPushButton[mode="new_shapes"][selection_state="multiple"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 
@@ -52,7 +52,7 @@ QtViewerPushButton[mode="new_labels"][selection_state="single"] {
   border: 3px solid {{ darken(current, 5) }};
 }
 
-QtViewerPushButton[mode="new_labels"][selection_state="multi"] {
+QtViewerPushButton[mode="new_labels"][selection_state="multiple"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 

--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -342,25 +342,33 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     # Initially no selection, buttons should not be checked
     assert layer_buttons.newPointsButton.property('mode') == 'new_points'
     assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
+    assert layer_buttons.newPointsButton.property('selection_state') == 'none'
+    assert layer_buttons.newShapesButton.property('selection_state') == 'none'
 
     data_layer = viewer.add_image(np.zeros((10, 10)))
     data_layer2 = viewer.add_image(np.zeros((10, 10)))
 
-    # Selecting a layer should check the buttons (visual indicator)
+    # Selecting a single layer: buttons indicate single-layer inheritance
     viewer.layers.selection = [data_layer]
-    assert layer_buttons.newPointsButton.property('mode') == 'new_points_one'
-    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes_one'
+    assert layer_buttons.newPointsButton.property('mode') == 'new_points'
+    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
+    assert (
+        layer_buttons.newPointsButton.property('selection_state') == 'single'
+    )
+    assert (
+        layer_buttons.newShapesButton.property('selection_state') == 'single'
+    )
 
+    # Selecting multiple layers: buttons indicate multi-layer inheritance
     viewer.layers.selection = [data_layer, data_layer2]
+    assert layer_buttons.newPointsButton.property('mode') == 'new_points'
+    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
+    assert layer_buttons.newPointsButton.property('selection_state') == 'multi'
+    assert layer_buttons.newShapesButton.property('selection_state') == 'multi'
 
-    # Clear selection and buttons should no longer be checked
-    assert (
-        layer_buttons.newPointsButton.property('mode') == 'new_points_multiple'
-    )
-    assert (
-        layer_buttons.newShapesButton.property('mode') == 'new_shapes_multiple'
-    )
-
+    # Clearing selection: buttons return to default state
     viewer.layers.selection.clear()
     assert layer_buttons.newPointsButton.property('mode') == 'new_points'
     assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
+    assert layer_buttons.newPointsButton.property('selection_state') == 'none'
+    assert layer_buttons.newShapesButton.property('selection_state') == 'none'

--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -340,17 +340,27 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     viewer, layer_buttons = qt_layer_buttons
 
     # Initially no selection, buttons should not be checked
-    assert not layer_buttons.newPointsButton.isChecked()
-    assert not layer_buttons.newShapesButton.isChecked()
+    assert layer_buttons.newPointsButton.property('mode') == 'new_points'
+    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
 
-    data_layer = viewer.add_image(np.random.random((10, 15)))
+    data_layer = viewer.add_image(np.zeros((10, 10)))
+    data_layer2 = viewer.add_image(np.zeros((10, 10)))
 
     # Selecting a layer should check the buttons (visual indicator)
     viewer.layers.selection = [data_layer]
-    assert layer_buttons.newPointsButton.isChecked()
-    assert layer_buttons.newShapesButton.isChecked()
+    assert layer_buttons.newPointsButton.property('mode') == 'new_points_one'
+    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes_one'
+
+    viewer.layers.selection = [data_layer, data_layer2]
 
     # Clear selection and buttons should no longer be checked
+    assert (
+        layer_buttons.newPointsButton.property('mode') == 'new_points_multiple'
+    )
+    assert (
+        layer_buttons.newShapesButton.property('mode') == 'new_shapes_multiple'
+    )
+
     viewer.layers.selection.clear()
-    assert not layer_buttons.newPointsButton.isChecked()
-    assert not layer_buttons.newShapesButton.isChecked()
+    assert layer_buttons.newPointsButton.property('mode') == 'new_points'
+    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'

--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -342,49 +342,46 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     # Initially no selection, buttons should not be checked
     assert layer_buttons.newPointsButton.property('mode') == 'new_points'
     assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
-    assert layer_buttons.newPointsButton.property('selection_state') == 'none'
-    assert layer_buttons.newShapesButton.property('selection_state') == 'none'
-    assert layer_buttons.newLabelsButton.property('selection_state') == 'none'
+    assert layer_buttons.newPointsButton.property('creation_state') == 'none'
+    assert layer_buttons.newShapesButton.property('creation_state') == 'none'
+    assert layer_buttons.newLabelsButton.property('creation_state') == 'none'
     # no layers in the viewer, labels button is enabled
     assert layer_buttons.newLabelsButton.isEnabled()
 
     data_layer = viewer.add_image(np.zeros((10, 10)))
     data_layer2 = viewer.add_image(np.zeros((10, 10)))
+    points_layer = viewer.add_points(ndim=2, size=10)
 
     # Selecting a single layer: buttons indicate single-layer inheritance
     viewer.layers.selection = [data_layer]
-    assert layer_buttons.newPointsButton.property('mode') == 'new_points'
-    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
+    assert layer_buttons.newPointsButton.property('creation_state') == 'full'
+    assert layer_buttons.newShapesButton.property('creation_state') == 'full'
+    assert layer_buttons.newLabelsButton.property('creation_state') == 'full'
+
+    viewer.layers.selection = [points_layer]
+
+    assert layer_buttons.newPointsButton.property('creation_state') == 'full'
+    assert layer_buttons.newShapesButton.property('creation_state') == 'full'
     assert (
-        layer_buttons.newPointsButton.property('selection_state') == 'single'
-    )
-    assert (
-        layer_buttons.newShapesButton.property('selection_state') == 'single'
-    )
-    assert (
-        layer_buttons.newLabelsButton.property('selection_state') == 'single'
+        layer_buttons.newLabelsButton.property('creation_state') == 'partial'
     )
 
     # Selecting multiple layers: buttons indicate multi-layer inheritance
     viewer.layers.selection = [data_layer, data_layer2]
-    assert layer_buttons.newPointsButton.property('mode') == 'new_points'
-    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
     assert (
-        layer_buttons.newPointsButton.property('selection_state') == 'multiple'
+        layer_buttons.newPointsButton.property('creation_state') == 'partial'
     )
     assert (
-        layer_buttons.newShapesButton.property('selection_state') == 'multiple'
+        layer_buttons.newShapesButton.property('creation_state') == 'partial'
     )
     assert (
-        layer_buttons.newLabelsButton.property('selection_state') == 'multiple'
+        layer_buttons.newLabelsButton.property('creation_state') == 'partial'
     )
 
     # Clearing selection: buttons return to default state
     viewer.layers.selection.clear()
-    assert layer_buttons.newPointsButton.property('mode') == 'new_points'
-    assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
-    assert layer_buttons.newPointsButton.property('selection_state') == 'none'
-    assert layer_buttons.newShapesButton.property('selection_state') == 'none'
-    assert layer_buttons.newLabelsButton.property('selection_state') == 'none'
+    assert layer_buttons.newPointsButton.property('creation_state') == 'none'
+    assert layer_buttons.newShapesButton.property('creation_state') == 'none'
+    assert layer_buttons.newLabelsButton.property('creation_state') == 'none'
     # layers present but none selected, labels button is disabled
     assert not layer_buttons.newLabelsButton.isEnabled()

--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -369,9 +369,15 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     viewer.layers.selection = [data_layer, data_layer2]
     assert layer_buttons.newPointsButton.property('mode') == 'new_points'
     assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
-    assert layer_buttons.newPointsButton.property('selection_state') == 'multi'
-    assert layer_buttons.newShapesButton.property('selection_state') == 'multi'
-    assert layer_buttons.newLabelsButton.property('selection_state') == 'multi'
+    assert (
+        layer_buttons.newPointsButton.property('selection_state') == 'multiple'
+    )
+    assert (
+        layer_buttons.newShapesButton.property('selection_state') == 'multiple'
+    )
+    assert (
+        layer_buttons.newLabelsButton.property('selection_state') == 'multiple'
+    )
 
     # Clearing selection: buttons return to default state
     viewer.layers.selection.clear()

--- a/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_viewer_buttons.py
@@ -344,6 +344,9 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
     assert layer_buttons.newPointsButton.property('selection_state') == 'none'
     assert layer_buttons.newShapesButton.property('selection_state') == 'none'
+    assert layer_buttons.newLabelsButton.property('selection_state') == 'none'
+    # no layers in the viewer, labels button is enabled
+    assert layer_buttons.newLabelsButton.isEnabled()
 
     data_layer = viewer.add_image(np.zeros((10, 10)))
     data_layer2 = viewer.add_image(np.zeros((10, 10)))
@@ -358,6 +361,9 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     assert (
         layer_buttons.newShapesButton.property('selection_state') == 'single'
     )
+    assert (
+        layer_buttons.newLabelsButton.property('selection_state') == 'single'
+    )
 
     # Selecting multiple layers: buttons indicate multi-layer inheritance
     viewer.layers.selection = [data_layer, data_layer2]
@@ -365,6 +371,7 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
     assert layer_buttons.newPointsButton.property('selection_state') == 'multi'
     assert layer_buttons.newShapesButton.property('selection_state') == 'multi'
+    assert layer_buttons.newLabelsButton.property('selection_state') == 'multi'
 
     # Clearing selection: buttons return to default state
     viewer.layers.selection.clear()
@@ -372,3 +379,6 @@ def test_layer_buttons_checked_on_selection(qt_layer_buttons):
     assert layer_buttons.newShapesButton.property('mode') == 'new_shapes'
     assert layer_buttons.newPointsButton.property('selection_state') == 'none'
     assert layer_buttons.newShapesButton.property('selection_state') == 'none'
+    assert layer_buttons.newLabelsButton.property('selection_state') == 'none'
+    # layers present but none selected, labels button is disabled
+    assert not layer_buttons.newLabelsButton.isEnabled()

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -135,17 +135,35 @@ class QtLayerButtons(QFrame):
         clicking on it.
         """
         if self.viewer.layers.selection.active is not None:
-            self.newPointsButton._change_selection_state('single')
-            self.newShapesButton._change_selection_state('single')
-            self.newLabelsButton._change_selection_state('single')
+            self.newPointsButton._change_selection_state(
+                ButtonSelectionState.SINGLE
+            )
+            self.newShapesButton._change_selection_state(
+                ButtonSelectionState.SINGLE
+            )
+            self.newLabelsButton._change_selection_state(
+                ButtonSelectionState.SINGLE
+            )
         elif self.viewer.layers.selection:
-            self.newPointsButton._change_selection_state('multi')
-            self.newShapesButton._change_selection_state('multi')
-            self.newLabelsButton._change_selection_state('multi')
+            self.newPointsButton._change_selection_state(
+                ButtonSelectionState.MULTIPLE
+            )
+            self.newShapesButton._change_selection_state(
+                ButtonSelectionState.MULTIPLE
+            )
+            self.newLabelsButton._change_selection_state(
+                ButtonSelectionState.MULTIPLE
+            )
         else:
-            self.newPointsButton._change_selection_state('none')
-            self.newShapesButton._change_selection_state('none')
-            self.newLabelsButton._change_selection_state('none')
+            self.newPointsButton._change_selection_state(
+                ButtonSelectionState.NONE
+            )
+            self.newShapesButton._change_selection_state(
+                ButtonSelectionState.NONE
+            )
+            self.newLabelsButton._change_selection_state(
+                ButtonSelectionState.NONE
+            )
 
         self.newLabelsButton.setEnabled(
             not self._layers_present_and_none_selected()
@@ -766,6 +784,12 @@ def _omit_viewer_args(constructor):
     return _func
 
 
+class ButtonSelectionState(StrEnum):
+    NONE = 'none'
+    SINGLE = 'single'
+    MULTIPLE = 'multiple'
+
+
 class QtViewerPushButton(QPushButton):
     """Push button.
 
@@ -780,11 +804,6 @@ class QtViewerPushButton(QPushButton):
     action : str
         action name to be triggered on button click
     """
-
-    class SelectionState(StrEnum):
-        NONE = 'none'
-        SINGLE = 'single'
-        MULTI = 'multi'
 
     @_omit_viewer_args
     def __init__(
@@ -806,10 +825,11 @@ class QtViewerPushButton(QPushButton):
                 action, self, extra_tooltip_text=extra_tooltip_text
             )
 
-    def _change_selection_state(self, state: str) -> None:
+    def _change_selection_state(
+        self, state: str | ButtonSelectionState
+    ) -> None:
         """Change the selection state of a new-layer button."""
-        # convert to str enum to validate
-        self.setProperty('selection_state', self.SelectionState(state).value)
+        self.setProperty('selection_state', ButtonSelectionState(state).value)
         self._refresh_qss()
 
     def _refresh_qss(self) -> None:

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -21,6 +21,7 @@ from napari._qt.dialogs.qt_modal import QtPopup
 from napari._qt.widgets.qt_dims_sorter import QtDimsSorter
 from napari._qt.widgets.qt_spinbox import QtSpinBox
 from napari._qt.widgets.qt_tooltip import QtToolTipLabel
+from napari.layers._scalar_field import ScalarFieldBase
 from napari.utils.action_manager import action_manager
 from napari.utils.camera_orientations import (
     DepthAxisOrientation,
@@ -142,9 +143,13 @@ class QtLayerButtons(QFrame):
             self.newShapesButton._change_selection_state(
                 ButtonSelectionState.SINGLE
             )
-            self.newLabelsButton._change_selection_state(
-                ButtonSelectionState.SINGLE
-            )
+            if isinstance(
+                self.viewer.layers.selection.active, ScalarFieldBase
+            ):
+                state = ButtonSelectionState.SINGLE
+            else:
+                state = ButtonSelectionState.MULTIPLE
+            self.newLabelsButton._change_selection_state(state)
         elif self.viewer.layers.selection:
             self.newPointsButton._change_selection_state(
                 ButtonSelectionState.MULTIPLE

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -138,37 +138,37 @@ class QtLayerButtons(QFrame):
         """
         if self.viewer.layers.selection.active is not None:
             self.newPointsButton._change_selection_state(
-                ButtonSelectionState.SINGLE
+                LayerCreationState.FULL
             )
             self.newShapesButton._change_selection_state(
-                ButtonSelectionState.SINGLE
+                LayerCreationState.FULL
             )
             if isinstance(
                 self.viewer.layers.selection.active, ScalarFieldBase
             ):
-                state = ButtonSelectionState.SINGLE
+                state = LayerCreationState.FULL
             else:
-                state = ButtonSelectionState.MULTIPLE
+                state = LayerCreationState.PARTIAL
             self.newLabelsButton._change_selection_state(state)
         elif self.viewer.layers.selection:
             self.newPointsButton._change_selection_state(
-                ButtonSelectionState.MULTIPLE
+                LayerCreationState.PARTIAL
             )
             self.newShapesButton._change_selection_state(
-                ButtonSelectionState.MULTIPLE
+                LayerCreationState.PARTIAL
             )
             self.newLabelsButton._change_selection_state(
-                ButtonSelectionState.MULTIPLE
+                LayerCreationState.PARTIAL
             )
         else:
             self.newPointsButton._change_selection_state(
-                ButtonSelectionState.NONE
+                LayerCreationState.NONE
             )
             self.newShapesButton._change_selection_state(
-                ButtonSelectionState.NONE
+                LayerCreationState.NONE
             )
             self.newLabelsButton._change_selection_state(
-                ButtonSelectionState.NONE
+                LayerCreationState.NONE
             )
 
         self.newLabelsButton.setEnabled(
@@ -790,10 +790,10 @@ def _omit_viewer_args(constructor):
     return _func
 
 
-class ButtonSelectionState(StrEnum):
+class LayerCreationState(StrEnum):
     NONE = 'none'
-    SINGLE = 'single'
-    MULTIPLE = 'multiple'
+    FULL = 'full'
+    PARTIAL = 'partial'
 
 
 class QtViewerPushButton(QPushButton):
@@ -831,11 +831,9 @@ class QtViewerPushButton(QPushButton):
                 action, self, extra_tooltip_text=extra_tooltip_text
             )
 
-    def _change_selection_state(
-        self, state: str | ButtonSelectionState
-    ) -> None:
+    def _change_selection_state(self, state: str | LayerCreationState) -> None:
         """Change the selection state of a new-layer button."""
-        self.setProperty('selection_state', ButtonSelectionState(state).value)
+        self.setProperty('creation_state', LayerCreationState(state).value)
         self._refresh_qss()
 
     def _refresh_qss(self) -> None:

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -134,14 +134,7 @@ class QtLayerButtons(QFrame):
     ) -> None:
         """Change the selection state of a new-layer button."""
         button.setProperty('selection_state', state)
-        QtLayerButtons._refresh_button_qss(button)
-
-    @staticmethod
-    def _refresh_button_qss(button: 'QtViewerPushButton') -> None:
-        """Refresh the button's QSS (Qt Style Sheet)."""
-        button.style().unpolish(button)
-        button.style().polish(button)
-        button.update()
+        button._refresh_qss()
 
     def _on_selection_changed(self, event=None) -> None:
         """Update button selection/enablement state based on the layer selection.
@@ -815,3 +808,9 @@ class QtViewerPushButton(QPushButton):
             action_manager.bind_button(
                 action, self, extra_tooltip_text=extra_tooltip_text
             )
+
+    def _refresh_qss(self) -> None:
+        """Refresh the button's QSS (Qt Style Sheet)."""
+        self.style().unpolish(self)
+        self.style().polish(self)
+        self.update()

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -107,7 +107,10 @@ class QtLayerButtons(QFrame):
             ),
             self.viewer._new_labels,
         )
-        self.newLabelsButton.setCheckable(True)
+        # Labels button disabled when there are layers present but none are selected
+        self.newLabelsButton.setEnabled(
+            not self._layers_present_and_none_selected()
+        )
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -136,7 +139,7 @@ class QtLayerButtons(QFrame):
         button.update()
 
     def _on_selection_changed(self, event=None) -> None:
-        """Update button selection state based on the layer selection.
+        """Update button selection/enablement state based on the layer selection.
 
         This allows indicating which mode of buttons will be triggered after
         clicking on it.
@@ -144,12 +147,25 @@ class QtLayerButtons(QFrame):
         if self.viewer.layers.selection.active is not None:
             self._change_button_selection_state(self.newPointsButton, 'single')
             self._change_button_selection_state(self.newShapesButton, 'single')
+            self._change_button_selection_state(self.newLabelsButton, 'single')
         elif self.viewer.layers.selection:
             self._change_button_selection_state(self.newPointsButton, 'multi')
             self._change_button_selection_state(self.newShapesButton, 'multi')
+            self._change_button_selection_state(self.newLabelsButton, 'multi')
         else:
             self._change_button_selection_state(self.newPointsButton, 'none')
             self._change_button_selection_state(self.newShapesButton, 'none')
+            self._change_button_selection_state(self.newLabelsButton, 'none')
+
+        self.newLabelsButton.setEnabled(
+            not self._layers_present_and_none_selected()
+        )
+
+    def _layers_present_and_none_selected(self) -> bool:
+        """Check if there are layers present but none selected."""
+        return bool(self.viewer.layers) and not bool(
+            self.viewer.layers.selection
+        )
 
 
 def labeled_double_slider(

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -134,6 +134,11 @@ class QtLayerButtons(QFrame):
     ) -> None:
         """Change the selection state of a new-layer button."""
         button.setProperty('selection_state', state)
+        QtLayerButtons._refresh_button_qss(button)
+
+    @staticmethod
+    def _refresh_button_qss(button: 'QtViewerPushButton') -> None:
+        """Refresh the button's QSS (Qt Style Sheet)."""
         button.style().unpolish(button)
         button.style().polish(button)
         button.update()

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -130,11 +130,10 @@ class QtLayerButtons(QFrame):
         button.update()
 
     def _on_selection_changed(self, event=None) -> None:
-        """Update button checked state when layer selection changes.
+        """Update button mode based on the selection state.
 
-        When a layer is selected, some new layer buttons are checked
-        to indicate that creating a new layer will inherit properties from the
-        selected layer.
+        This allows indicating which mode of buttons will be triggered after
+        clicking on it.
         """
         if self.viewer.layers.selection.active is not None:
             self._change_button_mode(self.newPointsButton, 'new_points_one')

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -121,32 +121,30 @@ class QtLayerButtons(QFrame):
         self._on_selection_changed()
 
     @staticmethod
-    def _change_button_mode(button: 'QtViewerPushButton', mode: str) -> None:
-        """Change the mode of a button."""
-        button.setProperty('mode', mode)
+    def _change_button_selection_state(
+        button: 'QtViewerPushButton', state: str
+    ) -> None:
+        """Change the selection state of a new-layer button."""
+        button.setProperty('selection_state', state)
         button.style().unpolish(button)
         button.style().polish(button)
         button.update()
 
     def _on_selection_changed(self, event=None) -> None:
-        """Update button mode based on the selection state.
+        """Update button selection state based on the layer selection.
 
         This allows indicating which mode of buttons will be triggered after
         clicking on it.
         """
         if self.viewer.layers.selection.active is not None:
-            self._change_button_mode(self.newPointsButton, 'new_points_one')
-            self._change_button_mode(self.newShapesButton, 'new_shapes_one')
+            self._change_button_selection_state(self.newPointsButton, 'single')
+            self._change_button_selection_state(self.newShapesButton, 'single')
         elif self.viewer.layers.selection:
-            self._change_button_mode(
-                self.newPointsButton, 'new_points_multiple'
-            )
-            self._change_button_mode(
-                self.newShapesButton, 'new_shapes_multiple'
-            )
+            self._change_button_selection_state(self.newPointsButton, 'multi')
+            self._change_button_selection_state(self.newShapesButton, 'multi')
         else:
-            self._change_button_mode(self.newPointsButton, 'new_points')
-            self._change_button_mode(self.newShapesButton, 'new_shapes')
+            self._change_button_selection_state(self.newPointsButton, 'none')
+            self._change_button_selection_state(self.newShapesButton, 'none')
 
 
 def labeled_double_slider(

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -1,5 +1,5 @@
 import warnings
-from enum import Enum, EnumMeta
+from enum import Enum, EnumMeta, StrEnum
 from functools import partial, wraps
 from typing import TYPE_CHECKING
 
@@ -128,14 +128,6 @@ class QtLayerButtons(QFrame):
         self.viewer.layers.events.removed.connect(self._on_selection_changed)
         self._on_selection_changed()
 
-    @staticmethod
-    def _change_button_selection_state(
-        button: 'QtViewerPushButton', state: str
-    ) -> None:
-        """Change the selection state of a new-layer button."""
-        button.setProperty('selection_state', state)
-        button._refresh_qss()
-
     def _on_selection_changed(self, event=None) -> None:
         """Update button selection/enablement state based on the layer selection.
 
@@ -143,17 +135,17 @@ class QtLayerButtons(QFrame):
         clicking on it.
         """
         if self.viewer.layers.selection.active is not None:
-            self._change_button_selection_state(self.newPointsButton, 'single')
-            self._change_button_selection_state(self.newShapesButton, 'single')
-            self._change_button_selection_state(self.newLabelsButton, 'single')
+            self.newPointsButton._change_selection_state('single')
+            self.newShapesButton._change_selection_state('single')
+            self.newLabelsButton._change_selection_state('single')
         elif self.viewer.layers.selection:
-            self._change_button_selection_state(self.newPointsButton, 'multi')
-            self._change_button_selection_state(self.newShapesButton, 'multi')
-            self._change_button_selection_state(self.newLabelsButton, 'multi')
+            self.newPointsButton._change_selection_state('multi')
+            self.newShapesButton._change_selection_state('multi')
+            self.newLabelsButton._change_selection_state('multi')
         else:
-            self._change_button_selection_state(self.newPointsButton, 'none')
-            self._change_button_selection_state(self.newShapesButton, 'none')
-            self._change_button_selection_state(self.newLabelsButton, 'none')
+            self.newPointsButton._change_selection_state('none')
+            self.newShapesButton._change_selection_state('none')
+            self.newLabelsButton._change_selection_state('none')
 
         self.newLabelsButton.setEnabled(
             not self._layers_present_and_none_selected()
@@ -789,6 +781,11 @@ class QtViewerPushButton(QPushButton):
         action name to be triggered on button click
     """
 
+    class SelectionState(StrEnum):
+        NONE = 'none'
+        SINGLE = 'single'
+        MULTI = 'multi'
+
     @_omit_viewer_args
     def __init__(
         self,
@@ -808,6 +805,12 @@ class QtViewerPushButton(QPushButton):
             action_manager.bind_button(
                 action, self, extra_tooltip_text=extra_tooltip_text
             )
+
+    def _change_selection_state(self, state: str) -> None:
+        """Change the selection state of a new-layer button."""
+        # convert to str enum to validate
+        self.setProperty('selection_state', self.SelectionState(state).value)
+        self._refresh_qss()
 
     def _refresh_qss(self) -> None:
         """Refresh the button's QSS (Qt Style Sheet)."""

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -82,7 +82,6 @@ class QtLayerButtons(QFrame):
             ),
             partial(new_points, self.viewer),
         )
-        # self.newPointsButton.setCheckable(True)
 
         self.newShapesButton = QtViewerPushButton(
             'new_shapes',

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -82,7 +82,7 @@ class QtLayerButtons(QFrame):
             ),
             partial(new_points, self.viewer),
         )
-        self.newPointsButton.setCheckable(True)
+        # self.newPointsButton.setCheckable(True)
 
         self.newShapesButton = QtViewerPushButton(
             'new_shapes',
@@ -95,7 +95,6 @@ class QtLayerButtons(QFrame):
             ),
             partial(new_shapes, self.viewer),
         )
-        self.newShapesButton.setCheckable(True)
 
         self.newLabelsButton = QtViewerPushButton(
             'new_labels',
@@ -122,6 +121,14 @@ class QtLayerButtons(QFrame):
         )
         self._on_selection_changed()
 
+    @staticmethod
+    def _change_button_mode(button: 'QtViewerPushButton', mode: str) -> None:
+        """Change the mode of a button."""
+        button.setProperty('mode', mode)
+        button.style().unpolish(button)
+        button.style().polish(button)
+        button.update()
+
     def _on_selection_changed(self, event=None) -> None:
         """Update button checked state when layer selection changes.
 
@@ -129,9 +136,19 @@ class QtLayerButtons(QFrame):
         to indicate that creating a new layer will inherit properties from the
         selected layer.
         """
-        has_selection = bool(self.viewer.layers.selection)
-        self.newPointsButton.setChecked(has_selection)
-        self.newShapesButton.setChecked(has_selection)
+        if self.viewer.layers.selection.active is not None:
+            self._change_button_mode(self.newPointsButton, 'new_points_one')
+            self._change_button_mode(self.newShapesButton, 'new_shapes_one')
+        elif self.viewer.layers.selection:
+            self._change_button_mode(
+                self.newPointsButton, 'new_points_multiple'
+            )
+            self._change_button_mode(
+                self.newShapesButton, 'new_shapes_multiple'
+            )
+        else:
+            self._change_button_mode(self.newPointsButton, 'new_points')
+            self._change_button_mode(self.newShapesButton, 'new_shapes')
 
 
 def labeled_double_slider(

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -21,7 +21,6 @@ from napari._qt.dialogs.qt_modal import QtPopup
 from napari._qt.widgets.qt_dims_sorter import QtDimsSorter
 from napari._qt.widgets.qt_spinbox import QtSpinBox
 from napari._qt.widgets.qt_tooltip import QtToolTipLabel
-from napari.layers._scalar_field import ScalarFieldBase
 from napari.utils.action_manager import action_manager
 from napari.utils.camera_orientations import (
     DepthAxisOrientation,

--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -1,5 +1,5 @@
 import warnings
-from enum import Enum, EnumMeta, StrEnum
+from enum import Enum, EnumMeta
 from functools import partial, wraps
 from typing import TYPE_CHECKING
 
@@ -30,6 +30,7 @@ from napari.utils.camera_orientations import (
     VerticalAxisOrientation,
     VerticalAxisOrientationStr,
 )
+from napari.utils.compat import StrEnum
 from napari.utils.misc import in_ipython, in_jupyter, in_python_repl
 from napari.utils.translations import trans
 

--- a/src/napari/utils/events/containers/_selection.py
+++ b/src/napari/utils/events/containers/_selection.py
@@ -135,6 +135,16 @@ class Selection(EventedSet[_T]):
             self._current = None
         super().clear()
 
+    def _add_and_remove(self, add: Iterable[_T], remove: Iterable[_T]) -> None:
+        """Add and remove obj from selection."""
+        self._set.update(add)
+        self._set.difference_update(remove)
+        self._update_active()
+        self._emit_change(
+            added=set(add),
+            removed=set(remove),
+        )
+
     def toggle(self, obj: _T) -> None:
         """Toggle selection state of obj."""
         self.symmetric_difference_update({obj})


### PR DESCRIPTION
# References and relevant issues

Follow up of #8649

# Description

As currently we have 3 modes for adding new points and shapes (and pending #8702 for labels)

But code from #8649 provide to signal only 2 states in user interface. 
As using spatial matadata is no so popular yet, the user might not notice the difference and have wrong expectations.

The modes are:

1) No layer selected - provide default layer with not spatial metadata (except dimensionality)
2) One layer selected - inherit all spatial metadata from this layer 
3) More than one layer selected - from selected layers inherit scale (and units in future). 

https://github.com/user-attachments/assets/ddf0a98b-3308-4412-9ebb-a1e587ea1465

I'm not sure if I select proper colors. 

This PR also update our Selection to emit only one event when change selection of layers in layer list  