### PR TITLE
Allow to disable selected modes by provide custom subclasees

### DIFF
--- a/examples/layer_with_limited_modes.py
+++ b/examples/layer_with_limited_modes.py
@@ -1,0 +1,25 @@
+"""
+Limit Layer Modes
+=================
+
+Show example how to limit the available modes for a layer using subclassing.
+
+.. tags:: layers
+"""
+
+
+import numpy as np
+
+from napari import Viewer, run
+from napari.layers import Labels
+
+
+class OwnLabels(Labels):
+    def support_mode(self, mode: str):
+        return super().support_mode(mode) and mode != 'erase'
+
+viewer = Viewer()
+layer = OwnLabels(np.zeros((512, 512), dtype='uint8'), name='labels')
+viewer.add_layer(layer)
+
+run()

--- a/src/napari/_qt/widgets/qt_mode_buttons.py
+++ b/src/napari/_qt/widgets/qt_mode_buttons.py
@@ -32,15 +32,24 @@ class QtModeRadioButton(QRadioButton):
         self, layer, button_name, mode, *, tooltip=None, checked=False
     ) -> None:
         super().__init__()
-
+        self._layer_enabled = layer.support_mode(mode)
         self.layer_ref = weakref.ref(layer)
         self.setToolTip(tooltip or button_name)
         self.setChecked(checked)
         self.setProperty('mode', button_name)
         self.setFixedWidth(28)
         self.mode = mode
+        self.setEnabled(True)
         if mode is not None:
             self.toggled.connect(self._set_mode)
+
+    def setEnabled(self, enabled):
+        super().setEnabled(enabled and self._layer_enabled)
+
+    def setToolTip(self, text: str):
+        if not self._layer_enabled:
+            text = f'{text} (not supported by this layer)'
+        super().setToolTip(text)
 
     def _set_mode(self, mode_selected):
         """Toggle the mode associated with the layer.

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -792,6 +792,8 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     @mode.setter
     def mode(self, mode: Mode | str) -> None:
         mode_enum = self._mode_setter_helper(mode)
+        if not self.support_mode(mode_enum):
+            return
         if mode_enum == self._mode:
             return
         self._mode = mode_enum
@@ -2437,6 +2439,15 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
     ) -> _LayerSlicingState:
         """Return a LayerSlicer instance appropriate for this layer."""
         raise NotImplementedError
+
+    @classmethod
+    def support_mode(cls, mode: str | StringEnum) -> bool:
+        """Return whether this layer supports the given mode.
+
+        It is to allow plugin to limit the supported modes
+        for plugin created layers
+        """
+        return mode in cls._modeclass
 
 
 mgui.register_type(type_=list[Layer], return_callback=add_layers_to_viewer)


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/channel/309872-plugins/topic/Deactivating.20buttons.20on.20layers.20created.20within.20plugin/near/577253786

# Description

This PR introduce options to disable subset of modes for a given layer by subclassing. 

Usage of subclass is intentional to allow doing this only by a layer creator. So one plugin cannot simply break in other plugin workflow. 

I'm open for any naming changes.
