### PR TITLE
Improve sizing of dims ordering popup

### DIFF
--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -750,9 +750,8 @@ QPushButton#lockButton:!checked {
 
 /* ------------- Set size for dims sorter --------- */
 
-QtDimsSorter > QtListView {
-  max-height: 100px;
-  max-width: 150px;
+QtDimsSorter > QtListView::item {
+  padding: 2px;
 }
 
 /* ------------- Lock check buttons for dims sorter --------- */

--- a/src/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
@@ -49,3 +49,17 @@ def test_dims_sorter_with_reordered_init(qtbot):
     dim_sorter = QtDimsSorter(dims, parent)
     qtbot.addWidget(dim_sorter)
     assert tuple(dim_sorter.axis_list) == tuple(dims.order)
+
+
+def test_dims_sorter_height_caps_visible_rows(qtbot):
+    parent = QWidget()
+    small_sorter = QtDimsSorter(Dims(ndim=2), parent)
+    capped_sorter = QtDimsSorter(Dims(ndim=6), parent)
+    large_sorter = QtDimsSorter(Dims(ndim=10), parent)
+
+    qtbot.addWidget(small_sorter)
+    qtbot.addWidget(capped_sorter)
+    qtbot.addWidget(large_sorter)
+
+    assert small_sorter.view.height() < capped_sorter.view.height()
+    assert capped_sorter.view.height() == large_sorter.view.height()

--- a/src/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims_sorter.py
@@ -49,17 +49,3 @@ def test_dims_sorter_with_reordered_init(qtbot):
     dim_sorter = QtDimsSorter(dims, parent)
     qtbot.addWidget(dim_sorter)
     assert tuple(dim_sorter.axis_list) == tuple(dims.order)
-
-
-def test_dims_sorter_height_caps_visible_rows(qtbot):
-    parent = QWidget()
-    small_sorter = QtDimsSorter(Dims(ndim=2), parent)
-    capped_sorter = QtDimsSorter(Dims(ndim=6), parent)
-    large_sorter = QtDimsSorter(Dims(ndim=10), parent)
-
-    qtbot.addWidget(small_sorter)
-    qtbot.addWidget(capped_sorter)
-    qtbot.addWidget(large_sorter)
-
-    assert small_sorter.view.height() < capped_sorter.view.height()
-    assert capped_sorter.view.height() == large_sorter.view.height()

--- a/src/napari/_qt/widgets/qt_dims_sorter.py
+++ b/src/napari/_qt/widgets/qt_dims_sorter.py
@@ -1,4 +1,3 @@
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QAbstractScrollArea, QGridLayout, QLabel, QWidget
 
 from napari._qt.containers import QtListView
@@ -44,8 +43,6 @@ class QtDimsSorter(QWidget):
         Selectable evented list representing the viewer axes.
     """
 
-    _MAX_VISIBLE_DIMS = 6
-
     def __init__(self, dims: Dims, parent: QWidget) -> None:
         super().__init__(parent=parent)
         self.dims = dims
@@ -54,9 +51,6 @@ class QtDimsSorter(QWidget):
         self.view = QtListView(self.axis_list)
         self.view.setSizeAdjustPolicy(
             QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents
-        )
-        self.view.setVerticalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAsNeeded
         )
 
         layout = QGridLayout()
@@ -77,7 +71,6 @@ class QtDimsSorter(QWidget):
         layout.addWidget(widget_title, 0, 0)
         layout.addWidget(widget_tooltip, 0, 1)
         layout.addWidget(self.view, 1, 0, 1, 2)
-        self._update_view_height()
 
         # connect axis_list and dims
         self.axis_list.events.reordered.connect(
@@ -94,20 +87,6 @@ class QtDimsSorter(QWidget):
         # Regenerate AxisList upon Dims side order changes for easy cleanup
         self.axis_list = AxisList.from_dims(self.dims)
         self.view.setRoot(self.axis_list)
-        self._update_view_height()
         self.axis_list.events.reordered.connect(
             self._axis_list_reorder_callback,
         )
-
-    def _update_view_height(self) -> None:
-        row_count = self.view.model().rowCount()
-        visible_rows = min(row_count, self._MAX_VISIBLE_DIMS)
-        row_height = self.view.sizeHintForRow(0)
-        if row_height <= 0:
-            row_height = self.view.fontMetrics().height() + 8
-
-        view_height = (2 * self.view.frameWidth()) + (
-            visible_rows * row_height
-        )
-        self.view.setFixedHeight(view_height)
-        self.updateGeometry()

--- a/src/napari/_qt/widgets/qt_dims_sorter.py
+++ b/src/napari/_qt/widgets/qt_dims_sorter.py
@@ -1,4 +1,5 @@
-from qtpy.QtWidgets import QGridLayout, QLabel, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QAbstractScrollArea, QGridLayout, QLabel, QWidget
 
 from napari._qt.containers import QtListView
 from napari._qt.containers.qt_axis_model import AxisList, AxisModel
@@ -43,15 +44,20 @@ class QtDimsSorter(QWidget):
         Selectable evented list representing the viewer axes.
     """
 
+    _MAX_VISIBLE_DIMS = 6
+
     def __init__(self, dims: Dims, parent: QWidget) -> None:
         super().__init__(parent=parent)
         self.dims = dims
         self.axis_list = AxisList.from_dims(self.dims)
 
         self.view = QtListView(self.axis_list)
-        if len(self.axis_list) <= 2:
-            # prevent excess space in popup
-            self.view.setSizeAdjustPolicy(QtListView.AdjustToContents)
+        self.view.setSizeAdjustPolicy(
+            QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents
+        )
+        self.view.setVerticalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
 
         layout = QGridLayout()
         self.setLayout(layout)
@@ -68,9 +74,10 @@ class QtDimsSorter(QWidget):
 
         widget_title = QLabel(trans._('Dims. Ordering'), self)
 
-        self.layout().addWidget(widget_title, 0, 0)
-        self.layout().addWidget(widget_tooltip, 0, 1)
-        self.layout().addWidget(self.view, 1, 0, 1, 2)
+        layout.addWidget(widget_title, 0, 0)
+        layout.addWidget(widget_tooltip, 0, 1)
+        layout.addWidget(self.view, 1, 0, 1, 2)
+        self._update_view_height()
 
         # connect axis_list and dims
         self.axis_list.events.reordered.connect(
@@ -87,6 +94,20 @@ class QtDimsSorter(QWidget):
         # Regenerate AxisList upon Dims side order changes for easy cleanup
         self.axis_list = AxisList.from_dims(self.dims)
         self.view.setRoot(self.axis_list)
+        self._update_view_height()
         self.axis_list.events.reordered.connect(
             self._axis_list_reorder_callback,
         )
+
+    def _update_view_height(self) -> None:
+        row_count = self.view.model().rowCount()
+        visible_rows = min(row_count, self._MAX_VISIBLE_DIMS)
+        row_height = self.view.sizeHintForRow(0)
+        if row_height <= 0:
+            row_height = self.view.fontMetrics().height() + 8
+
+        view_height = (2 * self.view.frameWidth()) + (
+            visible_rows * row_height
+        )
+        self.view.setFixedHeight(view_height)
+        self.updateGeometry()


### PR DESCRIPTION
# References and relevant issues

The Dims Reordering popup has a scroll bar as soon as there are 3 dims. This is a really bad UX, since the point of the widget is to be able to drag.
While exploring some of the theme PRs of late, this thorn in our GUI was noticeable. I've had this be a problem in workshops

# Description

1. Changes it so that the widget is no longer size limited
2. It will auto add a scrollbar just like the layerlist does. I checked with 40 dimensions (but needs #8953 to not be positioned weird)
3. qss uses the `LayerList` styling and then a modification. I'm not seeing why this original qss was added in #5986, I think it's vestigial given that it was hard capped in the python code. I removed it and just decreased the padding a bit compared to the layer list so that they weren't quite so chunky. We could just remove the qss altogether (it doesn't do much).

This PR:
<img width="546" height="491" alt="image" src="https://github.com/user-attachments/assets/52b84616-6ba0-42b4-947e-70a0cbbd6919" />

Main:
<img width="556" height="411" alt="image" src="https://github.com/user-attachments/assets/f762fa43-9f48-490d-8c56-2208b76ed439" />


More dims now:
<img width="477" height="606" alt="image" src="https://github.com/user-attachments/assets/23228c3f-a860-485c-863c-6cd599e2fbb6" />

