### PR TITLE
Use viewer-based caching for font manager

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -33,7 +33,6 @@ from napari._qt.widgets.qt_viewer_buttons import (
     QtViewerButtons,
 )
 from napari._qt.widgets.qt_viewer_dock_widget import QtViewerDockWidget
-from napari._vispy.utils.qt_font import QtFontManager
 from napari.components.camera import Camera
 from napari.components.layerlist import LayerList
 from napari.errors import MultipleReaderError, ReaderPluginError
@@ -202,15 +201,11 @@ class QtViewer(QSplitter):
         self._dockConsole = None
         self._dockPerformance = None
         self._show_welcome_screen = show_welcome_screen
-        self._font_manager = QtFontManager()
-        self._overlay_font = QGuiApplication.font().family()
 
         # This dictionary holds the corresponding vispy visual for each layer
         self.canvas = canvas_class(
             viewer=viewer,
             parent=self,
-            font_manager=self._font_manager,
-            font_family=self._overlay_font,
             key_map_handler=self._key_map_handler,
             size=self.viewer._canvas_size,
             autoswap=get_settings().experimental.autoswap_buffers,  # see #5734
@@ -1453,14 +1448,6 @@ class QtViewer(QSplitter):
         if path is not None:
             imsave(path, img)
         return img
-
-    def font_manager(self) -> QtFontManager:
-        """Return the font manager for this viewer."""
-        return self._font_manager
-
-    def overlay_font(self) -> str:
-        """Return the font used for overlays."""
-        return self._overlay_font
 
 
 if TYPE_CHECKING:

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -20,7 +20,6 @@ from napari._vispy.camera import VispyCamera
 from napari._vispy.mouse_event import NapariMouseEvent
 from napari._vispy.utils.cursor import QtCursorVisual
 from napari._vispy.utils.gl import get_max_texture_sizes
-from napari._vispy.utils.qt_font import QtFontManager
 from napari._vispy.utils.visual import create_vispy_overlay
 from napari.components._viewer_constants import CanvasPosition
 from napari.components.overlays import CanvasOverlay
@@ -169,8 +168,6 @@ class VispyCanvas:
         self,
         viewer: ViewerModel,
         key_map_handler: KeymapHandler,
-        font_manager: QtFontManager,
-        font_family: str,
         *args,
         **kwargs,
     ) -> None:
@@ -180,8 +177,6 @@ class VispyCanvas:
         self.max_texture_sizes = None
         self._last_theme_color = None
         self._background_color_override = None
-        self._font_manager = font_manager
-        self._overlay_font = font_family
         self.viewer = viewer
         self._scene_canvas = NapariSceneCanvas(
             *args, keys=None, vsync=True, **kwargs
@@ -937,8 +932,6 @@ class VispyCanvas:
                 overlay=overlay,
                 viewer=self.viewer,
                 parent=parent,
-                font_manager=self._font_manager,
-                font_family=self._overlay_font,
             )
             self._overlay_to_visual[overlay].append(vispy_overlay)
 

--- a/src/napari/_vispy/overlays/axes.py
+++ b/src/napari/_vispy/overlays/axes.py
@@ -1,5 +1,4 @@
 import numpy as np
-from vispy.visuals.text.text import FontManager
 
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispySceneOverlay
 from napari._vispy.visuals.axes import Axes
@@ -18,8 +17,6 @@ class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):
         viewer,
         overlay,
         parent=None,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
     ) -> None:
         self._scale = 1.0
 
@@ -27,12 +24,10 @@ class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self._target_length = 80
 
         super().__init__(
-            node=Axes(font_manager=font_manager, font_family=font_family),
+            node=Axes(font_manager_cache_key=viewer),
             viewer=viewer,
             overlay=overlay,
             parent=parent,
-            font_manager=font_manager,
-            font_family=font_family,
         )
         self.overlay.events.colored.connect(self._on_data_change)
         self.overlay.events.dashed.connect(self._on_data_change)

--- a/src/napari/_vispy/overlays/colorbar.py
+++ b/src/napari/_vispy/overlays/colorbar.py
@@ -12,7 +12,6 @@ from napari.utils.colormaps.colormap_utils import (
 
 if TYPE_CHECKING:
     from vispy.scene import Node
-    from vispy.visuals.text.text import FontManager
 
     from napari.components import ViewerModel
     from napari.components.overlays import ColorBarOverlay, Overlay
@@ -29,17 +28,13 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
         viewer: ViewerModel,
         overlay: Overlay,
         parent: Node | None = None,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
     ) -> None:
         super().__init__(
-            node=ColorBar(font_manager=font_manager, font_family=font_family),
+            node=ColorBar(font_manager_cache_key=viewer),
             layer=layer,
             viewer=viewer,
             overlay=overlay,
             parent=parent,
-            font_manager=font_manager,
-            font_family=font_family,
         )
         self.layer: Image | Surface
         self.x_size = 50

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -16,7 +16,6 @@ from napari.utils._units import PREFERRED_VALUES
 
 if TYPE_CHECKING:
     from vispy.scene import ViewBox
-    from vispy.visuals.text.text import FontManager
 
     from napari.components import ViewerModel
 
@@ -32,8 +31,6 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         viewer: ViewerModel,
         overlay: Overlay,
         parent: ViewBox | None = None,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
     ) -> None:
         self._target_length = 150.0
         self._current_length = 150.0
@@ -41,12 +38,10 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self._unit = pint.Quantity('1 pixel')
 
         super().__init__(
-            node=ScaleBar(font_manager=font_manager, font_family=font_family),
+            node=ScaleBar(font_manager_cache_key=viewer),
             viewer=viewer,
             overlay=overlay,
             parent=parent,
-            font_manager=font_manager,
-            font_family=font_family,
         )
 
         self.overlay.events.color.connect(self._on_rendering_change)

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -97,10 +97,8 @@ class _VispyBaseTextOverlay(VispyCanvasOverlay):
 
 class _VispyViewerTextOverlay(ViewerOverlayMixin, _VispyBaseTextOverlay):
     def __init__(self, **kwargs):
-        font_manager = kwargs.get('font_manager')
-        font_family = kwargs.get('font_family', 'OpenSans')
         super().__init__(
-            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
+            node=Text(pos=(0, 0), font_manager_cache_key=kwargs['viewer']),
             **kwargs,
         )
 
@@ -110,7 +108,10 @@ class _VispyViewerTextOverlay(ViewerOverlayMixin, _VispyBaseTextOverlay):
 
 class _VispyLayerTextOverlay(LayerOverlayMixin, _VispyBaseTextOverlay):
     def __init__(self, **kwargs):
-        super().__init__(node=Text(pos=(0, 0)), **kwargs)
+        super().__init__(
+            node=Text(pos=(0, 0), font_manager_cache_key=kwargs['viewer']),
+            **kwargs,
+        )
 
         self._connect_events()
         self.reset()

--- a/src/napari/_vispy/overlays/welcome.py
+++ b/src/napari/_vispy/overlays/welcome.py
@@ -15,7 +15,6 @@ from napari.settings import get_settings
 if TYPE_CHECKING:
     from vispy.scene import Node
     from vispy.util.event import Event
-    from vispy.visuals.text.text import FontManager
 
     from napari.components import ViewerModel
     from napari.components.overlays import WelcomeOverlay
@@ -29,17 +28,13 @@ class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         *,
         viewer: ViewerModel,
         overlay: WelcomeOverlay,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
         parent: Node | None = None,
     ) -> None:
         super().__init__(
-            node=Welcome(font_manager=font_manager, face=font_family),
+            node=Welcome(font_manager_cache_key=viewer),
             viewer=viewer,
             overlay=overlay,
             parent=parent,
-            font_manager=font_manager,
-            font_family=font_family,
         )
         self.viewer.events.theme.connect(self._on_theme_change)
         self.viewer.layers.events.inserted.connect(self._on_visible_change)

--- a/src/napari/_vispy/visuals/axes.py
+++ b/src/napari/_vispy/visuals/axes.py
@@ -1,6 +1,5 @@
 import numpy as np
 from vispy.scene.visuals import Compound, Line, Mesh
-from vispy.visuals.text.text import FontManager
 
 from napari._vispy.visuals.text import Text
 from napari.layers.shapes._shapes_utils import triangulate_ellipse
@@ -130,8 +129,7 @@ def color_arrowheads(colors, num_segments):
 class Axes(Compound):
     def __init__(
         self,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
+        font_manager_cache_key,
     ) -> None:
         self._num_segments_arrowhead = 100
         # CMYRGB for 6 axes data in x, y, z, ... ordering
@@ -196,8 +194,7 @@ class Axes(Compound):
                     font_size=10,
                     anchor_x='center',
                     anchor_y='center',
-                    face=font_family,
-                    font_manager=font_manager,
+                    font_manager_cache_key=font_manager_cache_key,
                 ),
             ]
         )

--- a/src/napari/_vispy/visuals/colorbar.py
+++ b/src/napari/_vispy/visuals/colorbar.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
     from vispy.color import Colormap as VispyColormap
-    from vispy.visuals.text.text import FontManager
 
     from napari.utils.color import ColorValue
 
@@ -30,8 +29,7 @@ class ColorBar(Node):
 
     def __init__(
         self,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
+        font_manager_cache_key,
     ) -> None:
         super().__init__()
         self.ticks = Axis(
@@ -47,8 +45,7 @@ class ColorBar(Node):
         self.ticks._text = Text(
             font_size=self.ticks.tick_font_size,
             color=self.ticks.text_color,
-            font_manager=font_manager,
-            face=font_family,
+            font_manager_cache_key=font_manager_cache_key,
         )
         self.ticks.add_subvisual(self.ticks._text)
 

--- a/src/napari/_vispy/visuals/scale_bar.py
+++ b/src/napari/_vispy/visuals/scale_bar.py
@@ -1,6 +1,5 @@
 import numpy as np
 from vispy.scene.visuals import Compound, Line
-from vispy.visuals.text.text import FontManager
 
 from napari._vispy.visuals.text import Text
 
@@ -18,8 +17,7 @@ class ScaleBar(Compound):
 
     def __init__(
         self,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
+        font_manager_cache_key,
     ) -> None:
         # Layout constants
         self.PADDING = 6  # Space around the entire scale bar
@@ -45,8 +43,7 @@ class ScaleBar(Compound):
             anchor_x='center',
             anchor_y='bottom',
             font_size=10,
-            face=font_family,
-            font_manager=font_manager,
+            font_manager_cache_key=font_manager_cache_key,
         )
         self.line = Line(
             connect='segments', method='gl', width=3, antialias=True

--- a/src/napari/_vispy/visuals/text.py
+++ b/src/napari/_vispy/visuals/text.py
@@ -1,4 +1,5 @@
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from vispy.scene.visuals import Text as BaseText
 
@@ -7,13 +8,10 @@ from napari._vispy.utils.text import (
     get_text_width_height,
 )
 
-# Global Qt-based font manager instance shared across all Text visuals
-_qt_font_manager = None
-
-_FONT_FAMILY = 'OpenSans'
+FM_CACHE = WeakKeyDictionary()
 
 
-def get_qt_font_manager(method: str = 'cpu') -> QtFontManager:
+def get_qt_font_manager(cache_key: Any, method: str = 'cpu') -> QtFontManager:
     """Get or create the global Qt font manager instance.
 
     Parameters
@@ -26,17 +24,16 @@ def get_qt_font_manager(method: str = 'cpu') -> QtFontManager:
     QtFontManager
         The global Qt font manager instance.
     """
-    global _qt_font_manager
-    if _qt_font_manager is None:
-        _qt_font_manager = QtFontManager(method=method)
-    return _qt_font_manager
+    if cache_key not in FM_CACHE:
+        FM_CACHE[cache_key] = QtFontManager(method)
+    return FM_CACHE[cache_key]
 
 
 class Text(BaseText):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        # If using Qt fonts, pass the Qt font manager to the base class
-        if 'face' not in kwargs:
-            kwargs['face'] = _FONT_FAMILY
+    def __init__(
+        self, *args: Any, font_manager_cache_key: Any, **kwargs: Any
+    ) -> None:
+        kwargs['font_manager'] = get_qt_font_manager(font_manager_cache_key)
         super().__init__(*args, **kwargs)
 
     def get_width_height(self) -> tuple[float, float]:

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -20,15 +20,13 @@ from napari.utils.action_manager import action_manager
 from napari.utils.interactions import Shortcut
 
 if TYPE_CHECKING:
-    from vispy.visuals.text.text import FontManager
-
     from napari.utils.color import ColorValue
 
 vispy_logger = logging.getLogger('vispy')
 
 
 class Welcome(Node):
-    def __init__(self, font_manager: FontManager, face: str) -> None:
+    def __init__(self, font_manager_cache_key) -> None:
         old_level = vispy_logger.level
         vispy_logger.setLevel(logging.ERROR)
         self.logo_coords = (
@@ -57,8 +55,7 @@ class Welcome(Node):
             anchor_x='center',
             anchor_y='bottom',
             parent=self,
-            font_manager=font_manager,
-            face=face,
+            font_manager_cache_key=font_manager_cache_key,
         )
         self.shortcut_keybindings = Text(
             text='',
@@ -67,8 +64,7 @@ class Welcome(Node):
             anchor_x='right',
             anchor_y='bottom',
             parent=self,
-            font_manager=font_manager,
-            face=face,
+            font_manager_cache_key=font_manager_cache_key,
         )
         self.shortcut_descriptions = Text(
             text='',
@@ -77,8 +73,7 @@ class Welcome(Node):
             anchor_x='left',
             anchor_y='bottom',
             parent=self,
-            font_manager=font_manager,
-            face=face,
+            font_manager_cache_key=font_manager_cache_key,
         )
         self.tip = Text(
             text='',
@@ -87,8 +82,7 @@ class Welcome(Node):
             anchor_x='center',
             anchor_y='bottom',
             parent=self,
-            font_manager=font_manager,
-            face=face,
+            font_manager_cache_key=font_manager_cache_key,
         )
 
         self.transform = STTransform()


### PR DESCRIPTION
# References and relevant issues
Discussed in community meeting as followup to #8751 which was merged a bit in a rush.

# Description
Summary of the discussion:
- This is a vispy thing more than it is a qt thing (though it depends on the latter) so it shouldn't live in the qt viewer
- remove font_face from kwargs (can be handled more elegantly with events and something like #8426) 
- adding all of these extra kwargs makes it more unwieldy than it should. We can actually use a cache instead that uses (for now) the `viewer` object as key, to ensure separate managers are used for separate viewers

This is essentially a pure refactor, so nothing should change in behaviour.

Followup:
- [ ] switch out the cache key to be canvas-related (e.g in #8633) so in the future multiple canvases still work.
- [ ] the same thing can/should be done with layers containing text (e.g: Points) so they share the same manager. It takes some extra work cause currently vispy layer objects are unaware of what viewer/canvas they are in.
