### PR TITLE
Speed up welcome overlay with shared FontManager

### DIFF
--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -56,7 +56,6 @@ class Welcome(Node):
             pos=[0, 0],
             anchor_x='center',
             anchor_y='bottom',
-            method='gpu',
             font_manager=self._font_manager,
             parent=self,
         )
@@ -66,7 +65,6 @@ class Welcome(Node):
             pos=[-80, 60],
             anchor_x='right',
             anchor_y='bottom',
-            method='gpu',
             font_manager=self._font_manager,
             parent=self,
         )
@@ -76,7 +74,6 @@ class Welcome(Node):
             pos=[-60, 60],
             anchor_x='left',
             anchor_y='bottom',
-            method='gpu',
             font_manager=self._font_manager,
             parent=self,
         )
@@ -86,7 +83,6 @@ class Welcome(Node):
             pos=[0, 160],
             anchor_x='center',
             anchor_y='bottom',
-            method='gpu',
             font_manager=self._font_manager,
             parent=self,
         )

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -10,6 +10,7 @@ import numpy as np
 from vispy.scene.node import Node
 from vispy.scene.visuals import Polygon
 from vispy.util.svg import Document
+from vispy.visuals.text.text import FontManager
 from vispy.visuals.transforms import STTransform
 
 from napari._app_model import get_app_model
@@ -45,6 +46,7 @@ class Welcome(Node):
         # move it up
         self.logo_coords[:, 1] -= 130  # magic number shifting up logo
         super().__init__()
+        self._font_manager = FontManager(method='gpu')
 
         self.logo = Polygon(
             self.logo_coords, border_method='agg', border_width=2, parent=self
@@ -55,6 +57,7 @@ class Welcome(Node):
             anchor_x='center',
             anchor_y='bottom',
             method='gpu',
+            font_manager=self._font_manager,
             parent=self,
         )
         self.shortcut_keybindings = Text(
@@ -64,6 +67,7 @@ class Welcome(Node):
             anchor_x='right',
             anchor_y='bottom',
             method='gpu',
+            font_manager=self._font_manager,
             parent=self,
         )
         self.shortcut_descriptions = Text(
@@ -73,6 +77,7 @@ class Welcome(Node):
             anchor_x='left',
             anchor_y='bottom',
             method='gpu',
+            font_manager=self._font_manager,
             parent=self,
         )
         self.tip = Text(
@@ -82,6 +87,7 @@ class Welcome(Node):
             anchor_x='center',
             anchor_y='bottom',
             method='gpu',
+            font_manager=self._font_manager,
             parent=self,
         )
 


### PR DESCRIPTION
# References and relevant issues

Alternative / supplement to #8727 and #8735

# Description

I tracked down through the Vispy text, because @brisvag identified that its the `Text` glyph construction that is slow. My thought was to try to find a way to share the glyph state across all `Text` nodes.

I found that each `TextVisual` creates a `FontManager` isntance on construction. My thought instead was to pass a shared `FontManager` instance to each `Text`, which seemed to be the speedup that I was looking for.

In addition, by default `FontManager` uses 'cpu' method, but I _think_ I observed a performance improvement with 'gpu'. Edit: I see that `method='gpu'` was already being used, so I guess others agreed. Regardless, setting `font_manager` would override `method`.

For me, I think this completely resolves the issue, but I will need to test more later. I merged this in with #8727 and #8735 and found no improvement on top of what this already offers. 

Indeed, with my startup test script, it's the FIRST time that I've seen the qt_viewer launch faster, and not just the first draw event. In this instance, I go from 3.1s -> 2.7s for qt_viewer initiatilization (this is the first time ever I've had napari launch in less than 3s!!!!!). This also results, then, in the first draw being 400ms sooner. I just tested on my laptop and I get complete initialization (seeing overlay) in 7.5s with this PR vs 9s on main.

~~A follow-up may be to just create a single `FontManager` on napari init and share that in **every** `Text` instance? Rather than just for the welcome overlay, like here.~~ see: https://github.com/napari/napari/pull/8738#issuecomment-4006895552