### PR TITLE
Improve make_release workflow's release steps

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
         with:
           attest-build-provenance-github: 'true'
@@ -35,6 +36,7 @@ jobs:
         with:
           repository: napari/docs
           path: docs
+          persist-credentials: false
       - name: Get release tag from github ref
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -124,7 +124,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/napari
     steps:
-      - name: Download built artifact to dist/
+      - name: Download build artifact to dist/
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Get latest relese
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          echo "tag_=$(gh release view --json tagName --jq '.tagName | ltrimstr(\"v\")')" >> "$GITHUB_ENV"
+          echo "tag_=$(gh release view --repo napari/napari --json tagName --jq '.tagName | ltrimstr(\"v\")')" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Get latest relese
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
-              echo "tag_=$(gh release view --json tagName --jq '.tagName | ltrimstr(\"v\")')" >> "$GITHUB_ENV"
+          echo "tag_=$(gh release view --json tagName --jq '.tagName | ltrimstr(\"v\")')" >> "$GITHUB_ENV"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Find Release Notes
         id: release_notes
         run: |

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -72,7 +72,7 @@ jobs:
           name: release_notes
           path: release_notes.md
 
-  create-release:
+  create-github-release:
     needs: [extract_release_notes, build-and-inspect-package]
     permissions:
       contents: write

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -23,6 +23,7 @@ jobs:
   extract_release_notes:
     name: Extract release notes
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout docs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Get latest relese
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          echo "tag_=$(gh release view --repo napari/napari --json tagName --jq '.tagName | ltrimstr(\"v\")')" >> "$GITHUB_ENV"
+          echo "tag_=$(gh release view --repo napari/napari --json tagName --jq '.tagName | ltrimstr("v")')" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -55,7 +55,8 @@ jobs:
 
   create-release:
     needs: [extract_release_notes, build-and-inspect-package]
-
+    permissions:
+      contents: write
     name: Create Release
     runs-on: ubuntu-latest
     if: github.repository == 'napari/napari'

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Find Release Notes
         id: release_notes
         run: |
-          TAG="${{ env.tag_ }}"  # clean tag
           VER="${TAG/a*/}"  # remove alpha identifier
           VER="${VER/b*/}"  # remove beta identifier
           VER="${VER/rc*/}"  # remove rc identifier
@@ -63,10 +62,15 @@ jobs:
           echo tag: "${TAG}"
           echo release_notes_path: "${RELEASE_NOTES_PATH}"
           ls docs/docs/release
+        env:
+          TAG: ${{ env.tag_ }}
+
 
       - name: Copy Release Notes
         run: |
-          cp ${{ env.release_notes_path }} release_notes.md
+          cp ${RELEASE_NOTES_PATH} release_notes.md
+        env:
+          RELEASE_NOTES_PATH: ${{ env.release_notes_path }}
 
       - name: Upload Release Notes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -9,16 +9,22 @@ on:
 
 name: Create Release
 
+permissions: {}
+
 jobs:
   build-and-inspect-package:
     name: Build & inspect package.
     runs-on: ubuntu-latest
-
+    permissions:
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
+        with:
+          attest-build-provenance-github: 'true'
 
   extract_release_notes:
     name: Extract release notes

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Copy Release Notes
         run: |
-          cp ${RELEASE_NOTES_PATH} release_notes.md
+          cp "${RELEASE_NOTES_PATH}" release_notes.md
         env:
           RELEASE_NOTES_PATH: ${{ env.release_notes_path }}
 

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
         with:
-          attest-build-provenance-github: 'true'
+          attest-build-provenance-github: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
 
   extract_release_notes:
     name: Extract release notes

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -10,33 +10,23 @@ on:
 name: Create Release
 
 jobs:
-  build:
-    permissions:
-      contents: write
-      id-token: write
-    name: Create Release
+  build-and-inspect-package:
+    name: Build & inspect package.
     runs-on: ubuntu-latest
-    if: github.repository == 'napari/napari'
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@v4
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
+
+  extract_release_notes:
+    name: Extract release notes
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout docs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: napari/docs
           path: docs
-
-      - name: Install Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.12
-          cache-dependency-path: pyproject.toml
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[build]  # need full install so we can build type stubs
-      - name: Build Distribution
-        run: make dist
       - name: Find Release Notes
         id: release_notes
         run: |
@@ -53,6 +43,34 @@ jobs:
           echo release_notes_path: "${RELEASE_NOTES_PATH}"
           ls docs/docs/release
 
+      - name: Copy Release Notes
+        run: |
+          cp ${{ env.release_notes_path }} release_notes.md
+
+      - name: Upload Release Notes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release_notes
+          path: release_notes.md
+
+  create-release:
+    needs: [extract_release_notes, build-and-inspect-package]
+
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: github.repository == 'napari/napari'
+    steps:
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: dist
+      - name: Download release notes to notes/
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release_notes
+          path: notes
+
       - name: Create Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -60,12 +78,29 @@ jobs:
           tag_name: ${{ github.ref }}
           name: ${{ env.tag }}
           body: pre-release ${{ env.tag }}
-          body_path: ${{ env.release_notes_path }}
+          body_path: notes/release_notes.md
           draft: false
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
           target_commitish: ${{ github.sha }}
           files: |
             dist/*
-      - name: Publish PyPI Package
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+  upload-to-pypi:
+    name: Upload package to PyPI
+    needs: [extract_release_notes, build-and-inspect-package]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing, but
+      # should NOT be granted anywhere else!
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/napari
+    steps:
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: napari/docs
           path: docs
-      - name: Get tag from github ref
+      - name: Get release tag from github ref
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "tag_=${GITHUB_REF/refs\/tags\/v/}" >> "$GITHUB_ENV"
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'napari/napari'
     steps:
-      - name: Download built artifact to dist/
+      - name: Download build artifact to dist/
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
@@ -99,8 +99,8 @@ jobs:
           files: |
             dist/*
 
-  upload-to-pypi:
-    name: Upload package to PyPI
+  publish-to-pypi:
+    name: Publish release to PyPI
     needs: [extract_release_notes, build-and-inspect-package]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
 
   extract_release_notes:

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -23,17 +23,24 @@ jobs:
   extract_release_notes:
     name: Extract release notes
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout docs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: napari/docs
           path: docs
+      - name: Get tag from github ref
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "tag_=${GITHUB_REF/refs\/tags\/v/}" >> "$GITHUB_ENV"
+      - name: Get latest relese
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+              echo "tag_=$(gh release view --json tagName --jq '.tagName | ltrimstr(\"v\")')" >> "$GITHUB_ENV"
       - name: Find Release Notes
         id: release_notes
         run: |
-          TAG="${GITHUB_REF/refs\/tags\/v/}"  # clean tag
+          TAG="${{ env.tag_ }}"  # clean tag
           VER="${TAG/a*/}"  # remove alpha identifier
           VER="${VER/b*/}"  # remove beta identifier
           VER="${VER/rc*/}"  # remove rc identifier

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           RELEASE_NOTES_PATH: ${{ env.release_notes_path }}
 
-      - name: Upload Release Notes
+      - name: Upload Release Notes to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release_notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1009,3 +1009,7 @@ layers = ["napari.qt","napari.components"]
 ignore_imports = [
     "napari.plugins._npe2 -> napari._qt._qplugins",
 ]
+
+
+[tool.check-wheel-contents]
+toplevel = ["napari", "napari_builtins"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,7 +373,7 @@ napari_builtins = [
 
 [tool.setuptools_scm]
 write_to = "src/napari/_version.py"
-fallback_version = "0.6.4.dev0"
+fallback_version = "0.7.1.dev0"
 
 [tool.check-manifest]
 ignore = [

--- a/src/napari/resources/icons/none.svg
+++ b/src/napari/resources/icons/none.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 90"></svg>


### PR DESCRIPTION
# References and relevant issues

# Description

When reviewing release notes I spot that we run normal seeps with unnecessary permissions. 

This PR refactors make_release workflow for a better separation and limit permissions only where it is needed. 

