### PR TITLE
[maint] Use ubuntu-slim 1 vCPU runners for simple jobs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   actionlint:
     name: Action lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check workflow files

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -11,7 +11,7 @@ concurrency:
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: "github.event.context == 'ci/circleci: build-docs'"
     permissions:
       statuses: write

--- a/.github/workflows/citation_cff_validate.yml
+++ b/.github/workflows/citation_cff_validate.yml
@@ -10,7 +10,7 @@ on:
 name: CITATION.cff
 jobs:
   Validate-CITATION-cff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Validate CITATION.cff
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/constraints_comment_trigger.yml
+++ b/.github/workflows/constraints_comment_trigger.yml
@@ -12,7 +12,7 @@ jobs:
   add_eyes:
     name: Add eyes reaction
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@napari-bot update constraints')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Add eyes reaction
         run: |
@@ -31,7 +31,7 @@ jobs:
   add_rocket:
     name: Add rocket reaction
     needs: trigger-benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Add rocket reaction
         run: |

--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check_labels:
     name: Remove html comments
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -16,7 +16,7 @@ jobs:
   check_labels:
     if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge'))
     name: Check ready-to-merge PR has at least one type label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check labels
         uses: docker://agilepathway/pull-request-label-checker:latest
@@ -27,7 +27,7 @@ jobs:
   check_next_milestone:
     name: Check milestone is next release
     if: (github.event_name == 'pull_request' && github.event.pull_request.milestone != null)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check milestone for closest due date
         env:
@@ -72,7 +72,7 @@ jobs:
   check_citation_cff_for_pr_author:
     name: Check PR author is in CITATION.cff
     if: (github.event_name == 'pull_request')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -16,7 +16,7 @@ jobs:
   check_labels:
     if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge'))
     name: Check ready-to-merge PR has at least one type label
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Check labels
         uses: docker://agilepathway/pull-request-label-checker:latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
       with:

--- a/.github/workflows/pr_dependency.yml
+++ b/.github/workflows/pr_dependency.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, 'merge')) || github.event_name == 'pull_request'
     name: Check Dependencies
     steps:

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   remove_label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Remove label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
# References and relevant issues
Prompted by Jaime making similar PRs in the conda-forge repos
https://github.com/conda-forge/conda-forge.github.io/issues/2742

# Description
GitHub has offered ubuntu-slim 1 vCPU runners for a bit. In this PR I change our really simple CI jobs (labeling, citations, etc.) to use the `ubuntu-slim` runner, with the idea that it may free up runners for other jobs -- though I don't think we routinely hit new 60 concurrency limit at present. Still, it's also a bit more respectful of the resources, so worth it I think as long as the jobs all work.

Docs for these runners:
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners

My understanding is they are also quicker to spin up, because they are containers and not full VMs.

Edit: Reading the docs some more, I'm not sure this really changes anything in terms of the concurrency limits.