### PR TITLE
Do not import builtins from core (and forbid doing so)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1009,3 +1009,9 @@ layers = ["napari.qt","napari.components"]
 ignore_imports = [
     "napari.plugins._npe2 -> napari._qt._qplugins",
 ]
+
+[[tool.importlinter.contracts]]
+name = "Block import from napari_builtins in napari core"
+type = "forbidden"
+source_modules = "napari"
+forbidden_modules = ["napari_builtins"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1018,3 +1018,6 @@ name = "Block imports from napari_builtins in napari core"
 type = "forbidden"
 source_modules = "napari"
 forbidden_modules = ["napari_builtins"]
+ignore_imports = [
+    "napari.utils.io -> napari_builtins"  # to be removed in 0.8.0
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1011,7 +1011,7 @@ ignore_imports = [
 ]
 
 [[tool.importlinter.contracts]]
-name = "Block import from napari_builtins in napari core"
+name = "Block imports from napari_builtins in napari core"
 type = "forbidden"
 source_modules = "napari"
 forbidden_modules = ["napari_builtins"]

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -54,7 +54,6 @@ from napari.utils.misc import in_ipython, in_jupyter
 from napari.utils.naming import CallerFrame
 from napari.utils.notifications import show_info
 from napari.utils.translations import trans
-from napari_builtins.io import imsave_extensions
 
 from napari._vispy import VispyCanvas, create_vispy_layer  # isort:skip
 
@@ -89,52 +88,6 @@ def _npe2_decode_selected_filter(
         if entry.startswith(selected_filter):
             return writer
     return None
-
-
-def _extension_string_for_layers(
-    layers: Sequence[Layer],
-) -> tuple[str, list[WriterContribution]]:
-    """Return an extension string and the list of corresponding writers.
-
-    The extension string is a ";;" delimeted string of entries. Each entry
-    has a brief description of the file type and a list of extensions.
-
-    The writers, when provided, are the npe2.manifest.io.WriterContribution
-    objects. There is one writer per entry in the extension string. If npe2
-    is not importable, the list of writers will be empty.
-    """
-    # try to use npe2
-    ext_str, writers = _npe2.file_extensions_string_for_layers(layers)
-    if ext_str:
-        return ext_str, writers
-
-    # fallback to old behavior
-
-    if len(layers) == 1:
-        selected_layer = layers[0]
-        # single selected layer.
-        if selected_layer._type_string == 'image':
-            ext = imsave_extensions()
-
-            ext_list = [f'*{val}' for val in ext]
-            ext_str = ';;'.join(ext_list)
-
-            ext_str = trans._(
-                'All Files (*);; Image file types:;;{ext_str}',
-                ext_str=ext_str,
-            )
-
-        elif selected_layer._type_string == 'points':
-            ext_str = trans._('All Files (*);; *.csv;;')
-
-        else:
-            # layer other than image or points
-            ext_str = trans._('All Files (*);;')
-
-    else:
-        # multiple layers.
-        ext_str = trans._('All Files (*);;')
-    return ext_str, []
 
 
 class QtViewer(QSplitter):
@@ -782,7 +735,7 @@ class QtViewer(QSplitter):
             raise OSError(trans._('Nothing to save'))
 
         # prepare list of extensions for drop down menu.
-        ext_str, writers = _extension_string_for_layers(
+        ext_str, writers = _npe2.file_extensions_string_for_layers(
             list(self.viewer.layers.selection)
             if selected
             else self.viewer.layers

--- a/src/napari/utils/_startup_script.py
+++ b/src/napari/utils/_startup_script.py
@@ -4,6 +4,7 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
+from napari.utils.io import execute_python_code
 from napari.utils.translations import trans
 
 
@@ -44,10 +45,6 @@ def _run_configured_startup_script() -> None:
             )
         )
         return
-
-    from napari_builtins.io._read import (
-        execute_python_code,
-    )
 
     script_code = script_path.read_text()
     start_time = time.time()

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -148,7 +148,7 @@ def __getattr__(name: str):
     }:
         warnings.warn(
             trans._(
-                '{name} was moved from napari.utils.io in v0.4.17. Import it from napari_builtins.io instead.',
+                '{name} was moved to napari_builtins.io and will be removed from here in v0.8.0.',
                 deferred=True,
                 name=name,
             ),

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -156,7 +156,7 @@ def execute_python_code(code: str, script_path: str | Path = '') -> None:
         try:
             patched_viewer = current_viewer()
             script_namespace = _SCRIPT_NAMESPACES.setdefault(script_path, {})
-            
+
             # The `__name__` variable stores the module name.
             # If a module is imported, set `__name__` to the module name.
             # If a module is executed with `python -m ...` or

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -163,7 +163,7 @@ def execute_python_code(code: str, script_path: str | Path = '') -> None:
             # `python script.py` it is set to '__main__'.
             # If code is executed with `exec(code, namespace)` it is set to `builtins` if
             # `__name__` is not set in the namespace.
-            # So ww set it to `__main__` to execute `if __name__ == '__main__':` blocks
+            # So we set it to `__main__` to execute `if __name__ == '__main__':` blocks
             script_namespace['__name__'] = '__main__'
             exec(code, script_namespace)
             _add_variables_to_viewer_console(

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from napari.viewer import Viewer
 
-_SCRIPT_NAMESPACES = {}
+_SCRIPT_NAMESPACES: dict[str | Path, dict[str, Any]] = {}
 # This is a global dictionary to store the namespace for scripts that are
 # executed using drag and drop or the Python file reader.
 # The content is a mapping from the script path to the namespace.
@@ -138,9 +138,7 @@ def imsave_tiff(filename, data):
             )
 
 
-def execute_python_code(
-    code: str, script_path: str | Path | None = None
-) -> None:
+def execute_python_code(code: str, script_path: str | Path = '') -> None:
     """Execute Python code in the current viewer's context.
 
     Store the executed cod variables in _SCRIPT_NAMESPACES dict
@@ -194,7 +192,7 @@ def _patched_viewer_new():
         if not kwargs and not args:
             viewer = current_viewer()
             if ndisplay is not None:
-                viewer.dims.ndisplay = ndisplay
+                viewer.dims.ndisplay = ndisplay  # type: ignore
             if viewer is not None:
                 Viewer.__new__ = original_new
                 return viewer

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -1,15 +1,30 @@
+from __future__ import annotations
+
 import os
 import struct
-import warnings
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from napari._qt import qt_event_loop
 from napari._version import __version__
-from napari.utils.notifications import show_warning
+from napari.utils.notifications import notification_manager, show_warning
 from napari.utils.translations import trans
+from napari.viewer import Viewer, current_viewer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SCRIPT_NAMESPACES = {}
+# This is a global dictionary to store the namespace for scripts that are
+# executed using drag and drop or the Python file reader.
+# The content is a mapping from the script path to the namespace.
+# The dict should not be overwritten but only modified, as
+# it may be broken the execution of scripts that are already running.
 
 
-def imsave(filename: str, data: 'np.ndarray'):
+def imsave(filename: str, data: np.ndarray):
     """Custom implementation of imsave to avoid skimage dependency.
 
     Parameters
@@ -123,25 +138,129 @@ def imsave_tiff(filename, data):
             )
 
 
-def __getattr__(name: str):
-    if name in {
-        'imsave_extensions',
-        'write_csv',
-        'read_csv',
-        'csv_to_layer_data',
-        'read_zarr_dataset',
-    }:
-        warnings.warn(
-            trans._(
-                '{name} was moved from napari.utils.io in v0.4.17. Import it from napari_builtins.io instead.',
-                deferred=True,
-                name=name,
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        import napari_builtins.io
+def execute_python_code(
+    code: str, script_path: str | Path | None = None
+) -> None:
+    """Execute Python code in the current viewer's context.
 
-        return getattr(napari_builtins.io, name)
+    Store the executed cod variables in _SCRIPT_NAMESPACES dict
 
-    raise AttributeError(f'module {__name__} has no attribute {name}')
+    Parameters
+    ----------
+    code: str
+        python code to be executed
+    script_path: str | Path
+        Path to the script file from which the code is executed.
+        Used to store the namespace in the _SCRIPT_NAMESPACES.
+    """
+
+    with _patched_viewer_new(), _noop_napari_run():
+        try:
+            viewer = current_viewer()
+            script_namespace = _SCRIPT_NAMESPACES.setdefault(script_path, {})
+            # The `__name__` variable is storing the name of the module.
+            # If a module is imported, it is set to the module name.
+            # If a module is executed with `python -m ...` or
+            # `python script.py` it is set to '__main__'.
+            # If code is executed with `exec(code, namespace)` it is set to `builtins` if
+            # `__name__` is not set in the namespace.
+            # So ww set it to `__main__` to execute `if __name__ == '__main__':` blocks
+            script_namespace['__name__'] = '__main__'
+            exec(code, script_namespace)
+            _add_variables_to_viewer_console(
+                _SCRIPT_NAMESPACES[script_path], viewer
+            )
+        except BaseException as e:  # noqa: BLE001
+            notification_manager.receive_error(type(e), e, e.__traceback__)
+
+
+@contextmanager
+def _patched_viewer_new():
+    """Context manager to patch the viewer's new method."""
+
+    original_new = Viewer.__new__
+    original_init = Viewer.__init__
+
+    def patched_init(self, *args, **kwargs):
+        Viewer.__init__ = original_init
+
+    def patched_new(cls, *args, **kwargs):
+        ndisplay = None
+        if len(kwargs) == 1 and 'ndisplay' in kwargs:
+            ndisplay = kwargs.pop('ndisplay')
+
+        if not kwargs and not args:
+            viewer = current_viewer()
+            if ndisplay is not None:
+                viewer.dims.ndisplay = ndisplay
+            if viewer is not None:
+                Viewer.__new__ = original_new
+                return viewer
+        Viewer.__init__ = original_init
+        return original_new(cls)
+
+    Viewer.__new__ = patched_new
+    Viewer.__init__ = patched_init
+    try:
+        yield
+    finally:
+        Viewer.__new__ = original_new
+        Viewer.__init__ = original_init
+
+
+@contextmanager
+def _noop_napari_run():
+    """Context manager to patch napari.run to always be a no-op.
+
+    napari.run() executes the Qt event loop, *except* when napari
+    is running in IPython and therefore IPython's Qt integration
+    already has the event loop.
+
+    When running a script by dragging-and-dropping onto a
+    running napari Viewer, we already have an event loop, so we
+    should not start a new nested loop, even though we are not
+    in IPython.
+
+    This context manager temporarily patches the IPython check
+    to always return True, causing a fast exit from napari.run()
+    without a new event loop.
+    """
+    original_ipython_check = qt_event_loop._ipython_has_eventloop
+
+    def patched_ipython_check() -> bool:
+        """A patched ipython_check that always returns True.
+
+        napari's script running from drag-and-dropping a script
+        into a viewer uses this patch to prevent nested event loops.
+        """
+        return True
+
+    qt_event_loop._ipython_has_eventloop = patched_ipython_check
+    try:
+        yield
+    finally:
+        qt_event_loop._ipython_has_eventloop = original_ipython_check
+
+
+def _filter_variables(variables: dict[str, Any]) -> dict[str, Any]:
+    res = variables.copy()
+    res.pop('viewer', None)
+    res.pop(
+        '__name__', None
+    )  # Remove the __name__ variable to not affect the console
+    return res
+
+
+def _add_variables_to_viewer_console(
+    variables: dict[str, Any], viewer: Viewer | None
+) -> None:
+    if viewer is None:
+        return
+
+    variables = _filter_variables(variables)
+
+    if viewer.window._qt_viewer._console is None:
+        viewer.window._qt_viewer.add_to_console_backlog(variables)
+    else:
+        console = viewer.window._qt_viewer._console
+        console.push(variables)

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from napari._qt import qt_event_loop
 from napari._version import __version__
 from napari.utils.notifications import notification_manager, show_warning
 from napari.utils.translations import trans
-from napari.viewer import Viewer, current_viewer
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from napari.viewer import Viewer
 
 _SCRIPT_NAMESPACES = {}
 # This is a global dictionary to store the namespace for scripts that are
@@ -153,6 +153,7 @@ def execute_python_code(
         Path to the script file from which the code is executed.
         Used to store the namespace in the _SCRIPT_NAMESPACES.
     """
+    from napari.viewer import current_viewer
 
     with _patched_viewer_new(), _noop_napari_run():
         try:
@@ -177,6 +178,7 @@ def execute_python_code(
 @contextmanager
 def _patched_viewer_new():
     """Context manager to patch the viewer's new method."""
+    from napari.viewer import Viewer, current_viewer
 
     original_new = Viewer.__new__
     original_init = Viewer.__init__
@@ -225,6 +227,8 @@ def _noop_napari_run():
     to always return True, causing a fast exit from napari.run()
     without a new event loop.
     """
+    from napari._qt import qt_event_loop
+
     original_ipython_check = qt_event_loop._ipython_has_eventloop
 
     def patched_ipython_check() -> bool:

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -217,7 +217,8 @@ def _noop_napari_run():
 
     If launching a script by dragging-and-dropping onto a
     running napari Viewer, an event loop exists, so we
-    should not start a new nested event loop. This applies whether or not IPython is running.
+    should not start a new nested event loop.
+    This applies whether or not IPython is running.
 
     This context manager temporarily patches the IPython check
     to always return True, causing a fast exit from napari.run()

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -155,7 +155,11 @@ def __getattr__(name: str):
             FutureWarning,
             stacklevel=2,
         )
-        import napari_builtins.io  # noqa
+        import napari_builtins.io
+
+        return getattr(napari_builtins.io, name)
+
+    raise AttributeError(f'module {__name__} has no attribute {name}')
 
 
 def execute_python_code(code: str, script_path: str | Path = '') -> None:

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -141,15 +141,15 @@ def imsave_tiff(filename, data):
 def execute_python_code(code: str, script_path: str | Path = '') -> None:
     """Execute Python code in the current viewer's context.
 
-    Store the executed cod variables in _SCRIPT_NAMESPACES dict
+    Store the execution code in _SCRIPT_NAMESPACES dict
 
     Parameters
     ----------
     code: str
-        python code to be executed
+        The script's Python source code
     script_path: str | Path
-        Path to the script file from which the code is executed.
-        Used to store the namespace in the _SCRIPT_NAMESPACES.
+        Path to the script file.
+        Used to store the script's namespace in the _SCRIPT_NAMESPACES.
     """
     from napari.viewer import current_viewer
 
@@ -178,11 +178,11 @@ def _patched_viewer_new():
     """Context manager to patch the viewer's new method."""
     from napari.viewer import Viewer, current_viewer
 
-    original_new = Viewer.__new__
-    original_init = Viewer.__init__
+    _saved_new = Viewer.__new__
+    _saved_init = Viewer.__init__
 
     def patched_init(self, *args, **kwargs):
-        Viewer.__init__ = original_init
+        Viewer.__init__ = _saved_init
 
     def patched_new(cls, *args, **kwargs):
         ndisplay = None
@@ -194,32 +194,31 @@ def _patched_viewer_new():
             if ndisplay is not None:
                 viewer.dims.ndisplay = ndisplay  # type: ignore
             if viewer is not None:
-                Viewer.__new__ = original_new
+                Viewer.__new__ = _saved_new
                 return viewer
-        Viewer.__init__ = original_init
-        return original_new(cls)
+        Viewer.__init__ = _saved_init
+        return _saved_new(cls)
 
     Viewer.__new__ = patched_new
     Viewer.__init__ = patched_init
     try:
         yield
     finally:
-        Viewer.__new__ = original_new
-        Viewer.__init__ = original_init
+        Viewer.__new__ = _saved_new
+        Viewer.__init__ = _saved_init
 
 
 @contextmanager
 def _noop_napari_run():
-    """Context manager to patch napari.run to always be a no-op.
+    """Context manager used to patch napari.run to be a no-op.
 
     napari.run() executes the Qt event loop, *except* when napari
     is running in IPython and therefore IPython's Qt integration
     already has the event loop.
 
-    When running a script by dragging-and-dropping onto a
-    running napari Viewer, we already have an event loop, so we
-    should not start a new nested loop, even though we are not
-    in IPython.
+    If launching a script by dragging-and-dropping onto a
+    running napari Viewer, an event loop exists, so we
+    should not start a new nested event loop. This applies whether or not IPython is running.
 
     This context manager temporarily patches the IPython check
     to always return True, causing a fast exit from napari.run()

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import struct
+import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -135,6 +136,26 @@ def imsave_tiff(filename, data):
                 compressionargs={'level': 1},
                 bigtiff=True,
             )
+
+
+def __getattr__(name: str):
+    if name in {
+        'imsave_extensions',
+        'write_csv',
+        'read_csv',
+        'csv_to_layer_data',
+        'read_zarr_dataset',
+    }:
+        warnings.warn(
+            trans._(
+                '{name} was moved from napari.utils.io in v0.4.17. Import it from napari_builtins.io instead.',
+                deferred=True,
+                name=name,
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+        import napari_builtins.io  # noqa
 
 
 def execute_python_code(code: str, script_path: str | Path = '') -> None:

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -154,19 +154,20 @@ def execute_python_code(code: str, script_path: str | Path = '') -> None:
 
     with _patched_viewer_new(), _noop_napari_run():
         try:
-            viewer = current_viewer()
+            patched_viewer = current_viewer()
             script_namespace = _SCRIPT_NAMESPACES.setdefault(script_path, {})
-            # The `__name__` variable is storing the name of the module.
-            # If a module is imported, it is set to the module name.
+            
+            # The `__name__` variable stores the module name.
+            # If a module is imported, set `__name__` to the module name.
             # If a module is executed with `python -m ...` or
-            # `python script.py` it is set to '__main__'.
-            # If code is executed with `exec(code, namespace)` it is set to `builtins` if
-            # `__name__` is not set in the namespace.
-            # So we set it to `__main__` to execute `if __name__ == '__main__':` blocks
+            # `python script.py`, set `__name__` to '__main__'.
+            # If `__name__` is not already set in the namespace and
+            # code will be executed with `exec(code, namespace)`, set `__name__` to `builtins`.
+            # Set `__main__` to execute `if __name__ == '__main__':` blocks
             script_namespace['__name__'] = '__main__'
             exec(code, script_namespace)
             _add_variables_to_viewer_console(
-                _SCRIPT_NAMESPACES[script_path], viewer
+                _SCRIPT_NAMESPACES[script_path], patched_viewer
             )
         except BaseException as e:  # noqa: BLE001
             notification_manager.receive_error(type(e), e, e.__traceback__)

--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -16,12 +16,11 @@ if TYPE_CHECKING:
 
     from napari.viewer import Viewer
 
+# Stores namespace associated with a script executed by drag and drop
+# or the Python file reader. It maps the script path to the
+# namespace. This global dict should only be modified; overwriting
+# it may break other scripts that are already running.
 _SCRIPT_NAMESPACES: dict[str | Path, dict[str, Any]] = {}
-# This is a global dictionary to store the namespace for scripts that are
-# executed using drag and drop or the Python file reader.
-# The content is a mapping from the script path to the namespace.
-# The dict should not be overwritten but only modified, as
-# it may be broken the execution of scripts that are already running.
 
 
 def imsave(filename: str, data: np.ndarray):

--- a/src/napari_builtins/io/_read.py
+++ b/src/napari_builtins/io/_read.py
@@ -4,10 +4,10 @@ import csv
 import itertools
 import os
 import re
-from contextlib import contextmanager, suppress
+from contextlib import suppress
 from glob import glob
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 from urllib.parse import urlparse
 
 import imageio.v3 as iio
@@ -15,14 +15,13 @@ import numpy as np
 import requests
 from dask import delayed
 
+from napari.utils.io import execute_python_code
 from napari.utils.misc import abspath_or_url
-from napari.utils.notifications import notification_manager
 from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from napari import Viewer
     from napari.types import FullLayerData, LayerData, ReaderFunction
 
 
@@ -32,13 +31,6 @@ def _alphanumeric_key(s: str) -> list[str | int]:
 
 
 URL_REGEX = re.compile(r'https?://|ftps?://|file://|file:\\')
-
-_DROPPED_SCRIPTS_NAMESPACE = {}
-# This is a global dictionary to store the namespace for scripts that are
-# executed using drag and drop or the Python file reader.
-# The content is a mapping from the script path to the namespace.
-# The dict should not be overwritten but only modified, as
-# it may be broken the execution of scripts that are already running.
 
 
 def _is_url(filename):
@@ -601,101 +593,6 @@ def napari_get_reader(
     return _magic_imreader
 
 
-@contextmanager
-def _patch_viewer_new():
-    """Context manager to patch the viewer's new method."""
-    from napari.viewer import Viewer, current_viewer
-
-    original_new = Viewer.__new__
-    original_init = Viewer.__init__
-
-    def patched_init(self, *args, **kwargs):
-        Viewer.__init__ = original_init
-
-    def patched_new(cls, *args, **kwargs):
-        ndisplay = None
-        if len(kwargs) == 1 and 'ndisplay' in kwargs:
-            ndisplay = kwargs.pop('ndisplay')
-
-        if not kwargs and not args:
-            viewer = current_viewer()
-            if ndisplay is not None:
-                viewer.dims.ndisplay = ndisplay
-            if viewer is not None:
-                Viewer.__new__ = original_new
-                return viewer
-        Viewer.__init__ = original_init
-        return original_new(cls)
-
-    Viewer.__new__ = patched_new
-    Viewer.__init__ = patched_init
-    try:
-        yield
-    finally:
-        Viewer.__new__ = original_new
-        Viewer.__init__ = original_init
-
-
-@contextmanager
-def _patch_napari_run():
-    """Context manager to patch napari.run to always be a no-op.
-
-    napari.run() executes the Qt event loop, *except* when napari
-    is running in IPython and therefore IPython's Qt integration
-    already has the event loop.
-
-    When running a script by dragging-and-dropping onto a
-    running napari Viewer, we already have an event loop, so we
-    should not start a new nested loop, even though we are not
-    in IPython.
-
-    This context manager temporarily patches the IPython check
-    to always return True, causing a fast exit from napari.run()
-    without a new event loop.
-    """
-    from napari._qt import qt_event_loop
-
-    original_ipython_check = qt_event_loop._ipython_has_eventloop
-
-    def patched_ipython_check() -> bool:
-        """A patched ipython_check that always returns True.
-
-        napari's script running from drag-and-dropping a script
-        into a viewer uses this patch to prevent nested event loops.
-        """
-        return True
-
-    qt_event_loop._ipython_has_eventloop = patched_ipython_check
-    try:
-        yield
-    finally:
-        qt_event_loop._ipython_has_eventloop = original_ipython_check
-
-
-def filter_variables(variables: dict[str, Any]) -> dict[str, Any]:
-    res = variables.copy()
-    res.pop('viewer', None)
-    res.pop(
-        '__name__', None
-    )  # Remove the __name__ variable to not affect the console
-    return res
-
-
-def _add_dropped_scripts_to_console(
-    variables: dict[str, Any], viewer: Viewer | None
-) -> None:
-    if viewer is None:
-        return
-
-    variables = filter_variables(variables)
-
-    if viewer.window._qt_viewer._console is None:
-        viewer.window._qt_viewer.add_to_console_backlog(variables)
-    else:
-        console = viewer.window._qt_viewer._console
-        console.push(variables)
-
-
 def load_and_execute_python_code(script_path: str) -> list[LayerData]:
     """Load and execute Python code from a file.
 
@@ -714,43 +611,6 @@ def load_and_execute_python_code(script_path: str) -> list[LayerData]:
         code = Path(script_path).read_text()
     execute_python_code(code, script_path)
     return [(None,)]
-
-
-def execute_python_code(code: str, script_path: str | Path) -> None:
-    """Execute Python code in the current viewer's context.
-
-    Store the executed cod variables in _DROPPED_SCRIPTS_NAMESPACE dict
-
-    Parameters
-    ----------
-    code: str
-        python code to be executed
-    script_path: str | Path
-        Path to the script file from which the code is executed.
-        Used to store the namespace in the _DROPPED_SCRIPTS_NAMESPACE.
-    """
-    from napari.viewer import current_viewer
-
-    with _patch_viewer_new(), _patch_napari_run():
-        try:
-            viewer = current_viewer()
-            script_namespace = _DROPPED_SCRIPTS_NAMESPACE.setdefault(
-                script_path, {}
-            )
-            # The `__name__` variable is storing the name of the module.
-            # If a module is imported, it is set to the module name.
-            # If a module is executed with `python -m ...` or
-            # `python script.py` it is set to '__main__'.
-            # If code is executed with `exec(code, namespace)` it is set to `builtins` if
-            # `__name__` is not set in the namespace.
-            # So ww set it to `__main__` to execute `if __name__ == '__main__':` blocks
-            script_namespace['__name__'] = '__main__'
-            exec(code, script_namespace)
-            _add_dropped_scripts_to_console(
-                _DROPPED_SCRIPTS_NAMESPACE[script_path], viewer
-            )
-        except BaseException as e:  # noqa: BLE001
-            notification_manager.receive_error(type(e), e, e.__traceback__)
 
 
 def napari_get_py_reader(path: str) -> ReaderFunction | None:


### PR DESCRIPTION
# References and relevant issues
- https://github.com/napari/napari/pull/8815#issuecomment-4136379473

# Description
Builtins should bve treated like all other plugins and handled lazily (we also plan to move them out of this repo for ease of release). Thhis PR removes some legacy code that still imported builtins, and enforces a new contract for importlint that prevents importing this.

I also had to move the logic for exectuing python code in the viewer from builtins to napari core (whhich makes sense to me). So now it's builtins which imports from napari in order to execute py scripts inbto it, and just provides the i/o wrapper.