### PR TITLE
Normalize tracks data

### DIFF
--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -1,15 +1,12 @@
-from typing import TYPE_CHECKING
-
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
+from scipy.sparse import coo_matrix
+from scipy.spatial import cKDTree
 
 from napari.layers.utils.layer_utils import _FeatureTable
 from napari.utils.events.custom_types import Array
 from napari.utils.translations import trans
-
-if TYPE_CHECKING:
-    import pandas as pd
-    from scipy.spatial import cKDTree
 
 
 class TrackManager:
@@ -79,7 +76,7 @@ class TrackManager:
         self._feature_table = _FeatureTable()
 
         self._data: npt.NDArray
-        self._order: np.ndarray[tuple[int], np.dtype[np.integer]]
+        self._order: list[int]
         self._kdtree: cKDTree
         self._points: npt.NDArray
         self._points_id: npt.NDArray
@@ -90,7 +87,7 @@ class TrackManager:
         self._track_connex: npt.NDArray | None = None
 
         self._graph: dict[int, list[int]] | None = None
-        self._graph_vertices: npt.NDArray | None = None
+        self._graph_vertices = None
         self._graph_connex: npt.NDArray | None = None
 
         # Parameters for hide_completed_tracks functionality
@@ -127,8 +124,6 @@ class TrackManager:
     @data.setter
     def data(self, data: list | np.ndarray) -> None:
         """set the vertex data and build the vispy arrays for display"""
-        from scipy.sparse import coo_matrix
-        from scipy.spatial import cKDTree
 
         # convert data to a numpy array if it is not already one
         data = np.asarray(data)
@@ -168,7 +163,7 @@ class TrackManager:
         self._track_end_times = None
 
     @property
-    def features(self) -> 'pd.DataFrame':
+    def features(self) -> pd.DataFrame:
         """Dataframe-like features table.
 
         It is an implementation detail that this is a `pandas.DataFrame`. In the future,
@@ -188,10 +183,10 @@ class TrackManager:
     @features.setter
     def features(
         self,
-        features: 'dict[str, np.ndarray] | pd.DataFrame',
+        features: dict[str, np.ndarray] | pd.DataFrame,
     ) -> None:
         self._feature_table.set_values(features, num_data=len(self.data))
-        self._feature_table.reorder(self._order)  # type: ignore[arg-type]
+        self._feature_table.reorder(self._order)
         if 'track_id' not in self._feature_table.values:
             self._feature_table.values['track_id'] = self.track_ids
 
@@ -509,3 +504,18 @@ class TrackManager:
             lbl = [f'ID:{i}' for i in self._points_id[lookup]]
 
         return lbl, pos
+    
+    def normalize_track_data(data, column_map):
+        required = ["track_id", "t", "y", "x"]
+        for key in required:
+            if key not in column_map:
+                raise ValueError ("key missing")
+            
+        order = [column_map["track_id"], column_map["t"]]
+
+        if "z" in column_map:
+            order.append(column_map["z"])
+        
+        order.extend([column_map["y"], column_map["x"]])
+
+        return data[:, order]

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -504,18 +504,18 @@ class TrackManager:
             lbl = [f'ID:{i}' for i in self._points_id[lookup]]
 
         return lbl, pos
-    
+
     def normalize_track_data(data, column_map):
-        required = ["track_id", "t", "y", "x"]
+        required = ['track_id', 't', 'y', 'x']
         for key in required:
             if key not in column_map:
-                raise ValueError ("key missing")
-            
-        order = [column_map["track_id"], column_map["t"]]
+                raise ValueError('key missing')
 
-        if "z" in column_map:
-            order.append(column_map["z"])
-        
-        order.extend([column_map["y"], column_map["x"]])
+        order = [column_map['track_id'], column_map['t']]
+
+        if 'z' in column_map:
+            order.append(column_map['z'])
+
+        order.extend([column_map['y'], column_map['x']])
 
         return data[:, order]

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -1,12 +1,15 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 import numpy.typing as npt
-import pandas as pd
-from scipy.sparse import coo_matrix
-from scipy.spatial import cKDTree
 
 from napari.layers.utils.layer_utils import _FeatureTable
 from napari.utils.events.custom_types import Array
 from napari.utils.translations import trans
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from scipy.spatial import cKDTree
 
 
 class TrackManager:
@@ -76,7 +79,7 @@ class TrackManager:
         self._feature_table = _FeatureTable()
 
         self._data: npt.NDArray
-        self._order: list[int]
+        self._order: np.ndarray[tuple[int], np.dtype[np.integer]]
         self._kdtree: cKDTree
         self._points: npt.NDArray
         self._points_id: npt.NDArray
@@ -87,7 +90,7 @@ class TrackManager:
         self._track_connex: npt.NDArray | None = None
 
         self._graph: dict[int, list[int]] | None = None
-        self._graph_vertices = None
+        self._graph_vertices: npt.NDArray | None = None
         self._graph_connex: npt.NDArray | None = None
 
         # Parameters for hide_completed_tracks functionality
@@ -124,6 +127,8 @@ class TrackManager:
     @data.setter
     def data(self, data: list | np.ndarray) -> None:
         """set the vertex data and build the vispy arrays for display"""
+        from scipy.sparse import coo_matrix
+        from scipy.spatial import cKDTree
 
         # convert data to a numpy array if it is not already one
         data = np.asarray(data)
@@ -163,7 +168,7 @@ class TrackManager:
         self._track_end_times = None
 
     @property
-    def features(self) -> pd.DataFrame:
+    def features(self) -> 'pd.DataFrame':
         """Dataframe-like features table.
 
         It is an implementation detail that this is a `pandas.DataFrame`. In the future,
@@ -183,10 +188,10 @@ class TrackManager:
     @features.setter
     def features(
         self,
-        features: dict[str, np.ndarray] | pd.DataFrame,
+        features: 'dict[str, np.ndarray] | pd.DataFrame',
     ) -> None:
         self._feature_table.set_values(features, num_data=len(self.data))
-        self._feature_table.reorder(self._order)
+        self._feature_table.reorder(self._order)  # type: ignore[arg-type]
         if 'track_id' not in self._feature_table.values:
             self._feature_table.values['track_id'] = self.track_ids
 

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -517,5 +517,6 @@ class TrackManager:
             order.append(column_map['z'])
 
         order.extend([column_map['y'], column_map['x']])
-
-        return data[:, order]
+        
+        # convert to numpy
+        return data[:, order].to_numpy()

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -517,6 +517,6 @@ class TrackManager:
             order.append(column_map['z'])
 
         order.extend([column_map['y'], column_map['x']])
-        
+
         # convert to numpy
         return data[:, order].to_numpy()

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -519,3 +519,4 @@ class TrackManager:
         order.extend([column_map["y"], column_map["x"]])
 
         return data[:, order]
+    

--- a/src/napari/layers/tracks/tracks.py
+++ b/src/napari/layers/tracks/tracks.py
@@ -9,11 +9,13 @@ import numpy as np
 import pandas as pd
 
 from napari.layers.base import Layer
-from napari.layers.tracks._track_utils import TrackManager
+from napari.layers.tracks._track_utils import (
+    TrackManager,
+    normalize_track_data,
+)
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
 from napari.utils.events import Event
 from napari.utils.translations import trans
-from napari.layers.tracks._track_utils import normalize_track_data
 
 
 class Tracks(Layer):
@@ -224,7 +226,7 @@ class Tracks(Layer):
         # reset the display before returning
         self._current_displayed_dims = None
 
-        #reorder dataframe columns
+        # reorder dataframe columns
         if column_map is not None:
             data = normalize_track_data(data, column_map)
 

--- a/src/napari/layers/tracks/tracks.py
+++ b/src/napari/layers/tracks/tracks.py
@@ -2,20 +2,18 @@
 # from napari.utils.events import Event
 # from napari.utils.colormaps import AVAILABLE_COLORMAPS
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any
 from warnings import warn
 
 import numpy as np
+import pandas as pd
 
-from napari.layers.base import Layer, _LayerSlicingState
+from napari.layers.base import Layer
 from napari.layers.tracks._track_utils import TrackManager
-from napari.types import LayerDataType
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
 from napari.utils.events import Event
 from napari.utils.translations import trans
-
-if TYPE_CHECKING:
-    import pandas as pd
+from napari.layers.tracks._track_utils import normalize_track_data
 
 
 class Tracks(Layer):
@@ -35,7 +33,7 @@ class Tracks(Layer):
         provided scale, rotate, and shear values.
     axis_labels : tuple of str, optional
         Dimension names of the layer data.
-        If not provided, axis_labels will be set to (..., '-2', '-1').
+        If not provided, axis_labels will be set to (..., 'axis -2', 'axis -1').
     blending : str
         One of a list of preset blending modes that determines how RGB and
         alpha values of the layer visual get mixed. Allowed values are
@@ -111,7 +109,6 @@ class Tracks(Layer):
     # The max number of tracks that will ever be used to render the thumbnail
     # If more tracks are present then they are randomly subsampled
     _max_tracks_thumbnail = 1024
-    _slicing_state: '_TracksSlicingState'
 
     def __init__(
         self,
@@ -124,6 +121,7 @@ class Tracks(Layer):
         color_by='track_id',
         colormap='turbo',
         colormaps_dict=None,
+        column_map=None,
         experimental_clipping_planes=None,
         features=None,
         graph=None,
@@ -225,8 +223,10 @@ class Tracks(Layer):
 
         # reset the display before returning
         self._current_displayed_dims = None
-        self._slicing_state.slice_done.connect(self.events.rebuild_tracks)
-        self._slicing_state.slice_done.connect(self.events.rebuild_graph)
+
+        #reorder dataframe columns
+        if column_map is not None:
+            data = normalize_track_data(data, column_map)
 
     @property
     def _extent_data(self) -> np.ndarray:
@@ -275,7 +275,18 @@ class Tracks(Layer):
         return state
 
     def _set_view_slice(self) -> None:
-        raise NotImplementedError
+        """Sets the view given the indices to slice with."""
+
+        # if the displayed dims have changed, update the shader data
+        dims_displayed = self._slice_input.displayed
+        if dims_displayed != self._current_displayed_dims:
+            # store the new dims
+            self._current_displayed_dims = dims_displayed
+            # fire the events to update the shaders
+            self.events.rebuild_tracks()
+            self.events.rebuild_graph()
+
+        return
 
     def _get_value(self, position) -> int | None:
         """Value of the data at a position in data coordinates.
@@ -347,12 +358,26 @@ class Tracks(Layer):
     @property
     def _view_data(self):
         """return a view of the data"""
-        return self._slicing_state._view_data
+        return self._pad_display_data(self._manager.track_vertices)
 
     @property
     def _view_graph(self):
         """return a view of the graph"""
-        return self._slicing_state._view_graph
+        return self._pad_display_data(self._manager.graph_vertices)
+
+    def _pad_display_data(self, vertices):
+        """pad display data when moving between 2d and 3d"""
+        if vertices is None:
+            return None
+
+        data = vertices[:, self._slice_input.displayed]
+        # if we're only displaying two dimensions, then pad the display dim
+        # with zeros
+        if self._slice_input.ndisplay == 2:
+            data = np.pad(data, ((0, 0), (0, 1)), 'constant')
+            return data[:, (1, 0, 2)]  # y, x, z -> x, y, z
+
+        return data[:, (2, 1, 0)]  # z, y, x -> x, y, z
 
     @property
     def current_time(self) -> int | None:
@@ -401,7 +426,7 @@ class Tracks(Layer):
         self._reset_editable()
 
     @property
-    def features(self) -> 'pd.DataFrame':
+    def features(self) -> pd.DataFrame:
         """Dataframe-like features table.
 
         It is an implementation detail that this is a `pandas.DataFrame`. In the future,
@@ -421,7 +446,7 @@ class Tracks(Layer):
     @features.setter
     def features(
         self,
-        features: 'dict[str, np.ndarray] | pd.DataFrame',
+        features: dict[str, np.ndarray] | pd.DataFrame,
     ) -> None:
         self._manager.features = features
         self._check_color_by_in_features()
@@ -661,7 +686,7 @@ class Tracks(Layer):
         if not labels:
             return None, (None, None)
 
-        padded_positions = self._slicing_state._pad_display_data(positions)
+        padded_positions = self._pad_display_data(positions)
         return labels, padded_positions
 
     def _check_color_by_in_features(self) -> None:
@@ -678,51 +703,3 @@ class Tracks(Layer):
             )
             self._color_by = 'track_id'
             self.events.color_by()
-
-    def _get_layer_slicing_state(
-        self, data: LayerDataType, cache: bool
-    ) -> '_TracksSlicingState':
-        return _TracksSlicingState(layer=self, data=data, cache=cache)
-
-
-class _TracksSlicingState(_LayerSlicingState):
-    layer: Tracks
-
-    def __init__(self, layer: Tracks, data: LayerDataType, cache: bool):
-        super().__init__(layer=layer, data=data, cache=cache)
-        self._current_displayed_dims: Optional[list[int]] = None
-
-    def _set_view_slice(self) -> None:
-        """Sets the view given the indices to slice with."""
-
-        # if the displayed dims have changed, update the shader data
-        dims_displayed = self._slice_input.displayed
-        if dims_displayed != self._current_displayed_dims:
-            # store the new dims
-            self._current_displayed_dims = dims_displayed
-            # fire the events to update the shaders
-            self.slice_done()
-
-    def _pad_display_data(self, vertices):
-        """pad display data when moving between 2d and 3d"""
-        if vertices is None:
-            return None
-
-        data = vertices[:, self._slice_input.displayed]
-        # if we're only displaying two dimensions, then pad the display dim
-        # with zeros
-        if self._slice_input.ndisplay == 2:
-            data = np.pad(data, ((0, 0), (0, 1)), 'constant')
-            return data[:, (1, 0, 2)]  # y, x, z -> x, y, z
-
-        return data[:, (2, 1, 0)]  # z, y, x -> x, y, z
-
-    @property
-    def _view_data(self):
-        """return a view of the data"""
-        return self._pad_display_data(self.layer._manager.track_vertices)
-
-    @property
-    def _view_graph(self):
-        """return a view of the graph"""
-        return self._pad_display_data(self.layer._manager.graph_vertices)

--- a/src/napari/layers/tracks/tracks.py
+++ b/src/napari/layers/tracks/tracks.py
@@ -11,7 +11,6 @@ import pandas as pd
 from napari.layers.base import Layer
 from napari.layers.tracks._track_utils import (
     TrackManager,
-    normalize_track_data,
 )
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
 from napari.utils.events import Event

--- a/src/napari/layers/tracks/tracks.py
+++ b/src/napari/layers/tracks/tracks.py
@@ -123,7 +123,6 @@ class Tracks(Layer):
         color_by='track_id',
         colormap='turbo',
         colormaps_dict=None,
-        column_map=None,
         experimental_clipping_planes=None,
         features=None,
         graph=None,
@@ -225,10 +224,6 @@ class Tracks(Layer):
 
         # reset the display before returning
         self._current_displayed_dims = None
-
-        # reorder dataframe columns
-        if column_map is not None:
-            data = normalize_track_data(data, column_map)
 
     @property
     def _extent_data(self) -> np.ndarray:


### PR DESCRIPTION
Issue:
The Tracks layer currently requires users to convert tracks data into a NumPy array with a preset column order: [track_id, t, (z), y, x]. Most tracking data column names already encode these semantics (track_id, frame, x, y, etc.) which forces users to manually reorder columns before passing data to tracks layer. This tripped me up a few times before and I thought I'd make a PR to fix.

This is in reference to the issue #8510 that I made a few months ago and looking forward to everyone's feedback.

Fix:
Introduce explicit, opt-in column mapping for Tracks input data, without changing existing behavior. By adding column_map= in add_tracks, we can allow explicit column call from API:

```
viewer.add_tracks(
data,
column_map={"track_id": "id", "t": ("z"), "y", "x"},
)
```

I added a helper function normalize_data in `._tracks_utils.py` that reorders tracks data and plugged it into `tracks_init_ in` `tracks.py. `
