### PR TITLE
maint: replace `StringEnum` base class with with `StrEnum`

### DIFF
--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -874,9 +874,9 @@ class Points(Layer):
         # the number of points in the data. If symbols is already an array,
         # this will check that it is the correct length.
         if coerced_symbols.size == 1:
-            coerced_symbols = np.full(
-                self.data.shape[0], coerced_symbols[0], dtype=object
-            )
+            fill = coerced_symbols[0]
+            coerced_symbols = np.empty(self.data.shape[0], dtype=object)
+            coerced_symbols[:] = fill
         else:
             coerced_symbols = np.array(coerced_symbols)
             if coerced_symbols.size != self.data.shape[0]:

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -874,9 +874,9 @@ class Points(Layer):
         # the number of points in the data. If symbols is already an array,
         # this will check that it is the correct length.
         if coerced_symbols.size == 1:
-            fill = coerced_symbols[0]
-            coerced_symbols = np.empty(self.data.shape[0], dtype=object)
-            coerced_symbols[:] = fill
+            coerced_symbols = np.full(
+                self.data.shape[0], coerced_symbols, dtype=object
+            )
         else:
             coerced_symbols = np.array(coerced_symbols)
             if coerced_symbols.size != self.data.shape[0]:

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 import warnings
-from enum import Enum, EnumMeta
+from enum import Enum
 from os import fspath, path as os_path
 from pathlib import Path
 from typing import (
@@ -281,13 +281,7 @@ else:
             return name.lower()
 
 
-class StringEnumMeta(EnumMeta):
-    def __getitem__(self, item: str) -> StringEnum:  # type: ignore[override]
-        """Case-insensitive name lookup: MyEnum['tHiNg'] -> MyEnum.THING."""
-        return super().__getitem__(item.upper())
-
-
-class StringEnum(StrEnum, metaclass=StringEnumMeta):
+class StringEnum(StrEnum):
     @staticmethod
     def _generate_next_value_(
         name: str, start: int, count: int, last_values: list[str]
@@ -345,6 +339,11 @@ class StringEnum(StrEnum, metaclass=StringEnumMeta):
     @classmethod
     def keys(cls) -> list[str]:
         return list(map(str, cls))
+
+    @classmethod
+    def __class_getitem__(cls, item: str) -> StringEnum:
+        """Case-insensitive name lookup: MyEnum['tHiNg'] -> MyEnum.THING."""
+        return super().__getitem__(item.upper())
 
 
 camel_to_snake_pattern = re.compile(r'(.)([A-Z][a-z]+)')

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -15,7 +15,7 @@ import os
 import re
 import sys
 import warnings
-from enum import Enum
+from enum import Enum, EnumMeta
 from os import fspath, path as os_path
 from pathlib import Path
 from typing import (
@@ -281,7 +281,13 @@ else:
             return name.lower()
 
 
-class StringEnum(StrEnum):
+class StringEnumMeta(EnumMeta):
+    def __getitem__(self, item: str) -> StringEnum:  # type: ignore[override]
+        """Case-insensitive name lookup: MyEnum['tHiNg'] -> MyEnum.THING."""
+        return super().__getitem__(item.upper())
+
+
+class StringEnum(StrEnum, metaclass=StringEnumMeta):
     @staticmethod
     def _generate_next_value_(
         name: str, start: int, count: int, last_values: list[str]
@@ -339,11 +345,6 @@ class StringEnum(StrEnum):
     @classmethod
     def keys(cls) -> list[str]:
         return list(map(str, cls))
-
-    @classmethod
-    def __class_getitem__(cls, item: str) -> StringEnum:
-        """Case-insensitive name lookup: MyEnum['tHiNg'] -> MyEnum.THING."""
-        return super().__getitem__(item.upper())
 
 
 camel_to_snake_pattern = re.compile(r'(.)([A-Z][a-z]+)')

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -288,6 +288,9 @@ class StringEnum(StrEnum, metaclass=StringEnumMeta):
         """Assign the lower-cased member name as its value."""
         return name.lower()
 
+    def __str__(self) -> str:
+        return self.value
+
     @classmethod
     def _missing_(cls, value: object) -> StringEnum | None:
         if isinstance(value, StringEnum):

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -243,7 +243,7 @@ if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
 
-    class StrEnum(str, Enum):  # type: ignore[no-redef]
+    class StrEnum(str, Enum):
         """Enum where members are also (and must be) strings."""
 
         def __new__(cls, *values: str) -> Self:
@@ -273,11 +273,9 @@ else:
 
 
 class StringEnumMeta(EnumMeta):
-    def __getitem__(self, item: object) -> StringEnum:
+    def __getitem__(self, item: str) -> StringEnum:  # type: ignore[override]
         """Case-insensitive name lookup: MyEnum['tHiNg'] -> MyEnum.THING."""
-        if isinstance(item, str):
-            item = item.upper()
-        return super().__getitem__(item)  # type: ignore[return-value]
+        return super().__getitem__(item.upper())
 
 
 class StringEnum(StrEnum, metaclass=StringEnumMeta):

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -35,9 +35,6 @@ if TYPE_CHECKING:
     import packaging.version
     from typing_extensions import Self
 
-# TODO: what's this?
-_sentinel = object()
-
 
 ROOT_DIR = os_path.dirname(os_path.dirname(__file__))
 

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -1,3 +1,7 @@
+# StrEnum is only available in Python 3.11+; a vendored version
+# from backports.strenum is used for older versions.
+# Source: https://github.com/ethanfurman/backports.strenum
+# License: https://docs.python.org/3/license.html
 """Miscellaneous utility functions."""
 
 from __future__ import annotations
@@ -25,12 +29,14 @@ import numpy.typing as npt
 
 from napari.utils.translations import trans
 
-_sentinel = object()
-
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
 
     import packaging.version
+    from typing_extensions import Self
+
+# TODO: what's this?
+_sentinel = object()
 
 
 ROOT_DIR = os_path.dirname(os_path.dirname(__file__))
@@ -233,33 +239,63 @@ def formatdoc(obj):
     return obj
 
 
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+
+    class StrEnum(str, Enum):  # type: ignore[no-redef]
+        """Enum where members are also (and must be) strings."""
+
+        def __new__(cls, *values: str) -> Self:
+            if len(values) > 3:
+                raise TypeError(f'too many arguments for str(): {values!r}')
+            if len(values) == 1 and not isinstance(values[0], str):
+                raise TypeError(f'{values[0]!r} is not a string')
+            if len(values) >= 2 and not isinstance(values[1], str):
+                raise TypeError(
+                    f'encoding must be a string, not {values[1]!r}'
+                )
+            if len(values) == 3 and not isinstance(values[2], str):
+                raise TypeError(f'errors must be a string, not {values[2]!r}')
+            value = str(*values)
+            member = str.__new__(cls, value)
+            member._value_ = value
+            return member
+
+        __str__ = str.__str__
+
+        @staticmethod
+        def _generate_next_value_(
+            name: str, start: int, count: int, last_values: list[str]
+        ) -> str:
+            """Return the lower-cased version of the member name."""
+            return name.lower()
+
+
 class StringEnumMeta(EnumMeta):
-    def __getitem__(self, item):
-        """set the item name case to uppercase for name lookup"""
+    def __getitem__(self, item: object) -> StringEnum:
+        """Case-insensitive name lookup: MyEnum['tHiNg'] -> MyEnum.THING."""
         if isinstance(item, str):
             item = item.upper()
+        return super().__getitem__(item)  # type: ignore[return-value]
 
-        return super().__getitem__(item)
 
-    def __call__(
-        cls,
-        value,
-        names=None,
-        *,
-        module=None,
-        qualname=None,
-        type=None,  # noqa: A002
-        start=1,
-    ):
-        """set the item value case to lowercase for value lookup"""
-        # simple value lookup
-        if names is None:
-            if isinstance(value, str):
-                return super().__call__(value.lower())
-            if isinstance(value, cls):
-                return value
+class StringEnum(StrEnum, metaclass=StringEnumMeta):
+    @staticmethod
+    def _generate_next_value_(
+        name: str, start: int, count: int, last_values: list[str]
+    ) -> str:
+        """Assign the lower-cased member name as its value."""
+        return name.lower()
 
-            raise ValueError(
+    @classmethod
+    def _missing_(cls, value: object) -> StringEnum | None:
+        if isinstance(value, StringEnum):
+            # ruff suggests to use TypeError for when
+            # a value is of the wrong type,
+            # but tests expect ValueError,
+            # so tests win here
+            raise ValueError(  # noqa: TRY004
                 trans._(
                     '{class_name} may only be called with a `str` or an instance of {class_name}. Got {dtype}',
                     deferred=True,
@@ -267,42 +303,38 @@ class StringEnumMeta(EnumMeta):
                     dtype=builtins.type(value),
                 )
             )
-
-        # otherwise create new Enum class
-        return cls._create_(
-            value,
-            names,
-            module=module,
-            qualname=qualname,
-            type=type,
-            start=start,
+        if isinstance(value, str):
+            for member in cls:
+                if member.value == value.lower():
+                    return member
+            return None
+        raise ValueError(
+            trans._(
+                '{class_name} may only be called with a `str` or an instance of {class_name}. Got {dtype}',
+                deferred=True,
+                class_name=cls,
+                dtype=builtins.type(value),
+            )
         )
-
-    def keys(self) -> list[str]:
-        return list(map(str, self))
-
-
-class StringEnum(Enum, metaclass=StringEnumMeta):
-    @staticmethod
-    def _generate_next_value_(name: str, start, count, last_values) -> str:
-        """autonaming function assigns each value its own name as a value"""
-        return name.lower()
-
-    def __str__(self) -> str:
-        """String representation: The string method returns the lowercase
-        string of the Enum name
-        """
-        return self.value
 
     def __eq__(self, other: object) -> bool:
         if type(self) is type(other):
             return self is other
+        if isinstance(other, StringEnum):
+            return False
         if isinstance(other, str):
             return str(self) == other
         return False
 
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)
+
     def __hash__(self) -> int:
         return hash(str(self))
+
+    @classmethod
+    def keys(cls) -> list[str]:
+        return list(map(str, cls))
 
 
 camel_to_snake_pattern = re.compile(r'(.)([A-Z][a-z]+)')


### PR DESCRIPTION
# References and relevant issues

Replaces #8418 
Closes #8372

# Description

In contrast to the previous PR, which was attempting to replace `StringEnum` with `StrEnum`, I realized that the first does much more than the second is capable of doing. So instead I'm shifting my focus to remove `napari.utils.compat` entirely in favor of subclassing `StrEnum` directly.

I'm approaching step by step to ensure that tests are not changed this time. I want to not break anything as it is not useful to change tests and/or the rest of the codebase.


I applied the initial changes with Claude Code but I reviewed the code myself.

Some things to note: in the first `isinstance` check of `_missing_`, ruff complains that the error thrown should be `TypeError` but tests expect `ValueError`. I'm biased towards maintaining current behavior so I silenced it.

I tried my best to annotate the vendoring of `backports.strenum` but please feel free to suggest a more formal approach. I know sometimes people use SPDX identifiers but I don't know if it applies to code licensed under the PSF license.

The addition of `__ne__` is to maintain the behavior of checking that, when comparing two values of an enumerator, there's the correct check passing through `__eq__`, otherwise if two different `StringEnum` with same values are compared via `!=`, the check still passes because it goes in the underlying `StrEnum.__ne__` and bypasses `__eq__`

If this implementation looks ok my instinct is to remove the `napari.utils.compat` and related tests (if any).


