### PR TITLE
Next fix of release workflow by pass directly `dist/*`

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -102,13 +102,12 @@ jobs:
         run: |
           gh release create "${name}" dist/* \
               --title "${name}" \
-              --notes-file "${body_path}" \
+              --notes-file notes/release_notes.md \
               --target "${target_commit}" \
               --prerelease "${prerelease}"
         env:
           name: ${{ github.ref_name }}
-          body_path: notes/release_notes.md
-          prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
+          prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'a') || contains(github.ref_name, 'b') }}
           target_commit: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -105,6 +105,7 @@ jobs:
               --notes-file notes/release_notes.md \
               --target "${target_commit}" \
               --prerelease "${prerelease}"
+        shell: bash
         env:
           name: ${{ github.ref_name }}
           prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'a') || contains(github.ref_name, 'b') }}

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -100,18 +100,16 @@ jobs:
       - name: Create Release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
-          gh release create "${name}" "${files}" \
+          gh release create "${name}" dist/* \
               --title "${name}" \
               --notes-file "${body_path}" \
               --target "${target_commit}" \
               --prerelease "${prerelease}"
         env:
-          name: ${{ env.tag }}
+          name: ${{ github.ref_name }}
           body_path: notes/release_notes.md
           prerelease: ${{ contains(env.tag, 'rc') || contains(env.tag, 'a') || contains(env.tag, 'b') }}
           target_commit: ${{ github.sha }}
-          files: |
-            dist/*
           GH_TOKEN: ${{ github.token }}
 
   publish-to-pypi:


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/actions/runs/25460314474/job/74700580013

# Description

It looks like passing "dist/*" prevents path expanding. 

This PR also fix prerelease check as env is not passed between steps and I introduced this bug in #8882

```
  gh release create "${name}" "${files}" \
      --title "${name}" \
      --notes-file "${body_path}" \
      --target "${target_commit}" \
      --prerelease "${prerelease}"
  shell: /usr/bin/bash -e {0}
  env:
    name: 
    body_path: notes/release_notes.md
    prerelease: false
    target_commit: 25b4ee84f6cdf6229eae727e2d4ed5be27135086
    files: dist/*
  
    GH_TOKEN: ***
no matches found for `dist/*
```

