### PR TITLE
Actually use theme type from npe contrib

### DIFF
--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -46,7 +46,7 @@ def get_icon_path() -> Path:
     return get_logo_path(
         logo=get_settings().appearance.logo,
         template='padded' if platform.system() == 'Darwin' else 'plain',
-        theme=get_system_theme(),
+        theme_type=get_system_theme(),
     )
 
 

--- a/src/napari/utils/logo.py
+++ b/src/napari/utils/logo.py
@@ -46,7 +46,7 @@ def _get_seasonal_logo(today: date | None = None, theme: str = 'dark') -> str:
 
 
 def get_logo_path(
-    logo: str, template: str, theme: str, today: date | None = None
+    logo: str, template: str, theme_type: str, today: date | None = None
 ) -> Path:
     logo_dir = Path(resources.files('napari').joinpath('resources', 'logos'))  # type: ignore
     if logo not in available_logos():
@@ -59,10 +59,10 @@ def get_logo_path(
 
     # eventually we should actually use the dark/light "type" that the theme spec of npe2 allows,
     # which is currently unused in napari
-    if theme not in {'dark', 'light'}:
-        theme = 'dark'
+    if theme_type not in {'dark', 'light'}:
+        theme_type = 'dark'
 
     if logo == 'auto':
-        logo = _get_seasonal_logo(today=today, theme=theme)
+        logo = _get_seasonal_logo(today=today, theme=theme_type)
 
-    return logo_dir / f'{logo}-{template}-{theme}.svg'
+    return logo_dir / f'{logo}-{template}-{theme_type}.svg'

--- a/src/napari/utils/theme.py
+++ b/src/napari/utils/theme.py
@@ -5,7 +5,7 @@ import re
 import sys
 from ast import literal_eval
 from contextlib import suppress
-from typing import Any
+from typing import Any, Literal
 
 import npe2
 from pydantic import field_validator
@@ -40,6 +40,8 @@ class Theme(EventedModel):
         will be saved to.
     label : str
         Name of the theme as it should be shown in the ui.
+    type: str
+        Whether the theme is "dark" or "light" type.
     syntax_style : str
         Name of the console style.
         See for more details: https://pygments.org/docs/styles/
@@ -69,6 +71,7 @@ class Theme(EventedModel):
 
     id: str
     label: str
+    type: Literal['dark', 'light']
     syntax_style: str
     canvas: Color
     console: Color
@@ -358,6 +361,7 @@ def rebuild_theme_settings():
 # Note: these colors are sometimes lightened / darkened in the qss file.
 DARK = Theme(
     id='dark',
+    type='dark',
     label='Default Dark',
     # Widgets / frame background (e.g. Preferences window). HEX: #262930
     background='rgb(38, 41, 48)',
@@ -388,6 +392,7 @@ DARK = Theme(
 )
 LIGHT = Theme(
     id='light',
+    type='light',
     label='Default Light',
     background='rgb(239, 235, 233)',
     foreground='rgb(214, 208, 206)',


### PR DESCRIPTION
# References and relevant issues
When looking into #8662 I remembered of this issue I noticed a while back.

# Description
While theme contributions on npe2 have a field called "type" which indicates whether the theme is dark or light, we currently do not use this in napari. This PR adds this info. It's currently only used for logo selection; I don't know which other places should be updated.
