### PR TITLE
[Maint, security] Apply zizmor --fix=all fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
         patterns:
           - "*"
     cooldown:
-      default-days: 5
+      default-days: 7

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Check workflow files
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -59,7 +59,9 @@ jobs:
 
       - name: Replace URLs
         run: |
-          sed -i 's@||BENCHMARK_CI_LOGS_URL||@${{ github.event.workflow_run.html_url }}@g' message.txt
+          sed -i 's@||BENCHMARK_CI_LOGS_URL||@${GITHUB_EVENT_WORKFLOW_RUN_HTML_URL}@g' message.txt
+        env:
+          GITHUB_EVENT_WORKFLOW_RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
 
       - name: Collect PR number if available
         run: |

--- a/.github/workflows/benchmarks_report.yml
+++ b/.github/workflows/benchmarks_report.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Replace URLs
         run: |
-          sed -i 's@||BENCHMARK_CI_LOGS_URL||@${GITHUB_EVENT_WORKFLOW_RUN_HTML_URL}@g' message.txt
+          sed -i "s@||BENCHMARK_CI_LOGS_URL||@${GITHUB_EVENT_WORKFLOW_RUN_HTML_URL}@g" message.txt
         env:
           GITHUB_EVENT_WORKFLOW_RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
 

--- a/.github/workflows/citation_cff_validate.yml
+++ b/.github/workflows/citation_cff_validate.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Validate CITATION.cff
         uses: dieghernan/cff-validator@114aae53e1850c3757733beb60036941900e3dc3 # v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -97,4 +99,6 @@ jobs:
 
       - name: Test Docker image
         run: |
-          docker run --rm --entrypoint=/bin/bash ${{ steps.docker_build.outputs.imageid }} -ec "python3 -m napari --version"
+          docker run --rm --entrypoint=/bin/bash ${STEPS_DOCKER_BUILD_OUTPUTS_IMAGEID} -ec "python3 -m napari --version"
+        env:
+          STEPS_DOCKER_BUILD_OUTPUTS_IMAGEID: ${{ steps.docker_build.outputs.imageid }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,6 +99,6 @@ jobs:
 
       - name: Test Docker image
         run: |
-          docker run --rm --entrypoint=/bin/bash ${STEPS_DOCKER_BUILD_OUTPUTS_IMAGEID} -ec "python3 -m napari --version"
+          docker run --rm --entrypoint=/bin/bash "${STEPS_DOCKER_BUILD_OUTPUTS_IMAGEID}" -ec "python3 -m napari --version"
         env:
           STEPS_DOCKER_BUILD_OUTPUTS_IMAGEID: ${{ steps.docker_build.outputs.imageid }}

--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: napari/napari
+          persist-credentials: false
       # install python and requests
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -98,6 +98,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Verify PR author exists in CITATION.cff
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -20,11 +20,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Checkout docs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: napari/docs
           path: docs
+          persist-credentials: false
 
       - name: Install Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/reusable_build_wheel.yml
+++ b/.github/workflows/reusable_build_wheel.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/reusable_pip_test.yml
+++ b/.github/workflows/reusable_pip_test.yml
@@ -14,8 +14,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: napari-from-github
+          persist-credentials: false
       - name: Cache pooch downloads
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ${{ github.workspace }}/.cache/scikit-image
@@ -50,7 +51,7 @@ jobs:
 
       - name: Install napari from wheel
         run: |
-          pip install "${{ env.WHEEL_PATH }}[pyqt]"
+          pip install "${WHEEL_PATH}[pyqt]"
           pip install --group napari-from-github/pyproject.toml:testing
         shell:
             bash

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -67,8 +67,10 @@ jobs:
       XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Cache pooch downloads
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ${{ github.workspace }}/.cache/scikit-image
@@ -141,18 +143,20 @@ jobs:
         # FOURTH=none
         shell: bash
         run: |
-          python tools/split_qt_backend.py 0 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
-          python tools/split_qt_backend.py 1 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
-          python tools/split_qt_backend.py 2 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
-          python tools/split_qt_backend.py 3 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 0 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 1 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 2 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 3 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
+        env:
+          INPUTS_QT_BACKEND: ${{ inputs.qt_backend }}
 
       - name: Test with tox main qt_backend
         timeout-minutes: ${{ inputs.timeout }}
         shell: bash
         run: |
-          echo ${{ env.MAIN }}
+          echo ${MAIN}
           tox --version
-          python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.MAIN }}
@@ -163,7 +167,7 @@ jobs:
         if : ${{ env.SECOND != 'none' }}
         shell: bash
         run: |
-          python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.SECOND }}
@@ -174,7 +178,7 @@ jobs:
         if : ${{ env.THIRD != 'none' }}
         shell: bash
         run: |
-          python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.THIRD }}
@@ -185,7 +189,7 @@ jobs:
         if: ${{ env.FOURTH != 'none' }}
         shell: bash
         run: |
-          python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.FOURTH }}

--- a/.github/workflows/reusable_run_tox_test.yml
+++ b/.github/workflows/reusable_run_tox_test.yml
@@ -143,10 +143,10 @@ jobs:
         # FOURTH=none
         shell: bash
         run: |
-          python tools/split_qt_backend.py 0 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
-          python tools/split_qt_backend.py 1 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
-          python tools/split_qt_backend.py 2 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
-          python tools/split_qt_backend.py 3 ${INPUTS_QT_BACKEND} >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 0 "${INPUTS_QT_BACKEND}" >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 1 "${INPUTS_QT_BACKEND}" >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 2 "${INPUTS_QT_BACKEND}" >> "$GITHUB_ENV"
+          python tools/split_qt_backend.py 3 "${INPUTS_QT_BACKEND}" >> "$GITHUB_ENV"
         env:
           INPUTS_QT_BACKEND: ${{ inputs.qt_backend }}
 
@@ -154,9 +154,9 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         shell: bash
         run: |
-          echo ${MAIN}
+          echo "${MAIN}"
           tox --version
-          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg "${WHEEL_PATH}" -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.MAIN }}
@@ -167,7 +167,7 @@ jobs:
         if : ${{ env.SECOND != 'none' }}
         shell: bash
         run: |
-          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg "${WHEEL_PATH}" -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.SECOND }}
@@ -178,7 +178,7 @@ jobs:
         if : ${{ env.THIRD != 'none' }}
         shell: bash
         run: |
-          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg "${WHEEL_PATH}" -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.THIRD }}
@@ -189,7 +189,7 @@ jobs:
         if: ${{ env.FOURTH != 'none' }}
         shell: bash
         run: |
-          python -m tox run --installpkg ${WHEEL_PATH} -- --basetemp=.pytest_tmp
+          python -m tox run --installpkg "${WHEEL_PATH}" -- --basetemp=.pytest_tmp
           rm -r .tox
         env:
           BACKEND: ${{ env.FOURTH }}

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: "Set up Python 3.12"
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -118,6 +120,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GHA_TOKEN_BOT_REPO_WORKFLOW }}
+          persist-credentials: false
       - name: Synchronize bot repository
         run: |
           git remote add napari-bot https://github.com/napari-bot/napari.git

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python 3.12
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -39,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
@@ -64,6 +68,8 @@ jobs:
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
@@ -215,6 +221,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/test_translations.yml
+++ b/.github/workflows/test_translations.yml
@@ -15,6 +15,8 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/test_typing.yml
+++ b/.github/workflows/test_typing.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"

--- a/.github/workflows/test_vendored.yml
+++ b/.github/workflows/test_vendored.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -89,11 +89,12 @@ jobs:
         if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
         run: |
           echo "FULL_NAME=${{ github.repository }}" >> "$GITHUB_ENV"
-          echo "BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Clone target repo (remote)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -103,6 +104,7 @@ jobs:
           repository: ${{ env.FULL_NAME }}
           ref: ${{ env.BRANCH }}
           token: ${{ secrets.GHA_TOKEN_BOT_REPO }}
+          persist-credentials: false
 
       - name: Clone target repo (pull request)
         # we need separate step as passing empty token to actions/checkout@v4 will not work
@@ -110,6 +112,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           path: napari_repo  # place in a named directory
+          persist-credentials: false
 
       - name: Clone target repo (main)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -119,6 +122,7 @@ jobs:
           repository: ${{ env.FULL_NAME }}
           ref: ${{ env.BRANCH }}
           token: ${{ secrets.GHA_TOKEN_BOT_REPO }}
+          persist-credentials: false
 
       - name: Add napari-bot/napari to napari_repo upstreams
         run: |
@@ -127,7 +131,7 @@ jobs:
           git remote add napari-bot https://github.com/napari-bot/napari.git
           git remote -v
       - name: Set up Python 3.12
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
# References and relevant issues
Part of mitigating: https://github.com/napari/napari/security/code-scanning

# Description
I ran `zizmor --gh-token $(gh auth token) --fix=all .` on the repo.

Note: this includes "unsafe" fixes, which was all but the dependabot one.

Looks like it takes us down from 102 to 60:
https://github.com/napari/napari/security/code-scanning?query=is%3Aopen+pr%3A8885+

```
Fix Summary
Successfully applied fixes to 19 files:
  ./.github/workflows/test_comprehensive.yml: 2 fixes
  ./.github/workflows/test_typing.yml: 1 fixes
  ./.github/workflows/test_translations.yml: 1 fixes
  ./.github/workflows/docker-publish.yml: 2 fixes
  ./.github/workflows/test_prereleases.yml: 1 fixes
  ./.github/workflows/make_release.yml: 2 fixes
  ./.github/workflows/citation_cff_validate.yml: 1 fixes
  ./.github/workflows/test_pull_requests.yml: 4 fixes
  ./.github/workflows/benchmarks.yml: 1 fixes
  ./.github/workflows/reusable_build_wheel.yml: 1 fixes
  ./.github/workflows/benchmarks_report.yml: 1 fixes
  ./.github/workflows/edit_pr_description.yml: 1 fixes
  ./.github/workflows/reusable_pip_test.yml: 3 fixes
  ./.github/dependabot.yml: 1 fixes
  ./.github/workflows/upgrade_test_constraints.yml: 6 fixes
  ./.github/workflows/actionlint.yml: 1 fixes
  ./.github/workflows/reusable_run_tox_test.yml: 11 fixes
  ./.github/workflows/label_and_milestone_checker.yml: 1 fixes
  ./.github/workflows/test_vendored.yml: 1 fixes
```


Full run output:
<details>

```
❯ zizmor --gh-token $(gh auth token) --fix=all .
 INFO zizmor: 🌈 zizmor v1.24.0
 INFO audit: zizmor: 🌈 completed ./.github/dependabot.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/actionlint.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/benchmark_labels_trigger.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/benchmarks.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/benchmarks_report.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/build_docs.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/circleci.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/citation_cff_validate.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/constraints_comment_trigger.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/deploy_docs.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/docker-publish.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/edit_pr_description.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/label_and_milestone_checker.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/labeler.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/make_bundle_conda.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/make_release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/pr_dependency.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/remove_ready_to_merge.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/reusable_build_wheel.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/reusable_pip_test.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/reusable_run_tox_test.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test_comprehensive.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test_prereleases.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test_pull_requests.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test_translations.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test_typing.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test_vendored.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/upgrade_test_constraints.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/zizmor.yml
help[dependabot-cooldown]: insufficient cooldown in Dependabot updates
  --> ./.github/dependabot.yml:18:7
   |
18 |       default-days: 5
   |       ^^^^^^^^^^^^^^^ insufficient default-days configured (less than 7)
   |
   = note: audit confidence → Medium
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/actionlint.yml:14:9
   |
14 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/actionlint.yml:10:3
   |
10 | /   actionlint:
11 | |     name: Action lint
12 | |     runs-on: ubuntu-slim
13 | |     steps:
...  |
18 | |           ./actionlint -color -ignore SC2129
19 | |         shell: bash
   | |                    ^
   | |                    |
   | |____________________this job
   |                      default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/benchmark_labels_trigger.yml:14:11
   |
14 |     uses: ./.github/workflows/benchmarks.yml
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this reusable workflow
15 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/benchmarks.yml:62:9
   |
62 |         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |  _________^
63 | |         with:
64 | |           fetch-depth: 0
   | |________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/benchmarks.yml:6:1
    |
  6 | / name: Benchmarks
  7 | |
  8 | | on:
  9 | |   workflow_call:
...   |
219 | |           name: asv-benchmark-results-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
220 | |           path: asv_result
    | |___________________________^ default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/benchmarks.yml:205:3
    |
205 | /   combine-artifacts:
206 | |     runs-on: ubuntu-latest
207 | |     needs: benchmark
208 | |     if: always() && needs.benchmark.result != 'skipped'
...   |
219 | |           name: asv-benchmark-results-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
220 | |           path: asv_result
    | |                           ^
    | |                           |
    | |___________________________this job
    |                             default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/benchmarks.yml:119:47
    |
106 |         run: |
    |         --- this run block
...
119 |             echo "Baseline:  ${BASE_REF} (${{ github.event.pull_request.base.label }})"
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/benchmarks.yml:123:27
    |
106 |         run: |
    |         --- this run block
...
123 |             BASE_REF="${{ fromJSON(steps.latest_release.outputs.data).target_commitish }}"
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/benchmarks.yml:125:47
    |
106 |         run: |
    |         --- this run block
...
125 |             echo "Baseline:  ${BASE_REF} (${{ fromJSON(steps.latest_release.outputs.data).tag_name }})"
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/benchmarks.yml:129:27
    |
106 |         run: |
    |         --- this run block
...
129 |             BASE_REF="${{ github.event.inputs.base_ref }}"
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/benchmarks.yml:130:32
    |
106 |         run: |
    |         --- this run block
...
130 |             CONTENDER_REF="${{ github.event.inputs.contender_ref }}"
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/benchmarks.yml:190:38
    |
176 |         run: |
    |         --- this run block
...
190 |           "finished with status '${{ steps.run_benchmark.outcome }}'. See the" \
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> ./.github/workflows/benchmarks.yml:88:81
   |
88 |       - uses: octokit/request-action@10df4beff76ddd0c48b0e983ecde429e7174dfd3 # v2.x
   |                                                                                 ^^ points to unknown ref
   |
   = note: audit confidence → High

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> ./.github/workflows/benchmarks_report.yml:12:1
   |
12 | / on:
13 | |   workflow_run:
14 | |     workflows: [Benchmarks, "Benchmark Trigger by Label"]
15 | |     types:
16 | |       - completed
   | |_________________^ workflow_run is almost always used insecurely
   |
   = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/benchmarks_report.yml:62:51
   |
61 |         run: |
   |         --- this run block
62 |           sed -i 's@||BENCHMARK_CI_LOGS_URL||@${{ github.event.workflow_run.html_url }}@g' message.txt
   |                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

error[github-env]: dangerous use of environment file
  --> ./.github/workflows/benchmarks_report.yml:65:9
   |
65 | /         run: |
66 | |           if [[ -f pr_number ]]; then
67 | |             echo "PR_NUMBER=$(cat pr_number)" >> "$GITHUB_ENV"
68 | |           fi
   | |____________^ write to GITHUB_ENV may allow code execution
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/build_docs.yml:21:3
   |
21 | /   build_docs:
22 | |     uses: napari/shared-workflows/.github/workflows/build_docs.yml@main
23 | |     secrets: inherit
24 | |     with:
...  |
28 | |       docs-ref: main
29 | |       make_target: "html"
   | |                          ^
   | |                          |
   | |__________________________this job
   |                            default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/build_docs.yml:22:11
   |
22 |     uses: napari/shared-workflows/.github/workflows/build_docs.yml@main
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/build_docs.yml:22:11
   |
22 |     uses: napari/shared-workflows/.github/workflows/build_docs.yml@main
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this reusable workflow
23 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/citation_cff_validate.yml:19:9
   |
19 |         - name: Checkout
   |  _________^
20 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   | |________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/citation_cff_validate.yml:12:3
   |
12 | /   Validate-CITATION-cff:
13 | |     runs-on: ubuntu-latest
14 | |     name: Validate CITATION.cff
15 | |     env:
...  |
22 | |       - name: Validate CITATION.cff
23 | |         uses: dieghernan/cff-validator@114aae53e1850c3757733beb60036941900e3dc3 # v4
   | |                                                                                     ^
   | |                                                                                     |
   | |_____________________________________________________________________________________this job
   |                                                                                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[excessive-permissions]: overly broad permissions
 --> ./.github/workflows/constraints_comment_trigger.yml:8:3
  |
8 |   pull-requests: write
  |   ^^^^^^^^^^^^^^^^^^^^ pull-requests: write is overly broad at the workflow level
  |
  = note: audit confidence → High

error[excessive-permissions]: overly broad permissions
 --> ./.github/workflows/constraints_comment_trigger.yml:9:3
  |
9 |   issues: write
  |   ^^^^^^^^^^^^^ issues: write is overly broad at the workflow level
  |
  = note: audit confidence → High

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/constraints_comment_trigger.yml:28:11
   |
28 |     uses: ./.github/workflows/upgrade_test_constraints.yml
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this reusable workflow
29 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/deploy_docs.yml:17:3
   |
17 | /   build-napari-docs:
18 | |     name: Build docs on napari/docs
19 | |     runs-on: ubuntu-latest
20 | |     steps:
...  |
47 | |           wait_workflow: true
48 | |           client_payload: '{"target_directory": "${{ env.target_directory }}", "napari_ref": "${{ env.branch_name }}", "docs_ref": "main"}'
   | |                                                                                                                                            ^
   | |                                                                                                                                            |
   | |____________________________________________________________________________________________________________________________________________this job
   |                                                                                                                                              default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/docker-publish.yml:45:9
   |
45 |         - name: Checkout repository
   |  _________^
46 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
47 | |
48 | |       # Login against a Docker registry except on PR
49 | |       # https://github.com/docker/login-action
   | |______________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/docker-publish.yml:100:54
    |
 99 |         run: |
    |         --- this run block
100 |           docker run --rm --entrypoint=/bin/bash ${{ steps.docker_build.outputs.imageid }} -ec "python3 -m napari --version"
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/edit_pr_description.yml:21:9
   |
21 |         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |  _________^
22 | |         with:
23 | |           repository: napari/napari
24 | |       # install python and requests
   | |___________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> ./.github/workflows/edit_pr_description.yml:3:1
   |
 3 | / on:
 4 | |   # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 5 | |   pull_request_target:
 6 | |     types:
...  |
11 | |   workflow_call:
12 | | # see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
   | |_________________________________________________________________________________^ pull_request_target is almost always used insecurely
   |
   = note: audit confidence → Medium

help[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/label_and_milestone_checker.yml:99:9
    |
 99 |         - name: Checkout repository
    |  _________^
100 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
    | |_________________________________________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/label_and_milestone_checker.yml:1:1
    |
  1 | / name: Labels and milestone
  2 | | on:
  3 | |   pull_request:
  4 | |     types:
...   |
125 | |             exit 1
126 | |           fi
    | |_____________^ default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/label_and_milestone_checker.yml:16:3
   |
16 | /   check_labels:
17 | |     if: (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ready to merge'))
18 | |     name: Check ready-to-merge PR has at least one type label
19 | |     runs-on: ubuntu-slim
...  |
46 | |           echo "  $allowed_labels"
47 | |           exit 1
   | |                ^
   | |                |
   | |________________this job
   |                  default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/label_and_milestone_checker.yml:49:3
   |
49 | /   check_next_milestone:
50 | |     name: Check milestone is next release
51 | |     if: (github.event_name == 'pull_request' && github.event.pull_request.milestone != null)
52 | |     runs-on: ubuntu-slim
...  |
91 | |             exit 1
92 | |           fi
   | |            ^
   | |            |
   | |____________this job
   |              default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/label_and_milestone_checker.yml:94:3
    |
 94 | /   check_citation_cff_for_pr_author:
 95 | |     name: Check PR author is in CITATION.cff
 96 | |     if: (github.event_name == 'pull_request')
 97 | |     runs-on: ubuntu-slim
...   |
125 | |             exit 1
126 | |           fi
    | |             ^
    | |             |
    | |_____________this job
    |               default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/labeler.yml:3:1
  |
3 | / on:
4 | | - pull_request_target
  | |_____________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/make_bundle_conda.yml:16:11
   |
16 |     uses: napari/packaging/.github/workflows/make_bundle_conda.yml@main
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/make_bundle_conda.yml:16:11
   |
16 |     uses: napari/packaging/.github/workflows/make_bundle_conda.yml@main
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this reusable workflow
17 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/make_release.yml:21:9
   |
21 |         - name: Checkout code
   |  _________^
22 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   | |________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/make_release.yml:23:9
   |
23 |         - name: Checkout docs
   |  _________^
24 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
25 | |         with:
26 | |           repository: napari/docs
27 | |           path: docs
   | |____________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

info[superfluous-actions]: action functionality is already included by the runner
  --> ./.github/workflows/make_release.yml:57:15
   |
56 |       - name: Create Release
   |         -------------------- this step
57 |         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use `gh release` in a script step
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/pr_dependency.yml:9:3
   |
 9 | /   check_dependencies:
10 | |     runs-on: ubuntu-slim
11 | |     if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, 'merge')) || github.event_name == 'pull_requ...
12 | |     name: Check Dependencies
...  |
15 | |       env:
16 | |         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   | |                                                  ^
   | |                                                  |
   | |__________________________________________________this job
   |                                                    default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/reusable_build_wheel.yml:10:9
   |
10 |         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |  _________^
11 | |         with:
12 | |           fetch-depth: 0
   | |________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/reusable_pip_test.yml:14:9
   |
14 |         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |  _________^
15 | |         with:
16 | |           path: napari-from-github
   | |__________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[template-injection]: code injection via template expansion
  --> ./.github/workflows/reusable_pip_test.yml:53:28
   |
52 |         run: |
   |         --- this run block
53 |           pip install "${{ env.WHEEL_PATH }}[pyqt]"
   |                            ^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> ./.github/workflows/reusable_pip_test.yml:18:72
   |
18 |         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v4
   |         ------------------------------------------------------------   ^^ points to commit 0057852bfaa8
   |         |
   |         is pointed to by tag v5.0.4
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/reusable_run_tox_test.yml:69:9
   |
69 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:144:50
    |
143 |         run: |
    |         --- this run block
144 |           python tools/split_qt_backend.py 0 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
    |                                                  ^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:145:50
    |
143 |         run: |
    |         --- this run block
144 |           python tools/split_qt_backend.py 0 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
145 |           python tools/split_qt_backend.py 1 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
    |                                                  ^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:146:50
    |
143 |         run: |
    |         --- this run block
...
146 |           python tools/split_qt_backend.py 2 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
    |                                                  ^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:147:50
    |
143 |         run: |
    |         --- this run block
...
147 |           python tools/split_qt_backend.py 3 ${{ inputs.qt_backend }} >> "$GITHUB_ENV"
    |                                                  ^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

help[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:153:20
    |
152 |         run: |
    |         --- this run block
153 |           echo ${{ env.MAIN }}
    |                    ^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

help[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:155:46
    |
152 |         run: |
    |         --- this run block
...
155 |           python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
    |                                              ^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

help[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:166:46
    |
165 |         run: |
    |         --- this run block
166 |           python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
    |                                              ^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

help[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:177:46
    |
176 |         run: |
    |         --- this run block
177 |           python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
    |                                              ^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

help[template-injection]: code injection via template expansion
   --> ./.github/workflows/reusable_run_tox_test.yml:188:46
    |
187 |         run: |
    |         --- this run block
188 |           python -m tox run --installpkg ${{ env.WHEEL_PATH }} -- --basetemp=.pytest_tmp
    |                                              ^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> ./.github/workflows/reusable_run_tox_test.yml:71:72
   |
71 |         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v4
   |         ------------------------------------------------------------   ^^ points to commit 0057852bfaa8
   |         |
   |         is pointed to by tag v5.0.4
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_comprehensive.yml:29:9
   |
29 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/test_comprehensive.yml:118:9
    |
118 |         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
    |  _________^
119 | |         with:
120 | |           token: ${{ secrets.GHA_TOKEN_BOT_REPO_WORKFLOW }}
    | |___________________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_comprehensive.yml:3:1
    |
  3 | / name: Comprehensive Test
  4 | |
  5 | | on:
  6 | |   push:
...   |
135 | |           filename: .github/BOT_REPO_UPDATE_FAIL_TEMPLATE.md
136 | |           update_existing: true
    | |________________________________^ default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_comprehensive.yml:25:3
   |
25 | /   manifest:
26 | |     name: Check Manifest
27 | |     runs-on: ubuntu-latest
28 | |     steps:
...  |
38 | |       - name: Check Manifest
39 | |         run: check-manifest
   | |                           ^
   | |                           |
   | |___________________________this job
   |                             default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_comprehensive.yml:41:3
   |
41 | /   build_wheel:
42 | |     name: Build wheel
43 | |     uses: ./.github/workflows/reusable_build_wheel.yml
   | |                                                      ^
   | |                                                      |
   | |______________________________________________________this job
   |                                                        default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_comprehensive.yml:45:3
   |
45 | /   test:
46 | |     name: ${{ matrix.platform }}
47 | |     uses: ./.github/workflows/reusable_run_tox_test.yml
48 | |     needs: build_wheel
...  |
82 | |       coverage: cov
83 | |       tox_extras: ${{ matrix.tox_extras }}
   | |                                          ^
   | |                                          |
   | |__________________________________________this job
   |                                            default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_comprehensive.yml:85:3
   |
85 | /   test_pip_install:
86 | |     name: pip install
87 | |     uses: ./.github/workflows/reusable_pip_test.yml
   | |                                                   ^
   | |                                                   |
   | |___________________________________________________this job
   |                                                     default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_comprehensive.yml:89:3
   |
89 | /   test_examples:
90 | |     name: test examples
91 | |     uses: ./.github/workflows/reusable_run_tox_test.yml
92 | |     needs: build_wheel
...  |
97 | |         constraints_suffix: _examples
98 | |         coverage: cov
   | |                     ^
   | |                     |
   | |_____________________this job
   |                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_comprehensive.yml:100:3
    |
100 | /   coverage_report:
101 | |     if: ${{ always() }}
102 | |     secrets: inherit
103 | |     needs:
...   |
107 | |     with:
108 | |       artifact-pattern: 'coverage reports*'
    | |                                           ^
    | |                                           |
    | |___________________________________________this job
    |                                             default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/test_comprehensive.yml:106:11
    |
106 |     uses: napari/shared-workflows/.github/workflows/upload_coverage.yml@main
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
   --> ./.github/workflows/test_comprehensive.yml:106:11
    |
102 |     secrets: inherit
    |     ---------------- inherits all parent secrets
...
106 |     uses: napari/shared-workflows/.github/workflows/upload_coverage.yml@main
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this reusable workflow
    |
    = note: audit confidence → High

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_prereleases.yml:40:9
   |
40 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_pull_requests.yml:23:9
   |
23 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_pull_requests.yml:41:9
   |
41 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_pull_requests.yml:66:9
   |
66 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/test_pull_requests.yml:215:9
    |
215 |         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
    |  _________^
216 | |         with:
217 | |           fetch-depth: 0
    | |________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_pull_requests.yml:2:1
    |
  2 | / name: PR Test
  3 | |
  4 | | on:
  5 | |   pull_request:
...   |
275 | |           name: triangulation-benchmarks
276 | |           path: /tmp/napari*
    | |_____________________________^ default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_pull_requests.yml:18:3
   |
18 | /   import_lint:
19 | |     name: Import lint
20 | |     timeout-minutes: 5
21 | |     runs-on: ubuntu-latest
...  |
32 | |       - name: Run import lint
33 | |         run: tox -e import-lint
   | |                               ^
   | |                               |
   | |_______________________________this job
   |                                 default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_pull_requests.yml:35:3
   |
35 | /   manifest:
36 | |     # make sure all necessary files will be bundled in the release
37 | |     name: Check Manifest
38 | |     timeout-minutes: 15
...  |
57 | |         run: |
58 | |           make check-manifest
   | |                             ^
   | |                             |
   | |_____________________________this job
   |                               default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_pull_requests.yml:60:3
   |
60 | /   localization_syntax:
61 | |     # make sure all necessary files will be bundled in the release
62 | |     name: Check l18n syntax
63 | |     runs-on: ubuntu-latest
...  |
74 | |           semgrep --error --lang python --pattern 'trans._(f"...")' src/napari
75 | |           semgrep --error --lang python --pattern "trans._(\$X.format(...))" src/napari
   | |                                                                                       ^
   | |                                                                                       |
   | |_______________________________________________________________________________________this job
   |                                                                                         default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_pull_requests.yml:77:3
   |
77 | /   build_wheel:
78 | |     name: Build wheel
79 | |     uses: ./.github/workflows/reusable_build_wheel.yml
   | |                                                      ^
   | |                                                      |
   | |______________________________________________________this job
   |                                                        default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_pull_requests.yml:81:3
    |
 81 | /   test_initial:
 82 | |     name: Initial test
 83 | |     uses: ./.github/workflows/reusable_run_tox_test.yml
 84 | |     needs: build_wheel
...   |
104 | |       min_req: ${{ matrix.MIN_REQ }}
105 | |       artifacts_suffix: "initial"
    | |                                 ^
    | |                                 |
    | |_________________________________this job
    |                                   default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_pull_requests.yml:107:3
    |
107 | /   test:
108 | |     name: ${{ matrix.platform }}
109 | |     uses: ./.github/workflows/reusable_run_tox_test.yml
110 | |     needs: test_initial
...   |
176 | |       tox_extras: ${{ matrix.tox_extras }}
177 | |       timeout: ${{ matrix.timeout-minutes || 40 }}
    | |                                                  ^
    | |                                                  |
    | |__________________________________________________this job
    |                                                    default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_pull_requests.yml:180:3
    |
180 | /   test_pip_install:
181 | |     needs: test_initial
182 | |     name: pip install
183 | |     uses: ./.github/workflows/reusable_pip_test.yml
    | |                                                   ^
    | |                                                   |
    | |___________________________________________________this job
    |                                                     default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_pull_requests.yml:185:3
    |
185 | /   test_examples:
186 | |     name: test examples
187 | |     uses: ./.github/workflows/reusable_run_tox_test.yml
188 | |     needs: test_initial
...   |
193 | |         constraints_suffix: _examples
194 | |         coverage: cov
    | |                     ^
    | |                     |
    | |_____________________this job
    |                       default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_pull_requests.yml:196:3
    |
196 | /   coverage_report:
197 | |     if: ${{ always() }}
198 | |     secrets: inherit
199 | |     needs:
...   |
203 | |     with:
204 | |       artifact-pattern: 'coverage reports*'
    | |                                           ^
    | |                                           |
    | |___________________________________________this job
    |                                             default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
   --> ./.github/workflows/test_pull_requests.yml:207:3
    |
207 | /   test_benchmarks:
208 | |     name: test benchmarks
209 | |     runs-on: ubuntu-latest
210 | |     needs: test_initial
...   |
275 | |           name: triangulation-benchmarks
276 | |           path: /tmp/napari*
    | |                             ^
    | |                             |
    | |_____________________________this job
    |                               default permissions used due to no permissions: block
    |
    = note: audit confidence → Medium

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/test_pull_requests.yml:266:71
    |
265 | ...   run: |
    |       --- this run block
266 | ...     asv run --show-stderr --quick  --attribute timeout=300  ${{ fromJSON(steps.latest_release.outputs.data).target_commitish }}^!
    |                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/test_pull_requests.yml:202:11
    |
202 |     uses: napari/shared-workflows/.github/workflows/upload_coverage.yml@main
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
   --> ./.github/workflows/test_pull_requests.yml:202:11
    |
198 |     secrets: inherit
    |     ---------------- inherits all parent secrets
...
202 |     uses: napari/shared-workflows/.github/workflows/upload_coverage.yml@main
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this reusable workflow
    |
    = note: audit confidence → High

warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
   --> ./.github/workflows/test_pull_requests.yml:236:81
    |
236 |       - uses: octokit/request-action@10df4beff76ddd0c48b0e983ecde429e7174dfd3 # v2.x
    |                                                                                 ^^ points to unknown ref
    |
    = note: audit confidence → High

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_translations.yml:17:9
   |
17 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_typing.yml:16:9
   |
16 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/test_typing.yml:13:3
   |
13 | /   mypy:
14 | |     runs-on: ubuntu-latest
15 | |     steps:
16 | |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
...  |
25 | |       - name: Run mypy on typed modules
26 | |         run: tox -e mypy
   | |                         ^
   | |                         |
   | |_________________________this job
   |                           default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/test_vendored.yml:21:9
   |
21 |       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/upgrade_test_constraints.yml:94:9
   |
94 |         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   |  _________^
95 | |         with:
96 | |           fetch-depth: 0
   | |________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/upgrade_test_constraints.yml:98:9
    |
 98 |         - name: Clone target repo (remote)
    |  _________^
 99 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
100 | |         if: github.event_name == 'issue_comment'
101 | |         with:
...   |
104 | |           ref: ${{ env.BRANCH }}
105 | |           token: ${{ secrets.GHA_TOKEN_BOT_REPO }}
    | |__________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/upgrade_test_constraints.yml:107:9
    |
107 |         - name: Clone target repo (pull request)
    |  _________^
108 | |         # we need separate step as passing empty token to actions/checkout@v4 will not work
109 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
110 | |         if: github.event_name == 'pull_request'
111 | |         with:
112 | |           path: napari_repo  # place in a named directory
    | |_________________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/upgrade_test_constraints.yml:114:9
    |
114 |         - name: Clone target repo (main)
    |  _________^
115 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
116 | |         if: github.event_name != 'issue_comment' && github.event_name != 'pull_request'
117 | |         with:
...   |
120 | |           ref: ${{ env.BRANCH }}
121 | |           token: ${{ secrets.GHA_TOKEN_BOT_REPO }}
    | |__________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/upgrade_test_constraints.yml:92:28
   |
90 |         run: |
   |         --- this run block
91 |           echo "FULL_NAME=${{ github.repository }}" >> "$GITHUB_ENV"
92 |           echo "BRANCH=${{ github.ref_name }}" >> "$GITHUB_ENV"
   |                            ^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/upgrade_test_constraints.yml:130:15
    |
130 |         uses: astral-sh/setup-uv@v7
    |               ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

193 findings (95 suppressed, 42 fixable): 6 informational, 32 low, 40 medium, 20 high

```

</details>