### PR TITLE
Replace v (shorter) with viewer in the examples

### DIFF
--- a/examples/3d_kymograph_.py
+++ b/examples/3d_kymograph_.py
@@ -151,19 +151,19 @@ for s in samples:
     print(f"Description: {s['description']}")
     s['vol'] = np.squeeze(IDR_fetch_image(s['IDRid']))
 
-v = napari.Viewer(ndisplay=3)
+viewer = napari.Viewer(ndisplay=3)
 scale = (5, 1, 1)  # "stretch" time domain
 for s in samples:
-    v.add_image(
+    viewer.add_image(
         s['vol'], name=s['description'], scale=scale, blending='opaque'
     )
 
-v.grid.enabled = True  # show the volumes in grid mode
-v.axes.visible = True  # magenta error shows time direction
+viewer.grid.enabled = True  # show the volumes in grid mode
+viewer.axes.visible = True  # magenta error shows time direction
 
 # set an oblique view angle onto the kymograph grid
-v.camera.center = (440, 880, 1490)
-v.camera.angles = (-20, 23, -50)
-v.camera.zoom = 0.17
+viewer.camera.center = (440, 880, 1490)
+viewer.camera.angles = (-20, 23, -50)
+viewer.camera.zoom = 0.17
 
 napari.run()

--- a/examples/pass_colormaps.py
+++ b/examples/pass_colormaps.py
@@ -15,15 +15,15 @@ import napari
 histo = data.astronaut() / 255
 rch, gch, bch = np.transpose(histo, (2, 0, 1))
 
-v = napari.Viewer()
+viewer = napari.Viewer()
 
-rlayer = v.add_image(
+rlayer = viewer.add_image(
     rch, name='red channel', colormap='red', blending='additive'
 )
-glayer = v.add_image(
+glayer = viewer.add_image(
     gch, name='green channel', colormap='green', blending='additive'
 )
-blayer = v.add_image(
+blayer = viewer.add_image(
     bch, name='blue channel', colormap='blue', blending='additive'
 )
 

--- a/examples/set_colormaps.py
+++ b/examples/set_colormaps.py
@@ -19,15 +19,15 @@ red = vispy.color.Colormap([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
 green = vispy.color.Colormap([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
 blue = vispy.color.Colormap([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 
-v = napari.Viewer()
+viewer = napari.Viewer()
 
-rlayer = v.add_image(rch, name='red channel')
+rlayer = viewer.add_image(rch, name='red channel')
 rlayer.blending = 'additive'
 rlayer.colormap = 'red', red
-glayer = v.add_image(gch, name='green channel')
+glayer = viewer.add_image(gch, name='green channel')
 glayer.blending = 'additive'
 glayer.colormap = green  # this will appear as [unnamed colormap]
-blayer = v.add_image(bch, name='blue channel')
+blayer = viewer.add_image(bch, name='blue channel')
 blayer.blending = 'additive'
 blayer.colormap = {'blue': blue}
 


### PR DESCRIPTION
Closes #8934 
# References and relevant issues

# Description
- Replace v (shorter) with viewer in the examples since it's the default when you launch napari from the terminal.

- need to discuss if we need to apply changes on tests also.



