### PR TITLE
Remove usage of `partial` from `qt_viewer_buttons`

### DIFF
--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import Enum, EnumMeta
-from functools import partial, wraps
+from functools import wraps
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QEvent, Qt
@@ -80,7 +80,7 @@ class QtLayerButtons(QFrame):
                 'Deselect all layers to create a new points layer with the\n'
                 'full extent of all the data.'
             ),
-            partial(new_points, self.viewer),
+            self._new_points,
         )
         self.newPointsButton.setCheckable(True)
 
@@ -93,7 +93,7 @@ class QtLayerButtons(QFrame):
                 'Deselect all layers to create a new shapes layer with the\n'
                 'full extent of all the data.'
             ),
-            partial(new_shapes, self.viewer),
+            self._new_shapes,
         )
         self.newShapesButton.setCheckable(True)
 
@@ -121,6 +121,12 @@ class QtLayerButtons(QFrame):
             self._on_selection_changed
         )
         self._on_selection_changed()
+
+    def _new_points(self):
+        new_points(self.viewer)
+
+    def _new_shapes(self):
+        new_shapes(self.viewer)
 
     def _on_selection_changed(self, event=None) -> None:
         """Update button checked state when layer selection changes.
@@ -156,7 +162,7 @@ def enum_combobox(
     parent: QtPopup,
     enum_class: EnumMeta,
     current_enum: Enum,
-    callback: 'Callable[[],Any] | Callable[[Enum],Any]',
+    callback: 'Callable[[],Any] | Callable[[Enum],Any] | Callable[[str],Any]',
 ) -> QEnumComboBox:
     """Create an enum combobox widget."""
     combo = QEnumComboBox(parent, enum_class=enum_class)
@@ -303,6 +309,18 @@ class QtViewerButtons(QFrame):
         )
         popup.show()
 
+    def _update_first_camera_angle(self, value: float) -> None:
+        """Update the camera angle along axis 0."""
+        self._update_camera_angles(0, value)
+
+    def _update_second_camera_angle(self, value: float) -> None:
+        """Update the camera angle along axis 1."""
+        self._update_camera_angles(1, value)
+
+    def _update_third_camera_angle(self, value: float) -> None:
+        """Update the camera angle along axis 2."""
+        self._update_camera_angles(2, value)
+
     def _add_3d_camera_controls(
         self,
         popup: QtPopup,
@@ -325,7 +343,7 @@ class QtViewerButtons(QFrame):
             parent=popup,
             value=self.viewer.camera.angles[0],
             value_range=(-180, 180),
-            callback=partial(self._update_camera_angles, 0),
+            callback=self._update_first_camera_angle,
         )
 
         # value_range is [-89, 89] because at >=+/-90 gimbal locks the camera.
@@ -334,14 +352,14 @@ class QtViewerButtons(QFrame):
             parent=popup,
             value=self.viewer.camera.angles[1],
             value_range=(-89, 89),
-            callback=partial(self._update_camera_angles, 1),
+            callback=self._update_second_camera_angle,
         )
 
         self.rx = labeled_double_slider(
             parent=popup,
             value=self.viewer.camera.angles[2],
             value_range=(-180, 180),
-            callback=partial(self._update_camera_angles, 2),
+            callback=self._update_third_camera_angle,
         )
 
         angle_help_symbol = help_tooltip(
@@ -386,6 +404,24 @@ class QtViewerButtons(QFrame):
         grid_layout.addWidget(self.zoom, 1, 1)
         grid_layout.addWidget(zoom_help_symbol, 1, 2)
 
+    def _update_verical_axis_orientation(
+        self, value: VerticalAxisOrientationStr
+    ) -> None:
+        """Update the vertical axis orientation of the camera."""
+        self._update_orientation(VerticalAxisOrientation, value)
+
+    def _update_horizontal_axis_orientation(
+        self, value: HorizontalAxisOrientationStr
+    ) -> None:
+        """Update the horizontal axis orientation of the camera."""
+        self._update_orientation(HorizontalAxisOrientation, value)
+
+    def _update_depth_axis_orientation(
+        self, value: DepthAxisOrientationStr
+    ) -> None:
+        """Update the depth axis orientation of the camera."""
+        self._update_orientation(DepthAxisOrientation, value)
+
     def _add_orientation_controls(
         self,
         popup: QtPopup,
@@ -400,18 +436,14 @@ class QtViewerButtons(QFrame):
             parent=popup,
             enum_class=VerticalAxisOrientation,
             current_enum=self.viewer.camera.orientation[1],
-            callback=partial(
-                self._update_orientation, VerticalAxisOrientation
-            ),
+            callback=self._update_verical_axis_orientation,
         )
 
         self.horizontal_combo = enum_combobox(
             parent=popup,
             enum_class=HorizontalAxisOrientation,
             current_enum=self.viewer.camera.orientation[2],
-            callback=partial(
-                self._update_orientation, HorizontalAxisOrientation
-            ),
+            callback=self._update_horizontal_axis_orientation,
         )
 
         if self.viewer.dims.ndisplay == 2:
@@ -427,9 +459,7 @@ class QtViewerButtons(QFrame):
                 parent=popup,
                 enum_class=DepthAxisOrientation,
                 current_enum=self.viewer.camera.orientation[0],
-                callback=partial(
-                    self._update_orientation, DepthAxisOrientation
-                ),
+                callback=self._update_depth_axis_orientation,
             )
 
             orientation_layout.addWidget(self.depth_combo)


### PR DESCRIPTION
# References and relevant issues

# Description

The usage of partial as a callback might lead to keeping objects alive (or worse partially alive) for longer that it is needed so it might end with crashes on CI (or maybe even on long sessions in real life) 

This PR removes usage of partial as callbacks and replace it with class methods that simplify the managing of objects live. 