### PR TITLE
Revert Citation validator from ubuntu-slim to use ubuntu-latest

### DIFF
--- a/.github/workflows/citation_cff_validate.yml
+++ b/.github/workflows/citation_cff_validate.yml
@@ -10,7 +10,7 @@ on:
 name: CITATION.cff
 jobs:
   Validate-CITATION-cff:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     name: Validate CITATION.cff
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
cff-validator requires R which is not installed in `ubuntu-slim`

# References and relevant issues
Fixes citation check in #8848 

# Description
Citation validator requires R. Recent change to `ubuntu-slim` is missing R. Move back to `ubuntu-latest`. 
