### PR TITLE
Deprecate make_default_color_array

### DIFF
--- a/src/napari/utils/colormaps/_tests/test_colormap_utils.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap_utils.py
@@ -6,6 +6,7 @@ from napari.utils.colormaps.colormap_utils import (
     CoercedContrastLimits,
     _coerce_contrast_limits,
     label_colormap,
+    make_default_color_array,
 )
 
 FIRST_COLORS = [
@@ -45,6 +46,19 @@ def test_label_colormap_exception():
         ValueError, match=r'.*Only up to 2\*\*16=65535 colors are supported'
     ):
         label_colormap(2**16 + 1)
+
+
+def test_make_default_color_array_deprecated():
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            'make_default_color_array is deprecated and will be removed in a '
+            'future release. Use an explicit array such as '
+            r'np\.array\(\[0, 0, 0, 1\]\) instead\.'
+        ),
+    ):
+        arr = make_default_color_array()
+    assert np.array_equal(arr, np.array([0, 0, 0, 1]))
 
 
 def test_coerce_contrast_limits_with_valid_input():

--- a/src/napari/utils/colormaps/_tests/test_colormap_utils.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap_utils.py
@@ -52,9 +52,8 @@ def test_make_default_color_array_deprecated():
     with pytest.warns(
         DeprecationWarning,
         match=(
-            'make_default_color_array is deprecated and will be removed in a '
-            'future release. Use an explicit array such as '
-            r'np\.array\(\[0, 0, 0, 1\]\) instead\.'
+            r'make_default_color_array is deprecated in 0\.7\.1 and will be removed in 0\.8\.0 release\. '
+            r'Use an explicit array such as np\.array\(\[0, 0, 0, 1\]\) instead\.'
         ),
     ):
         arr = make_default_color_array()

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -961,6 +961,18 @@ def _colormap_from_colors(
 
 
 def make_default_color_array():
+    """Return the default RGBA color array.
+
+    .. deprecated::
+        This helper is deprecated and will be removed in a future release.
+        Use an explicit array such as ``np.array([0, 0, 0, 1])`` instead.
+    """
+    warnings.warn(
+        'make_default_color_array is deprecated and will be removed in a future release.'
+        ' Use an explicit array such as np.array([0, 0, 0, 1]) instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return np.array([0, 0, 0, 1])
 
 

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -963,12 +963,12 @@ def _colormap_from_colors(
 def make_default_color_array():
     """Return the default RGBA color array.
 
-    .. deprecated::
+    .. deprecated:: 0.7.1
         This helper is deprecated and will be removed in a future release.
         Use an explicit array such as ``np.array([0, 0, 0, 1])`` instead.
     """
     warnings.warn(
-        'make_default_color_array is deprecated and will be removed in a future release.'
+        'make_default_color_array is deprecated in 0.7.1 and will be removed in 0.8.0 release.'
         ' Use an explicit array such as np.array([0, 0, 0, 1]) instead.',
         DeprecationWarning,
         stacklevel=2,


### PR DESCRIPTION
# References and relevant issues
Closes #6254 

# Description

- Added depreciation warning for make_default_color_array and test for depreciation. 

There was not much discussion in issue, I'd love to know maintainers thoughts on this, Thank you :)