### PR TITLE
Deprecate color_dict_to_colormap with FutureWarning

### DIFF
--- a/src/napari/utils/colormaps/_tests/test_colormap_utils.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap_utils.py
@@ -5,6 +5,7 @@ import pytest
 from napari.utils.colormaps.colormap_utils import (
     CoercedContrastLimits,
     _coerce_contrast_limits,
+    color_dict_to_colormap,
     label_colormap,
 )
 
@@ -111,3 +112,18 @@ def test_coerce_contrast_limits_small_values():
     npt.assert_allclose(
         result.contrast_limits, result.coerce_data(np.array(contrast_limits))
     )
+
+
+def test_color_dict_to_colormap_deprecated_and_returns_values():
+    colors = {
+        1: np.array([1.0, 0.0, 0.0, 1.0]),
+        2: np.array([0.0, 1.0, 0.0, 1.0]),
+    }
+    with pytest.warns(
+        FutureWarning, match='color_dict_to_colormap is deprecated'
+    ):
+        cmap, mapping = color_dict_to_colormap(colors)
+
+    assert hasattr(cmap, 'map')
+    assert isinstance(mapping, dict)
+    assert set(mapping.keys()) == set(colors.keys())

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -341,6 +341,13 @@ def color_dict_to_colormap(colors):
         Mapping of Label to color control point within colormap
     """
 
+    warnings.warn(
+        'color_dict_to_colormap is deprecated and will be removed in a future '
+        'release. Construct a Colormap and label-to-control mapping directly.',
+        category=FutureWarning,
+        stacklevel=2,
+    )
+
     MAX_DISTINCT_COLORS = LUT_len
 
     control_colors = np.unique(list(colors.values()), axis=0)

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -342,7 +342,7 @@ def color_dict_to_colormap(colors):
     """
 
     warnings.warn(
-        'color_dict_to_colormap is deprecated and will be removed in a future '
+        'color_dict_to_colormap is deprecated and will be removed in a 0.8.0 '
         'release. Construct a Colormap and label-to-control mapping directly.',
         category=FutureWarning,
         stacklevel=2,

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -346,7 +346,7 @@ def color_dict_to_colormap(colors):
 
     warnings.warn(
         'color_dict_to_colormap is deprecated in 0.7.1 and will be removed in '
-        '0.8.0. Construct a Colormap and label-to-control mapping directly.',
+        '0.8.0 release. Construct a Colormap and label-to-control mapping directly.',
         category=FutureWarning,
         stacklevel=2,
     )

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -325,8 +325,11 @@ def low_discrepancy_image(image, seed=0.5, margin=1 / 256) -> np.ndarray:
 
 
 def color_dict_to_colormap(colors):
-    """
-    Generate a color map based on the given color dictionary
+    """Generate a color map based on the given color dictionary.
+
+    .. deprecated:: 0.7.1
+        ``color_dict_to_colormap`` is deprecated as of ``0.7.1`` and will be
+        removed in ``0.8.0``.
 
     Parameters
     ----------
@@ -342,8 +345,8 @@ def color_dict_to_colormap(colors):
     """
 
     warnings.warn(
-        'color_dict_to_colormap is deprecated and will be removed in a 0.8.0 '
-        'release. Construct a Colormap and label-to-control mapping directly.',
+        'color_dict_to_colormap is deprecated in 0.7.1 and will be removed in '
+        '0.8.0. Construct a Colormap and label-to-control mapping directly.',
         category=FutureWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
# References and relevant issues
Closes #6253 

# Description

- Deprecate color_dict_to_colormap with FutureWarning 



