### PR TITLE
Fix `image_depth.py` example by setting `blending` to `translucent`

### DIFF
--- a/examples/image_depth.py
+++ b/examples/image_depth.py
@@ -12,8 +12,8 @@ import napari
 im_data = np.zeros((50, 50, 50))
 im_data[30:40, 25:35, 25:35] = 1
 viewer = napari.Viewer()
-layer = viewer.add_image(im_data, colormap='magenta', rendering='iso')
-viewer.add_image(im_data, colormap='green', rendering='iso', translate=(30, 0, 0))
+layer = viewer.add_image(im_data, colormap='magenta', rendering='iso', blending='translucent')
+viewer.add_image(im_data, colormap='green', rendering='iso', blending='translucent', translate=(30, 0, 0))
 
 points_data = [
     [50, 30, 30],

--- a/examples/image_depth.py
+++ b/examples/image_depth.py
@@ -4,6 +4,10 @@ Image depth
 
 Display a 3D image and 3D points layer to show how napari handles depth.
 
+The default blending for images is `translucent_no_depth`, which places objects
+on the same rendering "plane". Here, we use `translucent` allows us to see the effect
+of depth.
+
 .. tags:: visualization-basic
 """
 
@@ -14,8 +18,6 @@ import napari
 im_data = np.zeros((50, 50, 50))
 im_data[30:40, 25:35, 25:35] = 1
 viewer = napari.Viewer()
-# default blending for images is `translucent_no_depth`
-# `translucent` allows us to see the effect
 layer = viewer.add_image(im_data, colormap='magenta', rendering='iso', blending='translucent')
 viewer.add_image(im_data, colormap='green', rendering='iso', blending='translucent', translate=(30, 0, 0))
 

--- a/examples/image_depth.py
+++ b/examples/image_depth.py
@@ -2,6 +2,8 @@
 Image depth
 ===========
 
+Display a 3D image and 3D points layer to show how napari handles depth.
+
 .. tags:: visualization-basic
 """
 
@@ -12,6 +14,8 @@ import napari
 im_data = np.zeros((50, 50, 50))
 im_data[30:40, 25:35, 25:35] = 1
 viewer = napari.Viewer()
+# default blending for images is `translucent_no_depth`
+# `translucent` allows us to see the effect
 layer = viewer.add_image(im_data, colormap='magenta', rendering='iso', blending='translucent')
 viewer.add_image(im_data, colormap='green', rendering='iso', blending='translucent', translate=(30, 0, 0))
 

--- a/examples/image_depth.py
+++ b/examples/image_depth.py
@@ -4,9 +4,10 @@ Image depth
 
 Display a 3D image and 3D points layer to show how napari handles depth.
 
-The default blending for images is `translucent_no_depth`, which places objects
-on the same rendering "plane". Here, we use `translucent` which allows us to see the effect
-of camera depth.
+The default blending for images is `translucent_no_depth`, which ignores depth and
+always draws the layer on top of lower layers. Switching to `translucent` allows
+objects in this layer to disappear behind objects in other layers depending
+on the distance from the camera.
 
 .. tags:: visualization-basic
 """

--- a/examples/image_depth.py
+++ b/examples/image_depth.py
@@ -27,7 +27,7 @@ points_data = [
 viewer.add_points(points_data, size=4)
 
 viewer.dims.ndisplay = 3
-viewer.camera.angles = (0, -10, 10)
+viewer.camera.angles = (0, -30, 10)
 viewer.fit_to_view()
 
 if __name__ == '__main__':

--- a/examples/image_depth.py
+++ b/examples/image_depth.py
@@ -5,8 +5,8 @@ Image depth
 Display a 3D image and 3D points layer to show how napari handles depth.
 
 The default blending for images is `translucent_no_depth`, which places objects
-on the same rendering "plane". Here, we use `translucent` allows us to see the effect
-of depth.
+on the same rendering "plane". Here, we use `translucent` which allows us to see the effect
+of camera depth.
 
 .. tags:: visualization-basic
 """


### PR DESCRIPTION
# References and relevant issues
Closes #8712

# Description
Change the `blending` mode of the added images in the example to `translucent` to show the points rendered "in between"
the boxes.

<img width="1156" height="848" alt="image" src="https://github.com/user-attachments/assets/1add4f1a-823c-419f-a174-e7ab4638cc3f" />

