### PR TITLE
fix: add `fit_to_view()` to gallery examples using grid mode

### DIFF
--- a/examples/3d_kymograph_.py
+++ b/examples/3d_kymograph_.py
@@ -164,6 +164,6 @@ viewer.axes.visible = True  # magenta error shows time direction
 # set an oblique view angle onto the kymograph grid
 viewer.camera.center = (440, 880, 1490)
 viewer.camera.angles = (-20, 23, -50)
-viewer.camera.zoom = 0.17
+viewer.fit_to_view()
 
 napari.run()

--- a/examples/colorbar_tiling.py
+++ b/examples/colorbar_tiling.py
@@ -29,6 +29,7 @@ viewer.scale_bar.gridded = True
 # enable grid with stride 2 to get layers split two-by-two
 viewer.grid.enabled = True
 viewer.grid.stride = 2
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/export_rois.py
+++ b/examples/export_rois.py
@@ -81,6 +81,7 @@ for index, roi in enumerate(screenshot_rois_scaled):
 
 viewer.grid.enabled = True
 viewer.grid.shape = (3, 3)
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/fourier_transform_playground.py
+++ b/examples/fourier_transform_playground.py
@@ -169,6 +169,7 @@ wdg()
 
 # wait for the layers to be added before running the viewer
 wait_for_layers(viewer, ['wave 0'])
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/grid_mode.py
+++ b/examples/grid_mode.py
@@ -32,6 +32,7 @@ viewer.scale_bar.visible = True
 viewer.scale_bar.box = True
 # show scalebar in each grid instead of just once
 viewer.scale_bar.gridded = True
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/image_border.py
+++ b/examples/image_border.py
@@ -37,6 +37,7 @@ viewer.layers[1].bounding_box.line_color = 'orange'
 viewer.layers[1].bounding_box.line_thickness = 2
 viewer.layers[1].bounding_box.opacity = 0.8 # default: 1
 # viewer_2d.layers[1].bounding_box.blending = 'additive' # default: 'translucent'
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/layers.py
+++ b/examples/layers.py
@@ -23,6 +23,7 @@ viewer.add_image(data.moon(), name='moon')
 viewer.add_image(np.random.random((512, 512)), name='random')
 viewer.add_image(data.binary_blobs(length=512, volume_fraction=0.2, n_dim=2), name='blobs')
 viewer.grid.enabled = True
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()

--- a/examples/screenshot_and_export_figure.py
+++ b/examples/screenshot_and_export_figure.py
@@ -95,6 +95,7 @@ viewer.add_image(figure, rgb=True, name='figure')
 
 viewer.grid.enabled = True
 viewer.grid.shape = (2, 3)
+viewer.fit_to_view()
 
 if __name__ == '__main__':
     napari.run()


### PR DESCRIPTION
# References and relevant issues
Closes #8078 

# Description
gallery examples using `viewer.grid.enabled = True` were missing a `viewer.fit_to_view()` call, so it was not visualizing the example as intended.
- solution was already pointer in the issue by @TimMonko 😊 
- i'll try to run this and verify locally how it works now, to reduce the review work, so till then converting in draft .  Thanks!




