### PR TITLE
Update box and position of text overlay on font size change

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1087,6 +1087,8 @@ class VispyCanvas:
                     layer=layer,
                     viewer=self.viewer,
                     parent=parent,
+                    font_manager=self._font_manager,
+                    font_family=self._overlay_font,
                 )
                 overlay_to_visual[overlay] = vispy_overlay
                 if isinstance(overlay, CanvasOverlay):

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -65,7 +65,7 @@ class NapariSceneCanvas(SceneCanvas_):
     """Vispy SceneCanvas used to allow for ignoring mouse wheel events with modifiers."""
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, dpi=150, **kwargs)
+        super().__init__(*args, **kwargs)
 
         orig_enterEvent = self.native.enterEvent
         orig_leaveEvent = self.native.leaveEvent

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -65,7 +65,7 @@ class NapariSceneCanvas(SceneCanvas_):
     """Vispy SceneCanvas used to allow for ignoring mouse wheel events with modifiers."""
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, dpi=150, **kwargs)
 
         orig_enterEvent = self.native.enterEvent
         orig_leaveEvent = self.native.leaveEvent

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -51,6 +51,7 @@ class _VispyBaseTextOverlay(VispyCanvasOverlay):
 
     def _on_font_size_change(self):
         self.node.font_size = self.overlay.font_size
+        self._on_position_change()
 
     def _on_position_change(self, event=None):
         position = self.overlay.position

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -111,7 +111,12 @@ class _VispyViewerTextOverlay(ViewerOverlayMixin, _VispyBaseTextOverlay):
 
 class _VispyLayerTextOverlay(LayerOverlayMixin, _VispyBaseTextOverlay):
     def __init__(self, **kwargs):
-        super().__init__(node=Text(pos=(0, 0)), **kwargs)
+        font_manager = kwargs.get('font_manager')
+        font_family = kwargs.get('font_family', 'OpenSans')
+        super().__init__(
+            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
+            **kwargs,
+        )
 
         self._connect_events()
         self.reset()

--- a/src/napari/_vispy/visuals/text.py
+++ b/src/napari/_vispy/visuals/text.py
@@ -41,7 +41,7 @@ class Text(BaseText):
 
     def get_width_height(self) -> tuple[float, float]:
         width, height = get_text_width_height(self)
-        return width, height
+        return width * self._vispy_dpi_ratio, height * self._vispy_dpi_ratio
 
     @property
     def font_size(self) -> float:
@@ -52,6 +52,14 @@ class Text(BaseText):
         adjusted_font_size = size / self.dpi_ratio
         self._font_size = max(0.0, adjusted_font_size)
         self.update()
+
+    @property
+    def _vispy_dpi_ratio(self) -> float:
+        # while 72 is considered the base dpi in vispy, most software assumes
+        # 96 as reference dpi, resulting in mismatch between gui and canvas
+        # when font sizes are the same. We need to account for this when
+        # we calculate things externally from vispy and
+        return 96 / 72
 
     @property
     def dpi_ratio(self) -> float:

--- a/src/napari/_vispy/visuals/text.py
+++ b/src/napari/_vispy/visuals/text.py
@@ -41,27 +41,13 @@ class Text(BaseText):
 
     def get_width_height(self) -> tuple[float, float]:
         width, height = get_text_width_height(self)
-        return width * self._vispy_dpi_ratio, height * self._vispy_dpi_ratio
+        return width, height
 
     @property
     def font_size(self) -> float:
-        return self._font_size * self.dpi_ratio
+        return self._font_size
 
     @font_size.setter
     def font_size(self, size: float) -> None:
-        adjusted_font_size = size / self.dpi_ratio
-        self._font_size = max(0.0, adjusted_font_size)
+        self._font_size = max(0.0, size)
         self.update()
-
-    @property
-    def _vispy_dpi_ratio(self) -> float:
-        # while 72 is considered the base dpi in vispy, most software assumes
-        # 96 as reference dpi, resulting in mismatch between gui and canvas
-        # when font sizes are the same. We need to account for this when
-        # we calculate things externally from vispy and
-        return 96 / 72
-
-    @property
-    def dpi_ratio(self) -> float:
-        dpi = self.transforms.dpi or 96
-        return dpi / 96

--- a/src/napari/_vispy/visuals/text.py
+++ b/src/napari/_vispy/visuals/text.py
@@ -45,9 +45,15 @@ class Text(BaseText):
 
     @property
     def font_size(self) -> float:
-        return self._font_size
+        return self._font_size * self.dpi_ratio
 
     @font_size.setter
     def font_size(self, size: float) -> None:
-        self._font_size = max(0.0, size)
+        adjusted_font_size = size / self.dpi_ratio
+        self._font_size = max(0.0, adjusted_font_size)
         self.update()
+
+    @property
+    def dpi_ratio(self) -> float:
+        dpi = self.transforms.dpi or 96
+        return dpi / 96


### PR DESCRIPTION
# References and relevant issues
- [zulip discussion](https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E7.2E0/near/578896196)

# Description
I thought this line was there at some point; either way, it needs to be there so the tiling position and the box size are updated accordingly!

EDIT: now also fixes the box sizes!

main:

<img width="995" height="644" alt="image" src="https://github.com/user-attachments/assets/c933ad8a-f78f-42a7-a045-308f95c9ce74" />

this PR:

<img width="995" height="644" alt="image" src="https://github.com/user-attachments/assets/1e891dea-a09a-4757-a243-ed7f5f1da835" />
