### PR TITLE
Update contributing info and include AI policy and guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,10 @@ please link to it with "Depends on #PR-number" or "Depends on org/repo#PR-number
 an improvement, or something else? Why is it necessary? If relevant, please add
 a screenshot or a screen capture: "An image is worth a thousand words!" -->
 
+<!-- AI Policy
+The [napari AI use policy and guidelines](https://napari.org/dev/developers/contributing/ai.html) should be read and followed when using AI tools to assist with development.
+-->
+
 <!-- Final Checklist
 - My PR is the minimum possible work for the desired functionality
 - I have commented my code, particularly in hard-to-understand areas

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@ a screenshot or a screen capture: "An image is worth a thousand words!" -->
 
 <!-- AI Policy
 The [napari AI use policy and guidelines](https://napari.org/dev/developers/contributing/ai.html) should be read and followed when using AI tools to assist with development.
+
+TLDR: We are humans who enjoy working with other humans. You may use whatever tools you like, but you are ultimately responsible for the changes you submit. Don’t submit changes you haven’t carefully read through yourself, and let us have a conversation with you, not a chatbot.
 -->
 
 <!-- Final Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# contributing
+
+Thank you for your interest in contributing to napari!
+Contributions to napari are very welcome and encouraged!
+If at any point you have questions or would like to discuss your contribution, the core team and napari community are active on the [napari Zulip chat](https://napari.zulipchat.com/) and available on regular [online community meetings](https://napari.org/dev/community/meeting_schedule.html).
+You may also reach out on our [GitHub Issues](https://github.com/napari/napari/issues).
+We are here and excited to help!
+
+Read our [contributing guide](https://napari.org/dev/developers/contributing/index.html) for a detailed overview of how to get started with contributing to napari, including how to set up a development environment, how to run tests, and how to submit a pull request.
+
+The [AI use policy and guidelines](https://napari.org/dev/developers/contributing/ai.html) should be read and followed when using AI tools to assist with development.
+
+If you want to contribute to or edit our documentation, go to [napari/docs](https://github.com/napari/docs) and also read our [documentation contributing guide](https://napari.org/dev/developers/contributing/documentation/index.html).
+
+Visit our [project weather report dashboard](https://napari.org/weather-report/) to see metrics and how development is progressing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,3 @@ Read our [contributing guide](https://napari.org/dev/developers/contributing/ind
 The [AI use policy and guidelines](https://napari.org/dev/developers/contributing/ai.html) should be read and followed when using AI tools to assist with development.
 
 If you want to contribute to or edit our documentation, go to [napari/docs](https://github.com/napari/docs) and also read our [documentation contributing guide](https://napari.org/dev/developers/contributing/documentation/index.html).
-
-Visit our [project weather report dashboard](https://napari.org/weather-report/) to see metrics and how development is progressing.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
+include CONTRIBUTING.md
 include *.cff
 graft src/napari/_vendor
 recursive-include src/napari *.pyi

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ You can see details of [the project roadmap here](https://napari.org/stable/road
 
 Contributions are encouraged! See [CONTRIBUTING.md](https://github.com/napari/napari/blob/main/CONTRIBUTING.md) for resources to get started.
 
+If you want to contribute to or edit our documentation, please go to [napari/docs](https://github.com/napari/docs).
+
 ## code of conduct
 
 `napari` has a [Code of Conduct](https://napari.org/stable/community/code_of_conduct.html) that should be honored by everyone who participates in the `napari` community.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Contributions are encouraged! See [CONTRIBUTING.md](https://github.com/napari/na
 
 If you want to contribute to or edit our documentation, please go to [napari/docs](https://github.com/napari/docs).
 
+Visit our [project weather report dashboard](https://napari.org/weather-report/) to see metrics and how development is progressing.
+
 ## code of conduct
 
 `napari` has a [Code of Conduct](https://napari.org/stable/community/code_of_conduct.html) that should be honored by everyone who participates in the `napari` community.

--- a/README.md
+++ b/README.md
@@ -102,11 +102,7 @@ You can see details of [the project roadmap here](https://napari.org/stable/road
 
 ## contributing
 
-Contributions are encouraged! Please read our [contributing guide](https://napari.org/dev/developers/contributing/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [GitHub Issues](https://github.com/napari/napari/issues) before jumping in. 
-
-If you want to contribute to or edit our documentation, please go to [napari/docs](https://github.com/napari/docs).
-
-Visit our [project weather report dashboard](https://napari.org/weather-report/) to see metrics and how development is progressing.
+Contributions are encouraged! See [CONTRIBUTING.md](https://github.com/napari/napari/blob/main/CONTRIBUTING.md) for resources to get started.
 
 ## code of conduct
 


### PR DESCRIPTION
# Description

This PR was made to accomplish a few goals:

1. Better exposing contributing information through CONTRIBUTING.md
2. Increasing visibility of the zulip chat and community meetings for interested contributors
3. Exposing the AI use policy and guidelines in napari/napari by adding to CONTRIBUTING _and_ the PR template

My thought process is that this CONTRIBUTING.md can serve as a base template that can basically be copy-pasted into our other org repos. Potentially replacing the reference to the contributing guide (because most contain their own), but allowing us to have quick reference to zulip, community meetings, and ai policy
