### PR TITLE
Fix: Qt6 font error on Windows when adding layers or widgets

### DIFF
--- a/src/napari/_qt/widgets/qt_dims.py
+++ b/src/napari/_qt/widgets/qt_dims.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 from qtpy.QtCore import Slot
-from qtpy.QtGui import QFont, QFontMetrics
 from qtpy.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
 
 from napari._qt.widgets.qt_dims_slider import (
@@ -182,7 +181,7 @@ class QtDims(QWidget):
                 if length > width:
                     width = length
         # gui width of a string of length `width`
-        fm = QFontMetrics(QFont('', 0))
+        fm = self.fontMetrics()
         width = fm.boundingRect('8' * width).width()
         for labl in self.findChildren(QWidget, 'slice_label'):
             labl.setFixedWidth(width + 6)


### PR DESCRIPTION
# References and relevant issues

~~I can't find where it was reported right now, but~~ I've been seeing it a long time.
Giovanni Cardone reported  [#general > napari 0.7.0rc0 is out! @ 💬](https://napari.zulipchat.com/#narrow/channel/212875-general/topic/napari.200.2E7.2E0rc0.20is.20out.21/near/578918655) (thanks Peter)

# Description

On Windows, and recently narrowed down to Qt6 (maybe even PyQt6), it was found that these errors are seen by folks (not just me):
```pytb
WARNING: DirectWrite: CreateFontFaceFromHDC() failed (Indicates an error in an input file such as a font file.) for QFontDef(Family="MS Sans Serif", pointsize=12, pixelsize=16, styleHint=5, weight=400, stretch=100, hintingPreference=0) LOGFONT("MS Sans Serif", lfWidth=0, lfHeight=-16) dpi=96
```
It is reproducible when adding a widget, or layers. Simplest reproducer:
```python
import napari
viewer = napari.Viewer()
viewer.open_sample('napari', 'cells3d')
napari.run()
```
Claude did a good job of finding this bugfix 😛 
The cause of the bug is that an empty QFont call, namely `QFont('',0)` tries to initialize a non-existent Windows font, namely `MS Sans Serif`. Then, when the dim widget was resized, it triggered the warning, which occurs such as when a widget was added.

This is the only place in the codebase with such a call, and it can be replicated as simply as with:
```python
from qtpy.QtGui import QFont, QFontMetrics
from qtpy.QtWidgets import QApplication

app = QApplication.instance() or QApplication([])
fm = QFontMetrics(QFont('',0)) 
fm.height()  # generates the warning
```
This replaces the bare `QFontMetrics` with the widgets own `fontMetric`

Not really sure there needs to be a regression test or anything, and its the only instance I could find in the codebase.