### PR TITLE
Derefer update units in vispy overlays on delete layer

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -795,7 +795,7 @@ class VispyCanvas:
         napari_layer.events.units.connect(self._deferred_world_units_update)
         self._overlay_callbacks[napari_layer] = overlay_callback
         self.viewer.camera.events.angles.connect(vispy_layer._on_camera_move)
-        self._update_world_units()
+        self._deferred_world_units_update()
 
         # we need to trigger _on_matrix_change once after adding the overlays so that
         # all children nodes are assigned the correct transforms
@@ -844,6 +844,7 @@ class VispyCanvas:
 
         self._update_layer_overlays(layer)
         del self._layer_overlay_to_visual[layer]
+        self._deferred_world_units_update()
         if self._pause_scene_graph:
             return
         self._clean_and_update_scenegraph()


### PR DESCRIPTION
# References and relevant issues

closes #8771
closes #8771

# Description

This PR add missed `_deferred_world_units_update` call in `_remove_layer` method to inform that units might need to be updated after layer deletion 

Also replace `_update_world_units` greedy call with `_deferred_world_units_update` in `add_layer_visual_mapping` 
