### PR TITLE
Remove sentinel leftover from `napari.utils.misc`

### DIFF
--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -25,8 +25,6 @@ import numpy.typing as npt
 
 from napari.utils.translations import trans
 
-_sentinel = object()
-
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
 


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/8835/changes#r3027249783

# Description

When removing deprecated API is #7729 the `_sentinel` module level object was not removed. Now is unused. 

This PR removes it. 