### PR TITLE
Restyle new_layer button creation state visuals

### DIFF
--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -38,13 +38,13 @@ QtViewerPushButton[mode="new_labels"]:disabled {
 QtViewerPushButton[mode="new_points"][creation_state="full"],
 QtViewerPushButton[mode="new_shapes"][creation_state="full"],
 QtViewerPushButton[mode="new_labels"][creation_state="full"] {
-  border: 3px solid {{ lighten(current, 10) }};
+  border: 3px solid {{ current }};
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="partial"],
 QtViewerPushButton[mode="new_shapes"][creation_state="partial"],
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
-  border: 3px dashed {{ darken(current, 10) }};
+  border: 3px solid {{ highlight }};
 }
 
 QtViewerPushButton[mode="warning"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -38,7 +38,7 @@ QtViewerPushButton[mode="new_labels"]:disabled {
 QtViewerPushButton[mode="new_points"][creation_state="full"],
 QtViewerPushButton[mode="new_shapes"][creation_state="full"],
 QtViewerPushButton[mode="new_labels"][creation_state="full"] {
-  border: 3px solid {{ lighten(current, 20) }};
+  border: 3px solid {{ lighten(current, 25) }};
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="partial"],

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -44,7 +44,7 @@ QtViewerPushButton[mode="new_labels"][creation_state="full"] {
 QtViewerPushButton[mode="new_points"][creation_state="partial"],
 QtViewerPushButton[mode="new_shapes"][creation_state="partial"],
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
-  border: 3px solid {{ highlight }};
+  border: 3px solid {{ secondary }};
 }
 
 QtViewerPushButton[mode="warning"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -38,13 +38,13 @@ QtViewerPushButton[mode="new_labels"]:disabled {
 QtViewerPushButton[mode="new_points"][creation_state="full"],
 QtViewerPushButton[mode="new_shapes"][creation_state="full"],
 QtViewerPushButton[mode="new_labels"][creation_state="full"] {
-  border: 3px solid {{ current }};
+  border: 3px solid {{ lighten(current, 20) }};
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="partial"],
 QtViewerPushButton[mode="new_shapes"][creation_state="partial"],
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
-  border: 3px solid {{ secondary }};
+  border: 3px solid {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="warning"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -16,7 +16,7 @@ QtViewerPushButton[mode="delete_button"] {
 QtViewerPushButton[mode="new_points"],
 QtViewerPushButton[mode="new_shapes"],
 QtViewerPushButton[mode="new_labels"] {
-  border: 3px solid transparent;
+  border: 3px solid {{ background }};
 }
 
 QtViewerPushButton[mode="new_points"] {
@@ -32,7 +32,7 @@ QtViewerPushButton[mode="new_labels"] {
 }
 
 QtViewerPushButton[mode="new_labels"]:disabled {
-  border: 3px solid transparent;
+  border: 3px solid {{ background }};
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="full"],

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -31,13 +31,13 @@ QtViewerPushButton[mode="new_labels"] {
 QtViewerPushButton[mode="new_points"][creation_state="full"],
 QtViewerPushButton[mode="new_shapes"][creation_state="full"],
 QtViewerPushButton[mode="new_labels"][creation_state="full"] {
-  border: 3px solid {{ lighten(current, 20) }};
+  border: 3px solid {{ lighten(current, 15) }};
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="partial"],
 QtViewerPushButton[mode="new_shapes"][creation_state="partial"],
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
-  border: 3px solid {{ darken(current, 5) }};
+  border: 3px dashed {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="warning"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -18,25 +18,9 @@ QtViewerPushButton[mode="new_points"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="new_points"][creation_state="full"] {
-  border: 3px solid {{ lighten(current, 20) }};
-}
-
-QtViewerPushButton[mode="new_points"][creation_state="partial"] {
-  border: 3px solid {{ darken(current, 5) }};
-}
-
 QtViewerPushButton[mode="new_shapes"] {
   image: url("theme_{{ id }}:/new_shapes.svg");
   border: 3px solid {{ background }};
-}
-
-QtViewerPushButton[mode="new_shapes"][creation_state="full"] {
-  border: 3px solid {{ lighten(current, 20) }};
-}
-
-QtViewerPushButton[mode="new_shapes"][creation_state="partial"] {
-  border: 3px solid {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="warning"] {
@@ -48,10 +32,14 @@ QtViewerPushButton[mode="new_labels"] {
   border: 3px solid {{ background }};
 }
 
+QtViewerPushButton[mode="new_points"][creation_state="full"],
+QtViewerPushButton[mode="new_shapes"][creation_state="full"],
 QtViewerPushButton[mode="new_labels"][creation_state="full"] {
   border: 3px solid {{ lighten(current, 20) }};
 }
 
+QtViewerPushButton[mode="new_points"][creation_state="partial"],
+QtViewerPushButton[mode="new_shapes"][creation_state="partial"],
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
   border: 3px solid {{ darken(current, 5) }};
 }

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -23,10 +23,6 @@ QtViewerPushButton[mode="new_shapes"] {
   border: 3px solid {{ background }};
 }
 
-QtViewerPushButton[mode="warning"] {
-  image: url("theme_{{ id }}:/warning.svg");
-}
-
 QtViewerPushButton[mode="new_labels"] {
   image: url("theme_{{ id }}:/new_labels.svg");
   border: 3px solid {{ background }};
@@ -42,6 +38,10 @@ QtViewerPushButton[mode="new_points"][creation_state="partial"],
 QtViewerPushButton[mode="new_shapes"][creation_state="partial"],
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
   border: 3px solid {{ darken(current, 5) }};
+}
+
+QtViewerPushButton[mode="warning"] {
+  image: url("theme_{{ id }}:/warning.svg");
 }
 
 QtViewerPushButton[mode="console"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -13,19 +13,26 @@ QtViewerPushButton[mode="delete_button"] {
    image: url("theme_{{ id }}:/delete.svg");
 }
 
+QtViewerPushButton[mode="new_points"],
+QtViewerPushButton[mode="new_shapes"],
+QtViewerPushButton[mode="new_labels"] {
+  border: 3px solid transparent;
+}
+
 QtViewerPushButton[mode="new_points"] {
   image: url("theme_{{ id }}:/new_points.svg");
-  border: 3px solid {{ background }};
 }
 
 QtViewerPushButton[mode="new_shapes"] {
   image: url("theme_{{ id }}:/new_shapes.svg");
-  border: 3px solid {{ background }};
 }
 
 QtViewerPushButton[mode="new_labels"] {
   image: url("theme_{{ id }}:/new_labels.svg");
-  border: 3px solid {{ background }};
+}
+
+QtViewerPushButton[mode="new_labels"]:disabled {
+  border: 3px solid transparent;
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="full"],

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -38,13 +38,13 @@ QtViewerPushButton[mode="new_labels"]:disabled {
 QtViewerPushButton[mode="new_points"][creation_state="full"],
 QtViewerPushButton[mode="new_shapes"][creation_state="full"],
 QtViewerPushButton[mode="new_labels"][creation_state="full"] {
-  border: 3px solid {{ lighten(current, 15) }};
+  border: 3px solid {{ lighten(current, 10) }};
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="partial"],
 QtViewerPushButton[mode="new_shapes"][creation_state="partial"],
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
-  border: 3px dashed {{ darken(current, 5) }};
+  border: 3px dashed {{ darken(current, 10) }};
 }
 
 QtViewerPushButton[mode="warning"] {

--- a/src/napari/_qt/qt_resources/styles/01_buttons.qss
+++ b/src/napari/_qt/qt_resources/styles/01_buttons.qss
@@ -19,11 +19,11 @@ QtViewerPushButton[mode="new_points"] {
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="full"] {
-  border: 3px solid {{ darken(current, 5) }};
+  border: 3px solid {{ lighten(current, 20) }};
 }
 
 QtViewerPushButton[mode="new_points"][creation_state="partial"] {
-  border: 3px solid {{ lighten(current, 20) }};
+  border: 3px solid {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="new_shapes"] {
@@ -32,11 +32,11 @@ QtViewerPushButton[mode="new_shapes"] {
 }
 
 QtViewerPushButton[mode="new_shapes"][creation_state="full"] {
-  border: 3px solid {{ darken(current, 5) }};
+  border: 3px solid {{ lighten(current, 20) }};
 }
 
 QtViewerPushButton[mode="new_shapes"][creation_state="partial"] {
-  border: 3px solid {{ lighten(current, 20) }};
+  border: 3px solid {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="warning"] {
@@ -49,11 +49,11 @@ QtViewerPushButton[mode="new_labels"] {
 }
 
 QtViewerPushButton[mode="new_labels"][creation_state="full"] {
-  border: 3px solid {{ darken(current, 5) }};
+  border: 3px solid {{ lighten(current, 20) }};
 }
 
 QtViewerPushButton[mode="new_labels"][creation_state="partial"] {
-  border: 3px solid {{ lighten(current, 20) }};
+  border: 3px solid {{ darken(current, 5) }};
 }
 
 QtViewerPushButton[mode="console"] {


### PR DESCRIPTION
# References and relevant issues

Closes #8757 
Follow-up to #8723

# Description

Previously, the "full" creation state was darker and the "partial" was lighter, this resulted in a a non-intuitive and, in my opinion, reverse implicit understanding of how things would be interpreted. I implemented it originally as "more layers = more bright", but now that creation state isn't tied to as many layers, but as in how much is inherited, I wanted to try something different.

First, I switched full to be "brighter" by having that one be current at its base color value
Second, I used "highlight" for the partial inheritance so that it has clear visual contrast but is still connected to thelayer list.

Other changes just clean up the QSS and also make sure the new_labels button visually matches size when disabled.
It also normalizes the brightness and darkness towards the mean, which I think makes it look more consistent across light, dark, and custom themes in my testing.

Current PR:

![new_layer_highlights current](https://github.com/user-attachments/assets/17361e45-dbca-4770-be11-d74c882eedb5)


Original PR:

First, I switched full to be brighter and partial to be darker.
Then, I added a dash line for partial so that it would _look_ incomplete. This is the more important change.

![new_layer_highlights](https://github.com/user-attachments/assets/8a68aea5-ad72-4c4b-bc7e-09833cbaf789)

#8723:

![layer_highlights](https://github.com/user-attachments/assets/7f71c6a8-173e-4734-869a-3ba41d7b37e9)


Other things tried (in meeting with Grzegorz and Lorenzo) included:
1. a 2px line for the partial state, but this causes buttons t o shift in space
2. a dotted line, but its not uniform and looks really bad
3. not having the bright/dark styling. this just looked less, impactful. I think 2 elements of the styling really emphasizes the different.