### PR TITLE
Disable opacity slider for multiplicative blending

### DIFF
--- a/src/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_image_base_layer_.py
@@ -155,7 +155,7 @@ def test_tensorstore_clim_popup(qtbot):
 
 
 def test_blending_opacity_slider(qtbot):
-    """Tests whether opacity slider is disabled for minimum and opaque blending."""
+    """Tests whether opacity slider is disabled for minimum, opaque, and multiplicative blending."""
     layer = Image(np.random.rand(8, 8))
     qtctrl = QtLayerControls(layer)
     qtbot.addWidget(qtctrl)
@@ -176,6 +176,14 @@ def test_blending_opacity_slider(qtbot):
     # set the blending back to 'translucent' confirm the slider is enabled
     layer.blending = 'translucent'
     assert layer.blending == 'translucent'
+    assert qtctrl._opacity_blending_controls.opacity_slider.isEnabled()
+    # set multiplicative blending, the opacity slider should be disabled
+    layer.blending = 'multiplicative'
+    assert layer.blending == 'multiplicative'
+    assert not qtctrl._opacity_blending_controls.opacity_slider.isEnabled()
+    # set the blending back to 'additive' confirm the slider is enabled
+    layer.blending = 'additive'
+    assert layer.blending == 'additive'
     assert qtctrl._opacity_blending_controls.opacity_slider.isEnabled()
 
 

--- a/src/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -23,8 +23,12 @@ from napari.utils.action_manager import action_manager
 from napari.utils.events import disconnect_events
 from napari.utils.translations import trans
 
-# opaque and minimum blending do not support changing alpha (opacity)
-NO_OPACITY_BLENDING_MODES = {str(Blending.MINIMUM), str(Blending.OPAQUE)}
+# opaque, minimum, and multiplicative blending do not support changing alpha (opacity)
+NO_OPACITY_BLENDING_MODES = {
+    str(Blending.MINIMUM),
+    str(Blending.OPAQUE),
+    str(Blending.MULTIPLICATIVE),
+}
 
 
 class LayerFormLayout(QFormLayout):

--- a/src/napari/_qt/layer_controls/widgets/qt_opacity_blending_controls.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_opacity_blending_controls.py
@@ -15,8 +15,12 @@ from napari.layers.base.base import Layer
 from napari.utils.events.event_utils import connect_setattr
 from napari.utils.translations import trans
 
-# opaque and minimum blending do not support changing alpha (opacity)
-NO_OPACITY_BLENDING_MODES = {str(Blending.MINIMUM), str(Blending.OPAQUE)}
+# opaque, minimum, and multiplicative blending do not support changing alpha (opacity)
+NO_OPACITY_BLENDING_MODES = {
+    str(Blending.MINIMUM),
+    str(Blending.OPAQUE),
+    str(Blending.MULTIPLICATIVE),
+}
 
 
 class QtOpacityBlendingControls(QtWidgetControlsBase):


### PR DESCRIPTION
## What
Disables the opacity slider when multiplicative blending is selected, matching the existing behavior for minimum and opaque blending modes.

## Why
The multiplicative blend function uses hardcoded alpha values (`one`, `one`), so the opacity slider has no visual effect. Users see an active slider that does nothing, which is confusing.

## How
Added `Blending.MULTIPLICATIVE` to `NO_OPACITY_BLENDING_MODES` in both `qt_opacity_blending_controls.py` and `qt_layer_controls_base.py`.

## Testing
Extended `test_blending_opacity_slider` to verify the slider is disabled for multiplicative blending and re-enabled when switching back.

Closes #7947