### PR TITLE
Pass token to make `gh` working in create release workflow

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -112,6 +112,7 @@ jobs:
           target_commit: ${{ github.sha }}
           files: |
             dist/*
+          GH_TOKEN: ${{ github.token }}
 
   publish-to-pypi:
     name: Publish release to PyPI


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/actions/runs/25455771658/job/74684788443

# Description

Fix

```
Run gh release create "${name}" "${files}" \
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
Error: Process completed with exit code 4.
```