### PR TITLE
Add session type to --info

### DIFF
--- a/src/napari/utils/info.py
+++ b/src/napari/utils/info.py
@@ -74,6 +74,12 @@ def _sys_name() -> str:
     return ''
 
 
+def _desktop_env() -> str:
+    if sys.platform == 'linux':
+        return f'{os.getenv("XDG_SESSION_TYPE")} - {os.getenv("XDG_SESSION_DESKTOP")}'
+    return ''
+
+
 def _napari_from_conda() -> bool:
     """
     Try to check if napari was installed using conda.
@@ -187,6 +193,9 @@ def sys_info(as_html: bool = False) -> str:
     __sys_name = _sys_name()
     if __sys_name:
         text += f'<b>System</b>: {__sys_name}<br>'
+    __desktop_env = _desktop_env()
+    if __desktop_env:
+        text += f'<b>Session</b>: {__desktop_env}<br>'
 
     text += f'<b>Python</b>: {sys_version}<br>'
 


### PR DESCRIPTION
# References and relevant issues
- see https://github.com/napari/napari/issues/8879#issuecomment-4214292948

# Description
Add info about linux session type and desktop environment via `napari --info`.

For me, it now looks like this:

```yaml
napari: 0.7.1.dev18+g31d439eeb
Platform: Linux-6.19.11-arch1-1-x86_64-with-glibc2.43
System: Arch Linux
Session: wayland - sway:wlroots
...
```
