### PR TITLE
fix: fix `napari.imshow` return type hint

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -253,6 +253,11 @@ authors:
   affiliation: Swiss Federal Institute of Technology (EPFL), Lausanne, Switzerland
   orcid: https://orcid.org/0000-0002-3656-2449
   alias: jeylau
+- given-names: Samuel
+  family-names: Le Meur-Diebolt
+  affiliation: University College London
+  orcid: https://orcid.org/0000-0002-9788-7263
+  alias: sdiebolt
 - given-names: Gregor
   family-names: Lichtner
   affiliation: Universitätsmedizin Greifswald

--- a/src/napari/view_layers.py
+++ b/src/napari/view_layers.py
@@ -4,7 +4,7 @@ This module provides the `imshow` function.
 """
 
 import inspect
-from typing import Any
+from typing import Any, overload
 
 from napari.components.dims import Dims
 from napari.layers import Image
@@ -75,6 +75,88 @@ def _make_viewer_then(
     return viewer, added
 
 
+@overload
+def imshow(
+    data,
+    *,
+    channel_axis: None = ...,
+    affine=...,
+    axis_labels=...,
+    attenuation=...,
+    blending=...,
+    cache=...,
+    colormap=...,
+    contrast_limits=...,
+    custom_interpolation_kernel_2d=...,
+    depiction=...,
+    experimental_clipping_planes=...,
+    gamma=...,
+    interpolation2d=...,
+    interpolation3d=...,
+    iso_threshold=...,
+    metadata=...,
+    multiscale=...,
+    name=...,
+    opacity=...,
+    plane=...,
+    projection_mode=...,
+    rendering=...,
+    rgb=...,
+    rotate=...,
+    scale=...,
+    shear=...,
+    translate=...,
+    units=...,
+    visible=...,
+    viewer=...,
+    title=...,
+    ndisplay=...,
+    order=...,
+    show=...,
+) -> tuple[Viewer, Image]: ...
+
+
+@overload
+def imshow(
+    data,
+    *,
+    channel_axis: int,
+    affine=...,
+    axis_labels=...,
+    attenuation=...,
+    blending=...,
+    cache=...,
+    colormap=...,
+    contrast_limits=...,
+    custom_interpolation_kernel_2d=...,
+    depiction=...,
+    experimental_clipping_planes=...,
+    gamma=...,
+    interpolation2d=...,
+    interpolation3d=...,
+    iso_threshold=...,
+    metadata=...,
+    multiscale=...,
+    name=...,
+    opacity=...,
+    plane=...,
+    projection_mode=...,
+    rendering=...,
+    rgb=...,
+    rotate=...,
+    scale=...,
+    shear=...,
+    translate=...,
+    units=...,
+    visible=...,
+    viewer=...,
+    title=...,
+    ndisplay=...,
+    order=...,
+    show=...,
+) -> tuple[Viewer, tuple[Image, ...]]: ...
+
+
 def imshow(
     data,
     *,
@@ -112,7 +194,7 @@ def imshow(
     ndisplay=2,
     order=(),
     show=True,
-) -> tuple[Viewer, Image | list[Image]]:
+) -> tuple[Viewer, Image | tuple[Image, ...]]:
     """Load data into an Image layer and return the Viewer and Layer.
 
     Parameters
@@ -245,7 +327,7 @@ def imshow(
     -------
     viewer : napari.Viewer
         The created or passed viewer.
-    layer(s) : napari.layers.Image or List[napari.layers.Image]
+    layer(s) : napari.layers.Image or tuple of napari.layers.Image
         The added layer(s). (May be more than one if the ``channel_axis`` keyword
         argument is given.
     """

--- a/src/napari/view_layers.py
+++ b/src/napari/view_layers.py
@@ -112,7 +112,7 @@ def imshow(
     ndisplay=2,
     order=(),
     show=True,
-) -> tuple[Viewer, list['Image']]:
+) -> tuple[Viewer, Image | list[Image]]:
     """Load data into an Image layer and return the Viewer and Layer.
 
     Parameters


### PR DESCRIPTION
# References and relevant issues

Closes #8724.

# Description

`napari.imshow` was unconditionally annotated as returning `tuple[Viewer, list[Image]]`, but at runtime it returns a single `Image` when `channel_axis` is not provided. This adds the `tuple[Viewer, Image | list[Image]]` return signature already used by `Viewer.add_image`. The documentation was already correctly stating that either an `Image` or a list of `Image` could be returned.

Another (cleaner) way of doing this would be to write overloads, so that types are narrowed down depending on `channel_axis`. Given the lenth of `imshow`'s signature, this would add a lot of clutter to the source file though. I'm happy to add it if you think it would be worthwile.


