### PR TITLE
Refactor Welcome overlay to use Qt for text handling and rasterization

### DIFF
--- a/src/napari/_qt/_tests/test_qt_utils.py
+++ b/src/napari/_qt/_tests/test_qt_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import pytest
 from qtpy.QtCore import QByteArray, QObject, Signal
-from qtpy.QtGui import QColor, QFont
+from qtpy.QtGui import QColor, QFont, QFontMetricsF
 from qtpy.QtWidgets import QColorDialog, QMainWindow
 
 from napari._qt.utils import (
@@ -124,6 +124,23 @@ def test_rasterize_text_blocks_to_array_empty():
     )
     np.testing.assert_array_equal(array, np.zeros((1, 1, 4), dtype=np.uint8))
     assert origin == (0.0, 0.0)
+
+
+@pytest.mark.usefixtures('qapp')
+def test_rasterize_text_blocks_fixed_line_spacing():
+    font = QFont()
+    font.setPixelSize(20)
+    metrics = QFontMetricsF(font)
+    expected_height = int(np.ceil(2 * (metrics.ascent() + metrics.descent())))
+    array, _ = rasterize_text_blocks_to_array(
+        [('Hg\nHg', 0, 0, 'left')],
+        font=font,
+        line_height=1,
+        raster_scale=1,
+        padding=0,
+    )
+
+    assert array.shape[0] == expected_height
 
 
 def test_add_flash_animation(qtbot):

--- a/src/napari/_qt/_tests/test_qt_utils.py
+++ b/src/napari/_qt/_tests/test_qt_utils.py
@@ -143,6 +143,29 @@ def test_rasterize_text_blocks_fixed_line_spacing():
     assert array.shape[0] == expected_height
 
 
+@pytest.mark.usefixtures('qapp')
+def test_rasterize_text_blocks_uses_pixel_size_for_extra_leading():
+    font = QFont()
+    font.setPixelSize(20)
+    metrics = QFontMetricsF(font)
+    font_height = metrics.ascent() + metrics.descent()
+    line_height = 1.25
+    expected_height = int(
+        np.ceil(
+            font_height + (font_height + (line_height - 1) * font.pixelSize())
+        )
+    )
+    array, _ = rasterize_text_blocks_to_array(
+        [('Hg\nHg', 0, 0, 'left')],
+        font=font,
+        line_height=line_height,
+        raster_scale=1,
+        padding=0,
+    )
+
+    assert array.shape[0] == expected_height
+
+
 def test_add_flash_animation(qtbot):
     widget = QMainWindow()
     qtbot.addWidget(widget)

--- a/src/napari/_qt/_tests/test_qt_utils.py
+++ b/src/napari/_qt/_tests/test_qt_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import pytest
 from qtpy.QtCore import QByteArray, QObject, Signal
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QFont
 from qtpy.QtWidgets import QColorDialog, QMainWindow
 
 from napari._qt.utils import (
@@ -16,6 +16,7 @@ from napari._qt.utils import (
     qbytearray_to_str,
     qt_might_be_rich_text,
     qt_signals_blocked,
+    rasterize_text_blocks_to_array,
     str_to_qbytearray,
 )
 from napari.utils._proxies import PublicOnlyProxy
@@ -93,6 +94,36 @@ def test_qbytearray_to_str_and_back(qtbot):
 
     qbyte = widget.saveState()
     assert str_to_qbytearray(qbytearray_to_str(qbyte)) == qbyte
+
+
+@pytest.mark.usefixtures('qapp')
+def test_rasterize_text_blocks_to_array():
+    font = QFont()
+    font.setPixelSize(18)
+    array, origin = rasterize_text_blocks_to_array(
+        [('hello', 0, 0, 'center'), ('world', 12, 25, 'left')],
+        font=font,
+        line_height=1.15,
+        color=(255, 255, 255, 255),
+        raster_scale=2,
+        padding=1,
+    )
+
+    assert array.ndim == 3
+    assert array.shape[-1] == 4
+    assert array[..., 3].max() > 0
+    assert len(origin) == 2
+
+
+@pytest.mark.usefixtures('qapp')
+def test_rasterize_text_blocks_to_array_empty():
+    font = QFont()
+    font.setPixelSize(18)
+    array, origin = rasterize_text_blocks_to_array(
+        [('', 0, 0, 'center')], font=font
+    )
+    np.testing.assert_array_equal(array, np.zeros((1, 1, 4), dtype=np.uint8))
+    assert origin == (0.0, 0.0)
 
 
 def test_add_flash_animation(qtbot):

--- a/src/napari/_qt/utils.py
+++ b/src/napari/_qt/utils.py
@@ -16,12 +16,22 @@ from qtpy.QtCore import (
     QByteArray,
     QCoreApplication,
     QObject,
+    QPointF,
     QPropertyAnimation,
     QSocketNotifier,
     Qt,
     QThread,
 )
-from qtpy.QtGui import QColor, QCursor, QDrag, QImage, QPainter, QPixmap
+from qtpy.QtGui import (
+    QColor,
+    QCursor,
+    QDrag,
+    QFont,
+    QFontMetricsF,
+    QImage,
+    QPainter,
+    QPixmap,
+)
 from qtpy.QtWidgets import (
     QColorDialog,
     QGraphicsColorizeEffect,
@@ -140,6 +150,124 @@ def QImg2array(
     # reversed.
     arr = arr[:, :, [2, 1, 0, 3]]
     return arr
+
+
+def _coerce_qcolor(color: QColor | Sequence[int]) -> QColor:
+    """Normalize a color input to a QColor instance."""
+    if isinstance(color, QColor):
+        return QColor(color)
+    if len(color) == 3:
+        red, green, blue = color
+        alpha = 255
+    elif len(color) == 4:
+        red, green, blue, alpha = color
+    else:
+        raise ValueError('color must have 3 (RGB) or 4 (RGBA) components')
+    return QColor(int(red), int(green), int(blue), int(alpha))
+
+
+def rasterize_text_blocks_to_array(
+    text_blocks: Sequence[
+        tuple[str, float, float, Literal['left', 'center', 'right']]
+    ],
+    *,
+    font: QFont,
+    line_height: float = 1.0,
+    color: QColor | Sequence[int] = (255, 255, 255, 255),
+    raster_scale: float = 1.0,
+    padding: float = 0.0,
+) -> tuple[
+    np.ndarray[tuple[int, int, Literal[4]], np.dtype[np.uint8]],
+    tuple[float, float],
+]:
+    """Rasterize anchored text blocks to an RGBA array and local origin.
+
+    Parameters
+    ----------
+    text_blocks : sequence
+        A sequence of `(text, anchor_x, anchor_y, alignment)` tuples.
+        `anchor_y` denotes the bottom of the multiline block in local units.
+    font : QFont
+        Font used for text rendering.
+    line_height : float, optional
+        Line-height multiplier applied to font metrics.
+    color : QColor or sequence of int, optional
+        Text color in RGB or RGBA 0-255 values.
+    raster_scale : float, optional
+        Supersampling scale factor applied during rasterization.
+    padding : float, optional
+        Extra local-space padding around the computed text bounds.
+
+    Returns
+    -------
+    array : np.ndarray
+        Rasterized RGBA array with shape `(height, width, 4)`.
+    origin : tuple[float, float]
+        Local-space origin where the raster should be placed.
+    """
+    if raster_scale <= 0:
+        raise ValueError('raster_scale must be > 0')
+    if line_height <= 0:
+        raise ValueError('line_height must be > 0')
+
+    metrics = QFontMetricsF(font)
+    line_height_px = metrics.height() * line_height
+    ascent = metrics.ascent()
+    descent = metrics.descent()
+
+    line_runs: list[tuple[str, float, float]] = []
+    min_x = min_y = np.inf
+    max_x = max_y = -np.inf
+    for text, anchor_x, anchor_y, alignment in text_blocks:
+        if not text:
+            continue
+
+        lines = text.split('\n')
+        block_height = metrics.height() + (len(lines) - 1) * line_height_px
+        block_top = anchor_y * raster_scale - block_height
+        anchor_x *= raster_scale
+
+        for idx, line in enumerate(lines):
+            line_width = metrics.horizontalAdvance(line)
+            if alignment == 'left':
+                line_x = anchor_x
+            elif alignment == 'right':
+                line_x = anchor_x - line_width
+            else:
+                line_x = anchor_x - line_width / 2
+
+            baseline = block_top + ascent + idx * line_height_px
+            line_runs.append((line, line_x, baseline))
+            min_x = min(min_x, line_x)
+            min_y = min(min_y, baseline - ascent)
+            max_x = max(max_x, line_x + line_width)
+            max_y = max(max_y, baseline + descent)
+
+    if not line_runs:
+        return np.zeros((1, 1, 4), dtype=np.uint8), (0.0, 0.0)
+
+    padding_px = padding * raster_scale
+    min_x -= padding_px
+    min_y -= padding_px
+    max_x += padding_px
+    max_y += padding_px
+
+    width = max(1, int(np.ceil(max_x - min_x)))
+    height = max(1, int(np.ceil(max_y - min_y)))
+    image = QImage(width, height, QImage.Format_ARGB32)
+    image.fill(0)
+
+    painter = QPainter(image)
+    painter.setRenderHint(QPainter.TextAntialiasing, True)
+    painter.setFont(font)
+    painter.setPen(_coerce_qcolor(color))
+    for line, line_x, baseline in line_runs:
+        painter.drawText(QPointF(line_x - min_x, baseline - min_y), line)
+    painter.end()
+
+    origin = (min_x / raster_scale, min_y / raster_scale)
+    # copy to detach from QImage memory managed by Qt
+    return QImg2array(image).copy(), origin
 
 
 @contextmanager

--- a/src/napari/_qt/utils.py
+++ b/src/napari/_qt/utils.py
@@ -213,11 +213,9 @@ def rasterize_text_blocks_to_array(
     metrics = QFontMetricsF(font)
     ascent = metrics.ascent()
     descent = metrics.descent()
-    # Avoid platform-specific leading in line advance calculations.
-    # This keeps multiline spacing consistent across backends/OSes.
-    font_height = max(1.0, ascent + descent)
+    # use pixelSize directly for font height, eliminating platform-specific leading
+    font_height = max(1.0, float(font.pixelSize()))
     line_height_px = font_height * line_height
-
     line_runs: list[tuple[str, float, float]] = []
     min_x = min_y = np.inf
     max_x = max_y = -np.inf

--- a/src/napari/_qt/utils.py
+++ b/src/napari/_qt/utils.py
@@ -211,9 +211,12 @@ def rasterize_text_blocks_to_array(
         raise ValueError('line_height must be > 0')
 
     metrics = QFontMetricsF(font)
-    line_height_px = metrics.height() * line_height
     ascent = metrics.ascent()
     descent = metrics.descent()
+    # Avoid platform-specific leading in line advance calculations.
+    # This keeps multiline spacing consistent across backends/OSes.
+    font_height = max(1.0, ascent + descent)
+    line_height_px = font_height * line_height
 
     line_runs: list[tuple[str, float, float]] = []
     min_x = min_y = np.inf
@@ -223,7 +226,7 @@ def rasterize_text_blocks_to_array(
             continue
 
         lines = text.split('\n')
-        block_height = metrics.height() + (len(lines) - 1) * line_height_px
+        block_height = font_height + (len(lines) - 1) * line_height_px
         block_top = anchor_y * raster_scale - block_height
         anchor_x *= raster_scale
 

--- a/src/napari/_vispy/_tests/test_vispy_welcome_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_welcome_overlay.py
@@ -1,0 +1,42 @@
+from napari._vispy.overlays.welcome import VispyWelcomeOverlay
+
+
+def _welcome_overlay(viewer) -> VispyWelcomeOverlay:
+    """Return the vispy welcome overlay backend instance for a viewer."""
+    return viewer.window._qt_viewer.canvas._overlay_to_visual[
+        viewer.welcome_screen
+    ][0]
+
+
+def test_welcome_tip_is_selected_once_per_display(
+    make_napari_viewer, monkeypatch
+):
+    viewer = make_napari_viewer(show=True, show_welcome_screen=True)
+    viewer.welcome_screen.tips = ('first tip', 'second tip')
+    welcome_overlay = _welcome_overlay(viewer)
+
+    picks = iter(('first tip', 'second tip'))
+    monkeypatch.setattr(
+        'napari._vispy.overlays.welcome.choice',
+        lambda tips: next(picks),
+    )
+
+    viewer.welcome_screen.visible = False
+    viewer.welcome_screen.visible = True
+    assert 'first tip' in welcome_overlay.node._tip
+
+    viewer.welcome_screen.visible = False
+    viewer.welcome_screen.visible = True
+    assert 'second tip' in welcome_overlay.node._tip
+    viewer.welcome_screen.visible = False
+
+
+def test_welcome_tip_falls_back_to_default(make_napari_viewer):
+    viewer = make_napari_viewer(show=True, show_welcome_screen=True)
+    viewer.welcome_screen.tips = ()
+    welcome_overlay = _welcome_overlay(viewer)
+
+    viewer.welcome_screen.visible = False
+    viewer.welcome_screen.visible = True
+    assert "You're awesome!" in welcome_overlay.node._tip
+    viewer.welcome_screen.visible = False

--- a/src/napari/_vispy/_tests/test_vispy_welcome_visual.py
+++ b/src/napari/_vispy/_tests/test_vispy_welcome_visual.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+from napari._vispy.visuals.welcome import Welcome
+
+
+@pytest.mark.usefixtures('qapp')
+def test_welcome_uses_rasterized_text():
+    welcome = Welcome()
+    welcome.set_color(np.array([1, 1, 1, 1], dtype=float))
+    welcome.set_version('0.0.0')
+    welcome.set_shortcuts(())
+    welcome.set_tip('Shortcut symbols: ⇧⌘⌥⌃↵')
+    welcome.set_scale_and_position(1200, 800)
+
+    texture = welcome.text_image._data
+    assert texture is not None
+    assert texture.ndim == 3
+    assert texture.shape[-1] == 4
+    assert texture[..., 3].max() > 0
+
+
+@pytest.mark.usefixtures('qapp')
+def test_welcome_text_and_logo_transforms_scale_with_canvas():
+    welcome = Welcome()
+    welcome.set_version('0.0.0')
+    welcome.set_tip('Did you know this is a rasterized text texture?')
+    welcome.set_scale_and_position(1000, 600)
+
+    expected_scale = min(1000, 600) * 0.002
+    np.testing.assert_allclose(
+        welcome.logo.transform.scale[:2], (expected_scale, expected_scale)
+    )
+    np.testing.assert_allclose(
+        welcome.text_image.transform.scale[:2],
+        (
+            expected_scale / welcome._TEXT_RASTER_SCALE,
+            expected_scale / welcome._TEXT_RASTER_SCALE,
+        ),
+    )

--- a/src/napari/_vispy/overlays/welcome.py
+++ b/src/napari/_vispy/overlays/welcome.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from itertools import cycle
-from random import sample
+from random import choice
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from vispy.app.timer import Timer
 from vispy.visuals.transforms import NullTransform
 
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
@@ -14,7 +12,6 @@ from napari.settings import get_settings
 
 if TYPE_CHECKING:
     from vispy.scene import Node
-    from vispy.util.event import Event
 
     from napari import Viewer
     from napari.components.overlays import WelcomeOverlay
@@ -22,6 +19,7 @@ if TYPE_CHECKING:
 
 class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     overlay: WelcomeOverlay
+    _DEFAULT_TIP = "You're awesome!"
 
     def __init__(
         self,
@@ -47,9 +45,7 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
         self.node.canvas.native.resized.connect(self._on_position_change)
 
-        self.tips_iterator = cycle(["You're awesome!"])
-        self.tip_timer = Timer(10, self.next_tip)
-        self.next_tip()
+        self._tips = (self._DEFAULT_TIP,)
 
         self.reset()
 
@@ -82,22 +78,12 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.node.set_color(color)
 
     def _on_visible_change(self) -> None:
+        """Update visibility and pick one tip when the overlay is shown."""
         show = self._should_be_visible()
+        was_visible = self.node.visible
         self.node.visible = show
-        if show:
-            self.tip_timer.start()
-        else:
-            try:
-                self.tip_timer.stop()
-            except RuntimeError as e:  # pragma: no cover
-                if (
-                    'wrapped C/C++ object of type' not in e.args[0]
-                    and 'Internal C++ object' not in e.args[0]
-                ):
-                    # checking if the object is partially deleted. Otherwise
-                    # reraise exception. For more details see:
-                    # https://github.com/napari/napari/pull/5499
-                    raise
+        if show and not was_visible:
+            self.next_tip()
 
     def _on_version_change(self) -> None:
         self.node.set_version(self.overlay.version)
@@ -106,15 +92,14 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.node.set_shortcuts(self.overlay.shortcuts)
 
     def _on_tips_change(self) -> None:
-        if self.overlay.tips:
-            self.tips_iterator = cycle(
-                sample(self.overlay.tips, len(self.overlay.tips))
-            )
-        else:
-            self.tips_iterator = cycle(["You're awesome!"])
+        """Refresh available tips and update visible tip immediately."""
+        self._tips = tuple(self.overlay.tips) or (self._DEFAULT_TIP,)
+        if self.node.visible:
+            self.next_tip()
 
-    def next_tip(self, event: Event | None = None) -> None:
-        self.node.set_tip(next(self.tips_iterator))
+    def next_tip(self) -> None:
+        """Select and display exactly one random tip from the current tip set."""
+        self.node.set_tip(choice(self._tips))
 
     def reset(self) -> None:
         super().reset()
@@ -122,8 +107,6 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self._on_version_change()
         self._on_shortcuts_change()
         self._on_tips_change()
-        self.next_tip()
 
     def close(self) -> None:
-        self.tip_timer.stop()
         super().close()

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -27,7 +27,7 @@ vispy_logger = logging.getLogger('vispy')
 
 class Welcome(Node):
     _BASE_FONT_SIZE = 14
-    _LINE_HEIGHT = 1.15
+    _LINE_HEIGHT = 1.4
     _TEXT_PADDING = 2
     _TEXT_RASTER_SCALE = 4
 

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -125,7 +125,10 @@ class Welcome(Node):
     def _font_compensation(self) -> float:
         """Return a size multiplier to keep text crisp at small canvas scales.
 
-        Capped at 8x to avoid absurdly large textures when the canvas is
+        This counteracts the actual scaling/transform, preventing text from
+        getting too small, aiming to keep the text size near the default
+        font size for legibility.
+        Note: Capped at 8x to avoid absurdly large textures when the canvas is
         extremely small (e.g. a minimised or unit-test window).
         """
         if self._scale <= 0:
@@ -162,6 +165,16 @@ class Welcome(Node):
 
         raster_scale = self._TEXT_RASTER_SCALE
         font = QFont(QGuiApplication.font())
+        # Safely try to set Antialiasing, if not set
+        prefer_antialias = getattr(QFont, 'PreferAntialias', None)
+        if prefer_antialias is None:
+            style_strategy_enum = getattr(QFont, 'StyleStrategy', None)
+            if style_strategy_enum is not None:
+                prefer_antialias = getattr(
+                    style_strategy_enum, 'PreferAntialias', None
+                )
+        if prefer_antialias is not None:
+            font.setStyleStrategy(font.styleStrategy() | prefer_antialias)
         font.setPixelSize(
             max(
                 1,

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -4,16 +4,16 @@ import logging
 import re
 import textwrap
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
+from qtpy.QtGui import QFont, QGuiApplication
 from vispy.scene.node import Node
-from vispy.scene.visuals import Polygon
+from vispy.scene.visuals import Image, Polygon
 from vispy.util.svg import Document
 from vispy.visuals.transforms import STTransform
 
 from napari._app_model import get_app_model
-from napari._vispy.visuals.text import Text
 from napari.resources import get_icon_path
 from napari.settings import get_settings
 from napari.utils.action_manager import action_manager
@@ -26,6 +26,11 @@ vispy_logger = logging.getLogger('vispy')
 
 
 class Welcome(Node):
+    _BASE_FONT_SIZE = 14
+    _LINE_HEIGHT = 1.15
+    _TEXT_PADDING = 2
+    _TEXT_RASTER_SCALE = 4
+
     def __init__(self) -> None:
         old_level = vispy_logger.level
         vispy_logger.setLevel(logging.ERROR)
@@ -49,57 +54,39 @@ class Welcome(Node):
         self.logo = Polygon(
             self.logo_coords, border_method='agg', border_width=2, parent=self
         )
-        self.header = Text(
-            text='',
-            pos=[0, 0],
-            anchor_x='center',
-            anchor_y='bottom',
-            method='gpu',
-            parent=self,
+        self.logo.transform = STTransform()
+        self.text_image = Image(
+            np.zeros((1, 1, 4), dtype=np.uint8), parent=self
         )
-        self.shortcut_keybindings = Text(
-            text='',
-            line_height=1.15,
-            pos=[-80, 60],
-            anchor_x='right',
-            anchor_y='bottom',
-            method='gpu',
-            parent=self,
-        )
-        self.shortcut_descriptions = Text(
-            text='',
-            line_height=1.15,
-            pos=[-60, 60],
-            anchor_x='left',
-            anchor_y='bottom',
-            method='gpu',
-            parent=self,
-        )
-        self.tip = Text(
-            text='',
-            line_height=1.15,
-            pos=[0, 160],
-            anchor_x='center',
-            anchor_y='bottom',
-            method='gpu',
-            parent=self,
-        )
+        self.text_image.transform = STTransform()
+        self.text_image.interpolation = 'linear'
 
         self.transform = STTransform()
+        self._scale = 1.0
+        self._text_origin = np.zeros(2, dtype=float)
+        self._text_color = (255, 255, 255, 255)
+        self._text_raster_cache_key: tuple[Any, ...] | None = None
+
+        self._header = ''
+        self._shortcut_keys = ''
+        self._shortcut_descriptions = ''
+        self._tip = ''
 
     def set_color(self, color: ColorValue) -> None:
         self.logo.color = color
         self.logo.border_color = color
-        self.header.color = color
-        self.shortcut_keybindings.color = color
-        self.shortcut_descriptions.color = color
-        self.tip.color = color
+        rgba = np.clip(np.asarray(color), 0, 1)
+        if len(rgba) == 3:
+            rgba = np.append(rgba, 1)
+        self._text_color = tuple(round(float(c) * 255) for c in rgba[:4])
+        self._update_text_texture()
 
     def set_version(self, version: str) -> None:
-        self.header.text = (
+        self._header = (
             f'napari {version}\n\n'
             'Drag file(s) here to open, or use the shortcuts below:'
         )
+        self._update_text_texture()
 
     def set_shortcuts(self, commands: tuple[str, ...]) -> None:
         shortcuts = {}
@@ -111,8 +98,9 @@ class Welcome(Node):
                 shortcuts[shortcut] = command
 
         # TODO: use template strings in the future
-        self.shortcut_keybindings.text = '\n'.join(shortcuts.keys())
-        self.shortcut_descriptions.text = '\n'.join(shortcuts.values())
+        self._shortcut_keys = '\n'.join(shortcuts.keys())
+        self._shortcut_descriptions = '\n'.join(shortcuts.values())
+        self._update_text_texture()
 
     def set_tip(self, tip: str) -> None:
         # TODO: this should use template strings in the future
@@ -128,9 +116,106 @@ class Welcome(Node):
             if shortcut:
                 tip = re.sub(match.group(), str(shortcut), tip)
 
-        # wrap tip so it's not clipped
-        self.tip.text = 'Did you know?\n' + '\n'.join(
-            textwrap.wrap(tip, break_on_hyphens=False)
+        # wrap tip so it's not clipped; width reduced proportionally with font size
+        self._tip = 'Did you know?\n' + '\n'.join(
+            textwrap.wrap(tip, width=60, break_on_hyphens=False)
+        )
+        self._update_text_texture()
+
+    def _font_compensation(self) -> float:
+        """Return a size multiplier to keep text crisp at small canvas scales.
+
+        Capped at 8x to avoid absurdly large textures when the canvas is
+        extremely small (e.g. a minimised or unit-test window).
+        """
+        if self._scale <= 0:
+            return 1
+        if self._scale < 1:
+            return min(8.0, round(1 / self._scale, 2))
+        return 1
+
+    def _text_blocks(
+        self,
+    ) -> tuple[
+        tuple[str, float, float, Literal['left', 'center', 'right']], ...
+    ]:
+        """Return text content with anchor points and alignment in local coords.
+
+        Coordinate system
+        -----------------
+        The canvas is centred at (0, 0) with y increasing *downward* (screen
+        coords).  Each ``(text, anchor_x, anchor_y, align)`` tuple places the
+        *bottom* edge of a text block at ``(anchor_x, anchor_y)``.  Text
+        extends *upward* (to more-negative y) from that anchor.  To move a
+        block lower on screen, increase anchor_y; to raise it, decrease it.
+        """
+        return (
+            (self._header, 0, 40, 'center'),
+            (self._shortcut_keys, -95, 120, 'right'),
+            (self._shortcut_descriptions, -70, 120, 'left'),
+            (self._tip, 0, 220, 'center'),
+        )
+
+    def _render_text_texture(self) -> tuple[np.ndarray, tuple[float, float]]:
+        """Render current welcome text into a Qt-backed RGBA texture and origin."""
+        from napari._qt.utils import rasterize_text_blocks_to_array
+
+        raster_scale = self._TEXT_RASTER_SCALE
+        font = QFont(QGuiApplication.font())
+        font.setPixelSize(
+            max(
+                1,
+                round(
+                    self._BASE_FONT_SIZE
+                    * self._font_compensation()
+                    * raster_scale
+                ),
+            )
+        )
+        return rasterize_text_blocks_to_array(
+            self._text_blocks(),
+            font=font,
+            line_height=self._LINE_HEIGHT,
+            color=self._text_color,
+            raster_scale=raster_scale,
+            padding=self._TEXT_PADDING,
+        )
+
+    def _update_text_texture(self) -> None:
+        """Re-rasterize text only when cached content/style inputs changed."""
+        cache_key = (
+            self._header,
+            self._shortcut_keys,
+            self._shortcut_descriptions,
+            self._tip,
+            self._text_color,
+            self._font_compensation(),
+        )
+        if cache_key == self._text_raster_cache_key:
+            self._update_text_transform()
+            return
+
+        text_data, origin = self._render_text_texture()
+        self.text_image.set_data(text_data)
+        self._text_origin = np.asarray(origin)
+        self._text_raster_cache_key = cache_key
+        self._update_text_transform()
+
+    def _update_text_transform(self) -> None:
+        """Apply scene transform for the raster texture using local text origin."""
+        scale = self._scale
+        raster_scale = self._TEXT_RASTER_SCALE
+        self.text_image.transform.scale = (
+            scale / raster_scale,
+            scale / raster_scale,
+            1,
+            1,
+        )
+        self.text_image.transform.translate = (
+            self._text_origin[0] * scale,
+            self._text_origin[1] * scale,
+            0,
+            0,
         )
 
     @staticmethod
@@ -159,15 +244,9 @@ class Welcome(Node):
     def set_scale_and_position(self, x: float, y: float) -> None:
         self.transform.translate = (x / 2, y / 2, 0, 0)
         scale = min(x, y) * 0.002  # magic number
-        self.transform.scale = (scale, scale, 0, 0)
-
-        for text in (
-            self.header,
-            self.shortcut_keybindings,
-            self.shortcut_descriptions,
-            self.tip,
-        ):
-            text.font_size = max(scale * 10, 10)
+        self._scale = scale
+        self.logo.transform.scale = (scale, scale, 1, 1)
+        self._update_text_texture()
 
     def set_gl_state(self, *args: Any, **kwargs: Any) -> None:
         for node in self.children:

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -29,7 +29,8 @@ class Welcome(Node):
     _BASE_FONT_SIZE = 14
     _LINE_HEIGHT = 1.4
     _TEXT_PADDING = 2
-    _TEXT_RASTER_SCALE = 4
+    # this should probably match HiDPI/UI scaling
+    _TEXT_RASTER_SCALE = 2
 
     def __init__(self) -> None:
         old_level = vispy_logger.level

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -78,7 +78,7 @@ class Welcome(Node):
         rgba = np.clip(np.asarray(color), 0, 1)
         if len(rgba) == 3:
             rgba = np.append(rgba, 1)
-        self._text_color = tuple(round(float(c) * 255) for c in rgba[:4])
+        self._text_color = tuple((rgba[:4] * 255).astype(int))
         self._update_text_texture()
 
     def set_version(self, version: str) -> None:


### PR DESCRIPTION
# References and relevant issues
Discussion: https://napari.zulipchat.com/#narrow/channel/212875-general/topic/Fonts.20in.20napari.200.2E7.2E0/with/576553892
- raises the point that the Welcome overlay doesn't match the rest of UI (Qt)
Alternative to:
- https://github.com/napari/napari/pull/8738
- https://github.com/napari/napari/pull/8739

# Description
This PR takes the font handling part out of vispy hands.
- vispy does not appear to handle glyphs from system fonts properly -- forcing us to use a custom font -- and the font manager and font handling is slow
My thought was to use Qt to handle the text, since it does a nice job with that and lets us keep the Welcome overlay synced with the UI/theme font, which is handled by Qt. We could use Qt to render and then rasterize that and just use the overlay for display.
Based on that concept and the fact that removing the text from the Welcome overlay made it much faster, I had Codex implement the idea. I then refactored it to make the rasterization be a standalone utility function, because it could be used somewhere else. I had to tweak the magic layout numbers to get a similar look to main -- not pixel identical.
For ease of testing, I removed the timer'd tip, making the same tip stay for a given welcome screen. However, I actually kind of like that and it simplifies things a bit.
I used Claude to review and add tests.

Here's the look:
<img width="1114" height="781" alt="image" src="https://github.com/user-attachments/assets/3e974cad-c62e-4942-b9e5-24decf3afedf" />

On my machine startup is 2.4-2.5s with this branch.
With main: 3.1 s
With #8739 2.9-3.0 s
With #8738 (with main merged in): 3 s