### PR TITLE
Remove check of Qt version that disable gradient in themes

### DIFF
--- a/src/napari/utils/theme.py
+++ b/src/napari/utils/theme.py
@@ -20,15 +20,6 @@ from napari.utils.events import EventedModel
 from napari.utils.events.containers._evented_dict import EventedDict
 from napari.utils.translations import trans
 
-try:
-    from qtpy import QT_VERSION
-
-    major, minor, *_ = QT_VERSION.split('.')  # type: ignore[attr-defined]
-    use_gradients = (int(major) >= 5) and (int(minor) >= 12)
-    del major, minor, QT_VERSION
-except (ImportError, RuntimeError):
-    use_gradients = False
-
 
 class Theme(EventedModel):
     """Theme model.
@@ -172,8 +163,6 @@ def opacity(color: str | Color, value: int = 255) -> str:
 
 
 def gradient(stops, horizontal: bool = True) -> str:
-    if not use_gradients:
-        return stops[-1]
 
     if horizontal:
         grad = 'qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, '


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/8904#issuecomment-4384304850

# Description

We found that there is a stupid check that try to validate if qt is below 5.12. It cannot happen as minimum supported version is 5.15. 

The worse part is that all Qt6 releases landed in this check, so gradient is effectively disabled. 

Left is main, right is this PR

<img width="673" height="127" alt="image" src="https://github.com/user-attachments/assets/1c9640d7-4f49-4a45-b987-eae019248a39" />

Changes should be more visible with a progress bar. 

