### PR TITLE
Fix: Blocks dims slider widget creation feedback to dims model

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -1,5 +1,6 @@
 import os
 from sys import platform
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -289,6 +290,32 @@ def test_update_dims_labels(qtbot):
     view.setFixedWidth(250)
     assert first_label.text() == view.dims.axis_labels[0]
     assert first_label._elidedText() == view.dims.axis_labels[0]
+
+
+def test_model_axis_label_updates_do_not_write_back(qtbot):
+    """Programmatic model updates should not re-enter through QLineEdit signals."""
+    dims = Dims(ndim=4)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+
+    calls = []
+    original = Dims.set_axis_label
+
+    def wrapped(self, axis, label):
+        calls.append((axis, label))
+        return original(self, axis, label)
+
+    with patch.object(Dims, 'set_axis_label', wrapped):
+        dims.axis_labels = ('T', 'Z', 'Y', 'X')
+
+    assert dims.axis_labels == ('T', 'Z', 'Y', 'X')
+    assert [widget.axis_label.text() for widget in view.slider_widgets] == [
+        'T',
+        'Z',
+        'Y',
+        'X',
+    ]
+    assert calls == []
 
 
 def test_slider_press_updates_last_used(qtbot):

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -223,7 +223,8 @@ class QtDimSliderWidget(QWidget):
     def _pull_label(self):
         """Updates the label LineEdit from the dims model."""
         label = self.dims.axis_labels[self.axis]
-        self.axis_label.setText(label)
+        with qt_signals_blocked(self.axis_label):
+            self.axis_label.setText(label)
 
     def _update_label(self):
         """Update dimension slider label."""


### PR DESCRIPTION
# References and relevant issues

Closes #8839 

# Description

Previously, growing the dims in a drag-n-drop script would grow the dim sliders, at the same time as these sliders grew, their `setText` would feedback into the Dims model and reset some axis labels. 

This changes that behavior to block the programmatic model->widget-X->model feedback

The test fails on main ('-4','-3','Y','X') but passes with the PR