### PR TITLE
Turn off contrast/color controls when surface has `vertex_colors`

### DIFF
--- a/examples/surface_texture_and_colors.py
+++ b/examples/surface_texture_and_colors.py
@@ -5,11 +5,12 @@ Surface with texture and vertex_colors
 Display a 3D surface with both texture and color maps.
 
 This example demonstrates how surfaces may be colored by:
-    * setting `vertex_values`, which colors the surface with the selected
-      `colormap`
+    * setting `vertex_values` as the 3rd element of the `data` tuple,
+      which colors the surface with the selected `colormap`
     * setting `vertex_colors`, which replaces/overrides any color from
-      `vertex_values`
-    * setting both `texture` and `texcoords`, which blends a the value from
+      `vertex_values`, resulting in colormap-based controls such as contrast limits and
+      gamma no longer affecting the rendered surface
+    * setting both `texture` and `texcoords`, which blends the value from
       a texture (image) with the underlying color from `vertex_values` or
       `vertex_colors`. Blending is achieved by multiplying the texture color by
       the underlying color - an underlying value of "white" will result in the
@@ -22,6 +23,7 @@ import numpy as np
 from vispy.io import imread, load_data_file, read_mesh
 
 import napari
+from napari.layers import Surface
 
 # load the model and texture
 mesh_path = load_data_file('spot/spot.obj.gz')
@@ -30,7 +32,7 @@ n = len(vertices)
 texture_path = load_data_file('spot/spot.png')
 texture = imread(texture_path)
 
-flat_spot = napari.layers.Surface(
+flat_spot = Surface(
     (vertices, faces),
     translate=(1, 0, 0),
     texture=texture,
@@ -40,7 +42,7 @@ flat_spot = napari.layers.Surface(
 )
 
 np.random.seed(0)
-plasma_spot = napari.layers.Surface(
+plasma_spot = Surface(
     (vertices, faces, np.random.random((3, 3, n))),
     texture=texture,
     texcoords=texcoords,
@@ -49,11 +51,12 @@ plasma_spot = napari.layers.Surface(
     name='vertex_values and texture',
 )
 
-rainbow_spot = napari.layers.Surface(
+rainbow_spot = Surface(
     (vertices, faces),
     translate=(-1, 0, 0),
     texture=texture,
     texcoords=texcoords,
+    # Direct vertex colors override colormap-based coloring.
     # the vertices are _roughly_ in [-1, 1] for this model and RGB values just
     # get clipped to [0, 1], adding 0.5 brightens it up a little :)
     vertex_colors=vertices + 0.5,

--- a/src/napari/_qt/layer_controls/_tests/test_qt_surface_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_surface_layer.py
@@ -10,6 +10,21 @@ values = np.linspace(0, 1, len(data))
 _SURFACE = (data, faces, values)
 
 
+def _assert_controls_enabled(controls, enabled):
+    for control in controls:
+        for label, widget in control.get_widget_controls():
+            assert label.isEnabled() is enabled
+            assert widget.isEnabled() is enabled
+
+
+def _scalar_coloring_controls(qtctrl):
+    return (
+        qtctrl._contrast_limits_control,
+        qtctrl._gamma_slider_control,
+        qtctrl._colormap_control,
+    )
+
+
 def test_shading_combobox(qtbot):
     layer = Surface(_SURFACE)
     qtctrl = QtSurfaceControls(layer)
@@ -39,12 +54,11 @@ def test_intensity_controls_disabled_with_vertex_colors(qtbot):
     qtctrl = QtSurfaceControls(layer)
     qtbot.addWidget(qtctrl)
 
-    assert all(
-        not widget.isEnabled()
-        for ctrl in qtctrl._intensity_controls
-        for _, widget in ctrl.get_widget_controls()
+    _assert_controls_enabled(_scalar_coloring_controls(qtctrl), False)
+    _assert_controls_enabled(
+        (qtctrl._shading_combobox_control,),
+        True,
     )
-    assert qtctrl._shading_combobox_control.shading_combobox.isEnabled()
 
 
 def test_intensity_controls_toggle_with_vertex_colors(qtbot):
@@ -52,22 +66,10 @@ def test_intensity_controls_toggle_with_vertex_colors(qtbot):
     qtctrl = QtSurfaceControls(layer)
     qtbot.addWidget(qtctrl)
 
-    assert all(
-        widget.isEnabled()
-        for ctrl in qtctrl._intensity_controls
-        for _, widget in ctrl.get_widget_controls()
-    )
+    _assert_controls_enabled(_scalar_coloring_controls(qtctrl), True)
 
     layer.vertex_colors = np.full((len(data), 3), 0.5)
-    assert all(
-        not widget.isEnabled()
-        for ctrl in qtctrl._intensity_controls
-        for _, widget in ctrl.get_widget_controls()
-    )
+    _assert_controls_enabled(_scalar_coloring_controls(qtctrl), False)
 
     layer.vertex_colors = None
-    assert all(
-        widget.isEnabled()
-        for ctrl in qtctrl._intensity_controls
-        for _, widget in ctrl.get_widget_controls()
-    )
+    _assert_controls_enabled(_scalar_coloring_controls(qtctrl), True)

--- a/src/napari/_qt/layer_controls/_tests/test_qt_surface_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_surface_layer.py
@@ -31,3 +31,43 @@ def test_shading_combobox(qtbot):
             qtctrl._shading_combobox_control.shading_combobox.currentText()
             == display
         )
+
+
+def test_intensity_controls_disabled_with_vertex_colors(qtbot):
+    vertex_colors = np.full((len(data), 3), 0.5)
+    layer = Surface(_SURFACE, vertex_colors=vertex_colors)
+    qtctrl = QtSurfaceControls(layer)
+    qtbot.addWidget(qtctrl)
+
+    assert all(
+        not widget.isEnabled()
+        for ctrl in qtctrl._intensity_controls
+        for _, widget in ctrl.get_widget_controls()
+    )
+    assert qtctrl._shading_combobox_control.shading_combobox.isEnabled()
+
+
+def test_intensity_controls_toggle_with_vertex_colors(qtbot):
+    layer = Surface(_SURFACE)
+    qtctrl = QtSurfaceControls(layer)
+    qtbot.addWidget(qtctrl)
+
+    assert all(
+        widget.isEnabled()
+        for ctrl in qtctrl._intensity_controls
+        for _, widget in ctrl.get_widget_controls()
+    )
+
+    layer.vertex_colors = np.full((len(data), 3), 0.5)
+    assert all(
+        not widget.isEnabled()
+        for ctrl in qtctrl._intensity_controls
+        for _, widget in ctrl.get_widget_controls()
+    )
+
+    layer.vertex_colors = None
+    assert all(
+        widget.isEnabled()
+        for ctrl in qtctrl._intensity_controls
+        for _, widget in ctrl.get_widget_controls()
+    )

--- a/src/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -8,9 +8,10 @@ from napari._qt.layer_controls.widgets import (
     QtContrastLimitsControl,
     QtGammaSliderControl,
 )
+from napari._qt.utils import set_widgets_enabled_with_opacity
 
 if TYPE_CHECKING:
-    from napari.layers import Image
+    from napari.layers import Image, Surface
 
 
 class QtBaseImageControls(QtLayerControls):
@@ -34,7 +35,7 @@ class QtBaseImageControls(QtLayerControls):
         Widget that wraps layer gamma adjustment slider widget.
     """
 
-    def __init__(self, layer: Image) -> None:
+    def __init__(self, layer: Image | Surface) -> None:
         super().__init__(layer)
         # Setup widgets controls
         self._contrast_limits_control = QtContrastLimitsControl(self, layer)
@@ -43,3 +44,18 @@ class QtBaseImageControls(QtLayerControls):
         self._add_widget_controls(self._gamma_slider_control)
         self._colormap_control = QtColormapControl(self, layer)
         self._add_widget_controls(self._colormap_control)
+        self._intensity_controls = [
+            self._contrast_limits_control,
+            self._gamma_slider_control,
+            self._colormap_control,
+        ]
+
+    def _set_intensity_controls_enabled(self, enabled: bool) -> None:
+        """Enable or disable intensity-based controls with matching opacity."""
+        widgets = [
+            wdg
+            for ctrl in self._intensity_controls
+            for label, widget in ctrl.get_widget_controls()
+            for wdg in (label, widget)
+        ]
+        set_widgets_enabled_with_opacity(self, widgets, enabled)

--- a/src/napari/_qt/layer_controls/qt_image_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_image_controls_base.py
@@ -8,7 +8,6 @@ from napari._qt.layer_controls.widgets import (
     QtContrastLimitsControl,
     QtGammaSliderControl,
 )
-from napari._qt.utils import set_widgets_enabled_with_opacity
 
 if TYPE_CHECKING:
     from napari.layers import Image, Surface
@@ -44,18 +43,3 @@ class QtBaseImageControls(QtLayerControls):
         self._add_widget_controls(self._gamma_slider_control)
         self._colormap_control = QtColormapControl(self, layer)
         self._add_widget_controls(self._colormap_control)
-        self._intensity_controls = [
-            self._contrast_limits_control,
-            self._gamma_slider_control,
-            self._colormap_control,
-        ]
-
-    def _set_intensity_controls_enabled(self, enabled: bool) -> None:
-        """Enable or disable intensity-based controls with matching opacity."""
-        widgets = [
-            wdg
-            for ctrl in self._intensity_controls
-            for label, widget in ctrl.get_widget_controls()
-            for wdg in (label, widget)
-        ]
-        set_widgets_enabled_with_opacity(self, widgets, enabled)

--- a/src/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -14,21 +14,11 @@ from napari._qt.layer_controls.widgets import (
 )
 from napari._qt.utils import set_widgets_enabled_with_opacity
 from napari._qt.widgets.qt_mode_buttons import QtModeRadioButton
-from napari.layers.base._base_constants import (
-    Blending,
-    Mode,
-)
+from napari.layers.base._base_constants import Mode
 from napari.layers.base.base import Layer
 from napari.utils.action_manager import action_manager
 from napari.utils.events import disconnect_events
 from napari.utils.translations import trans
-
-# opaque, minimum, and multiplicative blending do not support changing alpha (opacity)
-NO_OPACITY_BLENDING_MODES = {
-    str(Blending.MINIMUM),
-    str(Blending.OPAQUE),
-    str(Blending.MULTIPLICATIVE),
-}
 
 
 class LayerFormLayout(QFormLayout):

--- a/src/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/src/napari/_qt/layer_controls/qt_surface_controls.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from napari._qt.layer_controls.qt_image_controls_base import (
@@ -23,13 +25,20 @@ class QtSurfaceControls(QtBaseImageControls):
         Widget that wraps comboBox controlling current shading value of the layer.
     """
 
-    layer: 'napari.layers.Surface'
+    layer: napari.layers.Surface
     PAN_ZOOM_ACTION_NAME = 'activate_surface_pan_zoom_mode'
     TRANSFORM_ACTION_NAME = 'activate_surface_transform_mode'
 
-    def __init__(self, layer) -> None:
+    def __init__(self, layer: napari.layers.Surface) -> None:
         super().__init__(layer)
+        # Surface emits `data` when vertex_values or vertex_colors are reassigned.
+        self.layer.events.data.connect(self._on_surface_coloring_change)
 
         # Setup widgets controls
         self._shading_combobox_control = QtShadingComboBoxControl(self, layer)
         self._add_widget_controls(self._shading_combobox_control)
+        self._on_surface_coloring_change()
+
+    def _on_surface_coloring_change(self) -> None:
+        """Disable scalar-color controls when direct vertex colors are active."""
+        self._set_intensity_controls_enabled(self.layer.vertex_colors is None)

--- a/src/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/src/napari/_qt/layer_controls/qt_surface_controls.py
@@ -26,7 +26,6 @@ class QtSurfaceControls(QtBaseImageControls):
         Widget that wraps comboBox controlling current shading value of the layer.
     """
 
-    layer: napari.layers.Surface
     PAN_ZOOM_ACTION_NAME = 'activate_surface_pan_zoom_mode'
     TRANSFORM_ACTION_NAME = 'activate_surface_transform_mode'
 

--- a/src/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/src/napari/_qt/layer_controls/qt_surface_controls.py
@@ -6,6 +6,7 @@ from napari._qt.layer_controls.qt_image_controls_base import (
     QtBaseImageControls,
 )
 from napari._qt.layer_controls.widgets._surface import QtShadingComboBoxControl
+from napari._qt.utils import set_widgets_enabled_with_opacity
 
 if TYPE_CHECKING:
     import napari.layers
@@ -41,4 +42,13 @@ class QtSurfaceControls(QtBaseImageControls):
 
     def _on_surface_coloring_change(self) -> None:
         """Disable scalar-color controls when direct vertex colors are active."""
-        self._set_intensity_controls_enabled(self.layer.vertex_colors is None)
+        enabled = self.layer.vertex_colors is None
+        for control in (
+            self._contrast_limits_control,
+            self._gamma_slider_control,
+            self._colormap_control,
+        ):
+            for label, widget in control.get_widget_controls():
+                set_widgets_enabled_with_opacity(
+                    self, (label, widget), enabled
+                )

--- a/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtWidgets import QLabel, QWidget
@@ -48,7 +48,7 @@ class QtWidgetControlsBase(QObject, ABC, metaclass=MetaWidgetControlsBase):
         # so it is possible to disconnect them when the widget is being closed/deleted
         self._callbacks = []
 
-    @abstractclassmethod
+    @abstractmethod
     def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
         """
         Enable access to the created labels and control widgets.
@@ -59,6 +59,7 @@ class QtWidgetControlsBase(QObject, ABC, metaclass=MetaWidgetControlsBase):
             List of tuples of the label and widget controls available.
 
         """
+        raise NotImplementedError
 
     def disconnect_widget_controls(self) -> None:
         """


### PR DESCRIPTION
# References and relevant issues

While working on #8391, I wanted to figure out how intensity and the like worked on surface layers. It took a while for me to realize that contrast limits, gamma and colormap do things _only_ when `vertex_colors` is None on the layer. When `vertex_colors` is added to the layer it shortcircuits the vispy colormapping and uses the vertex colors only.

# Description

Simply, this PR dynamically disables the contrast limits, gamma, and colormap widgets in surface layer controls when `vertex_colors` is not None. I'd recommend `examples/surface_texture_and_colors.py` to see the changes in action. 

<img width="1415" height="1184" alt="image" src="https://github.com/user-attachments/assets/8e68f239-9f5f-4ae0-9f33-84a3e5596630" />

There are also two minor code cleanups -- removing dead code and updating typing. I could split these out into new PRs I guess, but I didn't think they were worth the CI time.

