### PR TITLE
Ensure all napari and plugin commands use . instead of :

### DIFF
--- a/src/napari/_qt/_qapp_model/_tests/test_file_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_file_menu.py
@@ -47,7 +47,7 @@ def test_sample_data_triggers_reader_dialog(
             'napari._qt.dialogs.qt_reader_dialog.handle_gui_reading'
         ) as mock_read,
     ):
-        app.commands.execute_command('tmp_plugin:tmp-sample')
+        app.commands.execute_command('tmp_plugin.tmp-sample')
 
     # assert that handle gui reading was called
     mock_read.assert_called_once()
@@ -67,9 +67,9 @@ def test_plugin_display_name_use_for_multiple_samples(
     assert samples_menu[0].title == 'napari builtins'
     # Now ensure that the actions are still correct
     # trigger the action, opening the first sample: `Astronaut`
-    assert 'napari:astronaut' in app.commands
+    assert 'napari.astronaut' in app.commands
     assert len(viewer.layers) == 0
-    app.commands.execute_command('napari:astronaut')
+    app.commands.execute_command('napari.astronaut')
     assert len(viewer.layers) == 1
     assert viewer.layers[0].name == 'astronaut'
 
@@ -109,19 +109,19 @@ def test_sample_menu_plugin_state_change(
     assert len(samples_sub_menu) == 2
     assert isinstance(samples_sub_menu[0], MenuItem)
     assert samples_sub_menu[0].command.title == 'Temp Sample One'
-    assert 'tmp_plugin:tmp-sample-1' in app.commands
+    assert 'tmp_plugin.tmp-sample-1' in app.commands
 
     # Disable plugin
     pm.disable(tmp_plugin.name)
     with pytest.raises(KeyError):
         app.menus.get_menu(MenuId.FILE_SAMPLES)
-    assert 'tmp_plugin:tmp-sample-1' not in app.commands
+    assert 'tmp_plugin.tmp-sample-1' not in app.commands
 
     # Enable plugin
     pm.enable(tmp_plugin.name)
     samples_sub_menu = app.menus.get_menu(MenuId.FILE_SAMPLES + '/tmp_plugin')
     assert len(samples_sub_menu) == 2
-    assert 'tmp_plugin:tmp-sample-1' in app.commands
+    assert 'tmp_plugin.tmp-sample-1' in app.commands
 
 
 def test_sample_menu_single_data(
@@ -143,7 +143,7 @@ def test_sample_menu_single_data(
     assert isinstance(samples_menu[0], MenuItem)
     assert len(samples_menu) == 1
     assert samples_menu[0].command.title == 'Temp Sample One (Temp Plugin)'
-    assert 'tmp_plugin:tmp-sample-1' in app.commands
+    assert 'tmp_plugin.tmp-sample-1' in app.commands
 
 
 def test_sample_menu_sorted(

--- a/src/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
@@ -60,7 +60,7 @@ def test_toggle_or_get_widget(
     viewer = make_napari_viewer(show=True)
 
     # Trigger the action, opening the widget: `Widget 1`
-    app.commands.execute_command('tmp_plugin:Widget')
+    app.commands.execute_command('tmp_plugin.Widget')
     widget = viewer.window._wrapped_dock_widgets[full_name]
     # Widget takes some time to appear
     qtbot.waitUntil(widget.isVisible)
@@ -105,9 +105,9 @@ def test_plugin_single_widget_menu(
     plugin_menu = app.menus.get_menu('napari/plugins')
     assert plugin_menu[0].command.title == 'Widget 1 (Temp Plugin)'
     assert len(viewer.window._wrapped_dock_widgets) == 0
-    assert 'tmp_plugin:Widget 1' in app.commands
+    assert 'tmp_plugin.Widget 1' in app.commands
     # trigger the action, opening the widget: `Widget 1`
-    app.commands.execute_command('tmp_plugin:Widget 1')
+    app.commands.execute_command('tmp_plugin.Widget 1')
     assert len(viewer.window._wrapped_dock_widgets) == 1
     assert 'Widget 1 (Temp Plugin)' in viewer.window._wrapped_dock_widgets
 
@@ -135,9 +135,9 @@ def test_plugin_multiple_widget_menu(
     plugin_submenu = app.menus.get_menu('napari/plugins/tmp_plugin')
     assert plugin_submenu[0].command.title == 'Widget 1'
     assert len(viewer.window._wrapped_dock_widgets) == 0
-    assert 'tmp_plugin:Widget 1' in app.commands
+    assert 'tmp_plugin.Widget 1' in app.commands
     # Trigger the action, opening the first widget: `Widget 1`
-    app.commands.execute_command('tmp_plugin:Widget 1')
+    app.commands.execute_command('tmp_plugin.Widget 1')
     assert len(viewer.window._wrapped_dock_widgets) == 1
     assert 'Widget 1 (Temp Plugin)' in viewer.window._wrapped_dock_widgets
 
@@ -175,13 +175,13 @@ def test_plugin_menu_plugin_state_change(
     assert len(plugin_submenu) == 2
     assert isinstance(plugin_submenu[0], MenuItem)
     assert plugin_submenu[0].command.title == 'Widget 1'
-    assert 'tmp_plugin:Widget 1' in app.commands
+    assert 'tmp_plugin.Widget 1' in app.commands
 
     # Disable plugin
     pm.disable(tmp_plugin.name)
     with pytest.raises(KeyError):
         app.menus.get_menu(MenuId.MENUBAR_PLUGINS + '/tmp_plugin')
-    assert 'tmp_plugin:Widget 1' not in app.commands
+    assert 'tmp_plugin.Widget 1' not in app.commands
 
     # Enable plugin
     pm.enable(tmp_plugin.name)
@@ -189,7 +189,7 @@ def test_plugin_menu_plugin_state_change(
         MenuId.MENUBAR_PLUGINS + '/tmp_plugin'
     )
     assert len(samples_sub_menu) == 2
-    assert 'tmp_plugin:Widget 1' in app.commands
+    assert 'tmp_plugin.Widget 1' in app.commands
 
 
 def test_plugin_widget_checked(
@@ -204,8 +204,8 @@ def test_plugin_widget_checked(
     app = get_app_model()
     viewer = make_napari_viewer()
 
-    assert 'tmp_plugin:Widget' in app.commands
-    widget_action = viewer.window.plugins_menu.findAction('tmp_plugin:Widget')
+    assert 'tmp_plugin.Widget' in app.commands
+    widget_action = viewer.window.plugins_menu.findAction('tmp_plugin.Widget')
     assert not widget_action.isChecked()
     # Trigger the action, opening the widget
     widget_action.trigger()

--- a/src/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_plugins_menu.py
@@ -59,8 +59,8 @@ def test_toggle_or_get_widget(
     # Viewer needs to be visible
     viewer = make_napari_viewer(show=True)
 
-    # Trigger the action, opening the widget: `Widget 1`
-    app.commands.execute_command('tmp_plugin.Widget')
+    # Trigger the action, opening the widget
+    app.commands.execute_command('tmp_plugin.widget1')
     widget = viewer.window._wrapped_dock_widgets[full_name]
     # Widget takes some time to appear
     qtbot.waitUntil(widget.isVisible)
@@ -105,9 +105,9 @@ def test_plugin_single_widget_menu(
     plugin_menu = app.menus.get_menu('napari/plugins')
     assert plugin_menu[0].command.title == 'Widget 1 (Temp Plugin)'
     assert len(viewer.window._wrapped_dock_widgets) == 0
-    assert 'tmp_plugin.Widget 1' in app.commands
+    assert 'tmp_plugin.widget1' in app.commands
     # trigger the action, opening the widget: `Widget 1`
-    app.commands.execute_command('tmp_plugin.Widget 1')
+    app.commands.execute_command('tmp_plugin.widget1')
     assert len(viewer.window._wrapped_dock_widgets) == 1
     assert 'Widget 1 (Temp Plugin)' in viewer.window._wrapped_dock_widgets
 
@@ -135,9 +135,9 @@ def test_plugin_multiple_widget_menu(
     plugin_submenu = app.menus.get_menu('napari/plugins/tmp_plugin')
     assert plugin_submenu[0].command.title == 'Widget 1'
     assert len(viewer.window._wrapped_dock_widgets) == 0
-    assert 'tmp_plugin.Widget 1' in app.commands
+    assert 'tmp_plugin.widget1' in app.commands
     # Trigger the action, opening the first widget: `Widget 1`
-    app.commands.execute_command('tmp_plugin.Widget 1')
+    app.commands.execute_command('tmp_plugin.widget1')
     assert len(viewer.window._wrapped_dock_widgets) == 1
     assert 'Widget 1 (Temp Plugin)' in viewer.window._wrapped_dock_widgets
 
@@ -175,13 +175,13 @@ def test_plugin_menu_plugin_state_change(
     assert len(plugin_submenu) == 2
     assert isinstance(plugin_submenu[0], MenuItem)
     assert plugin_submenu[0].command.title == 'Widget 1'
-    assert 'tmp_plugin.Widget 1' in app.commands
+    assert 'tmp_plugin.widget1' in app.commands
 
     # Disable plugin
     pm.disable(tmp_plugin.name)
     with pytest.raises(KeyError):
         app.menus.get_menu(MenuId.MENUBAR_PLUGINS + '/tmp_plugin')
-    assert 'tmp_plugin.Widget 1' not in app.commands
+    assert 'tmp_plugin.widget1' not in app.commands
 
     # Enable plugin
     pm.enable(tmp_plugin.name)
@@ -189,7 +189,7 @@ def test_plugin_menu_plugin_state_change(
         MenuId.MENUBAR_PLUGINS + '/tmp_plugin'
     )
     assert len(samples_sub_menu) == 2
-    assert 'tmp_plugin.Widget 1' in app.commands
+    assert 'tmp_plugin.widget1' in app.commands
 
 
 def test_plugin_widget_checked(
@@ -204,8 +204,10 @@ def test_plugin_widget_checked(
     app = get_app_model()
     viewer = make_napari_viewer()
 
-    assert 'tmp_plugin.Widget' in app.commands
-    widget_action = viewer.window.plugins_menu.findAction('tmp_plugin.Widget')
+    assert 'tmp_plugin.widget_contrib' in app.commands
+    widget_action = viewer.window.plugins_menu.findAction(
+        'tmp_plugin.widget_contrib'
+    )
     assert not widget_action.isChecked()
     # Trigger the action, opening the widget
     widget_action.trigger()

--- a/src/napari/_qt/_qapp_model/qactions/_window.py
+++ b/src/napari/_qt/_qapp_model/qactions/_window.py
@@ -12,19 +12,19 @@ Q_WINDOW_ACTIONS: list[Action] = []
 
 toggle_action_details = [
     (
-        'napari.window.window.toggle_window_console',
+        'napari:window:toggle_window_console',
         trans._('Console'),
         'dockConsole',
         trans._('Toggle console panel'),
     ),
     (
-        'napari.window.window.toggle_layer_controls',
+        'napari:window:toggle_layer_controls',
         trans._('Layer Controls'),
         'dockLayerControls',
         trans._('Toggle layer controls panel'),
     ),
     (
-        'napari.window.window.toggle_layer_list',
+        'napari:window:toggle_layer_list',
         trans._('Layer List'),
         'dockLayerList',
         trans._('Toggle layer list panel'),

--- a/src/napari/_qt/_qapp_model/qactions/_window.py
+++ b/src/napari/_qt/_qapp_model/qactions/_window.py
@@ -12,19 +12,19 @@ Q_WINDOW_ACTIONS: list[Action] = []
 
 toggle_action_details = [
     (
-        'napari:window:window:toggle_window_console',
+        'napari.window.window.toggle_window_console',
         trans._('Console'),
         'dockConsole',
         trans._('Toggle console panel'),
     ),
     (
-        'napari:window:window:toggle_layer_controls',
+        'napari.window.window.toggle_layer_controls',
         trans._('Layer Controls'),
         'dockLayerControls',
         trans._('Toggle layer controls panel'),
     ),
     (
-        'napari:window:window:toggle_layer_list',
+        'napari.window.window.toggle_layer_list',
         trans._('Layer List'),
         'dockLayerList',
         trans._('Toggle layer list panel'),

--- a/src/napari/_qt/_qapp_model/qactions/_window.py
+++ b/src/napari/_qt/_qapp_model/qactions/_window.py
@@ -24,7 +24,7 @@ toggle_action_details = [
         trans._('Toggle layer controls panel'),
     ),
     (
-        'napari:window:toggle_layer_list',
+        'napari.window.toggle_layer_list',
         trans._('Layer List'),
         'dockLayerList',
         trans._('Toggle layer list panel'),

--- a/src/napari/_qt/_qapp_model/qactions/_window.py
+++ b/src/napari/_qt/_qapp_model/qactions/_window.py
@@ -18,7 +18,7 @@ toggle_action_details = [
         trans._('Toggle console panel'),
     ),
     (
-        'napari:window:toggle_layer_controls',
+        'napari.window.toggle_layer_controls',
         trans._('Layer Controls'),
         'dockLayerControls',
         trans._('Toggle layer controls panel'),

--- a/src/napari/_qt/_qapp_model/qactions/_window.py
+++ b/src/napari/_qt/_qapp_model/qactions/_window.py
@@ -12,7 +12,7 @@ Q_WINDOW_ACTIONS: list[Action] = []
 
 toggle_action_details = [
     (
-        'napari:window:toggle_window_console',
+        'napari.window.toggle_window_console',
         trans._('Console'),
         'dockConsole',
         trans._('Toggle console panel'),

--- a/src/napari/_qt/_qplugins/_qnpe2.py
+++ b/src/napari/_qt/_qplugins/_qnpe2.py
@@ -121,7 +121,7 @@ def _build_samples_submenu_actions(
         title = title.replace('&', '&&')
 
         action: Action = Action(
-            id=f'{mf.name}:{sample.key}',
+            id=f'{mf.name}.{sample.key}',
             title=title,
             menus=[{'id': submenu_id, 'group': MenuGroup.NAVIGATION}],
             callback=_add_sample_partial,
@@ -279,7 +279,7 @@ def _build_widgets_submenu_actions(
 
         widget_actions.append(
             Action(
-                id=f'{mf.name}:{widget.display_name}',
+                id=f'{mf.name}.{widget.display_name}',
                 title=title,
                 callback=_widget_callback,
                 menus=action_menus,

--- a/src/napari/_qt/_qplugins/_qnpe2.py
+++ b/src/napari/_qt/_qplugins/_qnpe2.py
@@ -121,7 +121,7 @@ def _build_samples_submenu_actions(
         title = title.replace('&', '&&')
 
         action: Action = Action(
-            id=f'{mf.name}.{sample.key}',
+            id=sample.command,
             title=title,
             menus=[{'id': submenu_id, 'group': MenuGroup.NAVIGATION}],
             callback=_add_sample_partial,
@@ -279,7 +279,7 @@ def _build_widgets_submenu_actions(
 
         widget_actions.append(
             Action(
-                id=f'{mf.name}.{widget.display_name}',
+                id=widget.command,
                 title=title,
                 callback=_widget_callback,
                 menus=action_menus,

--- a/src/napari/_qt/_qplugins/_qnpe2.py
+++ b/src/napari/_qt/_qplugins/_qnpe2.py
@@ -121,7 +121,7 @@ def _build_samples_submenu_actions(
         title = title.replace('&', '&&')
 
         action: Action = Action(
-            id=sample.command,
+            id=f'{mf.name}.{sample.key}',
             title=title,
             menus=[{'id': submenu_id, 'group': MenuGroup.NAVIGATION}],
             callback=_add_sample_partial,

--- a/src/napari/_qt/_tests/test_plugin_widgets.py
+++ b/src/napari/_qt/_tests/test_plugin_widgets.py
@@ -164,5 +164,5 @@ def test_widget_types_supported(
     viewer.window.add_dock_widget = Mock(
         side_effect=viewer.window.add_dock_widget
     )
-    app.commands.execute_command('tmp_plugin:Widget')
+    app.commands.execute_command('tmp_plugin.Widget')
     viewer.window.add_dock_widget.assert_called_once()

--- a/src/napari/_qt/_tests/test_plugin_widgets.py
+++ b/src/napari/_qt/_tests/test_plugin_widgets.py
@@ -164,5 +164,6 @@ def test_widget_types_supported(
     viewer.window.add_dock_widget = Mock(
         side_effect=viewer.window.add_dock_widget
     )
-    app.commands.execute_command('tmp_plugin.Widget')
+    (widget_contrib,) = tmp_plugin.manifest.contributions.widgets
+    app.commands.execute_command(widget_contrib.command)
     viewer.window.add_dock_widget.assert_called_once()

--- a/src/napari/_qt/dialogs/_tests/test_reader_dialog.py
+++ b/src/napari/_qt/dialogs/_tests/test_reader_dialog.py
@@ -161,7 +161,7 @@ def test_open_sample_data_shows_all_readers(
             'napari._qt.dialogs.qt_reader_dialog.handle_gui_reading'
         ) as mock_read,
     ):
-        app.commands.execute_command('tmp_plugin:tmp-sample')
+        app.commands.execute_command('tmp_plugin.tmp-sample')
 
     mock_read.assert_called_once_with(
         ['some-path/some-file.fake'],

--- a/src/napari/_qt/widgets/qt_command_palette.py
+++ b/src/napari/_qt/widgets/qt_command_palette.py
@@ -413,8 +413,7 @@ def _match_score(action: CommandRule, input_text: str) -> float:
 
 
 def _format_action_name(cmd: CommandRule) -> str:
-    sep = ':' if ':' in cmd.id else '.'
-    *contexts, _ = cmd.id.split(sep)
+    *contexts, _ = cmd.id.split('.')
     title = ' > '.join(contexts)
     desc = cmd.title
     if title:


### PR DESCRIPTION
# References and relevant issues
Fixes #8358 

# Description
- replace` :` with` .` as a separator across plugin and built in commands
- and updates test assertions.




