### PR TITLE
[maint] Add `bermuda` to testing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ testing = [
     "IPython>=7.25.0",
     "qtconsole>=4.5.1",
     "rich>=12.0.0",
-    "napari[optional-base]",
+    "napari[optional-base, bermuda]",
 ]
 testing_extra = [
     "torch>=1.10.2",
@@ -265,7 +265,7 @@ testing = [
     "IPython>=7.25.0",
     "qtconsole>=4.5.1",
     "rich>=12.0.0",
-    "napari[optional-base]",
+    "napari[optional-base, bermuda]",
 ]
 testing_extra = [
     "torch>=1.10.2",


### PR DESCRIPTION
# References and relevant issues
Discussion here: https://napari.zulipchat.com/#narrow/channel/212875-general/topic/Linux.20ARM64.20install.3A.20napari.5Ball.5D.20triangle.20dependency.20issue/with/582274947
Related to: https://github.com/napari/napari/pull/8824

# Description
This PR adds bermuda to our testing group/extra. This ensures we test with bermuda and not just numba (in some envs).
