### PR TITLE
Add a Linux aarch64 test run (py313, pyqt6) to --pre, PR, and comprehensive tests 

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -73,6 +73,9 @@ jobs:
             platform: ubuntu-latest
             backend: pyside6
             tox_extras: "testing_extra"
+          - python: "3.14"
+            platform: ubuntu-24.04-arm
+            backend: pyqt6
 
     with:
       python_version: ${{ matrix.python }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -35,6 +35,9 @@ jobs:
           - platform: ubuntu-latest
             python: 3.12
             backend: pyqt6_no_numba
+          - platform: ubuntu-24.04-arm
+            python: 3.14
+            backend: pyqt6
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -167,6 +167,11 @@ jobs:
             platform: ubuntu-latest
             backend: pyside6
             coverage: cov
+          # linux aarch64 test
+          - python: "3.14"
+            platform: ubuntu-24.04-arm
+            backend: pyqt6
+            coverage: cov
     with:
       python_version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}


### PR DESCRIPTION
# References and relevant issues
Related to: https://github.com/napari/napari/issues/8823

# Description
Linux aarch64 (arm64) is definitely a thing, particularly in the cloud, but as we see from the issue, also local (nvidia hardware). This PR adds a single linux aarch64 run on py314, pyqt6. My motivation is to not overload our CI, but also that since linux aarch64 is fresh there is no need to test on legacy versions -- it's the other way around: support may be limited due to it being too new not too old.