### PR TITLE
Ensure that visible icon when dialog ask to select plugin to open file

### DIFF
--- a/src/napari/_qt/dialogs/qt_reader_dialog.py
+++ b/src/napari/_qt/dialogs/qt_reader_dialog.py
@@ -30,7 +30,13 @@ class QtReaderDialog(QDialog):
     ) -> None:
         if readers is None:
             readers = {}
+        style_sheet = None
+        if parent is not None and not parent.isVisible():
+            style_sheet = parent.styleSheet()
+            parent = None
         super().__init__(parent)
+        if style_sheet:
+            self.setStyleSheet(style_sheet)
         self.setObjectName('Choose reader')
         self.setWindowTitle(trans._('Choose reader'))
         self._current_file = pth


### PR DESCRIPTION
# References and relevant issues

https://forum.qt.io/topic/108374/no-taskbar-icon-on-qdialog-is-shown-before-mainwindow-show-is-called/5
https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E7.2E0.20-.20base.20conda.20python.20and.20qt6.20troubleshooting/near/580723777

> So, if napari path_to_image pops the reader dialog, then the viewer does not show until the reader dialog is finished, and if the reader dialog gets hidden behind a window, there is no taskbar item to know that it even launch. It's because the CLI args are still being processed, so viewer.show() doesn't fire ([#8725](https://github.com/napari/napari/issues/8725)). The same happens in [#8766](https://github.com/napari/napari/issues/8766) where the splash never disappears and its on top of the reader dialog, because the splash dissapears when the viewer is shown

# Description

On Windows, the dialog with parent do not add icon to taskbar. So this PR checks if napari window is visible and if not, then set parent to None.  

This lead to create icon, that do not allow hiding dialog under other windows. 