### PR TITLE
Add CI check for transitive migrator DAGs in settings migrations

### DIFF
--- a/src/napari/settings/_tests/test_migrations.py
+++ b/src/napari/settings/_tests/test_migrations.py
@@ -185,3 +185,29 @@ def test_060_to_070_migration():
     )
     assert settings_060_plain == settings_070_plain_expected
     assert settings_060_compiled == settings_070_compiled_expected
+
+
+def test_no_transitive_migrators():
+    """Ensure no direct A->C migrator exists when A->B and B->C already exist."""
+
+    edges: dict[str, set[str]] = {}
+    for m in _migrations._MIGRATORS:
+        a = str(m.from_)
+        c = str(m.to_)
+        edges.setdefault(a, set()).add(c)
+
+    violations: list[str] = []
+    for a, bs in edges.items():
+        for b in bs:
+            if b not in edges:
+                continue
+            for c in edges[b]:
+                if c in bs:
+                    violations.append(
+                        f'{a} -> {b} -> {c} and direct {a} -> {c}'
+                    )
+
+    assert not violations, (
+        'Found transitive migrators that create DAGs:\n'
+        + '\n'.join(violations)
+    )


### PR DESCRIPTION
# References and relevant issues
Closes #4234 

# Description

- Add test_no_transitive_migrators to check direct edges (A->C) when A->B and B->C already exist in the migration graph

@TimMonko could you please help me with this 😊 , as per suggestion from llm , i kept it as `violations`, but I'm not sure if we should keep this or different variable name. Thankyou !