### PR TITLE
UI: Add keybinding for Image layer reset_contrast_limits

### DIFF
--- a/src/napari/layers/image/_image_key_bindings.py
+++ b/src/napari/layers/image/_image_key_bindings.py
@@ -29,6 +29,12 @@ def register_image_mode_action(
     return register_layer_attr_action(Image, description, 'mode')
 
 
+@register_image_action(trans._('Apply auto-contrast'))
+def auto_contrast_once(layer: Image) -> None:
+    """Apply auto-contrast."""
+    layer.reset_contrast_limits()
+
+
 @register_image_action(trans._('Orient plane normal along z-axis'))
 def orient_plane_normal_along_z(layer: Image) -> None:
     orient_plane_normal_around_cursor(layer, plane_normal=(1, 0, 0))

--- a/src/napari/layers/image/_tests/test_image_key_bindings.py
+++ b/src/napari/layers/image/_tests/test_image_key_bindings.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from napari.layers.image import Image, _image_key_bindings as key_bindings
+
+
+def test_auto_contrast_once_sets_clims():
+    data = np.array([[0, 10]])
+    layer = Image(data)
+    # change to something else first
+    layer.contrast_limits = (1, 2)
+    key_bindings.auto_contrast_once(layer)
+    assert layer.contrast_limits == [0.0, 10.0]

--- a/src/napari/utils/shortcuts.py
+++ b/src/napari/utils/shortcuts.py
@@ -97,6 +97,7 @@ _default_shortcuts = {
     'napari:orient_plane_normal_along_y': [KeyCode.KeyY],
     'napari:orient_plane_normal_along_z': [KeyCode.KeyZ],
     'napari:orient_plane_normal_along_view_direction': [KeyCode.KeyO],
+    'napari:auto_contrast_once': [KeyCode.KeyC],
     'napari:activate_image_pan_zoom_mode': [KeyCode.Digit1],
     'napari:activate_image_transform_mode': [KeyCode.Digit2],
     # vectors


### PR DESCRIPTION
# References and relevant issues
Helps with: https://github.com/napari/napari/issues/8718

# Description
As the title says, this PR just registers an action for the reset_contrast_limits() (equivalent to the `once` button). I made the default binding be `C` which is conveniently next to V and easy to hit after a Shift-V to show just the one layer.
I also added a simple test, based on Shapes tests.
