### PR TITLE
Don't use random floats for image layer data in screenshot tests

### DIFF
--- a/src/napari/_qt/_tests/test_qt_window.py
+++ b/src/napari/_qt/_tests/test_qt_window.py
@@ -121,7 +121,7 @@ def test_screenshot_to_file(make_napari_viewer, tmp_path):
 
     np.random.seed(0)
     # Add image
-    data = np.random.random((10, 15))
+    data = np.ones((10, 15), dtype=np.uint8)
     viewer.add_image(data)
 
     # Add labels

--- a/src/napari/_qt/_tests/test_viewer_qt_integration.py
+++ b/src/napari/_qt/_tests/test_viewer_qt_integration.py
@@ -194,7 +194,7 @@ def test_screenshot(make_napari_viewer, qapp, qtbot):
     viewer = make_napari_viewer(show=True)
     rng = np.random.default_rng(0)
     # Add image
-    data = rng.random((10, 15))
+    data = np.ones((10, 15), dtype=np.uint8)
     viewer.add_image(data)
 
     # Add labels

--- a/src/napari/_tests/test_viewer.py
+++ b/src/napari/_tests/test_viewer.py
@@ -154,7 +154,7 @@ def test_screenshot(make_napari_viewer, qtbot):
 
     np.random.seed(0)
     # Add image
-    data = np.random.random((10, 15))
+    data = np.ones((10, 15), dtype=np.uint8)
     viewer.add_image(data)
 
     # Add labels

--- a/src/napari/_tests/test_with_screenshot.py
+++ b/src/napari/_tests/test_with_screenshot.py
@@ -476,7 +476,7 @@ def test_scale_bar_visible(make_napari_viewer):
 def test_screenshot_has_no_border(make_napari_viewer):
     """See https://github.com/napari/napari/issues/3357"""
     viewer = make_napari_viewer(show=True)
-    image_data = np.ones((60, 80))
+    image_data = np.ones((60, 80), dtype=np.uint8)
     viewer.add_image(image_data, colormap='red')
     # Zoom in dramatically to make the screenshot all red.
     viewer.camera.zoom = 1000

--- a/src/napari/_tests/test_with_screenshot.py
+++ b/src/napari/_tests/test_with_screenshot.py
@@ -476,7 +476,7 @@ def test_scale_bar_visible(make_napari_viewer):
 def test_screenshot_has_no_border(make_napari_viewer):
     """See https://github.com/napari/napari/issues/3357"""
     viewer = make_napari_viewer(show=True)
-    image_data = np.ones((60, 80), dtype=np.uint8)
+    image_data = np.ones((60, 80), dtype=np.float32)
     viewer.add_image(image_data, colormap='red')
     # Zoom in dramatically to make the screenshot all red.
     viewer.camera.zoom = 1000


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/8933

# Description
We have several screenshot tests that use random float64 data. This then goes through conversion hoops (to vispy, to screenshot) and results in flaky test failures.
In this PR i replace random float64 data in the screenshot tests with np.ones uint8. I don't think this materially affects the tests, but does reduce (eliminate?) some flake. I first did this in #8793 (https://github.com/napari/napari/commit/08ea81a07569e133231617b24a787a0141a06ecf) because I thought it was an issue with the canvas changes, but the same failure is common across PRs, so I pulled it out.
Note that some of these tests are skipped on CI, so we could consider rolling that back with this change.

Note: my goal is not a comprehensive overhaul of our tests to get rid of random data completely, just to get rid of this particular issue affecting tests right now.

