### PR TITLE
Update python version used to generate title and body of update constraints PR

### DIFF
--- a/.github/workflows/upgrade_test_constraints.yml
+++ b/.github/workflows/upgrade_test_constraints.yml
@@ -169,3 +169,4 @@ jobs:
             GHA_TOKEN_MAIN_REPO: ${{ secrets.GHA_TOKEN_NAPARI_BOT_MAIN_REPO }}
             PR_NUMBER: ${{ github.event.issue.number }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            PYTHON_VERSION_FOR_DESCRIPTION: "3.14"

--- a/tools/create_pr_or_update_existing_one.py
+++ b/tools/create_pr_or_update_existing_one.py
@@ -118,7 +118,9 @@ def commit_message(branch_name) -> str:
         changed_direct = get_changed_dependencies(
             all_packages=False,
             base_branch=branch_name,
-            python_version='3.11',
+            python_version=os.environ.get(
+                'PYTHON_VERSION_FOR_DESCRIPTION', '3.14'
+            ),
             src_dir=REPO_DIR,
         )
     if not changed_direct:
@@ -131,7 +133,9 @@ def long_description(branch_name: str) -> str:
         all_changed = get_changed_dependencies(
             all_packages=True,
             base_branch=branch_name,
-            python_version='3.11',
+            python_version=os.environ.get(
+                'PYTHON_VERSION_FOR_DESCRIPTION', '3.14'
+            ),
             src_dir=REPO_DIR,
         )
     return 'Updated packages: ' + ', '.join(f'`{x}`' for x in all_changed)


### PR DESCRIPTION
# References and relevant issues

closes #8956

# Description

Change python version used for generation of title and description of update constraints PR from python 3.11 to python 3.14 

Make this python version more explicit by allow setting it from workflow file.