### PR TITLE
Wrap Labels multiscale data in MultiScaleData object in setter

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -281,16 +281,16 @@ authors:
   family-names: Lowe
   affiliation: UCL & The Alan Turing Institute
   alias: quantumjot
-- given-names: Luca
-  family-names: Marconato
-  affiliation: EMBL Heidelberg
-  orcid: https://orcid.org/0000-0003-3198-1326
-  alias: LucaMarconato
 - given-names: Caroline
   family-names: Malin-Mayor
   affiliation: HHMI Janelia Research Campus
   orcid: https://orcid.org/0000-0002-9627-6030
   alias: cmalinmayor
+- given-names: Luca
+  family-names: Marconato
+  affiliation: EMBL Heidelberg
+  orcid: https://orcid.org/0000-0003-3198-1326
+  alias: LucaMarconato
 - given-names: Sean
   family-names: Martin
   affiliation: MetaCell

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -286,6 +286,11 @@ authors:
   affiliation: EMBL Heidelberg
   orcid: https://orcid.org/0000-0003-3198-1326
   alias: LucaMarconato
+- given-names: Caroline
+  family-names: Malin-Mayor
+  affiliation: HHMI Janelia Research Campus
+  orcid: https://orcid.org/0000-0002-9627-6030
+  alias: cmalinmayor
 - given-names: Sean
   family-names: Martin
   affiliation: MetaCell

--- a/src/napari/layers/labels/_tests/test_labels_multiscale.py
+++ b/src/napari/layers/labels/_tests/test_labels_multiscale.py
@@ -88,7 +88,7 @@ def test_3D_multiscale_labels_in_3D():
 def test_multiscale_labels_data_setter():
     """Setting .data on a multiscale Labels layer should not crash."""
     shapes = [(40, 20), (20, 10), (10, 5)]
-    data = [np.random.randint(20, size=s) for s in shapes]
+    data = [np.zeros(20, size=s) for s in shapes]
     layer = Labels(data, multiscale=True)
 
     new_data = [np.random.randint(20, size=s) for s in shapes]

--- a/src/napari/layers/labels/_tests/test_labels_multiscale.py
+++ b/src/napari/layers/labels/_tests/test_labels_multiscale.py
@@ -85,6 +85,20 @@ def test_3D_multiscale_labels_in_3D():
     ) == (2, 5)
 
 
+def test_multiscale_labels_data_setter():
+    """Setting .data on a multiscale Labels layer should not crash."""
+    shapes = [(40, 20), (20, 10), (10, 5)]
+    data = [np.random.randint(20, size=s) for s in shapes]
+    layer = Labels(data, multiscale=True)
+
+    new_data = [np.random.randint(20, size=s) for s in shapes]
+    layer.data = new_data
+
+    assert layer.multiscale is True
+    assert len(layer.data) == 3
+    assert layer.data[0].shape == (40, 20)
+
+
 def instantiate_3D_multiscale_labels():
     lowest_res_scale = np.arange(8).reshape(2, 2, 2)
     middle_res_scale = (

--- a/src/napari/layers/labels/_tests/test_labels_multiscale.py
+++ b/src/napari/layers/labels/_tests/test_labels_multiscale.py
@@ -88,7 +88,7 @@ def test_3D_multiscale_labels_in_3D():
 def test_multiscale_labels_data_setter():
     """Setting .data on a multiscale Labels layer should not crash."""
     shapes = [(40, 20), (20, 10), (10, 5)]
-    data = [np.zeros(20, size=s) for s in shapes]
+    data = [np.zeros(s) for s in shapes]
     layer = Labels(data, multiscale=True)
 
     new_data = [np.ones(s) for s in shapes]

--- a/src/napari/layers/labels/_tests/test_labels_multiscale.py
+++ b/src/napari/layers/labels/_tests/test_labels_multiscale.py
@@ -88,10 +88,10 @@ def test_3D_multiscale_labels_in_3D():
 def test_multiscale_labels_data_setter():
     """Setting .data on a multiscale Labels layer should not crash."""
     shapes = [(40, 20), (20, 10), (10, 5)]
-    data = [np.zeros(s) for s in shapes]
+    data = [np.zeros(s, dtype=np.int8) for s in shapes]
     layer = Labels(data, multiscale=True)
 
-    new_data = [np.ones(s) for s in shapes]
+    new_data = [np.ones(s, dtype=np.int8) for s in shapes]
     layer.data = new_data
 
     assert layer.multiscale is True

--- a/src/napari/layers/labels/_tests/test_labels_multiscale.py
+++ b/src/napari/layers/labels/_tests/test_labels_multiscale.py
@@ -91,7 +91,7 @@ def test_multiscale_labels_data_setter():
     data = [np.zeros(20, size=s) for s in shapes]
     layer = Labels(data, multiscale=True)
 
-    new_data = [np.random.randint(20, size=s) for s in shapes]
+    new_data = [np.ones(s) for s in shapes]
     layer.data = new_data
 
     assert layer.multiscale is True

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -600,7 +600,8 @@ class Labels(ScalarFieldBase):
     @data.setter
     def data(self, data: LayerDataProtocol | MultiScaleData):
         data = self._ensure_int_labels(data)
-        self._data = data
+        self._data_raw = data
+        self._data = MultiScaleData(data) if self.multiscale else data
         self._ndim = len(self._data.shape)
         self._reset_thumbnail_level_data()
         self._update_dims()

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -601,7 +601,7 @@ class Labels(ScalarFieldBase):
     def data(self, data: LayerDataProtocol | MultiScaleData):
         data = self._ensure_int_labels(data)
         self._data_raw = data
-        self._data = MultiScaleData(data) if self.multiscale else data
+        self._data = MultiScaleData(data) if self.multiscale else data  # type: ignore[arg-type]
         self._ndim = len(self._data.shape)
         self._reset_thumbnail_level_data()
         self._update_dims()


### PR DESCRIPTION
# References and relevant issues
Bug discovered during https://github.com/napari/napari/pull/8917 testing

# Description
Currently, Labels layers do not wrap their multiscale data in a MultiScaleData class during the data setter. This causes an `AttributeError: 'list' object has no attribute 'shape'` on: https://github.com/napari/napari/blob/c3e6c4ab549eaeb67c6f98502851dd99e4804522/src/napari/layers/labels/labels.py#L604 

Solution: do the same thing as the Image layer, save the original in `self._raw_data` (inherited from `ScalarBaseField`) and wrap self._data in `MultiScaleData` if self.multiscale is True. MultiScaleData has an ndim field, so this fixes the issue. There remains an issue with resetting the data_level if you reassign with new MultiScaleData that has fewer resolution levels, but this will be fixed in #8917 . Since the `ScalarFieldBase` has no data setter, I couldn't put the fix there, so duplicating the 2 lines of code seemed easiest.


