### PR TITLE
Fix Labels show_selected_label being silently dropped after color shuffle

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -483,5 +483,10 @@ authors:
   affiliation: Galgotias University
   orcid: https://orcid.org/0009-0004-4883-3797
   alias: Aniketsy
+- given-names: Lucien
+  family-names: Hinderling
+  affiliation: Institute of Cell Biology, University of Bern, Switzerland
+  orcid: https://orcid.org/0000-0002-3956-9363
+  alias: hinderling
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1717,6 +1717,49 @@ def test_color_mapping_with_show_selected_label():
     assert np.allclose(layer.colormap.map(data), mapped_colors_all)
 
 
+def test_show_selected_label_preserved_after_shuffle():
+    """Shuffling colors must not silently disable show_selected_label."""
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    seen = {}
+    layer.events.colormap.connect(
+        lambda e: seen.update(use_selection=layer.colormap.use_selection)
+    )
+    layer.new_colormap(seed=0)
+
+    # Selection state must be set before `events.colormap` fires, so the
+    # vispy shader is rebuilt with the right `use_selection`.
+    assert seen['use_selection'] is True
+    # And it must stick on the final colormap.
+    assert layer.colormap.use_selection is True
+    assert layer.colormap.selection == 2
+    label_mask = data == 2
+    npt.assert_allclose(layer.colormap.map(data)[~label_mask], 0)
+
+
+def test_shuffle_does_not_revive_stale_show_selected():
+    """Shuffling must reflect the layer's current show_selected_label state."""
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.selected_label = 2
+
+    # Enable, shuffle (detaches `_original_random_colormap` from the layer's
+    # mutations), then disable. Without the fix, the next shuffle would seed
+    # from the now-stale original and revive `use_selection=True`.
+    layer.show_selected_label = True
+    layer.new_colormap(seed=0)
+    layer.show_selected_label = False
+    layer.new_colormap(seed=1)
+
+    assert layer.colormap.use_selection is False
+    mapped = layer.colormap.map(data)
+    for value in range(1, 5):
+        assert np.any(mapped[data == value] != 0)
+
+
 def test_color_mapping_when_seed_is_changed():
     """Checks if the color mapping is updated when the color palette seed is changed."""
     np.random.seed(0)

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -549,9 +549,14 @@ class Labels(ScalarFieldBase):
             seed = int(np.random.default_rng().integers(2**32 - 1))
 
         orig = self._original_random_colormap
-        self.colormap = shuffle_and_extend_colormap(
+        new_cmap = shuffle_and_extend_colormap(
             self._original_random_colormap, seed
         )
+        # Sync from the layer (source of truth) before assignment, so
+        # `events.colormap` listeners observe the correct `use_selection`.
+        new_cmap.use_selection = self._show_selected_label
+        new_cmap.selection = self._selected_label
+        self.colormap = new_cmap
         self._original_random_colormap = orig
 
     @property


### PR DESCRIPTION
# References and relevant issues

No tracking issue found in repo search; reproduced locally on `main` (commit 0aec4fc4).

# Description

When `show_selected_label` is enabled on a `Labels` layer and the user shuffles colors (`new_colormap()` / shuffle button), the selected-label filter is silently dropped, and the user has to untick and re-tick the checkbox to restore it. A second variant of the same root cause goes the other way: enabling show_selected, shuffling, then disabling it leaves stale state that gets revived by the next shuffle.

Both stem from `new_colormap()` not synchronising the freshly-shuffled colormap with the layer's authoritative `_show_selected_label` / `_selected_label`. `shuffle_and_extend_colormap()` returns a `CyclicLabelColormap` with the dataclass defaults (`use_selection=False`, `selection=0`), and `_original_random_colormap`, used as the shuffle source, can carry stale values from earlier toggles since it is detached from the layer the moment a previous shuffle replaces `self.colormap`.

The fix sets `use_selection` and `selection` on the new colormap from the layer state **before** assigning it to `self.colormap`, so listeners of `events.colormap` (notably the vispy shader rebuild) observe the correct state. The same pattern is already used in `Labels.__init__` (labels.py:420-421) and the `show_selected_label` setter (labels.py:771-773); this just brings `new_colormap()` in line.

Manually verified in the GUI:
- show_selected ON, then shuffle: selected label stays visible in its new color, newly-painted pixels appear immediately.
- show_selected ON, then shuffle, then show_selected OFF, then shuffle: all labels visible (filter does not come back on its own).

Two regression tests cover both scenarios, including an event-time assertion for the bug variant where the colormap event would fire before the state was synced.