### PR TITLE
Deprecate image_reader_to_layerdata_reader

### DIFF
--- a/src/napari/_tests/test_magicgui.py
+++ b/src/napari/_tests/test_magicgui.py
@@ -508,7 +508,7 @@ def test_image_reader_to_layerdata_reader_deprecated_and_wraps_result():
         return np.array([[1, 2], [3, 4]])
 
     with pytest.warns(
-        FutureWarning,
+        DeprecationWarning,
         match='image_reader_to_layerdata_reader is deprecated in 0.7.1 and will be removed in 0.8.0 release.',
     ):
         wrapped = types.image_reader_to_layerdata_reader(_read)

--- a/src/napari/_tests/test_magicgui.py
+++ b/src/napari/_tests/test_magicgui.py
@@ -502,6 +502,22 @@ def test_magicgui_add_layer_data_tuple_list(make_napari_viewer):
     assert viewer.layers[1].source.widget == add_layer
 
 
+def test_image_reader_to_layerdata_reader_deprecated_and_wraps_result():
+    def _read(path):
+        assert path == 'fake-path'
+        return np.array([[1, 2], [3, 4]])
+
+    with pytest.warns(
+        FutureWarning,
+        match='image_reader_to_layerdata_reader is deprecated in 0.7.1 and will be removed in 0.8.0 release.',
+    ):
+        wrapped = types.image_reader_to_layerdata_reader(_read)
+
+    result = wrapped('fake-path')
+    assert len(result) == 1
+    assert np.array_equal(result[0][0], np.array([[1, 2], [3, 4]]))
+
+
 def test_magicgui_data_updated(make_napari_viewer):
     """Test that magic data parameters stay up to date."""
     viewer = make_napari_viewer()

--- a/src/napari/types.py
+++ b/src/napari/types.py
@@ -1,8 +1,8 @@
+import warnings
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import partial, wraps
 from pathlib import Path
 from types import TracebackType
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/src/napari/types.py
+++ b/src/napari/types.py
@@ -148,7 +148,7 @@ def image_reader_to_layerdata_reader(
     """
     warnings.warn(
         'image_reader_to_layerdata_reader is deprecated in 0.7.1 and will be removed in 0.8.0 release.',
-        FutureWarning,
+        DeprecationWarning,
         stacklevel=2,
     )
 

--- a/src/napari/types.py
+++ b/src/napari/types.py
@@ -131,7 +131,7 @@ def image_reader_to_layerdata_reader(
     """Convert a PathLike -> ArrayLike function to a PathLike -> LayerData.
 
     .. deprecated:: 0.7.1
-        This helper is deprecated and will be removed in 8.0.
+        This helper is deprecated and will be removed in 0.8.0.
 
     Parameters
     ----------

--- a/src/napari/types.py
+++ b/src/napari/types.py
@@ -2,6 +2,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import partial, wraps
 from pathlib import Path
 from types import TracebackType
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -129,6 +130,9 @@ def image_reader_to_layerdata_reader(
 ) -> ReaderFunction:
     """Convert a PathLike -> ArrayLike function to a PathLike -> LayerData.
 
+    .. deprecated:: 0.7.1
+        This helper is deprecated and will be removed in 8.0.
+
     Parameters
     ----------
     func : Callable[[PathLike], ArrayLike]
@@ -142,6 +146,11 @@ def image_reader_to_layerdata_reader(
         as a list of LayerData: List[Tuple[ArrayLike]]
 
     """
+    warnings.warn(
+        'image_reader_to_layerdata_reader is deprecated in 0.7.1 and will be removed in 0.8.0 release.',
+        FutureWarning,
+        stacklevel=2,
+    )
 
     @wraps(func)
     def reader_function(*args, **kwargs) -> list[LayerData]:


### PR DESCRIPTION
# References and relevant issues
Closes #6248 

# Description
- Deprecated` image_reader_to_layerdata_reader` for version 0.7.1 and can be removed in 8.0
- Added test 



