### PR TITLE
Use `gh release create` instead of `softprops/action-gh-release`

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -100,12 +100,12 @@ jobs:
       - name: Create Release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
-          gh release create ${name} ${files} \
-              --title ${name} \
-              --notes-file ${body_path} \
-              --target ${target_commit} \
-              --prerelease ${prerelease}
-        with:
+          gh release create "${name}" "${files}" \
+              --title "${name}" \
+              --notes-file "${body_path}" \
+              --target "${target_commit}" \
+              --prerelease "${prerelease}"
+        env:
           tag_name: ${{ github.ref }}
           name: ${{ env.tag }}
           body_path: notes/release_notes.md

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -106,7 +106,6 @@ jobs:
               --target "${target_commit}" \
               --prerelease "${prerelease}"
         env:
-          tag_name: ${{ github.ref }}
           name: ${{ env.tag }}
           body_path: notes/release_notes.md
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -98,16 +98,19 @@ jobs:
           path: notes
 
       - name: Create Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          gh release create ${name} ${files} \
+              --title ${name} \
+              --notes-file ${body_path} \
+              --target ${target_commit} \
+              --prerelease ${prerelease}
         with:
           tag_name: ${{ github.ref }}
           name: ${{ env.tag }}
-          body: pre-release ${{ env.tag }}
           body_path: notes/release_notes.md
-          draft: false
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
-          target_commitish: ${{ github.sha }}
+          target_commit: ${{ github.sha }}
           files: |
             dist/*
 


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/8944/changes#r3175576871

# Description

Instead of using `softprops/action-gh-release` use the `gh release create`. It should increase safety of our workflows. 