### PR TITLE
Reuse QMarginSlidersPopup between rightclicks

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -323,6 +323,11 @@ authors:
   family-names: Nauroth-Kreß
   affiliation: University Hospital Würzburg - Institute of Neuroradiology
   alias: Chris-N-K
+- given-names: Peter
+  family-names: Newstein
+  affiliation: University of Oregon
+  orcid: https://orcid.org/0000-0003-2966-783X
+  alias: pnewstein
 - given-names: Horst A.
   family-names: Obenhaus
   affiliation: Kavli Institute for Systems Neuroscience at NTNU, Trondheim, Norway

--- a/src/napari/_qt/widgets/_tests/test_qt_dims_slider.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims_slider.py
@@ -1,0 +1,32 @@
+from napari._qt.widgets.qt_dims import QtDims, QtDimSliderWidget
+from napari.components import Dims
+
+
+def test_same_margin_popup(qtbot):
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider: QtDimSliderWidget = view.slider_widgets[0]
+    # Lazily create the widget
+    assert slider.margins_popup is None
+    slider.show_margins_popupup()
+    old_margins_popup = slider.margins_popup
+    assert old_margins_popup is not None
+    # Reuse old margins popup
+    slider.show_margins_popupup()
+    assert old_margins_popup is slider.margins_popup
+
+
+def test_move_margin_popup(qtbot):
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider: QtDimSliderWidget = view.slider_widgets[0]
+    slider.show_margins_popupup()
+    # Check that values of the left slider matches the
+    # values of the dims margin_right after the
+    # margin_right has been moved within the dims
+    dims.margin_right = (2, 0, 0)
+    assert slider.margins_popup.right_slider.value() == dims.margin_right[0]
+    slider.margins_popup.left_slider.setValue(1)
+    assert slider.margins_popup.left_slider.value() == dims.margin_left[0]

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -192,8 +192,11 @@ class QtDimSliderWidget(QWidget):
         self.slider = slider
 
     def show_margins_popupup(self):
-        self.margins_popup = QMarginSlidersPopup(self.dims, self.axis, self)
-        self.margins_popup.setParent(self)
+        if self.margins_popup is None:
+            self.margins_popup = QMarginSlidersPopup(
+                self.dims, self.axis, self
+            )
+            self.margins_popup.setParent(self)
         self.margins_popup.show_above_mouse()
 
     def _create_play_button_widget(self):

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -44,7 +44,7 @@ class _ModifiedScrollBar(ModifiedScrollBar):
             The napari event that triggered this method.
         """
         if event.button() == Qt.MouseButton.RightButton:
-            self.parent().show_margins_popupup()
+            self.parent().show_margins_popup()
         else:
             super().mousePressEvent(event)
 
@@ -191,7 +191,7 @@ class QtDimSliderWidget(QWidget):
         slider.sliderPressed.connect(slider_focused_listener)
         self.slider = slider
 
-    def show_margins_popupup(self):
+    def show_margins_popup(self):
         if self.margins_popup is None:
             self.margins_popup = QMarginSlidersPopup(
                 self.dims, self.axis, self


### PR DESCRIPTION

# References and relevant issues

fixes #8818

# Description
changes show_margins_popupup to reuse old QMarginSlidersPopup

This keeps the lock button state between right-clicks to the dims slider and prevents behavior described in #8818 


# Checklist

- My PR is the minimum possible work for the desired functionality
> Done
- I have commented my code, particularly in hard-to-understand areas
> Done on the tests
- I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
 > No Docstrings on the fuction I changed
- I have added tests that prove my fix is effective or that my feature works
 > Done
- If an API has been modified, I have added a `.. versionadded::` or `.. versionchanged::`
  directive to the appropriate docstring (For more information see
  [the Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions)).
> not applicable

