### PR TITLE
Explicitly pass the repository name in command setting milestone

### DIFF
--- a/.github/workflows/auto_add_milestone.yml
+++ b/.github/workflows/auto_add_milestone.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set milestone on PR
         if: github.event.pull_request.milestone == null && steps.closest_milestone.outputs.name != ''
         run: |
-          gh pr edit "$PR_NUMBER" --milestone "$CLOSEST_MILESTONE_NAME"
+          gh pr edit "$PR_NUMBER" --repo ${{ github.repository }} --milestone "$CLOSEST_MILESTONE_NAME"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/actions/runs/25366259274/job/74377759671?pr=8954

```
Run gh pr edit "$PR_NUMBER" --milestone "$CLOSEST_MILESTONE_NAME"
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

# Description

I totally miss that I should test workflow outside napari repo, so `gh pr edit` read the repository from repo config. For security reasons, we don't want to check out repo, so we need to edit command. 

Tested locally outside repository.

