### PR TITLE
Add scale example for anisotropic 3D data

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -243,6 +243,11 @@ authors:
   family-names: Hutchings
   affiliation: University College London
   alias: katherine-hutchings
+- given-names: Hiroki
+  family-names: Kawai
+  affiliation: The University of Tokyo / LPIXEL Inc.
+  orcid: https://orcid.org/0000-0002-7129-2384
+  alias: hiroalchem
 - given-names: Robert
   family-names: Kozar
   affiliation: Naval Nuclear Laboratory

--- a/examples/anisotropic_scale.py
+++ b/examples/anisotropic_scale.py
@@ -15,24 +15,24 @@ Toggle the visibility of each layer to compare the difference.
 .. tags:: visualization-nD, layers
 """
 
-import numpy as np
 from skimage import data
 
 import napari
 
-# Subsample Z by 4x to simulate strongly anisotropic data
+# cells3d has voxel spacing approximately (0.29, 0.26, 0.26) in (z, y, x).
+# We subsample z by 4 and x by 2 to simulate more strongly anisotropic data.
+# After subsampling, the effective voxel spacing becomes (1.16, 0.26, 0.52),
+# which we pass to ``scale`` as the physical pixel size.
 cells = data.cells3d()
-nuclei = np.ascontiguousarray(cells[::4, 1])
+nuclei = cells[::4, 1, :, ::2]
 
-# Z voxel spacing is ~4.5x larger than XY after subsampling
-scale = (4.5, 1, 1)
+scale = (1.16, 0.26, 0.52)
 
 viewer = napari.Viewer(ndisplay=3)
 
 viewer.add_image(
     nuclei,
     name='no scale',
-    rendering='mip',
     blending='additive',
     colormap='magenta',
 )
@@ -40,14 +40,18 @@ viewer.add_image(
 viewer.add_image(
     nuclei,
     name='with scale',
-    rendering='mip',
     blending='additive',
     colormap='green',
     scale=scale,
 )
 
-viewer.camera.angles = (-25, 25, -140)
-viewer.camera.zoom = 1.5
+viewer.layers['no scale'].bounding_box.line_color = 'magenta'
+viewer.layers['no scale'].bounding_box.visible = True
+viewer.layers['with scale'].bounding_box.line_color = 'green'
+viewer.layers['with scale'].bounding_box.visible = True
+
+viewer.camera.angles = (-45, 0, -60)
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/anisotropic_scale.py
+++ b/examples/anisotropic_scale.py
@@ -1,0 +1,53 @@
+"""
+Anisotropic data with scale
+============================
+
+Display a 3D image with anisotropic voxel spacing using the ``scale``
+parameter so that the volume appears with correct proportions.
+
+Microscopy data is often anisotropic: the voxel spacing along the Z axis
+is larger than along X and Y.  Without ``scale``, napari treats every
+voxel as a unit cube and the volume looks compressed along Z.
+Setting ``scale`` to the real voxel dimensions corrects this.
+
+Toggle the visibility of each layer to compare the difference.
+
+.. tags:: visualization-nD, layers
+"""
+
+import numpy as np
+from skimage import data
+
+import napari
+
+# Subsample Z by 4x to simulate strongly anisotropic data
+cells = data.cells3d()
+nuclei = np.ascontiguousarray(cells[::4, 1])
+
+# Z voxel spacing is ~4.5x larger than XY after subsampling
+scale = (4.5, 1, 1)
+
+viewer = napari.Viewer(ndisplay=3)
+
+viewer.add_image(
+    nuclei,
+    name='no scale',
+    rendering='mip',
+    blending='additive',
+    colormap='magenta',
+)
+
+viewer.add_image(
+    nuclei,
+    name='with scale',
+    rendering='mip',
+    blending='additive',
+    colormap='green',
+    scale=scale,
+)
+
+viewer.camera.angles = (-25, 25, -140)
+viewer.camera.zoom = 1.5
+
+if __name__ == '__main__':
+    napari.run()

--- a/examples/anisotropic_scale.py
+++ b/examples/anisotropic_scale.py
@@ -5,9 +5,9 @@ Anisotropic data with scale
 Display a 3D image with anisotropic voxel spacing using the ``scale``
 parameter so that the volume appears with correct proportions.
 
-Microscopy data is often anisotropic: the voxel spacing along the Z axis
-is larger than along X and Y.  Without ``scale``, napari treats every
-voxel as a unit cube and the volume looks compressed along Z.
+Microscopy data is often anisotropic: the voxel spacing differs across
+axes.  Without ``scale``, napari treats every voxel as a unit cube and
+the volume appears with incorrect proportions.
 Setting ``scale`` to the real voxel dimensions corrects this.
 
 Toggle the visibility of each layer to compare the difference.

--- a/examples/anisotropic_scale.py
+++ b/examples/anisotropic_scale.py
@@ -21,12 +21,12 @@ import napari
 
 # cells3d has voxel spacing approximately (0.29, 0.26, 0.26) in (z, y, x).
 # We subsample z by 4 and x by 2 to simulate more strongly anisotropic data.
-# After subsampling, the effective voxel spacing becomes (1.16, 0.26, 0.52),
-# which we pass to ``scale`` as the physical pixel size.
+# After subsampling, the effective voxel spacing becomes (1.16, 0.26, 0.52).
+# The ratio is approximately (4.5, 1, 2), which we pass to ``scale``.
 cells = data.cells3d()
 nuclei = cells[::4, 1, :, ::2]
 
-scale = (1.16, 0.26, 0.52)
+scale = (4.5, 1, 2)
 
 viewer = napari.Viewer(ndisplay=3)
 


### PR DESCRIPTION
# References and relevant issues

Closes #8043
Part of #7991

# Description

Adds an example showing how to use `scale` to correctly display anisotropic 3D data.

The example uses `cells3d` from scikit-image, subsampled in Z to simulate anisotropic voxel spacing. Two layers are shown overlaid (with and without `scale`) so the user can toggle visibility to compare.