### PR TITLE
Fix: ValidationError in Drag to Zoom with data ndim>2

### DIFF
--- a/src/napari/_qt/_tests/test_qt_viewer.py
+++ b/src/napari/_qt/_tests/test_qt_viewer.py
@@ -1326,3 +1326,58 @@ def test_viewer_drag_to_zoom_with_cancel(
         'Zoom box canvas positions should match the drag coordinates'
     )
     zoom_area_mock.assert_not_called()
+
+
+@pytest.mark.show_qt_viewer
+def test_viewer_drag_to_zoom_3d_data(
+    qt_viewer: QtViewer, viewer_model: ViewerModel, qtbot: QtBot
+) -> None:
+    """Regression test: drag-to-zoom must not raise ValidationError with 3D data.
+
+    When the viewer has ndim>2 but ndisplay=2, event.position is a len(ndim)-tuple.
+    ZoomOverlay.zoom_area only accepts 2-tuples, so the drag_to_zoom binding
+    must slice to the displayed (last 2) coordinates before assigning.
+    """
+    canvas = qt_viewer.canvas
+
+    zoom_area_mock = mock.Mock()
+    viewer_model._zoom_box.events.zoom_area.connect(zoom_area_mock)
+
+    # 3D data so that event.position will have 3 components
+    data = np.random.default_rng(0).random((10, 20, 20))
+    viewer_model.add_image(data)
+    assert viewer_model.dims.ndim == 3
+    assert viewer_model.dims.ndisplay == 2
+
+    qtbot.wait(10)
+    canvas._scene_canvas.events.mouse_press(
+        pos=(0, 0), modifiers=('Alt',), button=0
+    )
+    qtbot.wait(10)
+    assert viewer_model._zoom_box.visible is True
+
+    canvas._scene_canvas.events.mouse_move(
+        pos=(100, 100),
+        modifiers=('Alt',),
+        button=0,
+        press_event=MouseEvent(
+            pos=(0, 0), modifiers=('Alt',), button=0, type='mouse_press'
+        ),
+    )
+    qtbot.wait(10)
+
+    # Release — this previously raised a pydantic ValidationError
+    canvas._scene_canvas.events.mouse_release(
+        pos=(100, 100), modifiers=('Alt',), button=0
+    )
+    qtbot.wait(10)
+
+    assert viewer_model._zoom_box.visible is False, (
+        'Zoom box should be hidden after release'
+    )
+    # zoom_area should have been set with 2-tuples (last 2 world coords)
+    assert zoom_area_mock.call_count == 1
+    zoom_area_value = zoom_area_mock.call_args[0][0]
+    assert len(zoom_area_value) == 2, 'zoom_area must be a 2-element tuple'
+    assert len(zoom_area_value[0]) == 2, 'each corner must be a 2-tuple'
+    assert len(zoom_area_value[1]) == 2, 'each corner must be a 2-tuple'

--- a/src/napari/components/_viewer_mouse_bindings.py
+++ b/src/napari/components/_viewer_mouse_bindings.py
@@ -51,34 +51,29 @@ def drag_to_zoom(viewer, event):
     holding the `Alt` key to create a zoom box. When the mouse is released,
     the camera zooms into the selected region.
     """
-    if 'Alt' not in event.modifiers:
+    if 'Alt' not in event.modifiers or event.type != 'mouse_press':
         return
 
     # on mouse press
-    press_pos, press_position = None, None
-    if event.type == 'mouse_press':
-        viewer._zoom_box.visible = True
-        press_pos = event.pos[::-1]
-        press_position = event.position
-        viewer._zoom_box.position = (press_pos, press_pos)
-        yield
-        event.handled = True
-
-    # on mouse move
+    viewer._zoom_box.visible = True
+    press_pos = event.pos[::-1]
+    press_position = event.position
     move_pos = press_pos
     move_position = press_position
-    cancel = False
+    viewer._zoom_box.position = (press_pos, press_pos)
+    yield
+    event.handled = True
+
+    # on mouse move
     while event.type == 'mouse_move':
-        if press_pos is None:
-            continue
-        if 'Alt' in event.modifiers:
-            move_pos = event.pos[::-1]
-            viewer._zoom_box.position = (press_pos, move_pos)
-            move_position = event.position
-        else:
-            # if Alt is released, cancel the zoom box
-            cancel = True
-            break
+        if 'Alt' not in event.modifiers:
+            viewer._zoom_box.visible = False
+            yield
+            return
+
+        move_pos = event.pos[::-1]
+        viewer._zoom_box.position = (press_pos, move_pos)
+        move_position = event.position
         yield
 
     # on mouse release
@@ -86,7 +81,7 @@ def drag_to_zoom(viewer, event):
 
     # only trigger zoom if the box is larger than a MIN_ZOOMBOX_SIZE in pixels
     distance = np.abs(np.array(press_pos) - np.array(move_pos))
-    if not cancel and distance.min() > MIN_ZOOMBOX_SIZE:
+    if distance.min() > MIN_ZOOMBOX_SIZE:
         # Slice to the last two coordinates (displayed axes) for cases where
         # ndim>2 and ndisplay=2
         viewer._zoom_box.zoom_area = (

--- a/src/napari/components/_viewer_mouse_bindings.py
+++ b/src/napari/components/_viewer_mouse_bindings.py
@@ -87,9 +87,8 @@ def drag_to_zoom(viewer, event):
     # only trigger zoom if the box is larger than a MIN_ZOOMBOX_SIZE in pixels
     distance = np.abs(np.array(press_pos) - np.array(move_pos))
     if not cancel and distance.min() > MIN_ZOOMBOX_SIZE:
-        # Slice to the last two coordinates (displayed axes) so that the
-        # 2-tuple constraint on ZoomOverlay.zoom_area is satisfied even when
-        # the viewer has more than 2 dimensions (e.g. ndim=3, ndisplay=2).
+        # Slice to the last two coordinates (displayed axes) for cases where
+        # ndim>2 and ndisplay=2
         viewer._zoom_box.zoom_area = (
             press_position[-2:],
             move_position[-2:],

--- a/src/napari/components/_viewer_mouse_bindings.py
+++ b/src/napari/components/_viewer_mouse_bindings.py
@@ -87,5 +87,11 @@ def drag_to_zoom(viewer, event):
     # only trigger zoom if the box is larger than a MIN_ZOOMBOX_SIZE in pixels
     distance = np.abs(np.array(press_pos) - np.array(move_pos))
     if not cancel and distance.min() > MIN_ZOOMBOX_SIZE:
-        viewer._zoom_box.zoom_area = (press_position, move_position)
+        # Slice to the last two coordinates (displayed axes) so that the
+        # 2-tuple constraint on ZoomOverlay.zoom_area is satisfied even when
+        # the viewer has more than 2 dimensions (e.g. ndim=3, ndisplay=2).
+        viewer._zoom_box.zoom_area = (
+            press_position[-2:],
+            move_position[-2:],
+        )
     yield


### PR DESCRIPTION
# References and relevant issues

[#release > 0.7.0 @ 💬](https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E7.2E0/near/580526194)

When trying to use Drag to Zoom (alt+drag) with ndim>2 there is a `ValidationError` because the `_zoom_box` tuple is bigger thann it should be when setting `zoom_area`. 

# Description

#8509 changed the `ZoomOverlay` (via `CanvasOverlay`) to inherit from `EventedModel` instead of just a raw event value

`viewer._zoom_box.events.zoom(value=(press_position, move_position))` -> `viewer._zoom_box.zoom_area = (press_position, move_position)`

Now, we get the last 2 values of the tuples s othat `zoom_area` gets the proper sized tuples. This is also modeled in how `double_click_to_zoom` works. 

Added a regression test.