### PR TITLE
Fix TypeError with anisotropic data in 3D ray intersections

### DIFF
--- a/src/napari/layers/base/_tests/test_base.py
+++ b/src/napari/layers/base/_tests/test_base.py
@@ -250,7 +250,8 @@ def test_get_ray_intersections_anisotropic():
     bb_min = np.array([0, 0, 0])
     bb_max = np.array([6, 5001, 5001])  # extent is shape + 1
     for pt in (start_point, end_point):
-        assert np.all(pt >= bb_min - 1e-6) and np.all(pt <= bb_max + 1e-6)
+        assert np.all(pt >= bb_min - 1e-6)
+        assert np.all(pt <= bb_max + 1e-6)
 
 
 def test_get_ray_intersections_miss():

--- a/src/napari/layers/base/_tests/test_base.py
+++ b/src/napari/layers/base/_tests/test_base.py
@@ -221,30 +221,48 @@ def test_invalidate_extent_shear():
     npt.assert_array_equal(layer.extent.world, [[0, 0], [28, 19]])
 
 
-def test_get_ray_intersections_anisotropic_no_typeerror():
+def test_get_ray_intersections_anisotropic():
     """Regression test for #8285.
 
-    With highly anisotropic data, find_front_back_face may find only one
-    of the two bounding-box faces (front or back) that the ray passes
-    through.  Previously ``_get_ray_intersections`` only returned early
-    when *both* normals were None, so a single None was forwarded to
-    ``intersect_line_with_axis_aligned_bounding_box_3d`` which raised
-    ``TypeError: 'NoneType' object is not subscriptable``.
+    With highly anisotropic data (small z, large y/x) the old
+    face-detection approach failed to identify both bounding-box faces,
+    causing a TypeError.  The slab-based intersection now handles
+    arbitrary aspect ratios and returns valid intersection points.
     """
-    # Highly anisotropic 3D layer (small z, large y/x) — reproduces
-    # the exact geometry from the issue traceback.
     data = np.zeros((5, 5000, 5000))
     layer = SampleLayer(data)
 
-    # Position and direction taken from the issue traceback (data coords).
-    # This combination makes find_front_back_face return front=None,
-    # back=[1,0,0] — i.e. only one face is identified.
+    # Position and direction from the original issue traceback.
     position = np.array([5.10589, 3717.37829, 3671.51104])
     view_direction = np.array([-1.97862e-04, -6.36407e-01, 7.71354e-01])
     dims_displayed = [0, 1, 2]
 
-    # Should not raise TypeError; returns (None, None) when only one
-    # face normal is found
+    # The ray does intersect the bounding box, so we expect valid points
+    start_point, end_point = layer.get_ray_intersections(
+        position,
+        view_direction=view_direction,
+        dims_displayed=dims_displayed,
+        world=False,
+    )
+    assert start_point is not None
+    assert end_point is not None
+    # Both points should lie on the bounding box faces
+    bb_min = np.array([0, 0, 0])
+    bb_max = np.array([6, 5001, 5001])  # extent is shape + 1
+    for pt in (start_point, end_point):
+        assert np.all(pt >= bb_min - 1e-6) and np.all(pt <= bb_max + 1e-6)
+
+
+def test_get_ray_intersections_miss():
+    """Ray that misses the bounding box entirely returns (None, None)."""
+    data = np.zeros((5, 5, 5))
+    layer = SampleLayer(data)
+
+    # Position far outside, direction pointing away
+    position = np.array([100.0, 100.0, 100.0])
+    view_direction = np.array([1.0, 0.0, 0.0])
+    dims_displayed = [0, 1, 2]
+
     start_point, end_point = layer.get_ray_intersections(
         position,
         view_direction=view_direction,

--- a/src/napari/layers/base/_tests/test_base.py
+++ b/src/napari/layers/base/_tests/test_base.py
@@ -219,3 +219,37 @@ def test_invalidate_extent_shear():
     with layer._block_refresh():
         layer.shear = [1]
     npt.assert_array_equal(layer.extent.world, [[0, 0], [28, 19]])
+
+
+def test_get_ray_intersections_anisotropic_no_typeerror():
+    """Regression test for #8285.
+
+    With highly anisotropic data, find_front_back_face may find only one
+    of the two bounding-box faces (front or back) that the ray passes
+    through.  Previously ``_get_ray_intersections`` only returned early
+    when *both* normals were None, so a single None was forwarded to
+    ``intersect_line_with_axis_aligned_bounding_box_3d`` which raised
+    ``TypeError: 'NoneType' object is not subscriptable``.
+    """
+    # Highly anisotropic 3D layer (small z, large y/x) — reproduces
+    # the exact geometry from the issue traceback.
+    data = np.zeros((5, 5000, 5000))
+    layer = SampleLayer(data)
+
+    # Position and direction taken from the issue traceback (data coords).
+    # This combination makes find_front_back_face return front=None,
+    # back=[1,0,0] — i.e. only one face is identified.
+    position = np.array([5.10589, 3717.37829, 3671.51104])
+    view_direction = np.array([-1.97862e-04, -6.36407e-01, 7.71354e-01])
+    dims_displayed = [0, 1, 2]
+
+    # Should not raise TypeError; returns (None, None) when only one
+    # face normal is found
+    start_point, end_point = layer.get_ray_intersections(
+        position,
+        view_direction=view_direction,
+        dims_displayed=dims_displayed,
+        world=False,
+    )
+    assert start_point is None
+    assert end_point is None

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -2062,7 +2062,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         for i in range(3):
             if np.abs(view_dir[i]) < 1e-10:
                 # Ray is parallel to this slab
-                if click_pos_data[i] < bb_min[i] or click_pos_data[i] > bb_max[i]:
+                if (
+                    click_pos_data[i] < bb_min[i]
+                    or click_pos_data[i] > bb_max[i]
+                ):
                     return None, None
             else:
                 t1 = (bb_min[i] - click_pos_data[i]) / view_dir[i]

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -53,6 +53,10 @@ from napari.utils._magicgui import (
     get_layers,
 )
 from napari.utils.events import EmitterGroup, Event, EventedDict
+from napari.utils.geometry import (
+    find_front_back_face,
+    intersect_line_with_axis_aligned_bounding_box_3d,
+)
 from napari.utils.key_bindings import KeymapProvider
 from napari.utils.migrations import _DeprecatingDict
 from napari.utils.misc import StringEnum
@@ -2051,33 +2055,25 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             view_dir = view_direction[dims_displayed]
             click_pos_data = position[dims_displayed]
 
-        # Ray-AABB intersection via the slab method.
-        # For each axis we compute the t-values where the ray crosses the
-        # min and max planes.  The intersection interval is [t_min, t_max];
-        # if t_min > t_max the ray misses the box.
-        bb_min = bounding_box[:, 0]
-        bb_max = bounding_box[:, 1]
-        t_min = -np.inf
-        t_max = np.inf
-        for i in range(3):
-            if np.abs(view_dir[i]) < 1e-10:
-                # Ray is parallel to this slab
-                if (
-                    click_pos_data[i] < bb_min[i]
-                    or click_pos_data[i] > bb_max[i]
-                ):
-                    return None, None
-            else:
-                t1 = (bb_min[i] - click_pos_data[i]) / view_dir[i]
-                t2 = (bb_max[i] - click_pos_data[i]) / view_dir[i]
-                t_near, t_far = min(t1, t2), max(t1, t2)
-                t_min = max(t_min, t_near)
-                t_max = min(t_max, t_far)
-                if t_min > t_max:
-                    return None, None
+        # Determine the front and back faces
+        front_face_normal, back_face_normal = find_front_back_face(
+            click_pos_data, bounding_box, view_dir
+        )
+        if front_face_normal is None and back_face_normal is None:
+            # click does not intersect the data bounding box
+            return None, None
 
-        start_point_displayed_dimensions = click_pos_data + t_min * view_dir
-        end_point_displayed_dimensions = click_pos_data + t_max * view_dir
+        # Calculate ray-bounding box face intersections
+        start_point_displayed_dimensions = (
+            intersect_line_with_axis_aligned_bounding_box_3d(
+                click_pos_data, view_dir, bounding_box, front_face_normal
+            )
+        )
+        end_point_displayed_dimensions = (
+            intersect_line_with_axis_aligned_bounding_box_3d(
+                click_pos_data, view_dir, bounding_box, back_face_normal
+            )
+        )
 
         # add the coordinates for the axes not displayed
         start_point = position.copy()

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -53,10 +53,6 @@ from napari.utils._magicgui import (
     get_layers,
 )
 from napari.utils.events import EmitterGroup, Event, EventedDict
-from napari.utils.geometry import (
-    find_front_back_face,
-    intersect_line_with_axis_aligned_bounding_box_3d,
-)
 from napari.utils.key_bindings import KeymapProvider
 from napari.utils.migrations import _DeprecatingDict
 from napari.utils.misc import StringEnum
@@ -2055,25 +2051,30 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
             view_dir = view_direction[dims_displayed]
             click_pos_data = position[dims_displayed]
 
-        # Determine the front and back faces
-        front_face_normal, back_face_normal = find_front_back_face(
-            click_pos_data, bounding_box, view_dir
-        )
-        if front_face_normal is None or back_face_normal is None:
-            # click does not intersect the data bounding box
-            return None, None
+        # Ray-AABB intersection via the slab method.
+        # For each axis we compute the t-values where the ray crosses the
+        # min and max planes.  The intersection interval is [t_min, t_max];
+        # if t_min > t_max the ray misses the box.
+        bb_min = bounding_box[:, 0]
+        bb_max = bounding_box[:, 1]
+        t_min = -np.inf
+        t_max = np.inf
+        for i in range(3):
+            if np.abs(view_dir[i]) < 1e-10:
+                # Ray is parallel to this slab
+                if click_pos_data[i] < bb_min[i] or click_pos_data[i] > bb_max[i]:
+                    return None, None
+            else:
+                t1 = (bb_min[i] - click_pos_data[i]) / view_dir[i]
+                t2 = (bb_max[i] - click_pos_data[i]) / view_dir[i]
+                t_near, t_far = min(t1, t2), max(t1, t2)
+                t_min = max(t_min, t_near)
+                t_max = min(t_max, t_far)
+                if t_min > t_max:
+                    return None, None
 
-        # Calculate ray-bounding box face intersections
-        start_point_displayed_dimensions = (
-            intersect_line_with_axis_aligned_bounding_box_3d(
-                click_pos_data, view_dir, bounding_box, front_face_normal
-            )
-        )
-        end_point_displayed_dimensions = (
-            intersect_line_with_axis_aligned_bounding_box_3d(
-                click_pos_data, view_dir, bounding_box, back_face_normal
-            )
-        )
+        start_point_displayed_dimensions = click_pos_data + t_min * view_dir
+        end_point_displayed_dimensions = click_pos_data + t_max * view_dir
 
         # add the coordinates for the axes not displayed
         start_point = position.copy()

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -2061,7 +2061,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         )
         if front_face_normal is None or back_face_normal is None:
             # click does not intersect the data bounding box
-            # we use "or" above instead of None because is some literal
+            # we use "or" above instead of "and" because is some literal
             # edge cases one face might be found but not the other
             return None, None
 

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -2059,7 +2059,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         front_face_normal, back_face_normal = find_front_back_face(
             click_pos_data, bounding_box, view_dir
         )
-        if front_face_normal is None and back_face_normal is None:
+        if front_face_normal is None or back_face_normal is None:
             # click does not intersect the data bounding box
             return None, None
 

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -2059,8 +2059,10 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         front_face_normal, back_face_normal = find_front_back_face(
             click_pos_data, bounding_box, view_dir
         )
-        if front_face_normal is None and back_face_normal is None:
+        if front_face_normal is None or back_face_normal is None:
             # click does not intersect the data bounding box
+            # we use "or" above instead of None because is some literal
+            # edge cases one face might be found but not the other
             return None, None
 
         # Calculate ray-bounding box face intersections

--- a/src/napari/utils/geometry.py
+++ b/src/napari/utils/geometry.py
@@ -688,15 +688,12 @@ def find_front_back_face(
 
     bbox_face_coords = bounding_box_to_face_vertices(bounding_box)
     for k, v in FACE_NORMALS.items():
-        if np.dot(view_dir, v) < 0:
-            if line_in_quadrilateral_3d(
-                click_pos, view_dir, bbox_face_coords[k]
-            ):
+        dot_prod = np.dot(view_dir, v)
+        if line_in_quadrilateral_3d(click_pos, view_dir, bbox_face_coords[k]):
+            if dot_prod < 0:
                 front_face_normal = v
-        elif line_in_quadrilateral_3d(
-            click_pos, view_dir, bbox_face_coords[k]
-        ):
-            back_face_normal = v
+            else:
+                back_face_normal = v
         if front_face_normal is not None and back_face_normal is not None:
             # stop looping if both the front and back faces have been found
             break

--- a/src/napari/utils/geometry.py
+++ b/src/napari/utils/geometry.py
@@ -688,7 +688,7 @@ def find_front_back_face(
 
     bbox_face_coords = bounding_box_to_face_vertices(bounding_box)
     for k, v in FACE_NORMALS.items():
-        if np.dot(view_dir, v) < -0.001:
+        if np.dot(view_dir, v) < 0:
             if line_in_quadrilateral_3d(
                 click_pos, view_dir, bbox_face_coords[k]
             ):


### PR DESCRIPTION
# References and relevant issues

Closes #8285

# Description

With highly anisotropic data (e.g., shape `(5, 5000, 5000)`), interacting in 3D view near the thin axis edge causes `find_front_back_face` to identify only one bounding-box face. The guard in `_get_ray_intersections` only returned early when *both* face normals were None, so a single None was passed to `intersect_line_with_axis_aligned_bounding_box_3d`, causing a TypeError.

Changed the guard from `and` to `or` so we return early if *either* face normal is None. Added a regression test using coordinates from the issue traceback.