### PR TITLE
Delay some stuff on welcome init

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -13,6 +13,7 @@ from weakref import WeakSet
 
 import numpy as np
 from OpenGL.error import GLError
+from qtpy.QtCore import QTimer
 from superqt.utils import qthrottled
 from vispy.scene import SceneCanvas as SceneCanvas_, ViewBox, Widget
 
@@ -903,6 +904,10 @@ class VispyCanvas:
                 overlay=overlay, viewer=self.viewer, parent=parent
             )
             self._overlay_to_visual[overlay].append(vispy_overlay)
+            if delayed_init := getattr(
+                vispy_overlay.node, 'delayed_init', None
+            ):
+                QTimer.singleShot(100, delayed_init)
 
             if isinstance(overlay, CanvasOverlay):
                 vispy_overlay.canvas_position_callback = (

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -55,7 +55,6 @@ class Welcome(Node):
             anchor_x='center',
             anchor_y='bottom',
             method='gpu',
-            parent=self,
         )
         self.shortcut_keybindings = Text(
             text='',
@@ -64,7 +63,6 @@ class Welcome(Node):
             anchor_x='right',
             anchor_y='bottom',
             method='gpu',
-            parent=self,
         )
         self.shortcut_descriptions = Text(
             text='',
@@ -73,7 +71,6 @@ class Welcome(Node):
             anchor_x='left',
             anchor_y='bottom',
             method='gpu',
-            parent=self,
         )
         self.tip = Text(
             text='',
@@ -82,10 +79,18 @@ class Welcome(Node):
             anchor_x='center',
             anchor_y='bottom',
             method='gpu',
-            parent=self,
         )
 
         self.transform = STTransform()
+
+    def delayed_init(self) -> None:
+        for text in (
+            self.header,
+            self.shortcut_keybindings,
+            self.shortcut_descriptions,
+            self.tip,
+        ):
+            text.parent = self
 
     def set_color(self, color: ColorValue) -> None:
         self.logo.color = color


### PR DESCRIPTION
# References and relevant issues
- alternative to #8727

# Description
It turns out that the real slow thing here is Text in vispy, for some reason. This PR just delays adding the text in the welcome screen; the result is similar to #8727, with 2 main differences:

1. A nonzero delay on the singleshot means that other things can happen in between. I found that 100 is a good value which allows the first layer to spawn in *before* the overlay can even be displayed, so if you run `napari examples/add_image.py` it's now as fast as before. The downside is that if the viewer is empty on launch, it freezes a bit after 100ms in order to add the text, but I found that hard to notice unless I really try to be fast at interacting with the canvas.
2. The logo at least shows, which I think is a bit better than a black screen in showing that things are working

The implementation is not super nice, we might wanna move this back up to the qt viewer similar to #8727.

