### PR TITLE
Defer welcome overlay activation for empty viewers

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -190,11 +190,6 @@ class _QtMainWindow(QMainWindow):
         # were defined somewhere in the `_qt` module and imported in init_qactions
         init_qactions()
 
-        # only after qaction are initialized we can get all shortcuts and actions,
-        # so we have to force update the welcome screen here.
-        viewer.welcome_screen.events.shortcuts()
-        viewer.welcome_screen.events.tips()
-
         with contextlib.suppress(IndexError):
             viewer.cursor.events.position.disconnect(
                 viewer.update_status_from_cursor

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -17,7 +17,7 @@ from typing import (
 from weakref import WeakSet, ref
 
 import numpy as np
-from qtpy.QtCore import QCoreApplication, QObject, Qt, QUrl
+from qtpy.QtCore import QCoreApplication, QObject, Qt, QTimer, QUrl
 from qtpy.QtGui import QGuiApplication, QImage
 from qtpy.QtWidgets import QFileDialog, QSplitter, QVBoxLayout, QWidget
 from superqt import ensure_main_thread
@@ -201,6 +201,7 @@ class QtViewer(QSplitter):
         self._dockConsole = None
         self._dockPerformance = None
         self._show_welcome_screen = show_welcome_screen
+        self._welcome_overlay_activated = False
 
         # This dictionary holds the corresponding vispy visual for each layer
         self.canvas = canvas_class(
@@ -226,6 +227,12 @@ class QtViewer(QSplitter):
         self._on_active_change()
         self.viewer.layers.events.inserted.connect(self._update_camera_depth)
         self.viewer.layers.events.removed.connect(self._update_camera_depth)
+        self.viewer.layers.events.inserted.connect(
+            self._on_welcome_layers_change
+        )
+        self.viewer.layers.events.removed.connect(
+            self._on_welcome_layers_change
+        )
         self.viewer.dims.events.ndisplay.connect(self._update_camera_depth)
         self.viewer.layers.selection.events.active.connect(
             self._on_active_change
@@ -261,11 +268,50 @@ class QtViewer(QSplitter):
         if tips is not None:
             viewer.welcome_screen.tips = tips
 
-    def showEvent(self, event):
+    def showEvent(self, event: Any) -> None:
         super().showEvent(event)
-        self.viewer.welcome_screen.visible = self._show_welcome_screen
+        if self._show_welcome_screen:
+            with contextlib.suppress(ValueError, RuntimeError):
+                self.canvas.events.draw.disconnect(self._on_welcome_draw)
+            self.canvas.events.draw.connect(
+                self._on_welcome_draw, position='last'
+            )
 
-    def hideEvent(self, event):
+    def _on_welcome_draw(self, event: Any = None) -> None:
+        """Defer welcome overlay until after first canvas draw.
+
+        VispyWelcomeOverlay inits all vispy visuals, so doing it synchronously
+        during QtViewer init causes a long delay before the window appears.
+        """
+        with contextlib.suppress(ValueError, RuntimeError):
+            self.canvas.events.draw.disconnect(self._on_welcome_draw)
+        # singleShot(0) defers the call to the next event loop
+        # ensuring that welcome overlay occurs after first draw is fully processed.
+        QTimer.singleShot(0, self._activate_welcome)
+
+    def _activate_welcome(self) -> None:
+        """Mark welcome overlay as initialized and update visibility."""
+        self._welcome_overlay_activated = True
+        self._update_welcome_visibility()
+
+    def _on_welcome_layers_change(self, event: Any = None) -> None:
+        """Recompute welcome visibility when layers are inserted/removed."""
+        self._update_welcome_visibility()
+
+    def _update_welcome_visibility(self) -> None:
+        """Update welcome visibility from current viewer/widget state."""
+        if not self._welcome_overlay_activated:
+            return
+        self.viewer.welcome_screen.visible = (
+            self._show_welcome_screen
+            and self.isVisible()
+            and not self.viewer.layers
+        )
+
+    def hideEvent(self, event: Any) -> None:
+        super().hideEvent(event)
+        with contextlib.suppress(ValueError, RuntimeError):
+            self.canvas.events.draw.disconnect(self._on_welcome_draw)
         self.viewer.welcome_screen.visible = False
 
     @property
@@ -276,7 +322,7 @@ class QtViewer(QSplitter):
     @show_welcome_screen.setter
     def show_welcome_screen(self, value: bool):
         self._show_welcome_screen = value
-        self.viewer.welcome_screen.visible = value and self.isVisible()
+        self._update_welcome_visibility()
 
     @staticmethod
     def _update_dask_cache_settings(

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -201,7 +201,6 @@ class QtViewer(QSplitter):
         self._dockConsole = None
         self._dockPerformance = None
         self._show_welcome_screen = show_welcome_screen
-        self._welcome_overlay_activated = False
 
         # This dictionary holds the corresponding vispy visual for each layer
         self.canvas = canvas_class(
@@ -228,10 +227,10 @@ class QtViewer(QSplitter):
         self.viewer.layers.events.inserted.connect(self._update_camera_depth)
         self.viewer.layers.events.removed.connect(self._update_camera_depth)
         self.viewer.layers.events.inserted.connect(
-            self._on_welcome_layers_change
+            self._update_welcome_visibility
         )
         self.viewer.layers.events.removed.connect(
-            self._on_welcome_layers_change
+            self._update_welcome_visibility
         )
         self.viewer.dims.events.ndisplay.connect(self._update_camera_depth)
         self.viewer.layers.selection.events.active.connect(
@@ -270,12 +269,14 @@ class QtViewer(QSplitter):
 
     def showEvent(self, event: Any) -> None:
         super().showEvent(event)
-        if self._show_welcome_screen:
+        if self._show_welcome_screen and not self.viewer.layers:
             with contextlib.suppress(ValueError, RuntimeError):
                 self.canvas.events.draw.disconnect(self._on_welcome_draw)
             self.canvas.events.draw.connect(
                 self._on_welcome_draw, position='last'
             )
+            return
+        self._update_welcome_visibility()
 
     def _on_welcome_draw(self, event: Any = None) -> None:
         """Defer welcome overlay until after first canvas draw.
@@ -287,21 +288,10 @@ class QtViewer(QSplitter):
             self.canvas.events.draw.disconnect(self._on_welcome_draw)
         # singleShot(0) defers the call to the next event loop
         # ensuring that welcome overlay occurs after first draw is fully processed.
-        QTimer.singleShot(0, self._activate_welcome)
+        QTimer.singleShot(0, self._update_welcome_visibility)
 
-    def _activate_welcome(self) -> None:
-        """Mark welcome overlay as initialized and update visibility."""
-        self._welcome_overlay_activated = True
-        self._update_welcome_visibility()
-
-    def _on_welcome_layers_change(self, event: Any = None) -> None:
-        """Recompute welcome visibility when layers are inserted/removed."""
-        self._update_welcome_visibility()
-
-    def _update_welcome_visibility(self) -> None:
+    def _update_welcome_visibility(self, event: Any = None) -> None:
         """Update welcome visibility from current viewer/widget state."""
-        if not self._welcome_overlay_activated:
-            return
         self.viewer.welcome_screen.visible = (
             self._show_welcome_screen
             and self.isVisible()

--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -107,6 +107,24 @@ def test_layer_overlays(qt_viewer):
     assert len(canvas.view.scene.children) == scene_children
 
 
+def test_welcome_box_hidden_when_layers_present(qt_viewer):
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
+
+    viewer.welcome_screen.visible = True
+    vispy_welcome = canvas._overlay_to_visual[viewer.welcome_screen][0]
+
+    assert vispy_welcome.node.visible is True
+    assert vispy_welcome.box.parent is not None
+
+    viewer.add_image(np.zeros((8, 8)))
+
+    assert vispy_welcome.node.visible is False
+    assert vispy_welcome.box.parent is None
+
+    viewer.welcome_screen.visible = False
+
+
 def test_grid_mode(qt_viewer):
     viewer = qt_viewer.viewer
     canvas = qt_viewer.canvas

--- a/src/napari/_vispy/overlays/welcome.py
+++ b/src/napari/_vispy/overlays/welcome.py
@@ -84,6 +84,7 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     def _on_visible_change(self) -> None:
         show = self._should_be_visible()
         self.node.visible = show
+        self._on_box_change()
         if show:
             self.tip_timer.start()
         else:


### PR DESCRIPTION
# References and relevant issues

Addresses part of #8689. In there and other discussions, #8117 was observed to slow down initialization of napari.
In digging into that issue I learned that the slow down is the cost of importing Vispy things, when we did not have the prior to its existence as an overlay. After #8117, the time taken to activate the overlay also blocked the main thread of napari.

# Description

I eventually formed two goals to help speed things up 

1. Don't block napari with the welcome overlay, instead defer its initialization until after the first draw cycle is complete. This was done by using a QTimer to bump the overlay until after the draw completes. This makes the opening of napari seem much snappier. I had Copilot generate me a script to test this, but it implies only a 200ms speedup, when, visually, there is a much bigger difference. I suspect this is because the QtViewer shows in an incomplete state, _unless_ Vispy is blocking the thread, where then it doesn't show the viewer at all. I could see this in that it looks like the menu and such builds up in the blank Qt viewer when the overlay was deferred.

2. _Also_, don't initialize the welcome overlay if layers are present prior to showing napari, e.g.:
```python
import napari
viewer = napari.Viewer(show=False)
viewer.open_sample('napari', 'cell')
viewer.show()
napari.run()
```
This is useful for a very snappy opening of napari, with only the layer being the cost incurred (which includes many of the vispy inits). We additionally benefit by not flashing users in these instances with the welcome overlay. In proof that this was success, we now pay the cost on layer removal in order to initialize the welcome overlay. I think that this is a victory because for folks writing the above pattern, they want their image to be opened as soon as possible (and likely will not remove all layers to trigger the overlay).

The follow-up / related issue #8725 is working on removing this cost for `napari "path"` CLI.

I would like something like
```python
import napari
from skimage import data

napari.imshow(data.astronaut())
napari.run()
```
but can't figure out how we would do that correctly with the event loop implying both `show=True` and there's data. The only workaround would be the following, which I don't like very much

```python
viewer, _ = napari.imshow(data.astronaut(), show=False)
viewer.show()
napari.run()
```