### PR TITLE
Do not emit warning about units if there is no layer in viewer

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -809,7 +809,7 @@ class VispyCanvas:
     def _update_world_units(self):
         """Update the units of the canvas and all layers."""
         units = self.viewer.layers.extent.units
-        if units is None:
+        if units is None and len(self.viewer.layers) > 0:
             show_warning(
                 'Inconsistent units across layers; units will not be used for rendering.'
             )


### PR DESCRIPTION
# References and relevant issues

https://github.com/4DNucleome/PartSeg/issues/1364

# Description

If there are no layers, then `layers.extent.units` is `None`, but there is no reason to emit warning. 