### PR TITLE
Update bot repository synchronization with token

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -122,12 +122,13 @@ jobs:
           token: ${{ secrets.GHA_TOKEN_BOT_REPO_WORKFLOW }}
           persist-credentials: false
       - name: Synchronize bot repository
+        env:
+          BOT_TOKEN: ${{ secrets.GHA_TOKEN_BOT_REPO_WORKFLOW }}
         run: |
-          git remote add napari-bot https://github.com/napari-bot/napari.git
+          git remote add napari-bot https://x-access-token:${BOT_TOKEN}@github.com/napari-bot/napari.git
           git fetch napari-bot
           git push --force --set-upstream napari-bot main
       - name: Report Failures
-
         if: ${{ failure() }}
         uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         env:

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -125,7 +125,7 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.GHA_TOKEN_BOT_REPO_WORKFLOW }}
         run: |
-          git remote add napari-bot https://x-access-token:${BOT_TOKEN}@github.com/napari-bot/napari.git
+          git remote add napari-bot https://x-access-token:"${BOT_TOKEN}"@github.com/napari-bot/napari.git
           git fetch napari-bot
           git push --force --set-upstream napari-bot main
       - name: Report Failures


### PR DESCRIPTION
Move the token into an `env:` statement for the bot sync to occur without opening permissions to everything.

# References and relevant issues

Closes #8888 

# Description

Follow up to #8885