### PR TITLE
Fix Labels show_selected_label drift across colormap swaps

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -483,5 +483,10 @@ authors:
   affiliation: Galgotias University
   orcid: https://orcid.org/0009-0004-4883-3797
   alias: Aniketsy
+- given-names: Lucien
+  family-names: Hinderling
+  affiliation: Institute of Cell Biology, University of Bern, Switzerland
+  orcid: https://orcid.org/0000-0002-3956-9363
+  alias: hinderling
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -63,6 +63,25 @@ def test_changing_layer_show_selected_label_updates_check_box(
     assert qtctrl._display_selected_label_checkbox_control.selected_color_checkbox.isChecked()
 
 
+def test_color_mode_switch_preserves_show_selected_label(make_labels_controls):
+    """Switching color mode via the combobox is orthogonal to the
+    show-selected-label preference and should not flip the checkbox.
+    """
+    from napari.layers.labels._labels_constants import LabelColorMode
+
+    layer, qtctrl = make_labels_controls(colormap=_COLOR)
+    combo = qtctrl._colormode_combobox_control.color_mode_combobox
+    layer.show_selected_label = True
+
+    combo.setCurrentIndex(combo.findData(LabelColorMode.AUTO.value))
+    qtctrl._colormode_combobox_control.change_color_mode()
+    assert layer.show_selected_label is True
+
+    combo.setCurrentIndex(combo.findData(LabelColorMode.DIRECT.value))
+    qtctrl._colormode_combobox_control.change_color_mode()
+    assert layer.show_selected_label is True
+
+
 def test_rendering_combobox(make_labels_controls):
     """Changing the model attribute should update the view"""
     layer, qtctrl = make_labels_controls()

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
@@ -54,11 +54,20 @@ class QtColorModeComboBoxControl(QtWidgetControlsBase):
         self.color_mode_combobox_label = QtWrappedLabel(trans._('color mode:'))
 
     def change_color_mode(self) -> None:
-        """Change color mode of label layer"""
+        """Change color mode of label layer.
+
+        Each colormap carries its own ``use_selection`` flag, so swapping
+        modes would otherwise expose whichever value the new cmap last
+        held. The user toggled one widget; mode and filter are orthogonal
+        from the GUI perspective, so we restore the filter state across
+        the swap.
+        """
+        show_selected = self._layer.show_selected_label
         if self.color_mode_combobox.currentData() == LabelColorMode.AUTO.value:
             self._layer.colormap = self._layer._original_random_colormap
         else:
             self._layer.colormap = self._layer._direct_colormap
+        self._layer.show_selected_label = show_selected
 
     def _on_colormap_change(self) -> None:
         enable_combobox = not self._layer._is_default_colors(

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
@@ -58,16 +58,17 @@ class QtColorModeComboBoxControl(QtWidgetControlsBase):
 
         Each colormap carries its own ``use_selection`` flag, so swapping
         modes would otherwise expose whichever value the new cmap last
-        held. The user toggled one widget; mode and filter are orthogonal
-        from the GUI perspective, so we restore the filter state across
-        the swap.
+        held. Pre-sync the filter and selection onto the target cmap
+        before assignment so the swap is a single coherent event (no
+        spurious adopt-and-emit cycle on the layer setter).
         """
-        show_selected = self._layer.show_selected_label
         if self.color_mode_combobox.currentData() == LabelColorMode.AUTO.value:
-            self._layer.colormap = self._layer._original_random_colormap
+            new_cmap = self._layer._original_random_colormap
         else:
-            self._layer.colormap = self._layer._direct_colormap
-        self._layer.show_selected_label = show_selected
+            new_cmap = self._layer._direct_colormap
+        new_cmap.use_selection = self._layer.show_selected_label
+        new_cmap.selection = self._layer.selected_label
+        self._layer.colormap = new_cmap
 
     def _on_colormap_change(self) -> None:
         enable_combobox = not self._layer._is_default_colors(

--- a/src/napari/_vispy/overlays/labels_polygon.py
+++ b/src/napari/_vispy/overlays/labels_polygon.py
@@ -163,7 +163,7 @@ class VispyLabelsPolygonOverlay(LayerOverlayMixin, VispySceneOverlay):
 
     def _update_color(self):
         layer = self.layer
-        if layer._selected_label == layer.colormap.background_value:
+        if layer.selected_label == layer.colormap.background_value:
             self._set_color((1, 0, 0, 0))
         else:
             self._set_color(

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1717,8 +1717,13 @@ def test_color_mapping_with_show_selected_label():
     assert np.allclose(layer.colormap.map(data), mapped_colors_all)
 
 
-def test_show_selected_label_preserved_after_shuffle():
-    """Shuffling colors must not silently disable show_selected_label."""
+def test_shuffle_preserves_show_selected_label_in_both_directions():
+    """Shuffling must reflect the layer's current ``show_selected_label``
+    state, both when enabled and when disabled. Covers the original
+    #8947 bug (shuffle silently dropped the filter) and its mirror image
+    (after enable -> shuffle -> disable, the next shuffle seeded from a
+    stale ``_original_random_colormap`` and revived ``use_selection``).
+    """
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
     layer.selected_label = 2
@@ -1730,27 +1735,16 @@ def test_show_selected_label_preserved_after_shuffle():
     )
     layer.new_colormap(seed=0)
 
-    # Selection state must be set before `events.colormap` fires, so the
+    # Filter state must be set before `events.colormap` fires so the
     # vispy shader is rebuilt with the right `use_selection`.
     assert seen['use_selection'] is True
-    # And it must stick on the final colormap.
     assert layer.colormap.use_selection is True
     assert layer.colormap.selection == 2
     label_mask = data == 2
     npt.assert_allclose(layer.colormap.map(data)[~label_mask], 0)
 
-
-def test_shuffle_does_not_revive_stale_show_selected():
-    """Shuffling must reflect the layer's current show_selected_label state."""
-    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
-    layer = Labels(data)
-    layer.selected_label = 2
-
-    # Enable, shuffle (detaches `_original_random_colormap` from the layer's
-    # mutations), then disable. Without the fix, the next shuffle would seed
-    # from the now-stale original and revive `use_selection=True`.
-    layer.show_selected_label = True
-    layer.new_colormap(seed=0)
+    # Disable and shuffle again. The shuffle must seed from the layer's
+    # current state, not from a stale `_original_random_colormap`.
     layer.show_selected_label = False
     layer.new_colormap(seed=1)
 

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1820,7 +1820,10 @@ def test_show_selected_label_round_trip_honors_each_colormap():
     # has use_selection=False (its default); the proxy reads from the new
     # active colormap, so show_selected_label flips to False.
     layer.colormap = layer._original_random_colormap
-    assert layer.show_selected_label == layer._original_random_colormap.use_selection
+    assert (
+        layer.show_selected_label
+        == layer._original_random_colormap.use_selection
+    )
 
 
 def test_external_use_selection_mutation_bubbles_to_layer_event():

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1761,15 +1761,15 @@ def test_shuffle_does_not_revive_stale_show_selected():
 
 
 def test_direct_colormap_assignment_honors_new_use_selection():
-    """``layer.colormap = X`` honors X's ``use_selection`` and emits the
-    layer event when it differs from the previous value.
+    """``layer.colormap = X`` adopts ``X.use_selection`` into the layer
+    cache and emits ``events.show_selected_label`` when it differs from
+    the previous value.
 
     The colormap setter is the central swap point used by user code, the
-    qt color-mode combobox, and ``new_colormap()``. With the colormap as
-    the source of truth, assigning a fresh ``CyclicLabelColormap`` (which
-    defaults to ``use_selection=False``) flips the layer state to match
-    and fires ``events.show_selected_label`` so vispy and the qt checkbox
-    stay coherent.
+    qt color-mode combobox, and ``new_colormap()``. Assigning a fresh
+    ``CyclicLabelColormap`` (which defaults to ``use_selection=False``)
+    flips the layer state to match so vispy and the qt checkbox stay
+    coherent. (See PR discussion for the assign-honors-X tradeoff.)
     """
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
@@ -1791,9 +1791,10 @@ def test_show_selected_label_round_trip_honors_each_colormap():
     tracks whichever colormap is currently active at every step.
 
     ``_original_random_colormap`` is a snapshot whose ``use_selection``
-    reflects whatever it had when last touched. The proxy reads from the
-    active colormap, so the round trip's final state is determined by the
-    cmap, not by some stashed layer preference.
+    reflects whatever it had when last touched. The layer adopts the
+    assigned cmap's value on every ``layer.colormap = ...`` swap, so the
+    round trip's final state is determined by the cmap, not by some
+    stashed layer preference.
     """
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
@@ -1826,26 +1827,6 @@ def test_show_selected_label_round_trip_honors_each_colormap():
     )
 
 
-def test_external_use_selection_mutation_bubbles_to_layer_event():
-    """Mutating ``colormap.use_selection`` directly is reflected in
-    ``layer.show_selected_label`` (proxy) and bubbles up to fire
-    ``layer.events.show_selected_label`` so vispy and the qt checkbox
-    react to changes that bypass the layer setter.
-    """
-    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
-    layer = Labels(data)
-
-    seen = []
-    layer.events.show_selected_label.connect(
-        lambda e: seen.append(e.show_selected_label)
-    )
-
-    layer.colormap.use_selection = True
-
-    assert layer.show_selected_label is True
-    assert seen == [True]
-
-
 def test_labels_constructor_honors_colormap_use_selection():
     """Constructing ``Labels`` with a colormap whose ``use_selection`` is
     pre-set yields a layer whose ``show_selected_label`` reflects it.
@@ -1875,35 +1856,6 @@ def test_show_selected_label_survives_get_state_round_trip():
 
     assert new_layer.show_selected_label is True
     assert new_layer.colormap.use_selection is True
-
-
-def test_selected_label_setter_keeps_layer_self_consistent():
-    """After ``selected_label = X`` the layer's selection state on both
-    sides agrees. Regression guard for the public setter (also reached
-    via the ``M`` keybinding)."""
-    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
-    layer = Labels(data)
-    layer.colormap.use_selection = True
-
-    layer.selected_label = 4
-
-    assert layer.show_selected_label == layer.colormap.use_selection
-    assert layer.selected_label == layer.colormap.selection
-
-
-def test_swap_selected_and_background_keeps_layer_self_consistent():
-    """``swap_selected_and_background_labels()`` (also bound to a key)
-    must leave the layer self-consistent."""
-    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
-    layer = Labels(data)
-    layer.selected_label = 2
-    layer.show_selected_label = True
-    layer.colormap.use_selection = False
-
-    layer.swap_selected_and_background_labels()
-
-    assert layer.show_selected_label == layer.colormap.use_selection
-    assert layer.selected_label == layer.colormap.selection
 
 
 def test_deepcopy_preserves_selection_state():

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1760,6 +1760,167 @@ def test_shuffle_does_not_revive_stale_show_selected():
         assert np.any(mapped[data == value] != 0)
 
 
+def test_direct_colormap_assignment_honors_new_use_selection():
+    """``layer.colormap = X`` honors X's ``use_selection`` and emits the
+    layer event when it differs from the previous value.
+
+    The colormap setter is the central swap point used by user code, the
+    qt color-mode combobox, and ``new_colormap()``. With the colormap as
+    the source of truth, assigning a fresh ``CyclicLabelColormap`` (which
+    defaults to ``use_selection=False``) flips the layer state to match
+    and fires ``events.show_selected_label`` so vispy and the qt checkbox
+    stay coherent.
+    """
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.show_selected_label = True
+
+    seen = []
+    layer.events.show_selected_label.connect(
+        lambda e: seen.append(e.show_selected_label)
+    )
+    layer.colormap = label_colormap(49, seed=0.7)
+
+    assert layer.show_selected_label is False
+    assert layer.colormap.use_selection is False
+    assert seen == [False]
+
+
+def test_show_selected_label_round_trip_honors_each_colormap():
+    """AUTO -> DIRECT -> toggle show_selected -> AUTO. ``show_selected_label``
+    tracks whichever colormap is currently active at every step.
+
+    ``_original_random_colormap`` is a snapshot whose ``use_selection``
+    reflects whatever it had when last touched. The proxy reads from the
+    active colormap, so the round trip's final state is determined by the
+    cmap, not by some stashed layer preference.
+    """
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+
+    # Combobox path AUTO -> DIRECT (non-default colors). The new direct
+    # cmap has the default use_selection=False.
+    direct_cmap = DirectLabelColormap(
+        color_dict={
+            0: [0, 0, 0, 0],
+            1: [1, 0, 0, 1],
+            2: [0, 1, 0, 1],
+            None: [0, 0, 1, 1],
+        }
+    )
+    layer.colormap = direct_cmap
+    assert isinstance(layer.colormap, DirectLabelColormap)
+    assert layer.show_selected_label is False
+
+    # Toggle while in DIRECT mode -- mutates the active (direct) cmap.
+    layer.show_selected_label = True
+    assert layer.colormap.use_selection is True
+
+    # Combobox path DIRECT -> AUTO. The stashed _original_random_colormap
+    # has use_selection=False (its default); the proxy reads from the new
+    # active colormap, so show_selected_label flips to False.
+    layer.colormap = layer._original_random_colormap
+    assert layer.show_selected_label == layer._original_random_colormap.use_selection
+
+
+def test_external_use_selection_mutation_bubbles_to_layer_event():
+    """Mutating ``colormap.use_selection`` directly is reflected in
+    ``layer.show_selected_label`` (proxy) and bubbles up to fire
+    ``layer.events.show_selected_label`` so vispy and the qt checkbox
+    react to changes that bypass the layer setter.
+    """
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+
+    seen = []
+    layer.events.show_selected_label.connect(
+        lambda e: seen.append(e.show_selected_label)
+    )
+
+    layer.colormap.use_selection = True
+
+    assert layer.show_selected_label is True
+    assert seen == [True]
+
+
+def test_labels_constructor_honors_colormap_use_selection():
+    """Constructing ``Labels`` with a colormap whose ``use_selection`` is
+    pre-set yields a layer whose ``show_selected_label`` reflects it.
+
+    Note: ``selected_label`` vs ``colormap.selection`` is intentionally
+    out of scope here; that pair is being decoupled in #8699 (drawing
+    label vs display label).
+    """
+    cmap = label_colormap(49, seed=0.5)
+    cmap.use_selection = True
+
+    layer = Labels(np.zeros((4, 4), dtype=np.int32), colormap=cmap)
+
+    assert layer.show_selected_label is True
+
+
+def test_show_selected_label_survives_get_state_round_trip():
+    """``Labels._get_state()`` round-trips ``show_selected_label`` via the
+    serialised colormap object (which carries ``use_selection``).
+    """
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.show_selected_label = True
+
+    state = layer._get_state()
+    new_layer = Labels(**state)
+
+    assert new_layer.show_selected_label is True
+    assert new_layer.colormap.use_selection is True
+
+
+def test_selected_label_setter_keeps_layer_self_consistent():
+    """After ``selected_label = X`` the layer's selection state on both
+    sides agrees. Regression guard for the public setter (also reached
+    via the ``M`` keybinding)."""
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.colormap.use_selection = True
+
+    layer.selected_label = 4
+
+    assert layer.show_selected_label == layer.colormap.use_selection
+    assert layer.selected_label == layer.colormap.selection
+
+
+def test_swap_selected_and_background_keeps_layer_self_consistent():
+    """``swap_selected_and_background_labels()`` (also bound to a key)
+    must leave the layer self-consistent."""
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.selected_label = 2
+    layer.show_selected_label = True
+    layer.colormap.use_selection = False
+
+    layer.swap_selected_and_background_labels()
+
+    assert layer.show_selected_label == layer.colormap.use_selection
+    assert layer.selected_label == layer.colormap.selection
+
+
+def test_deepcopy_preserves_selection_state():
+    """``copy.deepcopy(layer)`` carries the selection state on the cloned
+    colormap. Guard against a future event-based sync regressing this if
+    listener wiring on the cloned colormap gets dropped."""
+    import copy
+
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    clone = copy.deepcopy(layer)
+
+    assert clone.colormap.use_selection is True
+    assert clone.colormap.selection == 2
+    assert clone.selected_label == 2
+
+
 def test_color_mapping_when_seed_is_changed():
     """Checks if the color mapping is updated when the color palette seed is changed."""
     np.random.seed(0)

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1765,11 +1765,13 @@ def test_direct_colormap_assignment_honors_new_use_selection():
     cache and emits ``events.show_selected_label`` when it differs from
     the previous value.
 
-    The colormap setter is the central swap point used by user code, the
-    qt color-mode combobox, and ``new_colormap()``. Assigning a fresh
-    ``CyclicLabelColormap`` (which defaults to ``use_selection=False``)
-    flips the layer state to match so vispy and the qt checkbox stay
-    coherent. (See PR discussion for the assign-honors-X tradeoff.)
+    The colormap setter is the central swap point used by user code and
+    ``new_colormap()``. Assigning a fresh ``CyclicLabelColormap`` (which
+    defaults to ``use_selection=False``) flips the layer state to match
+    so vispy and the qt checkbox stay coherent. The qt color-mode
+    combobox pre-syncs the new cmap before assignment to preserve the
+    user's filter preference across mode swaps; that GUI-side path is
+    covered by ``test_color_mode_switch_preserves_show_selected_label``.
     """
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
@@ -1799,8 +1801,10 @@ def test_show_selected_label_round_trip_honors_each_colormap():
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
 
-    # Combobox path AUTO -> DIRECT (non-default colors). The new direct
-    # cmap has the default use_selection=False.
+    # Direct API path AUTO -> DIRECT: assigning a fresh
+    # DirectLabelColormap (default use_selection=False) flips the layer
+    # state to match. (The qt combobox path pre-syncs first; see
+    # test_color_mode_switch_preserves_show_selected_label.)
     direct_cmap = DirectLabelColormap(
         color_dict={
             0: [0, 0, 0, 0],
@@ -1817,9 +1821,10 @@ def test_show_selected_label_round_trip_honors_each_colormap():
     layer.show_selected_label = True
     assert layer.colormap.use_selection is True
 
-    # Combobox path DIRECT -> AUTO. The stashed _original_random_colormap
-    # has use_selection=False (its default); the proxy reads from the new
-    # active colormap, so show_selected_label flips to False.
+    # Direct API path DIRECT -> AUTO: the stashed
+    # _original_random_colormap has use_selection=False (its default);
+    # the layer adopts that value on assignment, so
+    # show_selected_label flips to False.
     layer.colormap = layer._original_random_colormap
     assert (
         layer.show_selected_label

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1717,6 +1717,49 @@ def test_color_mapping_with_show_selected_label():
     assert np.allclose(layer.colormap.map(data), mapped_colors_all)
 
 
+def test_show_selected_label_preserved_after_shuffle():
+    """Shuffling colors must not silently disable show_selected_label."""
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    seen = {}
+    layer.events.colormap.connect(
+        lambda e: seen.update(use_selection=layer.colormap.use_selection)
+    )
+    layer.new_colormap(seed=0)
+
+    # Selection state must be set before `events.colormap` fires, so the
+    # vispy shader is rebuilt with the right `use_selection`.
+    assert seen['use_selection'] is True
+    # And it must stick on the final colormap.
+    assert layer.colormap.use_selection is True
+    assert layer.colormap.selection == 2
+    label_mask = data == 2
+    npt.assert_allclose(layer.colormap.map(data)[~label_mask], 0)
+
+
+def test_shuffle_does_not_revive_stale_show_selected():
+    """Shuffling must reflect the layer's current show_selected_label state."""
+    data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
+    layer = Labels(data)
+    layer.selected_label = 2
+
+    # Enable, shuffle (detaches `_original_random_colormap` from the layer's
+    # mutations), then disable. Without the fix, the next shuffle would seed
+    # from the now-stale original and revive `use_selection=True`.
+    layer.show_selected_label = True
+    layer.new_colormap(seed=0)
+    layer.show_selected_label = False
+    layer.new_colormap(seed=1)
+
+    assert layer.colormap.use_selection is False
+    mapped = layer.colormap.map(data)
+    for value in range(1, 5):
+        assert np.any(mapped[data == value] != 0)
+
+
 def test_color_mapping_when_seed_is_changed():
     """Checks if the color mapping is updated when the color palette seed is changed."""
     np.random.seed(0)

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -354,6 +354,7 @@ class Labels(ScalarFieldBase):
         )
         self._colormap = self._random_colormap
         self._color_mode = LabelColorMode.AUTO
+        self._show_selected_label = False
         self._contour = 0
 
         data = self._ensure_int_labels(data)
@@ -417,13 +418,10 @@ class Labels(ScalarFieldBase):
 
         self._selected_label = 1
         self.colormap.selection = self._selected_label
+        self.colormap.use_selection = self._show_selected_label
         self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self._updated_slice: tuple[slice, ...] | None = None
-        # Bubble cmap.events.use_selection up to layer.events.show_selected_label
-        # so external mutations (and cmap swaps) keep listeners coherent. Must
-        # connect before any path that might mutate the cmap's use_selection.
-        self._connect_colormap_events()
         if colormap is not None:
             self._set_colormap(colormap)
 
@@ -554,10 +552,10 @@ class Labels(ScalarFieldBase):
         new_cmap = shuffle_and_extend_colormap(
             self._original_random_colormap, seed
         )
-        # Carry the current selection state onto the shuffled colormap, so
-        # `events.colormap` listeners observe the correct `use_selection` and
-        # the public colormap setter doesn't fire a spurious change event.
-        new_cmap.use_selection = self._colormap.use_selection
+        # Carry the layer's selection state onto the shuffled colormap, so
+        # the assign below is a no-op for `use_selection` (no spurious event)
+        # and `events.colormap` listeners observe the correct values.
+        new_cmap.use_selection = self._show_selected_label
         new_cmap.selection = self._selected_label
         self.colormap = new_cmap
         self._original_random_colormap = orig
@@ -570,27 +568,7 @@ class Labels(ScalarFieldBase):
     def colormap(self, colormap: LabelColormapBase):
         self._set_colormap(colormap)
 
-    def _connect_colormap_events(self):
-        self._colormap.events.use_selection.connect(
-            self._on_cmap_use_selection_change
-        )
-
-    def _disconnect_colormap_events(self, cmap):
-        cmap.events.use_selection.disconnect(
-            self._on_cmap_use_selection_change
-        )
-
-    def _on_cmap_use_selection_change(self, event):
-        # Bubble cmap field event up so listeners (vispy shader rebuild,
-        # qt checkbox) react to external mutation. The layer's own setter
-        # blocks this listener (via .blocker()) to avoid double-firing.
-        self.events.show_selected_label(show_selected_label=event.value)
-        self.refresh(extent=False)
-
     def _set_colormap(self, colormap):
-        old_cmap = self._colormap
-        old_use_sel = old_cmap.use_selection
-        self._disconnect_colormap_events(old_cmap)
         colormap = _normalize_label_colormap(colormap)
         if isinstance(colormap, CyclicLabelColormap):
             self._random_colormap = colormap
@@ -613,17 +591,23 @@ class Labels(ScalarFieldBase):
             else:
                 color_mode = LabelColorMode.DIRECT
                 self._colormap = self._direct_colormap
+        # Adopt the new colormap's selection state into the layer's cache.
+        # `_show_selected_label` is the layer's source of truth, but each
+        # colormap object carries its own `use_selection`; honoring the
+        # incoming value keeps `_get_state` round-trips and externally-built
+        # cmaps coherent. Emit `events.show_selected_label` only when it
+        # actually changes so existing listeners don't see spurious fires.
+        old_show_selected = self._show_selected_label
+        new_show_selected = self._colormap.use_selection
+        self._show_selected_label = new_show_selected
         self._cached_labels = None  # invalidate the cached color mapping
         self._selected_color = self.get_color(self.selected_label)
         self._color_mode = color_mode
-        self._connect_colormap_events()
         self.events.colormap()  # Will update the LabelVispyColormap shader
         self.events.selected_label()
-        if self._colormap.use_selection != old_use_sel:
-            # Listener was rebound rather than seeing a field change, so emit
-            # the layer-level event explicitly.
+        if new_show_selected != old_show_selected:
             self.events.show_selected_label(
-                show_selected_label=self._colormap.use_selection
+                show_selected_label=new_show_selected
             )
         self.refresh(extent=False)
 
@@ -800,22 +784,18 @@ class Labels(ScalarFieldBase):
     def show_selected_label(self):
         """Whether to filter displayed labels to only the selected label or not.
 
-        Backed directly by ``self.colormap.use_selection``; mutating the
-        colormap field is reflected here and fires this property's event.
+        The layer-level ``_show_selected_label`` is the source of truth.
+        Mutating ``layer.colormap.use_selection`` directly will not update
+        this property or fire ``events.show_selected_label`` -- always go
+        through this setter.
         """
-        return self._colormap.use_selection
+        return self._show_selected_label
 
     @show_selected_label.setter
     def show_selected_label(self, show_selected):
-        # Block the bubbled listener so the setter's explicit fire below
-        # is the single emission (preserves the pre-proxy always-fire
-        # behavior, which several listeners depend on for unconditional
-        # refresh).
-        with self._colormap.events.use_selection.blocker(
-            self._on_cmap_use_selection_change
-        ):
-            self._colormap.use_selection = show_selected
-            self._colormap.selection = self.selected_label
+        self._show_selected_label = show_selected
+        self.colormap.use_selection = show_selected
+        self.colormap.selection = self.selected_label
         self.events.show_selected_label(show_selected_label=show_selected)
         self.refresh(extent=False)
 

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -549,9 +549,14 @@ class Labels(ScalarFieldBase):
             seed = int(np.random.default_rng().integers(2**32 - 1))
 
         orig = self._original_random_colormap
-        self.colormap = shuffle_and_extend_colormap(
+        new_cmap = shuffle_and_extend_colormap(
             self._original_random_colormap, seed
         )
+        # Sync from the layer (source of truth) before assignment, so
+        # `events.colormap` listeners observe the correct `use_selection`.
+        new_cmap.use_selection = self._show_selected_label
+        new_cmap.selection = self._selected_label
+        self.colormap = new_cmap
         self._original_random_colormap = orig
 
     @property

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -354,7 +354,6 @@ class Labels(ScalarFieldBase):
         )
         self._colormap = self._random_colormap
         self._color_mode = LabelColorMode.AUTO
-        self._show_selected_label = False
         self._contour = 0
 
         data = self._ensure_int_labels(data)
@@ -418,10 +417,13 @@ class Labels(ScalarFieldBase):
 
         self._selected_label = 1
         self.colormap.selection = self._selected_label
-        self.colormap.use_selection = self._show_selected_label
         self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self._updated_slice: tuple[slice, ...] | None = None
+        # Bubble cmap.events.use_selection up to layer.events.show_selected_label
+        # so external mutations (and cmap swaps) keep listeners coherent. Must
+        # connect before any path that might mutate the cmap's use_selection.
+        self._connect_colormap_events()
         if colormap is not None:
             self._set_colormap(colormap)
 
@@ -552,9 +554,10 @@ class Labels(ScalarFieldBase):
         new_cmap = shuffle_and_extend_colormap(
             self._original_random_colormap, seed
         )
-        # Sync from the layer (source of truth) before assignment, so
-        # `events.colormap` listeners observe the correct `use_selection`.
-        new_cmap.use_selection = self._show_selected_label
+        # Carry the current selection state onto the shuffled colormap, so
+        # `events.colormap` listeners observe the correct `use_selection` and
+        # the public colormap setter doesn't fire a spurious change event.
+        new_cmap.use_selection = self._colormap.use_selection
         new_cmap.selection = self._selected_label
         self.colormap = new_cmap
         self._original_random_colormap = orig
@@ -567,7 +570,27 @@ class Labels(ScalarFieldBase):
     def colormap(self, colormap: LabelColormapBase):
         self._set_colormap(colormap)
 
+    def _connect_colormap_events(self):
+        self._colormap.events.use_selection.connect(
+            self._on_cmap_use_selection_change
+        )
+
+    def _disconnect_colormap_events(self, cmap):
+        cmap.events.use_selection.disconnect(
+            self._on_cmap_use_selection_change
+        )
+
+    def _on_cmap_use_selection_change(self, event):
+        # Bubble cmap field event up so listeners (vispy shader rebuild,
+        # qt checkbox) react to external mutation. The layer's own setter
+        # blocks this listener (via .blocker()) to avoid double-firing.
+        self.events.show_selected_label(show_selected_label=event.value)
+        self.refresh(extent=False)
+
     def _set_colormap(self, colormap):
+        old_cmap = self._colormap
+        old_use_sel = old_cmap.use_selection
+        self._disconnect_colormap_events(old_cmap)
         colormap = _normalize_label_colormap(colormap)
         if isinstance(colormap, CyclicLabelColormap):
             self._random_colormap = colormap
@@ -593,8 +616,15 @@ class Labels(ScalarFieldBase):
         self._cached_labels = None  # invalidate the cached color mapping
         self._selected_color = self.get_color(self.selected_label)
         self._color_mode = color_mode
+        self._connect_colormap_events()
         self.events.colormap()  # Will update the LabelVispyColormap shader
         self.events.selected_label()
+        if self._colormap.use_selection != old_use_sel:
+            # Listener was rebound rather than seeing a field change, so emit
+            # the layer-level event explicitly.
+            self.events.show_selected_label(
+                show_selected_label=self._colormap.use_selection
+            )
         self.refresh(extent=False)
 
     @ScalarFieldBase.data.setter  # type: ignore[attr-defined]
@@ -768,14 +798,24 @@ class Labels(ScalarFieldBase):
 
     @property
     def show_selected_label(self):
-        """Whether to filter displayed labels to only the selected label or not"""
-        return self._show_selected_label
+        """Whether to filter displayed labels to only the selected label or not.
+
+        Backed directly by ``self.colormap.use_selection``; mutating the
+        colormap field is reflected here and fires this property's event.
+        """
+        return self._colormap.use_selection
 
     @show_selected_label.setter
     def show_selected_label(self, show_selected):
-        self._show_selected_label = show_selected
-        self.colormap.use_selection = show_selected
-        self.colormap.selection = self.selected_label
+        # Block the bubbled listener so the setter's explicit fire below
+        # is the single emission (preserves the pre-proxy always-fire
+        # behavior, which several listeners depend on for unconditional
+        # refresh).
+        with self._colormap.events.use_selection.blocker(
+            self._on_cmap_use_selection_change
+        ):
+            self._colormap.use_selection = show_selected
+            self._colormap.selection = self.selected_label
         self.events.show_selected_label(show_selected_label=show_selected)
         self.refresh(extent=False)
 


### PR DESCRIPTION
# References and relevant issues

Closes (partially) #8965, the `show_selected_label` half. Follow-up to #8947. Coordinated with #8699 (decoupling drawing label from display label).

# Description

The `Labels` layer kept the same boolean in two places: a private `_show_selected_label` cache on the layer, and `colormap.use_selection` on the colormap object. Several code paths updated only one of them, producing silent drift between the public API (`layer.show_selected_label`) and the renderer (vispy + accelerated cmap mapping, both of which read `colormap.use_selection` directly).

This PR keeps `_show_selected_label` as the layer's source of truth and fixes the drift at the assignment seams:

1. **Pre-syncing on shuffle and mode switch.** `new_colormap()` and the qt color-mode combobox write the layer's current `_show_selected_label` (and `_selected_label`) onto the new cmap *before* the assignment, so the swap is a single coherent event.
2. **Adopt-on-assign in `_set_colormap`.** The colormap setter reads `cmap.use_selection` from the incoming object and copies it into the layer cache, emitting `events.show_selected_label` only when it actually changes. This is the central swap point used by user code, the qt combobox, `new_colormap()`, and `_get_state` round-trips. Adopting here makes externally-built cmaps and serialised state coherent without per-call sync at every site.

No event listener on `cmap.events.use_selection`, no `.blocker()` machinery. Direct mutation of `layer.colormap.use_selection` is explicitly unsupported and documented as such on the property docstring; callers should use `layer.show_selected_label = ...`.

Also fixes `_vispy/overlays/labels_polygon.py:166` to read the public `layer.selected_label` instead of the private attribute, removing the last internal reader of `_selected_label` outside `labels.py`.

## Drift paths closed

Five previously-broken scenarios, each pinned by a test:

1. `layer.colormap = X` dropping the filter state.
2. `_original_random_colormap` carrying stale state across color-mode round-trips.
3. Constructor with a pre-configured cmap not seeding the layer's reported state.
4. `_get_state` round-trip silently losing `show_selected_label`.
5. Shuffle (`new_colormap()`) silently disabling `show_selected_label` (the original #8947 case, kept as a regression guard).

## To discuss

Two opinionated points where I'm unsure and would appreciate input.

### 1. `layer.colormap = X` honors `X.use_selection`

This PR makes assignment **honor** `X.use_selection`: assigning a fresh `CyclicLabelColormap` (default `use_selection=False`) flips the layer state to match and fires `events.show_selected_label`. Previously this was undefined drift.

The alternative is **assignment overwrites**: the layer cache wins, and the layer would write `_show_selected_label` onto whatever cmap is being assigned. Less surprising for code that builds fresh cmaps without thinking about `use_selection`, but it would mean drift paths 3 and 4 above (constructor-with-preconfigured-cmap, `_get_state` round-trip) need a different mechanism (likely: only the constructor and deserialisation paths adopt).

I'm unsure which is preferable. I went with **honor** because it makes `_get_state` round-trips and explicit-cmap construction work without special-casing those paths.

### 2. Direct mutation of `layer.colormap.use_selection` is unsupported

Trade-off accepted in this PR: writing `layer.colormap.use_selection = True` from outside the layer no longer propagates to `layer.show_selected_label` or fires the layer event. Documented on the property docstring; callers should always go through the layer property.

A grep of the napari codebase shows the renderer reads `cmap.use_selection` but never writes it; the only writers are the layer setters themselves and the qt combobox. So this isn't a feature anyone is using internally.

I tested an alternative that does support direct cmap mutation: a small idempotent listener on `cmap.events.use_selection`, plus disconnect/reconnect on every cmap swap. It works (all tests pass), and because the cache stays canonical the listener short-circuits naturally, so no `.blocker()` or setter ordering tricks are needed. The cost is roughly +30 production lines vs this PR, and it introduces a sub-field listener pattern on a swappable internal object that doesn't currently exist anywhere else in the layers package. The closest sibling is `Shapes._selected_data.events.items_changed`, but that object is owned for the layer's lifetime and never swapped.

I'm leaning toward the simpler version in this PR (no listener, document the constraint), but I'm genuinely unsure. Happy to switch if there's a real use case for direct cmap mutation that I haven't found.

## Out of scope

The `_selected_label` ↔ `colormap.selection` half of #8965 is intentionally untouched here. That pair is being decoupled in #8699 (drawing label vs display label, with a future `selected_data: Selection[int]`). Should this PR work out, the rebase on that side is straightforward: no removed attributes to recover.

## Manual verification

In the GUI:
- Toggle show_selected, shuffle colors → filter persists, label stays highlighted in its new color.
- Toggle show_selected, programmatically `layer.colormap = label_colormap(49, seed=0.7)` → checkbox unticks, all labels reappear (the assign-honors-X behaviour from discussion point 1 above).
- AUTO → DIRECT → AUTO via combobox → checkbox state preserved across both swaps.
- `Labels(data, colormap=cmap_with_use_selection_True)` → reports `show_selected_label is True` immediately.

## Tests

Tests covering the five drift paths (plus a deepcopy regression guard and the GUI mode-switch invariant). Existing #8947 shuffle tests retained unchanged.

