### PR TITLE
Prevent selection from overwriting feature_defaults

### DIFF
--- a/src/napari/layers/points/_tests/test_points.py
+++ b/src/napari/layers/points/_tests/test_points.py
@@ -586,7 +586,6 @@ def test_remove_selected_removes_corresponding_attributes():
         symbol=symbol[1:],
         border_width=size[1:],
         features={'feature': feature[1:]},
-        feature_defaults={'feature': feature[0]},
         face_color=color[1:],
         border_color=color[1:],
         text=text,  # computed from feature
@@ -772,15 +771,15 @@ def test_properties(properties):
     assert len(layer.properties['point_type']) == (shape[0] - 2)
     assert np.array_equal(layer.properties['point_type'], remove_properties)
 
-    # test selection of properties
+    # test that selection does not overwrite current_properties
     layer.selected_data = {0}
     selected_annotation = layer.current_properties['point_type']
     assert len(selected_annotation) == 1
-    assert selected_annotation[0] == 'A'
+    assert selected_annotation[0] == 'B'
 
     # test adding points with properties
     layer.add([10, 10])
-    add_annotations = np.concatenate((remove_properties, ['A']), axis=0)
+    add_annotations = np.concatenate((remove_properties, ['B']), axis=0)
     assert np.array_equal(layer.properties['point_type'], add_annotations)
 
     # test copy/paste
@@ -955,11 +954,10 @@ def test_text_from_property_fstring(properties):
     expected_text_3 = [*expected_text_2, 'type-ish: A']
     np.testing.assert_equal(layer.text.values, expected_text_3)
 
-    # add point
-    layer.selected_data = {0}
+    # add point — uses current_properties default ('B'), not the selected point
     new_shape = np.random.random((1, 2))
     layer.add(new_shape)
-    expected_text_4 = [*expected_text_3, 'type-ish: A']
+    expected_text_4 = [*expected_text_3, 'type-ish: B']
     np.testing.assert_equal(layer.text.values, expected_text_4)
 
 
@@ -1394,15 +1392,14 @@ def test_color_cycle(attribute, color_cycle):
     layer_color = getattr(layer, f'{attribute}_color')
     np.testing.assert_allclose(layer_color, color_array)
 
-    # Add new point and test its color
+    # Add new point — uses current_properties default ('B' -> 'blue')
     coord = [18, 18]
-    layer.selected_data = {0}
     layer.add(coord)
     layer_color = getattr(layer, f'{attribute}_color')
     assert len(layer_color) == shape[0] + 1
     np.testing.assert_allclose(
         layer_color,
-        np.vstack((color_array, transform_color('red'))),
+        np.vstack((color_array, transform_color('blue'))),
     )
 
     # Check removing data adjusts colors correctly
@@ -1414,7 +1411,7 @@ def test_color_cycle(attribute, color_cycle):
     assert len(layer_color) == shape[0] - 1
     np.testing.assert_allclose(
         layer_color,
-        np.vstack((color_array[1], color_array[3:], transform_color('red'))),
+        np.vstack((color_array[1], color_array[3:], transform_color('blue'))),
     )
 
     # test adding a point with a new property value
@@ -1555,15 +1552,14 @@ def test_color_colormap(attribute):
     attribute_color = getattr(layer, f'{attribute}_color')
     assert np.array_equal(attribute_color, color_array)
 
-    # Add new point and test its color
+    # Add new point — uses current_properties default (1.5 -> 'white')
     coord = [18, 18]
-    layer.selected_data = {0}
     layer.add(coord)
     attribute_color = getattr(layer, f'{attribute}_color')
     assert len(attribute_color) == shape[0] + 1
     np.testing.assert_allclose(
         attribute_color,
-        np.vstack((color_array, transform_color('black'))),
+        np.vstack((color_array, transform_color('white'))),
     )
 
     # Check removing data adjusts colors correctly
@@ -1578,7 +1574,7 @@ def test_color_colormap(attribute):
             (
                 color_array[1],
                 color_array[3:],
-                transform_color('black'),
+                transform_color('white'),
             )
         ),
     )
@@ -2798,3 +2794,17 @@ def test_points_layer_display_correct_slice_on_scale(viewer_model):
     request = pts._slicing_state._make_slice_request(viewer_model.dims)
     response = request()
     np.testing.assert_equal(response.indices, [0])
+
+
+def test_feature_defaults_not_overwritten_by_selection():
+    """feature_defaults should not change when selecting points."""
+    data = np.array([[0, 0], [10, 10]])
+    features = {'category': ['a', 'b']}
+    layer = Points(data, features=features)
+
+    defaults = {'category': ['c']}
+    layer.feature_defaults = defaults
+
+    layer.selected_data = {0}
+
+    assert layer.feature_defaults['category'][0] == 'c'

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -1414,13 +1414,6 @@ class Points(Layer):
             ) is not None:
                 self.current_symbol = unique_symbol
 
-            unique_properties = {}
-            for k, v in self.properties.items():
-                unique_properties[k] = _unique_element(v[index])
-
-            if all(p is not None for p in unique_properties.values()):
-                self.current_properties = unique_properties
-
         self._set_highlight()
 
     def interaction_box(self, index: list[int]) -> np.ndarray | None:

--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -98,17 +98,17 @@ def test_properties(properties):
     assert len(layer.properties['shape_type']) == (shape[0] - 2)
     assert np.array_equal(layer.properties['shape_type'], remove_properties)
 
-    # test selection of properties
+    # test that selection does not overwrite current_properties
     layer.selected_data = {0}
     selected_annotation = layer.current_properties['shape_type']
     assert len(selected_annotation) == 1
-    assert selected_annotation[0] == 'A'
+    assert selected_annotation[0] == 'B'
 
     # test adding shapes with properties
     new_data = np.random.random((1, 4, 2))
     new_shape_type = ['rectangle']
     layer.add(new_data, shape_type=new_shape_type)
-    add_properties = np.concatenate((remove_properties, ['A']), axis=0)
+    add_properties = np.concatenate((remove_properties, ['B']), axis=0)
     assert np.array_equal(layer.properties['shape_type'], add_properties)
 
     # test copy/paste
@@ -323,11 +323,10 @@ def test_text_from_property_fstring(properties):
     expected_text_3 = [*expected_text_2, 'type-ish: A']
     np.testing.assert_equal(layer.text.values, expected_text_3)
 
-    # add shape
-    layer.selected_data = {0}
+    # add shape — uses current_properties (default 'B'), not the selected shape
     new_shape = np.random.random((1, 4, 2))
     layer.add(new_shape)
-    expected_text_4 = [*expected_text_3, 'type-ish: A']
+    expected_text_4 = [*expected_text_3, 'type-ish: B']
     np.testing.assert_equal(layer.text.values, expected_text_4)
 
 
@@ -1863,15 +1862,14 @@ def test_color_cycle(attribute, color_cycle):
     layer_color = getattr(layer, f'{attribute}_color')
     np.testing.assert_allclose(layer_color, color_array)
 
-    # Add new shape and test its color
+    # Add new shape and test its color — uses current_properties default ('B' -> 'blue')
     new_shape = np.random.random((1, 4, 2))
-    layer.selected_data = {0}
     layer.add(new_shape)
     layer_color = getattr(layer, f'{attribute}_color')
     assert len(layer_color) == shape[0] + 1
     np.testing.assert_allclose(
         layer_color,
-        np.vstack((color_array, transform_color('red'))),
+        np.vstack((color_array, transform_color('blue'))),
     )
 
     # Check removing data adjusts colors correctly
@@ -1883,7 +1881,7 @@ def test_color_cycle(attribute, color_cycle):
     assert len(layer_color) == shape[0] - 1
     np.testing.assert_allclose(
         layer_color,
-        np.vstack((color_array[1], color_array[3:], transform_color('red'))),
+        np.vstack((color_array[1], color_array[3:], transform_color('blue'))),
     )
 
     # refresh colors
@@ -2002,15 +2000,14 @@ def test_color_colormap(attribute):
     attribute_color = getattr(layer, f'{attribute}_color')
     assert np.array_equal(attribute_color, color_array)
 
-    # Add new shape and test its color
+    # Add new shape — uses current_properties default (1.5 -> 'white')
     new_shape = np.random.random((1, 4, 2))
-    layer.selected_data = {0}
     layer.add(new_shape)
     attribute_color = getattr(layer, f'{attribute}_color')
     assert len(attribute_color) == shape[0] + 1
     np.testing.assert_allclose(
         attribute_color,
-        np.vstack((color_array, transform_color('black'))),
+        np.vstack((color_array, transform_color('white'))),
     )
 
     # Check removing data adjusts colors correctly
@@ -2025,7 +2022,7 @@ def test_color_colormap(attribute):
             (
                 color_array[1],
                 color_array[3:],
-                transform_color('black'),
+                transform_color('white'),
             )
         ),
     )
@@ -2674,3 +2671,17 @@ def test_finish_drawing_called_when_is_creating():
         layer.mode = 'select'
         mock_finish.assert_called_once()
     assert not layer._is_creating
+
+
+def test_feature_defaults_not_overwritten_by_selection():
+    """feature_defaults should not change when selecting shapes."""
+    data = [np.array([[0, 0], [0, 10], [10, 10], [10, 0]])]
+    features = {'category': ['a']}
+    layer = Shapes(data, features=features)
+
+    defaults = {'category': ['b']}
+    layer.feature_defaults = defaults
+
+    layer.selected_data = {0}
+
+    assert layer.feature_defaults['category'][0] == 'b'

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -1308,16 +1308,6 @@ class Shapes(Layer):
                 with self.block_update_properties():
                     self.current_edge_width = unique_edge_width
 
-            unique_properties = {}
-            for k, v in self.properties.items():
-                unique_properties[k] = _unique_element(
-                    v[selected_data_indices]
-                )
-
-            if all(p is not None for p in unique_properties.values()):
-                with self.block_update_properties():
-                    self.current_properties = unique_properties
-
         self._set_highlight()
 
     @property


### PR DESCRIPTION
## What
Prevent shape/point selection from silently overwriting user-set `feature_defaults`.

## Why
When a user sets `feature_defaults` and then selects a shape or point, the selection handler was calling `self.current_properties = unique_properties`, which went through `_FeatureTable.set_currents()` and overwrote `_defaults`. This meant `feature_defaults` would reflect the selected item's properties instead of the user's explicitly set defaults.

## How
Removed the `current_properties` assignment from the selection handlers in both Shapes (`_on_selection_changed`) and Points (`selected_data` setter). Selection events should not modify feature defaults.

**Note:** This means `current_properties` will no longer reflect the selected item's properties after selection. This is the intended behavior per the discussion in #8564 — `feature_defaults` should only change when the user explicitly sets them.

## Testing
Added tests for both Shapes and Points layers verifying that `feature_defaults` remains unchanged after selecting data. Updated existing tests that relied on the old (buggy) selection-overwrites-defaults behavior.

Closes #8564