### PR TITLE
Enable TC002 ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -441,7 +441,7 @@ select = [
     "T20", # flake8-print
 ]
 ignore = [
-    "E501", "TC001", "TC002",
+    "E501", "TC001",
     "A003", # flake8-builtins - we have class attributes violating these rule
     "COM812", # flake8-commas - we don't like adding comma on single line of arguments
     "COM819", # conflicts with ruff-format
@@ -471,7 +471,7 @@ builtins-allowed-modules = ["io", "types", "threading"]
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel", "pydantic.ConfigDict"]
-quote-annotations = true
+#quote-annotations = true
 
 [tool.ruff.lint.pyupgrade]
 keep-runtime-typing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -470,7 +470,7 @@ ignore = [
 builtins-allowed-modules = ["io", "types", "threading"]
 
 [tool.ruff.lint.flake8-type-checking]
-runtime-evaluated-base-classes = ["pydantic.BaseModel", "pydantic.ConfigDict"]
+runtime-evaluated-base-classes = ["pydantic.BaseModel", "pydantic.ConfigDict", "napari.utils.events.EventedModel"]
 #quote-annotations = true
 
 [tool.ruff.lint.pyupgrade]

--- a/src/napari/_qt/_qapp_model/_tests/test_file_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_file_menu.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import numpy as np
 import pytest
 from app_model.types import MenuItem, SubmenuItem
-from npe2 import DynamicPlugin
 from npe2.manifest.contributions import SampleDataURI
 from qtpy.QtGui import QGuiApplication
 from qtpy.QtWidgets import QApplication
@@ -14,6 +16,9 @@ from napari._qt._qapp_model._tests.utils import get_submenu_action
 from napari.layers import Image
 from napari.plugins._tests.test_npe2 import mock_pm  # noqa: F401
 from napari.utils.action_manager import action_manager
+
+if TYPE_CHECKING:
+    from npe2 import DynamicPlugin
 
 
 def test_sample_data_triggers_reader_dialog(

--- a/src/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import importlib
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 from app_model.types import MenuItem, SubmenuItem
-from npe2 import DynamicPlugin
 from qtpy.QtWidgets import QWidget
 
 from napari._app_model import get_app_model
@@ -12,6 +14,9 @@ from napari._qt._qapp_model.qactions import _plugins, init_qactions
 from napari._qt._qplugins._qnpe2 import _toggle_or_get_widget
 from napari._tests.utils import skip_local_popups
 from napari.plugins._tests.test_npe2 import mock_pm  # noqa: F401
+
+if TYPE_CHECKING:
+    from npe2 import DynamicPlugin
 
 
 class DummyWidget(QWidget):

--- a/src/napari/_qt/containers/_base_item_view.py
+++ b/src/napari/_qt/containers/_base_item_view.py
@@ -4,7 +4,6 @@ from itertools import chain, repeat
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from qtpy.QtCore import QItemSelection, QModelIndex, Qt
-from qtpy.QtWidgets import QAbstractItemView
 
 from napari._qt.containers._base_item_model import ItemRole
 from napari._qt.containers._factory import create_model
@@ -14,6 +13,7 @@ ItemType = TypeVar('ItemType')
 if TYPE_CHECKING:
     from qtpy.QtCore import QAbstractItemModel
     from qtpy.QtGui import QKeyEvent
+    from qtpy.QtWidgets import QAbstractItemView
 
     from napari._qt.containers._base_item_model import _BaseEventedItemModel
     from napari.utils.events import Event

--- a/src/napari/_qt/containers/qt_axis_model.py
+++ b/src/napari/_qt/containers/qt_axis_model.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from qtpy.QtCore import QModelIndex, Qt
-from typing_extensions import Self
 
 from napari._qt.containers.qt_list_model import QtListModel
 from napari.components import Dims
@@ -11,6 +10,8 @@ from napari.utils.events import SelectableEventedList
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from typing_extensions import Self
 
 
 class AxisModel:

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -22,7 +22,6 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
-import numpy as np
 from qtpy.QtCore import (
     QEvent,
     QEventLoop,
@@ -33,7 +32,7 @@ from qtpy.QtCore import (
     Qt,
     Slot,
 )
-from qtpy.QtGui import QHideEvent, QImage, QShowEvent
+from qtpy.QtGui import QImage
 from qtpy.QtWidgets import (
     QApplication,
     QDialog,
@@ -96,8 +95,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, MutableMapping, Sequence
     from pathlib import Path
 
+    import numpy as np
     from magicgui.widgets import Widget
-    from qtpy.QtGui import QImage
+    from qtpy.QtGui import QHideEvent, QImage, QShowEvent
 
     from napari.viewer import Viewer
 

--- a/src/napari/_qt/widgets/_tests/conftest.py
+++ b/src/napari/_qt/widgets/_tests/conftest.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from pytestqt.qtbot import QtBot
 
 from napari._qt.widgets.qt_dims import QtDims
 from napari.components import Dims
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+    from pytestqt.qtbot import QtBot
 
 
 @pytest.fixture

--- a/src/napari/_vispy/layers/image.py
+++ b/src/napari/_vispy/layers/image.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-from vispy.scene import Node
 
 from napari._vispy.layers.scalar_field import (
     _VISPY_FORMAT_TO_DTYPE,
@@ -19,6 +20,9 @@ from napari.utils.colormaps.colormap_utils import (
     _napari_cmap_to_vispy,
 )
 from napari.utils.translations import trans
+
+if TYPE_CHECKING:
+    from vispy.scene import Node
 
 
 class ImageLayerNode(ScalarFieldLayerNode):

--- a/src/napari/_vispy/layers/scalar_field.py
+++ b/src/napari/_vispy/layers/scalar_field.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
-from vispy.scene import Node
 from vispy.visuals import ImageVisual
 
 from napari._vispy.layers.base import VispyBaseLayer
@@ -14,6 +14,9 @@ from napari._vispy.visuals.labels import LabelNode
 from napari._vispy.visuals.volume import Volume as VolumeNode
 from napari.layers._scalar_field.scalar_field import ScalarFieldBase
 from napari.utils.translations import trans
+
+if TYPE_CHECKING:
+    from vispy.scene import Node
 
 
 class ScalarFieldLayerNode(ABC):

--- a/src/napari/_vispy/mouse_event.py
+++ b/src/napari/_vispy/mouse_event.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
 from vispy.app.canvas import MouseEvent
 
 if TYPE_CHECKING:
+    import numpy as np
     import numpy.typing as npt
 
 

--- a/src/napari/_vispy/utils/visual.py
+++ b/src/napari/_vispy/utils/visual.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from vispy.scene.widgets.viewbox import ViewBox
 
 from napari._vispy.layers.base import VispyBaseLayer
 from napari._vispy.layers.image import VispyImageLayer
@@ -58,6 +57,9 @@ from napari.layers import (
     Vectors,
 )
 from napari.utils.translations import trans
+
+if TYPE_CHECKING:
+    from vispy.scene.widgets.viewbox import ViewBox
 
 layer_to_visual: dict[type[Layer], type[VispyBaseLayer]] = {
     Image: VispyImageLayer,

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -24,7 +24,6 @@ import numpy as np
 
 # This cannot be condition to TYPE_CHECKING or the stubgen fails
 # with undefined Context.
-from app_model.expressions import Context
 from pydantic import Field, PrivateAttr, field_validator
 
 from napari import layers
@@ -104,6 +103,7 @@ from napari.utils.theme import available_themes, is_theme_available
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
+    from app_model.expressions import Context
     from npe2.types import SampleDataCreator
 
 

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -21,6 +21,7 @@ from typing import (
 from urllib.parse import urlparse
 
 import numpy as np
+from app_model.expressions import Context
 
 # This cannot be condition to TYPE_CHECKING or the stubgen fails
 # with undefined Context.
@@ -103,7 +104,6 @@ from napari.utils.theme import available_themes, is_theme_available
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
-    from app_model.expressions import Context
     from npe2.types import SampleDataCreator
 
 

--- a/src/napari/layers/_source.py
+++ b/src/napari/layers/_source.py
@@ -8,12 +8,13 @@ from weakref import ReferenceType
 
 from magicgui.widgets import FunctionGui
 from pydantic import BaseModel, ConfigDict, field_validator
-from typing_extensions import Self
 
 from napari.layers.base.base import Layer
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+    from typing_extensions import Self
 
 
 class Source(BaseModel):

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import magicgui as mgui
 import numpy as np
-import pint
 from npe2 import plugin_manager as pm
 
 from napari.layers.base._base_constants import (
@@ -70,6 +69,7 @@ from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     import numpy.typing as npt
+    import pint
 
     from napari.components.dims import Dims
     from napari.components.overlays import BoundingBoxOverlay, Overlay

--- a/src/napari/layers/utils/_slice_input.py
+++ b/src/napari/layers/utils/_slice_input.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
 import pint
-from typing_extensions import Self
 
 from napari.utils.misc import reorder_after_dim_reduction
 from napari.utils.transforms import Affine
@@ -16,6 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     import numpy.typing as npt
+    from typing_extensions import Self
 
     from napari.components.dims import Dims
 

--- a/src/napari/layers/utils/layer_utils.py
+++ b/src/napari/layers/utils/layer_utils.py
@@ -14,7 +14,6 @@ from typing import (
 
 import dask
 import numpy as np
-import pint
 
 from napari.utils.action_manager import action_manager
 from napari.utils.events.custom_types import Array
@@ -26,6 +25,7 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
     import pandas as pd
+    import pint
 
     from napari.layers._data_protocols import LayerDataProtocol
 else:

--- a/src/napari/plugins/_npe2.py
+++ b/src/napari/plugins/_npe2.py
@@ -6,7 +6,6 @@ from typing import (
     cast,
 )
 
-from app_model import Action
 from app_model.types import SubmenuItem
 from npe2 import io_utils, plugin_manager as pm
 from npe2.manifest import contributions
@@ -16,6 +15,7 @@ from napari.utils.translations import trans
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
+    from app_model import Action
     from npe2.manifest import PluginManifest
     from npe2.manifest.contributions import WriterContribution
     from npe2.plugin_manager import PluginName

--- a/src/napari/plugins/npe2api.py
+++ b/src/napari/plugins/npe2api.py
@@ -17,13 +17,14 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from npe2 import PackageMetadata
-from typing_extensions import NotRequired
 
 from napari.plugins.utils import normalized_name
 from napari.utils.notifications import show_warning
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from typing_extensions import NotRequired
 
 PyPIname = str
 

--- a/src/napari/plugins/utils.py
+++ b/src/napari/plugins/utils.py
@@ -4,12 +4,14 @@ import re
 from enum import IntFlag
 from fnmatch import fnmatch
 from functools import lru_cache
-
-from npe2 import PluginManifest
+from typing import TYPE_CHECKING
 
 from napari.plugins import _npe2
 from napari.settings import get_settings
 from napari.types import PathLike
+
+if TYPE_CHECKING:
+    from npe2 import PluginManifest
 
 
 class MatchFlag(IntFlag):

--- a/src/napari/settings/_base.py
+++ b/src/napari/settings/_base.py
@@ -19,7 +19,6 @@ from pydantic import (
     TypeAdapter,
     ValidationError,
 )
-from pydantic.fields import FieldInfo
 from pydantic_settings import (
     BaseSettings,
     EnvSettingsSource,
@@ -40,6 +39,8 @@ _logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, Union
+
+    from pydantic.fields import FieldInfo
 
     # TODO: needs to be fixed properly
     SettingsSourceCallable = Any

--- a/src/napari/utils/events/containers/_selection.py
+++ b/src/napari/utils/events/containers/_selection.py
@@ -1,14 +1,16 @@
 from collections import deque
 from collections.abc import Iterable, MutableSet
 from types import GeneratorType
-from typing import Any, Generic, TypeVar, Union, get_args
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, get_args
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
-from pydantic_core.core_schema import DictSchema, TypedDictSchema
 
 from napari.utils.events.containers._set import EventedSet
 from napari.utils.events.event import EmitterGroup
+
+if TYPE_CHECKING:
+    from pydantic_core.core_schema import DictSchema, TypedDictSchema
 
 _T = TypeVar('_T')
 _S = TypeVar('_S')

--- a/src/napari/utils/events/containers/_set.py
+++ b/src/napari/utils/events/containers/_set.py
@@ -4,15 +4,18 @@ from collections import deque
 from collections.abc import Iterable, Iterator, MutableSet
 from types import GeneratorType
 from typing import (
+    TYPE_CHECKING,
     Any,
     TypeVar,
     get_args,
 )
 
-from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
 
 from napari.utils.events import EmitterGroup
+
+if TYPE_CHECKING:
+    from pydantic import GetCoreSchemaHandler
 
 _T = TypeVar('_T')
 

--- a/src/napari/utils/naming.py
+++ b/src/napari/utils/naming.py
@@ -7,13 +7,13 @@ import re
 from collections import ChainMap, ChainMap as ChainMapType
 from typing import TYPE_CHECKING, Any
 
-from typing_extensions import Self
-
 from napari.utils.misc import ROOT_DIR, formatdoc
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from types import FrameType, TracebackType
+
+    from typing_extensions import Self
 
 sep = ' '
 start = 1


### PR DESCRIPTION
# References and relevant issues

Follow up #8791

https://github.com/astral-sh/ruff/issues/7866

# Description

This PR enables TC002 rule, but disable the `quote-annotations = true` option as ruff do not trace inheritance across files (see https://github.com/astral-sh/ruff/issues/7866) so it breaks pydantic base model. 

From now, it will auto move import to type checking block if `from __future__ import annotations` is on the top of the file. Not perfect, but improve current state. 

Plan to walk through files and identify ones that allow to use `from __future__ import annotations`