### PR TITLE
Perf: Defer importing scipy.spatial

### DIFF
--- a/src/napari/_vispy/camera.py
+++ b/src/napari/_vispy/camera.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.spatial.transform import Rotation
 from vispy.scene import ArcballCamera, BaseCamera, PanZoomCamera
 from vispy.util.quaternion import Quaternion
 
@@ -51,6 +50,8 @@ class VispyCamera:
         """
 
         if isinstance(self._view.camera, MouseToggledArcballCamera):
+            from scipy.spatial.transform import Rotation
+
             # Do conversion from quaternion representation to euler angles
             q = self._view.camera._quaternion
             rotation = Rotation.from_quat([q.x, q.y, q.z, q.w])
@@ -73,6 +74,8 @@ class VispyCamera:
 
         # Only update angles if current camera is 3D camera
         if isinstance(self._view.camera, MouseToggledArcballCamera):
+            from scipy.spatial.transform import Rotation
+
             # flip handedness so the rotation is always righthanded even with axis flipping
             angles = angles * np.where(
                 self._camera._vispy_flipped_axes(ndisplay=3), -1, 1

--- a/src/napari/components/camera.py
+++ b/src/napari/components/camera.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
 from pydantic import field_validator
-from scipy.spatial.transform import Rotation as R
 
 from napari.utils.camera_orientations import (
     DEFAULT_ORIENTATION_TYPED,
@@ -75,6 +74,8 @@ class Camera(EventedModel):
         3-tuple. This direction is in 3D scene coordinates, the world coordinate
         system for three currently displayed dimensions.
         """
+        from scipy.spatial.transform import Rotation as R
+
         # once we're in scene-land, we pretend to be in xyz space (axes names don't
         # mean anything after all...) which simplifies the logic a lot.
         rotation = R.from_euler('xyz', self.angles, degrees=True)
@@ -90,6 +91,8 @@ class Camera(EventedModel):
         3-tuple. This direction is in 3D scene coordinates, the world coordinate
         system for three currently displayed dimensions.
         """
+        from scipy.spatial.transform import Rotation as R
+
         # once we're in scene-land, we pretend to be in xyz space (axes names don't
         # mean anything after all...) which simplifies the logic a lot.
         rotation = R.from_euler('xyz', self.angles, degrees=True)
@@ -123,6 +126,8 @@ class Camera(EventedModel):
             to (0, -1, 0) unless the view direction is parallel to the y-axis,
             in which case will default to (-1, 0, 0).
         """
+        from scipy.spatial.transform import Rotation as R
+
         # project up onto view so we can remove the parallel component
         projection = np.dot(up_direction, view_direction) * np.array(
             view_direction

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -3,13 +3,13 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 from scipy.sparse import coo_matrix
-from scipy.spatial import cKDTree
 
 from napari.layers.utils.layer_utils import _FeatureTable
 from napari.utils.events.custom_types import Array
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
+    from scipy.spatial import cKDTree
     import pandas as pd
 
 
@@ -128,6 +128,7 @@ class TrackManager:
     @data.setter
     def data(self, data: list | np.ndarray) -> None:
         """set the vertex data and build the vispy arrays for display"""
+        from scipy.spatial import cKDTree
 
         # convert data to a numpy array if it is not already one
         data = np.asarray(data)

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -9,8 +9,8 @@ from napari.utils.events.custom_types import Array
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
-    from scipy.spatial import cKDTree
     import pandas as pd
+    from scipy.spatial import cKDTree
 
 
 class TrackManager:


### PR DESCRIPTION
# References and relevant issues
Part of: https://github.com/napari/napari/issues/8689

# Description
scipy.spatial is used by tracks KDTree and by the Arcball camera (3D).
Both of these use cases seem safe to defer the import.
On main:
`python -X importtime -c 'import napari; v = napari.Viewer()' 2>&1 | grep scipy.spatial`
gives between ~150 ms and 480 ms, depending on whether first run or re-run
With this branch, that check returns nothing because the import is deferred.