### PR TITLE
Fix colorbar box offset

### DIFF
--- a/src/napari/_vispy/visuals/colorbar.py
+++ b/src/napari/_vispy/visuals/colorbar.py
@@ -109,6 +109,11 @@ class ColorBar(Node):
         clim: tuple[float, float],
         color: ColorValue,
     ) -> tuple[float, float]:
+        # offset everything down by half the height of the font
+        # so we don't spill at the top with the tick text
+        for visual in (self.img, self.box, self.ticks):
+            visual.transform.translate = (0, font_size / 2)
+
         self.box.set_data(color=color)
         self.ticks.axis_color = color
         self.ticks.text_color = color


### PR DESCRIPTION
# References and relevant issues
- followup on https://github.com/napari/napari/pull/8654

# Description
There was still an offset in the colorbar contents relative to the box. This fixes it. 

With red box so it's easier to see:

- main:

<img width="1010" height="622" alt="image" src="https://github.com/user-attachments/assets/b6e1a800-1185-4d13-8594-712cb072a389" />


- this PR:


<img width="1010" height="622" alt="image" src="https://github.com/user-attachments/assets/9a5b7a07-86e9-44d3-a8ee-82019ca8c132" />


@DragaDoncila this is probably worth getting in 0.7.0 so the box never goes out broken?