### PR TITLE
Enh, minor, builtins: use urllib (and defer) instead of requests if reading a remote script path

### DIFF
--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 
 import imageio.v3 as iio
 import numpy as np
-import requests
 from dask import delayed
 
 from napari.utils.misc import abspath_or_url
@@ -703,6 +702,7 @@ def load_and_execute_python_code(script_path: str) -> list['LayerData']:
     """
     if _is_url(script_path):
         # download the script from the URL
+        import requests
 
         response = requests.get(_git_provider_url_to_raw_url(script_path))
         response.raise_for_status()

--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager, suppress
 from glob import glob
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
-from urllib.parse import urlparse
 
 import imageio.v3 as iio
 import numpy as np
@@ -58,6 +57,8 @@ def _git_provider_url_to_raw_url(filename: str) -> str:
     str
         The raw file URL.
     """
+    from urllib.parse import urlparse
+
     parsed_url = urlparse(filename)
     # For a GitLab file URL that contains `blob/` replace with `raw`
     if 'gitlab' in parsed_url.netloc:
@@ -702,11 +703,13 @@ def load_and_execute_python_code(script_path: str) -> list['LayerData']:
     """
     if _is_url(script_path):
         # download the script from the URL
-        import requests
 
-        response = requests.get(_git_provider_url_to_raw_url(script_path))
-        response.raise_for_status()
-        code = response.text
+        from urllib.request import urlopen
+
+        raw_url = _git_provider_url_to_raw_url(script_path)
+        with urlopen(raw_url) as response:
+            encoding = response.headers.get_content_charset() or 'utf-8'
+            code = response.read().decode(encoding)
     else:
         code = Path(script_path).read_text()
     execute_python_code(code, script_path)


### PR DESCRIPTION
# References and relevant issues
Part of: https://github.com/napari/napari/issues/8689

# Description
Requests was used by builtins for reading remote scripts.
It's ~50 ms import time for requests, which will most likely not be used.
Carol noted that it's not part of the standard library -- but we don't actually have it in napari dependencies! -- so I replaced the usage with `urllib` instead, a bit more verbose, but clear enough I think. urllib is fast, but I deferred it anyways.
