### PR TITLE
Explicitly set repository in make release workflow

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -109,9 +109,11 @@ jobs:
               --title "${name}" \
               --notes-file notes/release_notes.md \
               --target "${target_commit}" \
+              --repo ${repository} \
               "${prerelease[@]}"
         shell: bash
         env:
+          repository: ${{ github.repository }}
           name: ${{ github.ref_name }}
           target_commit: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -109,7 +109,7 @@ jobs:
               --title "${name}" \
               --notes-file notes/release_notes.md \
               --target "${target_commit}" \
-              --repo ${repository} \
+              --repo "${repository}" \
               "${prerelease[@]}"
         shell: bash
         env:


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/actions/runs/25521422114/job/74906249665
#8955

# Description

I read documentation a few times, Tim do it too. And I miss same error as fixed in #8955...

```
Run prerelease=()
  prerelease=()
  if [[ "${name}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
      prerelease=(--prerelease)
  fi
  
  gh release create "${name}" dist/* \
      --title "${name}" \
      --notes-file notes/release_notes.md \
      --target "${target_commit}" \
      "${prerelease[@]}"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    name: v0.7.1a5
    target_commit: 1599f945d408f7856c78ec9a3318df6a96b973da
    GH_TOKEN: ***
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```


