### PR TITLE
Fix welcome spacing

### DIFF
--- a/src/napari/_vispy/utils/text.py
+++ b/src/napari/_vispy/utils/text.py
@@ -136,8 +136,8 @@ def get_text_width_height(text: Text) -> tuple[float, float]:
     metrics = get_text_metrics(text)
     font_height = metrics.height()
 
-    height = 0
-    width = 0
+    height = 0.0
+    width = 0.0
 
     for string in strings:
         if string == '':

--- a/src/napari/_vispy/utils/text.py
+++ b/src/napari/_vispy/utils/text.py
@@ -109,6 +109,17 @@ def _get_qt_font_metrics(
     return QFontMetricsF(qfont)
 
 
+def get_text_metrics(text: Text) -> QFontMetricsF:
+    """Get qt font metrics from a text visual."""
+    face = (
+        text.face if hasattr(text, 'face') else QGuiApplication.font().family()
+    )
+    bold = text.bold if hasattr(text, 'bold') else False
+    italic = text.italic if hasattr(text, 'italic') else False
+
+    return _get_qt_font_metrics(face, int(text.font_size), bold, italic)
+
+
 def get_text_width_height(text: Text) -> tuple[float, float]:
     """Get the width and height of a vispy text visual in screen pixels.
 
@@ -122,14 +133,7 @@ def get_text_width_height(text: Text) -> tuple[float, float]:
     else:
         raise TypeError('Text should either be a string or a list of strings')
 
-    # Get font properties from the text visual
-    face = (
-        text.face if hasattr(text, 'face') else QGuiApplication.font().family()
-    )
-    bold = text.bold if hasattr(text, 'bold') else False
-    italic = text.italic if hasattr(text, 'italic') else False
-
-    metrics = _get_qt_font_metrics(face, int(text.font_size), bold, italic)
+    metrics = get_text_metrics(text)
     font_height = metrics.height()
 
     height = 0

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -169,7 +169,7 @@ class Welcome(Node):
 
     def set_scale_and_position(self, x: float, y: float) -> None:
         self.transform.translate = (x / 2, y / 2, 0, 0)
-        scale = min(x, y) * 0.002  # magic number
+        scale = min(x, y) / self.font_height * 0.04  # magic number
         self.transform.scale = (scale, scale, 0, 0)
 
         for text in (

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -13,6 +13,7 @@ from vispy.util.svg import Document
 from vispy.visuals.transforms import STTransform
 
 from napari._app_model import get_app_model
+from napari._vispy.utils.text import get_text_metrics
 from napari._vispy.visuals.text import Text
 from napari.resources import get_icon_path
 from napari.settings import get_settings
@@ -48,15 +49,12 @@ class Welcome(Node):
         self.logo_coords[:, 1] -= 130  # magic number shifting up logo
         super().__init__()
 
-        self.base_font_size = 10
-
         self.logo = Polygon(
             self.logo_coords, border_method='agg', border_width=2, parent=self
         )
         self.header = Text(
             text='',
-            line_height=1.5,
-            font_size=10,
+            line_height=1.65,
             pos=[0, 0],
             anchor_x='center',
             anchor_y='bottom',
@@ -64,11 +62,13 @@ class Welcome(Node):
             font_manager=font_manager,
             face=face,
         )
+
+        self.font_height = get_text_metrics(self.header).height()
+
         self.shortcut_keybindings = Text(
             text='',
             line_height=1.15,
-            font_size=10,
-            pos=[-80, 5.5 * self.base_font_size],
+            pos=[-80, 2.75 * self.font_height],
             anchor_x='right',
             anchor_y='bottom',
             parent=self,
@@ -78,8 +78,7 @@ class Welcome(Node):
         self.shortcut_descriptions = Text(
             text='',
             line_height=1.15,
-            font_size=10,
-            pos=[-60, 5.5 * self.base_font_size],
+            pos=[-60, 2.75 * self.font_height],
             anchor_x='left',
             anchor_y='bottom',
             parent=self,
@@ -89,8 +88,7 @@ class Welcome(Node):
         self.tip = Text(
             text='',
             line_height=1.15,
-            font_size=10,
-            pos=[0, 16 * self.base_font_size],
+            pos=[0, 7.5 * self.font_height],
             anchor_x='center',
             anchor_y='bottom',
             parent=self,
@@ -180,7 +178,7 @@ class Welcome(Node):
             self.shortcut_descriptions,
             self.tip,
         ):
-            text.font_size = max(scale * 8, self.base_font_size)
+            text.font_size = max(scale * 8, 10)
 
     def set_gl_state(self, *args: Any, **kwargs: Any) -> None:
         for node in self.children:

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -48,11 +48,15 @@ class Welcome(Node):
         self.logo_coords[:, 1] -= 130  # magic number shifting up logo
         super().__init__()
 
+        self.base_font_size = 10
+
         self.logo = Polygon(
             self.logo_coords, border_method='agg', border_width=2, parent=self
         )
         self.header = Text(
             text='',
+            line_height=1.5,
+            font_size=10,
             pos=[0, 0],
             anchor_x='center',
             anchor_y='bottom',
@@ -63,7 +67,8 @@ class Welcome(Node):
         self.shortcut_keybindings = Text(
             text='',
             line_height=1.15,
-            pos=[-80, 60],
+            font_size=10,
+            pos=[-80, 5.5 * self.base_font_size],
             anchor_x='right',
             anchor_y='bottom',
             parent=self,
@@ -73,7 +78,8 @@ class Welcome(Node):
         self.shortcut_descriptions = Text(
             text='',
             line_height=1.15,
-            pos=[-60, 60],
+            font_size=10,
+            pos=[-60, 5.5 * self.base_font_size],
             anchor_x='left',
             anchor_y='bottom',
             parent=self,
@@ -83,7 +89,8 @@ class Welcome(Node):
         self.tip = Text(
             text='',
             line_height=1.15,
-            pos=[0, 160],
+            font_size=10,
+            pos=[0, 16 * self.base_font_size],
             anchor_x='center',
             anchor_y='bottom',
             parent=self,
@@ -103,7 +110,7 @@ class Welcome(Node):
 
     def set_version(self, version: str) -> None:
         self.header.text = (
-            f'napari {version}\n\n'
+            f'napari {version}\n'
             'Drag file(s) here to open, or use the shortcuts below:'
         )
 
@@ -173,7 +180,7 @@ class Welcome(Node):
             self.shortcut_descriptions,
             self.tip,
         ):
-            text.font_size = max(scale * 8, 10)
+            text.font_size = max(scale * 8, self.base_font_size)
 
     def set_gl_state(self, *args: Any, **kwargs: Any) -> None:
         for node in self.children:

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -169,9 +169,7 @@ class Welcome(Node):
 
     def set_scale_and_position(self, x: float, y: float) -> None:
         self.transform.translate = (x / 2, y / 2, 0, 0)
-        scale = (
-            min(x, y) / self.font_height / self.header.dpi_ratio * 0.04
-        )  # magic number
+        scale = min(x, y) / self.font_height * 0.04  # magic number
         self.transform.scale = (scale, scale, 0, 0)
 
         for text in (

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -178,7 +178,7 @@ class Welcome(Node):
             self.shortcut_descriptions,
             self.tip,
         ):
-            text.font_size = max(scale * 8, 10)
+            text.font_size = max(scale / self.header.dpi_ratio * 8, 10)
 
     def set_gl_state(self, *args: Any, **kwargs: Any) -> None:
         for node in self.children:

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -169,7 +169,9 @@ class Welcome(Node):
 
     def set_scale_and_position(self, x: float, y: float) -> None:
         self.transform.translate = (x / 2, y / 2, 0, 0)
-        scale = min(x, y) / self.font_height * 0.04  # magic number
+        scale = (
+            min(x, y) / self.font_height / self.header.dpi_ratio * 0.04
+        )  # magic number
         self.transform.scale = (scale, scale, 0, 0)
 
         for text in (

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -28,26 +28,27 @@ if TYPE_CHECKING:
 vispy_logger = logging.getLogger('vispy')
 
 
+def _load_logo() -> np.ndarray:
+    # load logo (disabling logging for some svg reading warnings)
+    old_level = vispy_logger.level
+    vispy_logger.setLevel(logging.ERROR)
+    coords = Document(get_icon_path('logo_silhouette')).paths[0].vertices[0][0]
+    vispy_logger.setLevel(old_level)
+    # drop z: causes issues with polygon agg mode
+    coords = coords[:, :2]
+    # center
+    coords -= (np.max(coords, axis=0) + np.min(coords, axis=0)) / 2
+    return coords
+
+
 class Welcome(Node):
     def __init__(self, font_manager: FontManager, face: str) -> None:
-        old_level = vispy_logger.level
-        vispy_logger.setLevel(logging.ERROR)
-        self.logo_coords = (
-            Document(get_icon_path('logo_silhouette')).paths[0].vertices[0][0]
-        )
-        vispy_logger.setLevel(old_level)
-        self.logo_coords = self.logo_coords[
-            :, :2
-        ]  # drop z: causes issues with polygon agg mode
-        # center
-        self.logo_coords -= (
-            np.max(self.logo_coords, axis=0) + np.min(self.logo_coords, axis=0)
-        ) / 2
-        # make it smaller
-        self.logo_coords /= 4
-        # move it up
-        self.logo_coords[:, 1] -= 130  # magic number shifting up logo
+        self.logo_coords = _load_logo()
         super().__init__()
+
+        # make logo smaller and move it up (magic number)
+        self.logo_coords /= 4
+        self.logo_coords[:, 1] -= 130
 
         self.logo = Polygon(
             self.logo_coords, border_method='agg', border_width=2, parent=self
@@ -171,6 +172,9 @@ class Welcome(Node):
         self.transform.translate = (x / 2, y / 2, 0, 0)
         scale = min(x, y) / self.font_height * 0.04  # magic number
         self.transform.scale = (scale, scale, 0, 0)
+        # we don't want the logo to be affected by dpi ratio which is included in
+        # font_height, so we undo that
+        self.logo.transform.scale = 1 / self.header.dpi_ratio
 
         for text in (
             self.header,
@@ -178,7 +182,7 @@ class Welcome(Node):
             self.shortcut_descriptions,
             self.tip,
         ):
-            text.font_size = max(scale / self.header.dpi_ratio * 8, 10)
+            text.font_size = max(scale * 8, 10)
 
     def set_gl_state(self, *args: Any, **kwargs: Any) -> None:
         for node in self.children:

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -54,6 +54,7 @@ class Welcome(Node):
             self.logo_coords, border_method='agg', border_width=2, parent=self
         )
         self.logo.transform = STTransform()
+
         self.header = Text(
             text='',
             line_height=1.75,
@@ -64,6 +65,7 @@ class Welcome(Node):
             font_manager=font_manager,
             face=face,
         )
+        self.header.transform = STTransform()
 
         self.font_height = get_text_metrics(self.header).height()
 
@@ -77,6 +79,8 @@ class Welcome(Node):
             font_manager=font_manager,
             face=face,
         )
+        self.shortcut_keybindings.transform = STTransform()
+
         self.shortcut_descriptions = Text(
             text='',
             line_height=1.15,
@@ -87,6 +91,8 @@ class Welcome(Node):
             font_manager=font_manager,
             face=face,
         )
+        self.shortcut_descriptions.transform = STTransform()
+
         self.tip = Text(
             text='',
             line_height=1.15,
@@ -97,8 +103,7 @@ class Welcome(Node):
             font_manager=font_manager,
             face=face,
         )
-
-        self.transform = STTransform()
+        self.tip.transform = STTransform()
 
     def set_color(self, color: ColorValue) -> None:
         self.logo.color = color
@@ -170,21 +175,23 @@ class Welcome(Node):
         return shortcut, command
 
     def set_scale_and_position(self, x: float, y: float) -> None:
-        self.transform.translate = (x / 2, y / 2, 0, 0)
-        scale = min(x, y) / self.font_height * 0.04  # magic number
-        self.transform.scale = (scale, scale, 0, 0)
+        trans = (x / 2, y / 2, 0, 0)
         # we don't want the logo to be affected by dpi ratio which is included in
-        # font_height, so we undo that
-        logo_scale = 1 / self.header.dpi_ratio
+        # font_height, so we scale it separately
+        logo_scale = min(x, y) * 0.002  # magic number
+        self.logo.transform.translate = trans
         self.logo.transform.scale = (logo_scale, logo_scale, 0, 0)
 
+        text_scale = min(x, y) / self.font_height * 0.04  # magic number
         for text in (
             self.header,
             self.shortcut_keybindings,
             self.shortcut_descriptions,
             self.tip,
         ):
-            text.font_size = max(scale * 8, 10)
+            text.font_size = text_scale * 8
+            text.transform.translate = trans
+            text.transform.scale = (text_scale, text_scale, 0, 0)
 
     def set_gl_state(self, *args: Any, **kwargs: Any) -> None:
         for node in self.children:

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -54,8 +54,8 @@ class Welcome(Node):
         )
         self.header = Text(
             text='',
-            line_height=1.65,
-            pos=[0, 0],
+            line_height=1.75,
+            pos=[0, -10],
             anchor_x='center',
             anchor_y='bottom',
             parent=self,

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -53,6 +53,7 @@ class Welcome(Node):
         self.logo = Polygon(
             self.logo_coords, border_method='agg', border_width=2, parent=self
         )
+        self.logo.transform = STTransform()
         self.header = Text(
             text='',
             line_height=1.75,
@@ -174,7 +175,8 @@ class Welcome(Node):
         self.transform.scale = (scale, scale, 0, 0)
         # we don't want the logo to be affected by dpi ratio which is included in
         # font_height, so we undo that
-        self.logo.transform.scale = 1 / self.header.dpi_ratio
+        logo_scale = 1 / self.header.dpi_ratio
+        self.logo.transform.scale = (logo_scale, logo_scale, 0, 0)
 
         for text in (
             self.header,

--- a/src/napari/components/overlays/welcome.py
+++ b/src/napari/components/overlays/welcome.py
@@ -13,7 +13,6 @@ class WelcomeOverlay(CanvasOverlay):
     order: int = 10**6 + 10
     gridded: Literal[False] = False
     version: str = __version__
-    font_size: float = 10
     shortcuts: tuple[str, ...] = (
         'napari.window.file._image_from_clipboard',
         'napari.window.file.open_files_dialog',

--- a/src/napari/components/overlays/welcome.py
+++ b/src/napari/components/overlays/welcome.py
@@ -13,6 +13,7 @@ class WelcomeOverlay(CanvasOverlay):
     order: int = 10**6 + 10
     gridded: Literal[False] = False
     version: str = __version__
+    font_size: float = 10
     shortcuts: tuple[str, ...] = (
         'napari.window.file._image_from_clipboard',
         'napari.window.file.open_files_dialog',


### PR DESCRIPTION
# References and relevant issues
- followup from #8751

# Description
When we changed the text overlays to use qt fonts, we broke the hardcoded positioning in the welcome overlay. This PR tries to fix it permanently by adjusting spacing based on the font size. The problem with this is that it might lead to the text going out of the canvas, if the font is too tall. Here's a couple tests:

Noto Sans:

<img width="995" height="644" alt="image" src="https://github.com/user-attachments/assets/cb5ba291-b619-47fd-b202-6135aac9754e" />

Inconsolata:

<img width="985" height="644" alt="image" src="https://github.com/user-attachments/assets/ffdb95bd-2da8-43f8-809c-9766c5ae1730" />

Adwaita Sans:

<img width="997" height="644" alt="image" src="https://github.com/user-attachments/assets/3bc8a0bb-589f-4272-b03f-95a56c9ca3c6" />


---

To test, currrently there's no quick way other than changing this line with a hardcoded font family:

https://github.com/napari/napari/blob/main/src/napari/_qt/qt_viewer.py#L206