### PR TITLE
Perf: Instead of trying to import, check if IPython is already imported

### DIFF
--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -54,31 +54,44 @@ def running_as_constructor_app() -> bool:
 
 def in_jupyter() -> bool:
     """Return true if we're running in jupyter notebook/lab or qtconsole."""
-    with contextlib.suppress(ImportError):
-        from IPython import get_ipython
-
-        return get_ipython().__class__.__name__ == 'ZMQInteractiveShell'
-    return False
+    # check if IPython is imported already
+    ipy = sys.modules.get('IPython')
+    if ipy is None:
+        return False
+    get_ipython = ipy.get_ipython
+    shell = get_ipython()
+    return (
+        shell is not None and shell.__class__.__name__ == 'ZMQInteractiveShell'
+    )
 
 
 def in_ipython() -> bool:
     """Return true if we're running in an IPython interactive shell."""
-    with contextlib.suppress(ImportError):
-        from IPython import get_ipython
-
-        return get_ipython().__class__.__name__ == 'TerminalInteractiveShell'
-    return False
+    # check if IPython is imported already
+    ipy = sys.modules.get('IPython')
+    if ipy is None:
+        return False
+    get_ipython = ipy.get_ipython
+    shell = get_ipython()
+    return (
+        shell is not None
+        and shell.__class__.__name__ == 'TerminalInteractiveShell'
+    )
 
 
 def in_python_repl() -> bool:
     """Return true if we're running in a Python REPL."""
-    with contextlib.suppress(ImportError):
-        from IPython import get_ipython
-
-        return get_ipython().__class__.__name__ == 'NoneType' and hasattr(
-            sys, 'ps1'
-        )
-    return False
+    # check if IPython is imported already
+    ipy = sys.modules.get('IPython')
+    if ipy is None:
+        return hasattr(sys, 'ps1')
+    get_ipython = ipy.get_ipython
+    shell = get_ipython()
+    return (
+        shell is not None
+        and shell.__class__.__name__ == 'NoneType'
+        and hasattr(sys, 'ps1')
+    )
 
 
 def str_to_rgb(arg: str) -> list[int]:


### PR DESCRIPTION
# References and relevant issues
Part of: https://github.com/napari/napari/issues/8689

# Description

So the checks here are to see if we're running not from CLI essentially.
My logic is that *if* we're running from jupyter, ipython, etc. then IPython would be already imported. 
So instead of what is essentially a try/except, lets just check if it's imported -- this was inspired by what Grzegorz did in the dask.array PR.
I tested locally and the viewer button is disabled and manually calling the functions in each of the things works as expected.
E.g. Jupyter:
<img width="511" height="458" alt="image" src="https://github.com/user-attachments/assets/2dc6edfa-f17b-4fe1-a95d-e1556524ba68" />
In IPython:
<img width="349" height="264" alt="image" src="https://github.com/user-attachments/assets/05b364ce-ccde-4976-937e-e0e551b0474e" />
Python repl
<img width="395" height="208" alt="image" src="https://github.com/user-attachments/assets/af9a3216-0480-4287-8f7e-3038de007282" />

For me this shaves off ~0.2 s off startup.
With this branch:
`python -X importtime -c 'import napari; v = napari.Viewer()' 2>&1 | grep IPython`
returns nothing.
With main:
`import time:       532 |     187641 | IPython`
