### PR TITLE
If path arg is passed to CLI napari, don't show welcome overlay

### DIFF
--- a/src/napari/__main__.py
+++ b/src/napari/__main__.py
@@ -279,8 +279,8 @@ def _run() -> None:
         # but in the meantime if the garbage collector runs;
         # it will collect it and hang napari at start time.
         # in a way that is machine, os, time (and likely weather dependant).
-        # If files are being loaded, don't show the welcome screen
-        viewer = Viewer(show_welcome_screen=not bool(args.paths))
+        # don't show viewer until we've processed all the args
+        viewer = Viewer(show=False)
         _run_configured_startup_script()
 
         # For backwards compatibility
@@ -344,6 +344,8 @@ def _run() -> None:
         if running_as_constructor_app():
             install_certifi_opener()
             maybe_patch_conda_exe()
+        # now that we've processed all the args, show viewer
+        viewer.show()
         run(gui_exceptions=True)
 
 

--- a/src/napari/__main__.py
+++ b/src/napari/__main__.py
@@ -279,7 +279,8 @@ def _run() -> None:
         # but in the meantime if the garbage collector runs;
         # it will collect it and hang napari at start time.
         # in a way that is machine, os, time (and likely weather dependant).
-        viewer = Viewer()
+        # If files are being loaded, don't show the welcome screen
+        viewer = Viewer(show_welcome_screen=not bool(args.paths))
         _run_configured_startup_script()
 
         # For backwards compatibility

--- a/src/napari/_tests/test_cli.py
+++ b/src/napari/_tests/test_cli.py
@@ -88,7 +88,7 @@ def test_cli_runscript(monkeypatch, tmp_path, make_napari_viewer):
 
     with monkeypatch.context() as m:
         m.setattr(sys, 'argv', ['napari', str(script)])
-        m.setattr(__main__, 'Viewer', lambda: v)
+        m.setattr(__main__, 'Viewer', mock.Mock(return_value=v))
         m.setattr(
             'qtpy.QtWidgets.QApplication.exec_', lambda *_: None
         )  # revent event loop if run this test standalone


### PR DESCRIPTION
# Description

Improvement inspired when investigating #8689. When passing a path to napari from the terminal, there is no reason to show the welcome overlay. Indeed, preventing this brief flash is good for accessibility and aesthetics. The loading indicator still spins to show that napari is working

local test if checking out the PR `napari src/napari/resources/multichannel_cells.png`

It doesn't seem like this actually changes much for remote, but maybe because there is such a long spin up time that the overlay flash is almost non existent by the time the data is loaded:
`uvx --from . --with pyqt6 --with ndevio napari https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpD_chicken_embryo_MIP.ome.zarr`





