### PR TITLE
Clean up multiscale data class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -715,7 +715,6 @@ module = [
     'napari._vispy.utils.cursor',
     'napari.components.layerlist',
     'napari.layers._layer_actions',
-    'napari.layers._multiscale_data',
     'napari.layers.intensity_mixin',
     'napari.layers.points.points',
     'napari.layers.shapes._shapes_mouse_bindings',

--- a/src/napari/layers/_multiscale_data.py
+++ b/src/napari/layers/_multiscale_data.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import overload
 
 import numpy as np
+import numpy.typing as npt
 
 from napari.layers._data_protocols import LayerDataProtocol, assert_protocol
 from napari.utils.translations import trans
@@ -13,15 +15,13 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
     """Wrapper for multiscale data, to provide consistent API.
 
     :class:`LayerDataProtocol` is the subset of the python Array API that we
-    expect array-likes to provide.  Multiscale data is just a sequence of
-    array-likes (providing, e.g. `shape`, `dtype`, `__getitem__`).
+    expect array-likes to provide. Multiscale data is just a sequence of these
+    array-likes.
 
     Parameters
     ----------
     data : Sequence[LayerDataProtocol]
         Levels of multiscale data, from larger to smaller.
-    max_size : Sequence[int], optional
-        Maximum size of a displayed tile in pixels, by default`data[-1].shape`
 
     Raises
     ------
@@ -41,56 +41,51 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
                 trans._('Multiscale data must be a (non-empty) sequence')
             )
         for d in self._data:
-            assert_protocol(d)
+            assert_protocol(d, protocol=LayerDataProtocol)
 
     @property
     def size(self) -> int:
-        """Return size of the first scale.."""
+        """Size of the first scale."""
         return self._data[0].size
 
     @property
     def ndim(self) -> int:
-        """Return ndim of the first scale.."""
+        """ndim of the first scale."""
         return self._data[0].ndim
 
     @property
-    def dtype(self) -> np.dtype:
-        """Return dtype of the first scale.."""
+    def nlevels(self) -> int:
+        """Number of multiscale levels."""
+        return len(self._data)
+
+    @property
+    def dtype(self) -> npt.DTypeLike:
+        """dtype of the first scale.."""
         return self._data[0].dtype
 
     @property
     def shape(self) -> tuple[int, ...]:
-        """Shape of multiscale is just the biggest shape."""
+        """Shape of the first scale."""
         return self._data[0].shape
 
     @property
     def shapes(self) -> tuple[tuple[int, ...], ...]:
-        """Tuple shapes for all scales."""
+        """Tuple of shapes for all scales."""
         return tuple(im.shape for im in self._data)
 
-    def __getitem__(  # type: ignore [override]
-        self, key: int | tuple[slice, ...]
-    ) -> LayerDataProtocol:
-        """Multiscale indexing."""
+    @overload
+    def __getitem__(self, i: int) -> LayerDataProtocol: ...
+    @overload
+    def __getitem__(self, i: slice) -> Sequence[LayerDataProtocol]: ...
+    def __getitem__(
+        self, key: int | slice
+    ) -> LayerDataProtocol | Sequence[LayerDataProtocol]:
+        """Get individual multiscale levels."""
         return self._data[key]
 
     def __len__(self) -> int:
-        return len(self._data)
-
-    def __eq__(self, other) -> bool:
-        return self._data == other
-
-    def __add__(self, other) -> bool:
-        return self._data + other
-
-    def __mul__(self, other) -> bool:
-        return self._data * other
-
-    def __rmul__(self, other) -> bool:
-        return other * self._data
-
-    def __array__(self) -> np.ndarray:
-        return np.asarray(self._data[-1])
+        """Number of multiscale levels."""
+        return self.nlevels
 
     def __repr__(self) -> str:
         return (

--- a/src/napari/layers/_scalar_field/scalar_field.py
+++ b/src/napari/layers/_scalar_field/scalar_field.py
@@ -9,7 +9,6 @@ import numpy as np
 from numpy import typing as npt
 
 from napari.layers._data_protocols import LayerDataProtocol
-from napari.layers._multiscale_data import MultiScaleData
 from napari.layers._scalar_field._slice import (
     _ScalarFieldSliceRequest,
     _ScalarFieldSliceResponse,
@@ -21,6 +20,7 @@ from napari.layers.image._image_mouse_bindings import (
     set_plane_position as plane_double_click_callback,
 )
 from napari.layers.image._image_utils import guess_multiscale
+from napari.layers.multiscale_data import MultiScaleData
 from napari.layers.utils._slice_input import (
     _SliceInput,
     _ThickNDSlice,

--- a/src/napari/layers/image/_image_utils.py
+++ b/src/napari/layers/image/_image_utils.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from napari.layers._data_protocols import LayerDataProtocol
-from napari.layers._multiscale_data import MultiScaleData
+from napari.layers.multiscale_data import MultiScaleData
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -10,7 +10,6 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from napari.layers._data_protocols import LayerDataProtocol
-from napari.layers._multiscale_data import MultiScaleData
 from napari.layers._scalar_field._slice import _ScalarFieldSliceResponse
 from napari.layers._scalar_field.scalar_field import (
     ScalarFieldBase,
@@ -25,6 +24,7 @@ from napari.layers.image._image_constants import (
 from napari.layers.image._image_utils import guess_rgb
 from napari.layers.image._slice import _ImageSliceRequest
 from napari.layers.intensity_mixin import IntensityVisualizationMixin
+from napari.layers.multiscale_data import MultiScaleData
 from napari.layers.utils.layer_utils import calc_data_range
 from napari.types import LayerDataType
 from napari.utils._dtype import get_dtype_limits, normalize_dtype

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -17,7 +17,6 @@ from PIL import Image, ImageDraw
 from scipy import ndimage as ndi
 
 from napari.layers._data_protocols import LayerDataProtocol
-from napari.layers._multiscale_data import MultiScaleData
 from napari.layers._scalar_field.scalar_field import (
     ScalarFieldBase,
     ScalarFieldSlicingState,
@@ -48,6 +47,7 @@ from napari.layers.labels._labels_utils import (
     sphere_indices,
 )
 from napari.layers.labels._slice import _LabelsSliceRequest
+from napari.layers.multiscale_data import MultiScaleData
 from napari.layers.utils.layer_utils import _FeatureTable
 from napari.types import LayerDataType
 from napari.utils._dtype import (

--- a/src/napari/layers/multiscale_data.py
+++ b/src/napari/layers/multiscale_data.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import overload
 
-import numpy as np
 import numpy.typing as npt
 
 from napari.layers._data_protocols import LayerDataProtocol, assert_protocol

--- a/src/napari/layers/multiscale_data.py
+++ b/src/napari/layers/multiscale_data.py
@@ -86,7 +86,7 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
         """Number of multiscale levels."""
         return self.nlevels
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         return self._data == other
 
     def __repr__(self) -> str:

--- a/src/napari/layers/multiscale_data.py
+++ b/src/napari/layers/multiscale_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import overload
 
+import numpy as np
 import numpy.typing as npt
 
 from napari.layers._data_protocols import LayerDataProtocol, assert_protocol
@@ -81,6 +82,13 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
     ) -> LayerDataProtocol | Sequence[LayerDataProtocol]:
         """Get individual multiscale levels."""
         return self._data[key]
+
+    def __array__(self) -> npt.NDArray:
+        """Get numpy array of the lowest resolution level."""
+        # TODO:
+        # deprecate this, and replace with a more verbose API
+        # like get_level_array(self, level: int) -> npt.ndarray
+        return np.asarray(self._data[-1])
 
     def __len__(self) -> int:
         """Number of multiscale levels."""

--- a/src/napari/layers/multiscale_data.py
+++ b/src/napari/layers/multiscale_data.py
@@ -86,6 +86,9 @@ class MultiScaleData(Sequence[LayerDataProtocol]):
         """Number of multiscale levels."""
         return self.nlevels
 
+    def __eq__(self, other) -> bool:
+        return self._data == other
+
     def __repr__(self) -> str:
         return (
             f'<MultiScaleData at {hex(id(self))}. '

--- a/src/napari/utils/stubgen.py
+++ b/src/napari/utils/stubgen.py
@@ -98,8 +98,7 @@ def generate_function_stub(func) -> tuple[set[str], str]:
         imports.update(set(_iter_imports(hint)))
     imports -= {'typing'}
 
-    doc = f'"""{func.__doc__}"""' if func.__doc__ else '...'
-    return imports, f'def {func.__name__}{sig}:\n    {doc}\n'
+    return imports, f'def {func.__name__}{sig}:\n    {"..."}\n'
 
 
 def _get_subclass_methods(cls: type[Any]) -> set[str]:
@@ -139,8 +138,7 @@ def generate_class_stubs(cls: type) -> tuple[set[str], str]:
         attrs.append(f'{name}: {hint.replace("builtins.", "")}')
         imports.update(set(_iter_imports(type_)))
 
-    doc = f'"""{cls.__doc__.lstrip()}"""' if cls.__doc__ else '...'
-    stub = f'class {cls.__name__}({bases}):\n    {doc}\n'
+    stub = f'class {cls.__name__}({bases}):\n    {"..."}\n'
     stub += textwrap.indent('\n'.join(attrs), '    ')
     stub += '\n' + textwrap.indent('\n'.join(methods), '    ')
 


### PR DESCRIPTION
# References and relevant issues
This is a first step towards https://github.com/napari/napari/issues/8787.

# Description

This cleans up the `MultiScaleData` class by:

- Fixing typing
- Making the submodule public (ie, removing the leading `_`)
- Removing the special arithmetic methods and `__array__` methods. The idea here is the main use case for `MultiScaleData` is larger-than-memory images, and therefore users probably don't want to be adding/multiplying/casting to a numpy array, and indeed removing these methods guards against that happening accidentally and eating up all their RAM.
