### PR TITLE
Use capitalized name of source layer type when adding layer

### DIFF
--- a/src/napari/_app_model/actions/_file.py
+++ b/src/napari/_app_model/actions/_file.py
@@ -125,7 +125,7 @@ def _new_layer_from_active(
         raise ValueError('No active layer to create new layer from.')
     source_layer = layer_list.selection.active
     new_layer_name = get_layer_name(
-        f'{source_layer.name} - {layer_class.__name__.lower()}',
+        f'{source_layer.name} - {layer_class.__name__}',
         existing_names={layer.name for layer in layer_list},
     )
     return _create_single_layer(source_layer, layer_class, new_layer_name)


### PR DESCRIPTION
# References and relevant issues


# Description

While playing with #8701 I found that lowercase suffix "shapes" or "points` added when we copy spatial information from one layer look inconsistent with other cases when we add Capitalized name. So this PR changes to use "Shapes" or "Points" 