### PR TITLE
Use shared font manager for text

### DIFF
--- a/src/napari/_vispy/visuals/text.py
+++ b/src/napari/_vispy/visuals/text.py
@@ -1,11 +1,14 @@
 from typing import Any
 
 from vispy.scene.visuals import Text as BaseText
+from vispy.visuals.text.text import FontManager
 
 from napari._vispy.utils.text import (
     get_text_width_height,
     register_napari_fonts,
 )
+
+FONT_MANAGER = FontManager(method='gpu')
 
 
 class Text(BaseText):
@@ -13,7 +16,7 @@ class Text(BaseText):
         self, *args: Any, face: str = 'AlataPlus', **kwargs: Any
     ) -> None:
         register_napari_fonts()
-        super().__init__(*args, face=face, **kwargs)
+        super().__init__(*args, face=face, font_manager=FONT_MANAGER, **kwargs)
 
     def get_width_height(self) -> tuple[float, float]:
         width, height = get_text_width_height(self)


### PR DESCRIPTION
# References and relevant issues
- alternative/complementary to #8738, #8727, #8735

# Description
Based on #8727, but with a fully shared font manager across vispy.

By testing manually with a stopwatch, from launch of `napari examples/add_image.py` (identical to just `napari`) to interactable viewer we get:

- main: ~3.7s
- here: ~3s
- 2777a9236: ~2.7s

Note this is still slightly worse than pre-overlay because the fontmanager needs to be initialized at least once.

@psobolewskiPhD do you still see negligible benefits on your mac? This is pretty significant for me.