### PR TITLE
Adapt tests that use zarr to work on zarr < 3 and zarr > 3.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -539,7 +539,6 @@ filterwarnings = [
   "ignore:__array__ implementation doesn't accept a copy keyword, so passing copy=False failed.",
   "ignore:pkg_resources is deprecated",
   "ignore:Deprecated call to `pkg_resources.declare_namespace",
-  "ignore:Use Group.create_array instead."
 ]
 markers = [
     "examples: Test of examples",

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1259,7 +1259,7 @@ def test_fill_tensorstore(tmp_path, zarr_version, zarr_driver):
         shape=labels.shape,
         dtype=np.uint32,
         chunks=(1, 1, 8, 9),
-        zarr_version=zarr_version,
+        zarr_format=zarr_version,
     )
     labels_temp[:] = labels
     labels_ts_spec = {

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1238,8 +1238,10 @@ def test_large_label_values():
 
 if parse_version(version('zarr')) > parse_version('3.0.0a0'):
     driver = [(2, 'zarr'), (3, 'zarr3')]
+    ZARR_V3 = True
 else:
     driver = [(2, 'zarr')]
+    ZARR_V3 = False
 
 
 @pytest.mark.parametrize(('zarr_version', 'zarr_driver'), driver)
@@ -1259,7 +1261,9 @@ def test_fill_tensorstore(tmp_path, zarr_version, zarr_driver):
         shape=labels.shape,
         dtype=np.uint32,
         chunks=(1, 1, 8, 9),
-        zarr_format=zarr_version,
+        # zarr < 3 uses zarr_version, zarr > 3 uses zarr_format
+        # This can be removed in favor of zarr_format once napari drops py310
+        **{('zarr_format' if ZARR_V3 else 'zarr_version'): zarr_version},
     )
     labels_temp[:] = labels
     labels_ts_spec = {

--- a/src/napari_builtins/_tests/test_io.py
+++ b/src/napari_builtins/_tests/test_io.py
@@ -86,7 +86,7 @@ def test_zarr_nested(tmp_path):
     image_name = 'my_image'
     root_path = tmp_path / 'dataset.zarr'
     grp = zarr.open(store=str(root_path), mode='a')
-    grp.create_dataset(image_name, data=image, shape=image.shape)
+    grp.create_array(image_name, data=image)
 
     image_in = magic_imread([str(root_path / image_name)])
     np.testing.assert_array_equal(image, image_in)
@@ -97,7 +97,7 @@ def test_zarr_with_unrelated_file(tmp_path):
     image_name = 'my_image'
     root_path = tmp_path / 'dataset.zarr'
     grp = zarr.open(store=str(root_path), mode='a')
-    grp.create_dataset(image_name, data=image, shape=image.shape)
+    grp.create_array(image_name, data=image)
 
     txt_file_path = root_path / 'unrelated.txt'
     txt_file_path.touch()
@@ -117,7 +117,7 @@ def test_zarr_multiscale(tmp_path):
     root = zarr.open_group(fout, mode='a')
     for i in range(len(multiscale)):
         shape = 20 // 2**i
-        z = root.create_dataset(str(i), shape=(shape,) * 2, dtype=np.float64)
+        z = root.create_array(str(i), shape=(shape,) * 2, dtype=np.float64)
         z[:] = multiscale[i]
     multiscale_in = magic_imread([fout])
     assert len(multiscale) == len(multiscale_in)
@@ -415,9 +415,9 @@ def test_zarr_multiple_groups_reads_first(tmp_path, monkeypatch):
     data0 = np.zeros((10, 10))
 
     group_one = root.create_group('1')
-    group_one.create_dataset('data', data=data1, shape=data1.shape)
+    group_one.create_array('data', data=data1)
     group_zero = root.create_group('0')
-    group_zero.create_dataset('data', data=data0, shape=data0.shape)
+    group_zero.create_array('data', data=data0)
 
     # Mock show_info to check if it was called
     mock_show_info = MagicMock()

--- a/src/napari_builtins/_tests/test_io.py
+++ b/src/napari_builtins/_tests/test_io.py
@@ -23,6 +23,19 @@ from napari_builtins.io._read import (
 )
 from napari_builtins.io._write import write_csv
 
+
+def _create_zarr_array(group, name, **kwargs):
+    """This is a helper to handle creating arrays with zarr < 3 and >3.2.0
+
+    Zarr > 3 deprecated `create_dataset` and zarr 3.2.0 removed it, but
+    `create_array` is not part of zarr < 3 API.
+    Once napari drops py310, this can be removed in favor of just `create_array`.
+    """
+    if hasattr(group, 'create_array'):
+        return group.create_array(name, **kwargs)
+    return group.create_dataset(name, **kwargs)
+
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -86,7 +99,7 @@ def test_zarr_nested(tmp_path):
     image_name = 'my_image'
     root_path = tmp_path / 'dataset.zarr'
     grp = zarr.open(store=str(root_path), mode='a')
-    grp.create_array(image_name, data=image)
+    _create_zarr_array(grp, image_name, data=image)
 
     image_in = magic_imread([str(root_path / image_name)])
     np.testing.assert_array_equal(image, image_in)
@@ -97,7 +110,7 @@ def test_zarr_with_unrelated_file(tmp_path):
     image_name = 'my_image'
     root_path = tmp_path / 'dataset.zarr'
     grp = zarr.open(store=str(root_path), mode='a')
-    grp.create_array(image_name, data=image)
+    _create_zarr_array(grp, image_name, data=image)
 
     txt_file_path = root_path / 'unrelated.txt'
     txt_file_path.touch()
@@ -117,7 +130,9 @@ def test_zarr_multiscale(tmp_path):
     root = zarr.open_group(fout, mode='a')
     for i in range(len(multiscale)):
         shape = 20 // 2**i
-        z = root.create_array(str(i), shape=(shape,) * 2, dtype=np.float64)
+        z = _create_zarr_array(
+            root, str(i), shape=(shape,) * 2, dtype=np.float64
+        )
         z[:] = multiscale[i]
     multiscale_in = magic_imread([fout])
     assert len(multiscale) == len(multiscale_in)
@@ -415,9 +430,9 @@ def test_zarr_multiple_groups_reads_first(tmp_path, monkeypatch):
     data0 = np.zeros((10, 10))
 
     group_one = root.create_group('1')
-    group_one.create_array('data', data=data1)
+    _create_zarr_array(group_one, 'data', data=data1)
     group_zero = root.create_group('0')
-    group_zero.create_array('data', data=data0)
+    _create_zarr_array(group_zero, 'data', data=data0)
 
     # Mock show_info to check if it was called
     mock_show_info = MagicMock()


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8938

# Description

In zarr 3.2.0 some things from zarr < 3 that were deprecated have been removed affecting the way we create test data. See:
https://github.com/zarr-developers/zarr-python/pull/3901
and
https://github.com/zarr-developers/zarr-python/pull/3902

In this PR I implement checks whether using zarr > 3 or not and based on that use the correct argument and method, because zarr 3.0.0 dropped support for py310 that we still test napari on. 
Note: These changes are for the arrays we create in tests, not reading itself.

Once we drop py310 support we can switch to just the zarr > 3 API.