### PR TITLE
Ban expensive import in ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -458,7 +458,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/napari/_vispy/__init__.py" = ["E402"]
-"**/_tests/*.py" = ["B011", "INP001", "TRY301", "B018", "RUF012"]
+"**/_tests/*.py" = ["B011", "INP001", "TRY301", "B018", "RUF012", "TID253"]
 "src/napari/utils/_testsupport.py" = ["B011"]
 "tools/validate_strings.py" = ["F401"]
 "tools/**" = ["INP001", "T20", "LOG015"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -484,6 +484,7 @@ multiline-quotes = "double"
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.
 ban-relative-imports = "all"
+banned-module-level-imports = ["scipy", "pandas", "dask.array"]
 
 [tool.ruff.lint.isort]
 known-first-party=['napari']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -484,6 +484,7 @@ multiline-quotes = "double"
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.
 ban-relative-imports = "all"
+# Expensive imports should be lazy loaded within functions instead of module
 banned-module-level-imports = ["scipy", "pandas", "dask.array"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -465,6 +465,7 @@ ignore = [
 "examples/**" = ["ICN001", "INP001", "T20", "LOG015", "TID253"]
 "**/vendored/**" = ["TID"]
 "src/napari/benchmarks/**" = ["RUF012", "TID252", "TID253"]
+"src/napari_builtins/**" = ["TID253"]
 
 [tool.ruff.lint.flake8-builtins]
 builtins-allowed-modules = ["io", "types", "threading"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,7 +462,7 @@ ignore = [
 "src/napari/utils/_testsupport.py" = ["B011"]
 "tools/validate_strings.py" = ["F401"]
 "tools/**" = ["INP001", "T20", "LOG015"]
-"examples/**" = ["ICN001", "INP001", "T20", "LOG015"]
+"examples/**" = ["ICN001", "INP001", "T20", "LOG015", "TID253"]
 "**/vendored/**" = ["TID"]
 "src/napari/benchmarks/**" = ["RUF012", "TID252"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -464,7 +464,7 @@ ignore = [
 "tools/**" = ["INP001", "T20", "LOG015"]
 "examples/**" = ["ICN001", "INP001", "T20", "LOG015", "TID253"]
 "**/vendored/**" = ["TID"]
-"src/napari/benchmarks/**" = ["RUF012", "TID252"]
+"src/napari/benchmarks/**" = ["RUF012", "TID252", "TID253"]
 
 [tool.ruff.lint.flake8-builtins]
 builtins-allowed-modules = ["io", "types", "threading"]

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -7,7 +7,6 @@ import warnings
 from typing import Any, Literal, cast
 
 import numpy as np
-from scipy import ndimage as ndi
 
 from napari.layers._data_protocols import LayerDataProtocol
 from napari.layers._multiscale_data import MultiScaleData
@@ -493,6 +492,8 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
 
     def _update_thumbnail(self) -> None:
         """Update thumbnail with current image data and colormap."""
+        from scipy import ndimage as ndi
+
         # black thumbnail if there is no data in the slice
         if self._slice.empty:
             self.thumbnail = np.zeros(self._thumbnail_shape, self.dtype)

--- a/src/napari/layers/labels/_labels_utils.py
+++ b/src/napari/layers/labels/_labels_utils.py
@@ -1,7 +1,6 @@
 from functools import lru_cache
 
 import numpy as np
-from scipy import ndimage as ndi
 
 
 def interpolate_coordinates(old_coord, new_coord, brush_size):
@@ -221,6 +220,8 @@ def get_contours(labels: np.ndarray, thickness: int, background_label: int):
     -------
     A new label image in which only the boundaries of the input image are kept.
     """
+    from scipy import ndimage as ndi
+
     struct_elem = ndi.generate_binary_structure(labels.ndim, 1)
 
     thick_struct_elem = ndi.iterate_structure(struct_elem, thickness).astype(

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -14,7 +14,6 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 from PIL import Image, ImageDraw
-from scipy import ndimage as ndi
 
 from napari.layers._data_protocols import LayerDataProtocol
 from napari.layers._multiscale_data import MultiScaleData
@@ -975,6 +974,8 @@ class Labels(ScalarFieldBase):
         like adjusting gamma or changing the data based on the contrast
         limits.
         """
+        from scipy import ndimage as ndi
+
         if not self._slicing_state.loaded or self._slice.empty:
             # ASYNC_TODO: Do not compute the thumbnail until we are loaded.
             # Is there a nicer way to prevent this from getting called?
@@ -1136,6 +1137,8 @@ class Labels(ScalarFieldBase):
             Whether to refresh view slice or not. Set to False to batch paint
             calls.
         """
+        from scipy import ndimage as ndi
+
         int_coord = tuple(np.round(coord).astype(int))
         # If requested fill location is outside data shape then return
         if np.any(np.less(int_coord, 0)) or np.any(

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import coo_matrix
 
 from napari.layers.utils.layer_utils import _FeatureTable
 from napari.utils.events.custom_types import Array
@@ -128,6 +127,7 @@ class TrackManager:
     @data.setter
     def data(self, data: list | np.ndarray) -> None:
         """set the vertex data and build the vispy arrays for display"""
+        from scipy.sparse import coo_matrix
         from scipy.spatial import cKDTree
 
         # convert data to a numpy array if it is not already one

--- a/src/napari/utils/transforms/transform_utils.py
+++ b/src/napari/utils/transforms/transform_utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 import numpy.typing as npt
-import scipy.linalg
 
 from napari.utils.translations import trans
 
@@ -369,6 +368,8 @@ def decompose_linear_matrix(
         1-D array of upper triangular values or an n-D matrix if lower
         triangular.
     """
+    import scipy.linalg
+
     n = matrix.shape[0]
 
     if upper_triangular:


### PR DESCRIPTION
# References and relevant issues
- closes #8790

# Description
Use ruff to ban known expensive imports at module levels, for now: scipy, dask.array, and pandas.
