### PR TITLE
Try to fix passing prerelease to `gh release create`

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -100,15 +100,19 @@ jobs:
       - name: Create Release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
+          prerelease=()
+          if [[ "${name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
+              prerelease=(--prerelease)
+          fi
+
           gh release create "${name}" dist/* \
               --title "${name}" \
               --notes-file notes/release_notes.md \
               --target "${target_commit}" \
-              --prerelease "${prerelease}"
+              "${prerelease[@]}"
         shell: bash
         env:
           name: ${{ github.ref_name }}
-          prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'a') || contains(github.ref_name, 'b') }}
           target_commit: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/actions/runs/25481013267/job/74764993153

# Description

I don't know, why reading a help multiple time I ignored thy `--prerelease` is a flag, not accepting arguments (It is also bad interface decision for toll that is expected to be used on CI). 

```
Run gh release create "${name}" dist/* \
  gh release create "${name}" dist/* \
      --title "${name}" \
      --notes-file notes/release_notes.md \
      --target "${target_commit}" \
      --prerelease "${prerelease}"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    name: v0.7.1a4
    prerelease: true
    target_commit: dd6fe66bb248def5788849ac34a62489d9edb530
    GH_TOKEN: ***
no matches found for `true`
Error: Process completed with exit code 1.
```