### PR TITLE
Set pixel as default scalebar unit

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -9,3 +9,4 @@ def test_scale_bar_instantiation(make_napari_viewer):
     assert vispy_scale_bar.overlay.length is None
     model.length = 50
     assert vispy_scale_bar.overlay.length == 50
+    assert vispy_scale_bar.overlay.unit == 'px'

--- a/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -9,4 +9,4 @@ def test_scale_bar_instantiation(make_napari_viewer):
     assert vispy_scale_bar.overlay.length is None
     model.length = 50
     assert vispy_scale_bar.overlay.length == 50
-    assert vispy_scale_bar.overlay.unit == 'px'
+    assert vispy_scale_bar.overlay.unit == 'pixel'

--- a/src/napari/components/_tests/test_scale_bar.py
+++ b/src/napari/components/_tests/test_scale_bar.py
@@ -11,3 +11,9 @@ def test_scale_bar_fixed_length():
     """Test creating scale bar object with fixed length"""
     scale_bar = ScaleBarOverlay(length=50)
     assert scale_bar.length == 50
+
+
+def test_scale_bar_unit():
+    """Test the scale bar default unit set to px"""
+    scale_bar = ScaleBarOverlay()
+    assert scale_bar.unit == 'px'

--- a/src/napari/components/_tests/test_scale_bar.py
+++ b/src/napari/components/_tests/test_scale_bar.py
@@ -7,13 +7,8 @@ def test_scale_bar():
     assert scale_bar is not None
 
 
-def test_scale_bar_fixed_length():
+def test_scale_bar_fixed_length_and_units():
     """Test creating scale bar object with fixed length"""
     scale_bar = ScaleBarOverlay(length=50)
     assert scale_bar.length == 50
-
-
-def test_scale_bar_unit():
-    """Test the scale bar default unit set to px"""
-    scale_bar = ScaleBarOverlay()
     assert scale_bar.unit == 'px'

--- a/src/napari/components/_tests/test_scale_bar.py
+++ b/src/napari/components/_tests/test_scale_bar.py
@@ -11,4 +11,4 @@ def test_scale_bar_fixed_length_and_units():
     """Test creating scale bar object with fixed length"""
     scale_bar = ScaleBarOverlay(length=50)
     assert scale_bar.length == 50
-    assert scale_bar.unit == 'px'
+    assert scale_bar.unit == 'pixel'

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -51,5 +51,5 @@ class ScaleBarOverlay(CanvasOverlay):
     color: ColorValue = Field(default_factory=lambda: ColorValue([1, 0, 1, 1]))
     ticks: bool = True
     font_size: float = 10
-    unit: str | None = None
+    unit: str | None = 'pixel'
     length: float | None = None

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -51,5 +51,5 @@ class ScaleBarOverlay(CanvasOverlay):
     color: ColorValue = Field(default_factory=lambda: ColorValue([1, 0, 1, 1]))
     ticks: bool = True
     font_size: float = 10
-    unit: str | None = 'pixel'
+    unit: str | None = 'px'
     length: float | None = None

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -51,5 +51,5 @@ class ScaleBarOverlay(CanvasOverlay):
     color: ColorValue = Field(default_factory=lambda: ColorValue([1, 0, 1, 1]))
     ticks: bool = True
     font_size: float = 10
-    unit: str | None = 'px'
+    unit: str | None = 'pixel'
     length: float | None = None


### PR DESCRIPTION
# References and relevant issues
#8899 

# Description
This PR replaces the `ScaleBarOverlay` default unit to "px" so that the `VispyScaleBarOverlay` keeps the (hopefully) intended "1 pixel" `_unit` consistently and the scale bar displays the "px" label for the units as default and follows a similar approach to the `Layers` which have "pixel" as the default unit for the axes. 