### PR TITLE
Improve dask check to support more dask-backed array types

### DIFF
--- a/src/napari/layers/_tests/test_dask_layers.py
+++ b/src/napari/layers/_tests/test_dask_layers.py
@@ -72,7 +72,7 @@ def test_dask_array_creates_cache():
     layer2.set_view_slice()
 
 
-def test_list_of_dask_arrays_doesnt_create_cache():
+def test_list_of_dask_arrays_creates_cache():
     """Test that adding a list of dask array also creates a dask cache."""
     resize_dask_cache(1)  # in case other tests created it
     assert _dask_utils._DASK_CACHE.cache.available_bytes == 1
@@ -81,6 +81,50 @@ def test_list_of_dask_arrays_doesnt_create_cache():
     assert _dask_utils._DASK_CACHE.cache.available_bytes > 100
     assert not _dask_utils._DASK_CACHE.active
     assert dask.config.get('optimization.fuse.active', None) == original
+
+
+def test_xarray_dataarray_backed_by_dask_creates_cache():
+    """xarray DataArrays wrapping dask should get the same cache/fusion opts.
+
+    Regression test for https://github.com/napari/napari/issues/8878 where passing
+    an xarray.DataArray backed by a dask array was not triggering dask
+    optimizations.
+    """
+    xr = pytest.importorskip('xarray')
+    resize_dask_cache(1)
+    assert _dask_utils._DASK_CACHE.cache.available_bytes == 1
+    original = dask.config.get('optimization.fuse.active', None)
+
+    da_arr = da.ones((100, 100))
+    xr_arr = xr.DataArray(da_arr)
+
+    def mock_set_view_slice():
+        assert dask.config.get('optimization.fuse.active') is False
+
+    layer = layers.Image(xr_arr)
+    layer._set_view_slice = mock_set_view_slice
+    layer.set_view_slice()
+
+    # cache must have been allocated and task fusion must have been turned off
+    assert _dask_utils._DASK_CACHE.cache.available_bytes > 100
+    assert not _dask_utils._DASK_CACHE.active
+    assert dask.config.get('optimization.fuse.active', None) == original
+
+
+def test_xarray_dataarray_backed_by_numpy_no_cache():
+    """xarray DataArrays wrapping numpy should NOT trigger dask cache setup."""
+    xr = pytest.importorskip('xarray')
+    resize_dask_cache(1)
+    assert _dask_utils._DASK_CACHE.cache.available_bytes == 1
+
+    np_arr = np.ones((100, 100))
+    xr_arr = xr.DataArray(np_arr)
+
+    assert not _dask_utils._is_dask_data(xr_arr)
+    _ = layers.Image(xr_arr)
+    # numpy-backed xarray should not trigger cache resize
+    assert _dask_utils._DASK_CACHE.cache.available_bytes == 1
+    assert not _dask_utils._DASK_CACHE.active
 
 
 @pytest.fixture

--- a/src/napari/layers/_tests/test_dask_layers.py
+++ b/src/napari/layers/_tests/test_dask_layers.py
@@ -4,6 +4,7 @@ import dask
 import dask.array as da
 import numpy as np
 import pytest
+import xarray as xr
 
 from napari import layers
 from napari.components import ViewerModel
@@ -90,7 +91,6 @@ def test_xarray_dataarray_backed_by_dask_creates_cache():
     an xarray.DataArray backed by a dask array was not triggering dask
     optimizations.
     """
-    xr = pytest.importorskip('xarray')
     resize_dask_cache(1)
     assert _dask_utils._DASK_CACHE.cache.available_bytes == 1
     original = dask.config.get('optimization.fuse.active', None)

--- a/src/napari/utils/_dask_utils.py
+++ b/src/napari/utils/_dask_utils.py
@@ -2,7 +2,6 @@
 
 import collections.abc
 import contextlib
-import sys
 from collections.abc import Callable, Iterator
 from typing import Any
 
@@ -80,16 +79,19 @@ def resize_dask_cache(
 
 
 def _is_dask_data(data: Any) -> bool:
-    """Return True if data is a dask array or a list/tuple of dask arrays."""
+    """Return True if data has a dask computation graph.
 
-    da = sys.modules.get('dask.array')
-    if da is None:
-        # dask.array not imported yet.
-        return False
+    Uses dask's Protocol through `dask.is_dask_collection`, which
+    checks for the ``__dask_graph__`` attribute.  This covers things like
 
-    return isinstance(data, da.Array) or (
-        isinstance(data, collections.abc.Sequence)
-        and any(isinstance(i, da.Array) for i in data)
+    - `dask.array.Array` directly
+    - `xarray.DataArray` backed by a dask array (but *not* numpy-backed)
+    - Any other dask-collection type
+    """
+    if dask.is_dask_collection(data):
+        return True
+    return isinstance(data, collections.abc.Sequence) and any(
+        dask.is_dask_collection(i) for i in data
     )
 
 


### PR DESCRIPTION
# References and relevant issues

Closes #8878

# Description

This PR uses [`dask.is_dask_collection`](https://docs.dask.org/en/latest/_modules/dask/base.html#is_dask_collection) to "type check" if an array passed to a layer is dask backed. This means that anything that implements its API with a `__dask_graph__` it will work, so _both_ a `dask.array.Array` and a dask backed `xarray.DataArray`.
While this dask check is broader than array types (so will include something like a dask backed pd.DataFrame), it seems the rest of the layer building protocol makes this not a worry. 

I think this is better than an alternative implementation, where every dask backed array needs type checked itself for being dask backed. 