### PR TITLE
Fix: play button loop mode duplication

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -347,3 +347,19 @@ def test_play_button(qtbot, mock_qt_method_ctx, qt_dims):
     button.mode_combo.setCurrentText('once')
     assert slider.loop_mode == button.mode_combo.currentText() == 'once'
     qtbot.waitUntil(qt_dims._animation_thread.isFinished)
+
+
+def test_loop_mode_model_update_emits_once(qtbot):
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider = view.slider_widgets[0]
+
+    observed = []
+    slider.mode_changed.connect(observed.append)
+
+    slider.loop_mode = 'once'
+
+    assert slider.loop_mode == 'once'
+    assert slider.play_button.mode_combo.currentText() == 'once'
+    assert observed == ['once']

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -334,10 +334,13 @@ class QtDimSliderWidget(QWidget):
                 has been reached.
         """
         value = LoopMode(value)
+        if self._loop_mode == value:
+            return
         self._loop_mode = value
-        self.play_button.mode_combo.setCurrentText(
-            str(value).replace('_', ' ')
-        )
+        with qt_signals_blocked(self.play_button.mode_combo):
+            self.play_button.mode_combo.setCurrentText(
+                str(value).replace('_', ' ')
+            )
         self.mode_changed.emit(str(value))
 
     @property


### PR DESCRIPTION
# References and relevant issues

ID'd by Copilot when I requested checks on files after #8840 . This is much lower priority since it is internal though
Other Qt widgets all seem blocked correctly. See it wrongly with:

```python
import napari
import numpy as np

viewer = napari.Viewer()
viewer.add_image(np.random.random((20, 64, 64)))

slider = viewer.window._qt_viewer.dims.slider_widgets[0]

seen = []
slider.mode_changed.connect(seen.append)

slider.loop_mode = "once"

print(seen)
```
On main you will see `['once','once']`

# Description

Fixes duplication of the loop mode by A) returning if the value is identical and B) blocking the Qt signal feedback.
Adds test that fails on main and passes with this PR