### PR TITLE
Fix first execution of `visible` event in viewer and layer overlays. 

### DIFF
--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -232,10 +232,12 @@ def test_first_viewer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
     # Wait until the deferred disconnect scheduled with QTimer.singleShot(0,
     # ...) has been processed by the event loop.
     qtbot.waitUntil(
-        lambda: viewer.scale_bar.events.visible._slot_index(
-            canvas._update_viewer_overlays
+        lambda: (
+            viewer.scale_bar.events.visible._slot_index(
+                canvas._update_viewer_overlays
+            )
+            == -1
         )
-        == -1
     )
 
 
@@ -261,10 +263,12 @@ def test_first_layer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
     # Wait until the deferred disconnect scheduled with QTimer.singleShot(0,
     # ...) has been processed by the event loop.
     qtbot.waitUntil(
-        lambda: overlay.events.visible._slot_index(
-            canvas._overlay_callbacks[layer]
+        lambda: (
+            overlay.events.visible._slot_index(
+                canvas._overlay_callbacks[layer]
+            )
+            == -1
         )
-        == -1
     )
 
 

--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -241,37 +241,6 @@ def test_first_viewer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
     )
 
 
-def test_first_layer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
-    viewer = qt_viewer.viewer
-    canvas = qt_viewer.canvas
-    layer = viewer.add_points()
-    overlay = next(iter(layer._overlays.values()))
-
-    calls = []
-    overlay.events.visible.connect(lambda: calls.append('visible'))
-
-    assert not overlay.visible
-    assert (
-        overlay.events.visible._slot_index(canvas._overlay_callbacks[layer])
-        != -1
-    )
-
-    overlay.visible = True
-
-    assert calls == ['visible']
-
-    # Wait until the deferred disconnect scheduled with QTimer.singleShot(0,
-    # ...) has been processed by the event loop.
-    qtbot.waitUntil(
-        lambda: (
-            overlay.events.visible._slot_index(
-                canvas._overlay_callbacks[layer]
-            )
-            == -1
-        )
-    )
-
-
 def test_world_units_restored_after_removing_inconsistent_layer(qt_viewer):
     """Removing a units-inconsistent layer should re-enable unit-aware rendering.
 

--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -229,12 +229,10 @@ def test_first_viewer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
 
     assert calls == ['visible']
 
-    # Let the event loop process the deferred disconnect scheduled with
-    # QTimer.singleShot(0, ...).
-    qtbot.wait(0)
-
-    assert (
-        viewer.scale_bar.events.visible._slot_index(
+    # Wait until the deferred disconnect scheduled with QTimer.singleShot(0,
+    # ...) has been processed by the event loop.
+    qtbot.waitUntil(
+        lambda: viewer.scale_bar.events.visible._slot_index(
             canvas._update_viewer_overlays
         )
         == -1
@@ -260,12 +258,12 @@ def test_first_layer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
 
     assert calls == ['visible']
 
-    # Let the event loop process the deferred disconnect scheduled with
-    # QTimer.singleShot(0, ...).
-    qtbot.wait(0)
-
-    assert (
-        overlay.events.visible._slot_index(canvas._overlay_callbacks[layer])
+    # Wait until the deferred disconnect scheduled with QTimer.singleShot(0,
+    # ...) has been processed by the event loop.
+    qtbot.waitUntil(
+        lambda: overlay.events.visible._slot_index(
+            canvas._overlay_callbacks[layer]
+        )
         == -1
     )
 

--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -210,6 +210,66 @@ def test_tiling_canvas_overlays(qt_viewer):
     )
 
 
+def test_first_viewer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
+
+    calls = []
+    viewer.scale_bar.events.visible.connect(lambda: calls.append('visible'))
+
+    assert not viewer.scale_bar.visible
+    assert (
+        viewer.scale_bar.events.visible._slot_index(
+            canvas._update_viewer_overlays
+        )
+        != -1
+    )
+
+    viewer.scale_bar.visible = True
+
+    assert calls == ['visible']
+
+    # Let the event loop process the deferred disconnect scheduled with
+    # QTimer.singleShot(0, ...).
+    qtbot.wait(0)
+
+    assert (
+        viewer.scale_bar.events.visible._slot_index(
+            canvas._update_viewer_overlays
+        )
+        == -1
+    )
+
+
+def test_first_layer_overlay_visible_event_reaches_listener(qt_viewer, qtbot):
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
+    layer = viewer.add_points()
+    overlay = next(iter(layer._overlays.values()))
+
+    calls = []
+    overlay.events.visible.connect(lambda: calls.append('visible'))
+
+    assert not overlay.visible
+    assert (
+        overlay.events.visible._slot_index(canvas._overlay_callbacks[layer])
+        != -1
+    )
+
+    overlay.visible = True
+
+    assert calls == ['visible']
+
+    # Let the event loop process the deferred disconnect scheduled with
+    # QTimer.singleShot(0, ...).
+    qtbot.wait(0)
+
+    assert (
+        overlay.events.visible._slot_index(canvas._overlay_callbacks[layer])
+        == -1
+    )
+
+
 def test_world_units_restored_after_removing_inconsistent_layer(qt_viewer):
     """Removing a units-inconsistent layer should re-enable unit-aware rendering.
 

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -950,6 +950,33 @@ class VispyCanvas:
 
         QTimer.singleShot(0, _disconnect_if_initialized)
 
+    def _defer_layer_overlay_visible_disconnect(
+        self, layer: Layer, overlay: Overlay
+    ) -> None:
+        """Disconnect a layer overlay's lazy visible callback after emission.
+
+        Layer overlays use a per-layer bootstrap callback to lazily create the
+        vispy overlay when the model first becomes visible. As with viewer
+        overlays, disconnecting that callback from inside the active ``visible``
+        emission can mutate psygnal's live slot list and skip downstream
+        listeners. Deferring the disconnect keeps the callback one-shot without
+        modifying the slot list mid-emission.
+        """
+        from qtpy.QtCore import QTimer
+
+        def _disconnect_if_initialized() -> None:
+            if layer not in self.viewer.layers:
+                return
+            if overlay not in layer._overlays.values():
+                return
+            if overlay not in self._layer_overlay_to_visual.get(layer, {}):
+                return
+            overlay.events.visible.disconnect(
+                self._overlay_callbacks[layer], missing_ok=True
+            )
+
+        QTimer.singleShot(0, _disconnect_if_initialized)
+
     def _create_or_update_vispy_viewer_overlay(
         self,
         overlay: Overlay,
@@ -1089,7 +1116,7 @@ class VispyCanvas:
                     self._overlay_callbacks[layer], unique=True
                 )
                 continue
-            overlay.events.visible.disconnect(self._overlay_callbacks[layer])
+            self._defer_layer_overlay_visible_disconnect(layer, overlay)
 
             vispy_overlay = overlay_to_visual.get(overlay, None)
 

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -928,16 +928,7 @@ class VispyCanvas:
     def _defer_viewer_overlay_visible_disconnect(
         self, overlay: Overlay
     ) -> None:
-        """Disconnect the lazy visible callback after the current emission.
-
-        Viewer overlays are lazily instantiated by connecting
-        ``overlay.events.visible`` to ``_update_viewer_overlays`` while the
-        overlay is hidden. Once the overlay has been created, that bootstrap
-        callback should be removed, but doing so from inside the active
-        ``visible`` emission mutates psygnal's live slot list and can skip
-        downstream listeners. Deferring the disconnect preserves the one-shot
-        lazy behavior without mutating the callback list mid-emission.
-        """
+        # Disconnect the lazy visible callback after the current emission.
         def _disconnect_if_initialized() -> None:
             if overlay not in self.viewer._overlays.values():
                 return
@@ -952,15 +943,8 @@ class VispyCanvas:
     def _defer_layer_overlay_visible_disconnect(
         self, layer: Layer, overlay: Overlay
     ) -> None:
-        """Disconnect a layer overlay's lazy visible callback after emission.
+        # Disconnect a layer overlay's lazy visible callback after emission.
 
-        Layer overlays use a per-layer bootstrap callback to lazily create the
-        vispy overlay when the model first becomes visible. As with viewer
-        overlays, disconnecting that callback from inside the active ``visible``
-        emission can mutate psygnal's live slot list and skip downstream
-        listeners. Deferring the disconnect keeps the callback one-shot without
-        modifying the slot list mid-emission.
-        """
         def _disconnect_if_initialized() -> None:
             if layer not in self.viewer.layers:
                 return

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -12,6 +12,7 @@ from weakref import WeakSet
 
 import numpy as np
 from OpenGL.error import GLError
+from qtpy.QtCore import QTimer
 from superqt.utils import qthrottled
 from vispy.scene import Grid, SceneCanvas as SceneCanvas_, ViewBox, Widget
 
@@ -937,8 +938,6 @@ class VispyCanvas:
         downstream listeners. Deferring the disconnect preserves the one-shot
         lazy behavior without mutating the callback list mid-emission.
         """
-        from qtpy.QtCore import QTimer
-
         def _disconnect_if_initialized() -> None:
             if overlay not in self.viewer._overlays.values():
                 return
@@ -962,8 +961,6 @@ class VispyCanvas:
         listeners. Deferring the disconnect keeps the callback one-shot without
         modifying the slot list mid-emission.
         """
-        from qtpy.QtCore import QTimer
-
         def _disconnect_if_initialized() -> None:
             if layer not in self.viewer.layers:
                 return

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -944,7 +944,6 @@ class VispyCanvas:
         self, layer: Layer, overlay: Overlay
     ) -> None:
         # Disconnect a layer overlay's lazy visible callback after emission.
-
         def _disconnect_if_initialized() -> None:
             if layer not in self.viewer.layers:
                 return

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -924,6 +924,32 @@ class VispyCanvas:
             self._update_overlay_canvas_positions
         )
 
+    def _defer_viewer_overlay_visible_disconnect(
+        self, overlay: Overlay
+    ) -> None:
+        """Disconnect the lazy visible callback after the current emission.
+
+        Viewer overlays are lazily instantiated by connecting
+        ``overlay.events.visible`` to ``_update_viewer_overlays`` while the
+        overlay is hidden. Once the overlay has been created, that bootstrap
+        callback should be removed, but doing so from inside the active
+        ``visible`` emission mutates psygnal's live slot list and can skip
+        downstream listeners. Deferring the disconnect preserves the one-shot
+        lazy behavior without mutating the callback list mid-emission.
+        """
+        from qtpy.QtCore import QTimer
+
+        def _disconnect_if_initialized() -> None:
+            if overlay not in self.viewer._overlays.values():
+                return
+            if overlay not in self._overlay_to_visual:
+                return
+            overlay.events.visible.disconnect(
+                self._update_viewer_overlays, missing_ok=True
+            )
+
+        QTimer.singleShot(0, _disconnect_if_initialized)
+
     def _create_or_update_vispy_viewer_overlay(
         self,
         overlay: Overlay,
@@ -978,7 +1004,7 @@ class VispyCanvas:
                     self._update_viewer_overlays, unique=True
                 )
                 continue
-            overlay.events.visible.disconnect(self._update_viewer_overlays)
+            self._defer_viewer_overlay_visible_disconnect(overlay)
 
             vispy_overlays = self._overlay_to_visual.setdefault(overlay, [])
 

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -940,23 +940,6 @@ class VispyCanvas:
 
         QTimer.singleShot(0, _disconnect_if_initialized)
 
-    def _defer_layer_overlay_visible_disconnect(
-        self, layer: Layer, overlay: Overlay
-    ) -> None:
-        # Disconnect a layer overlay's lazy visible callback after emission.
-        def _disconnect_if_initialized() -> None:
-            if layer not in self.viewer.layers:
-                return
-            if overlay not in layer._overlays.values():
-                return
-            if overlay not in self._layer_overlay_to_visual.get(layer, {}):
-                return
-            overlay.events.visible.disconnect(
-                self._overlay_callbacks[layer], missing_ok=True
-            )
-
-        QTimer.singleShot(0, _disconnect_if_initialized)
-
     def _create_or_update_vispy_viewer_overlay(
         self,
         overlay: Overlay,
@@ -1098,7 +1081,7 @@ class VispyCanvas:
                     self._overlay_callbacks[layer], unique=True
                 )
                 continue
-            self._defer_layer_overlay_visible_disconnect(layer, overlay)
+            overlay.events.visible.disconnect(self._overlay_callbacks[layer])
 
             vispy_overlay = overlay_to_visual.get(overlay, None)
 

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1011,6 +1011,8 @@ class VispyCanvas:
                     self._update_viewer_overlays, unique=True
                 )
                 continue
+            # The disconnection needs to happen after the event emission is finished
+            # or else it will be consumed
             self._defer_viewer_overlay_visible_disconnect(overlay)
 
             vispy_overlays = self._overlay_to_visual.setdefault(overlay, [])


### PR DESCRIPTION
# References and relevant issues
This tries to solve the first visible event execution of lazy overlays as described on #8910 

# Description
It is a proposed change to fix the first `visible` event not being fully executed and prematurely disconnecting callbacks. It works by deferring the disconnection to a separate method after the event is finished. I used gpt-5.4 to supplement and polish the code. 

EDIT: First, I did it for both, the viewer overlays and the layer overlays, but the layer overlays start failing due to the disconnect changes and tear down of the layers. For now I will not add the layer overlays to the PR. 