### PR TITLE
Make label colormaps immutable, layer owns show_selected_label (alternative to #8967)

### DIFF
--- a/src/napari/_vispy/layers/labels.py
+++ b/src/napari/_vispy/layers/labels.py
@@ -279,24 +279,30 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
             self.texture_data = color_texture
 
         elif not auto_mode:  # only for raw_dtype.itemsize > 2
-            color_dict = colormap._values_mapping_to_minimum_values_set()[1]
+            use_selection = self.layer.show_selected_label
+            selected_label = self.layer.selected_label
+            color_dict = colormap._values_mapping_to_minimum_values_set(
+                use_selection=use_selection, selection=selected_label
+            )[1]
             max_size = get_max_texture_sizes()[0]
             val_texture = build_textures_from_dict(color_dict, max_size)
 
-            dtype = _texture_dtype(
-                self.layer._direct_colormap._num_unique_colors + 2,
-                raw_dtype,
+            num_colors = (
+                2
+                if use_selection
+                else self.layer._direct_colormap._num_unique_colors + 2
             )
+            dtype = _texture_dtype(num_colors, raw_dtype)
             if issubclass(dtype.type, np.integer):
                 scale = np.iinfo(dtype).max
             else:  # float32 texture
                 scale = 1.0
 
             selection_texture = colormap._selection_as_minimum_dtype(
-                self.layer.selected_label, raw_dtype
+                selected_label, raw_dtype, use_selection=use_selection
             )
             self.node.cmap = DirectLabelVispyColormap(
-                use_selection=self.layer.show_selected_label,
+                use_selection=use_selection,
                 selection=selection_texture,
                 scale=scale,
                 color_map_size=val_texture.shape[0],

--- a/src/napari/_vispy/layers/labels.py
+++ b/src/napari/_vispy/layers/labels.py
@@ -67,6 +67,9 @@ uniform vec2 LUT_shape;
 
 vec4 sample_label_color(float t) {
     t = t * $scale;
+    if (($use_selection) && ($selection != int(t + 0.5))) {
+        return vec4(0);
+    }
     return texture2D(
         texture2D_values,
         vec2(0.0, (t + 0.5) / $color_map_size)
@@ -81,6 +84,9 @@ uniform vec2 LUT_shape;
 
 vec4 sample_label_color(float t) {
     t = t * $scale;
+    if (($use_selection) && ($selection != int(t + 0.5))) {
+        return vec4(0);
+    }
     float row = mod(t, LUT_shape.x);
     float col = int(t / LUT_shape.x);
     return texture2D(
@@ -97,6 +103,8 @@ class LabelVispyColormap(VispyColormap):
         colormap: CyclicLabelColormap,
         view_dtype: np.dtype,
         raw_dtype: np.dtype,
+        use_selection: bool = False,
+        selection: int = 0,
     ):
         super().__init__(
             colors=['w', 'w'], controls=None, interpolation='zero'
@@ -116,12 +124,14 @@ class LabelVispyColormap(VispyColormap):
                 f'Cannot use dtype {view_dtype} with LabelVispyColormap'
             )
 
-        selection = colormap._selection_as_minimum_dtype(raw_dtype)
+        selection_texture = colormap._selection_as_minimum_dtype(
+            selection, raw_dtype
+        )
 
         self.glsl_map = (
             shader.replace('$color_map_size', str(len(colormap.colors)))
-            .replace('$use_selection', str(colormap.use_selection).lower())
-            .replace('$selection', str(selection))
+            .replace('$use_selection', str(use_selection).lower())
+            .replace('$selection', str(selection_texture))
         )
 
 
@@ -255,7 +265,11 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
                 colormap, view_dtype, raw_dtype
             )
             self.node.cmap = LabelVispyColormap(
-                colormap, view_dtype=view_dtype, raw_dtype=raw_dtype
+                colormap,
+                view_dtype=view_dtype,
+                raw_dtype=raw_dtype,
+                use_selection=self.layer.show_selected_label,
+                selection=self.layer.selected_label,
             )
             self.node.shared_program['texture2D_values'] = Texture2D(
                 color_texture,
@@ -278,9 +292,12 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
             else:  # float32 texture
                 scale = 1.0
 
+            selection_texture = colormap._selection_as_minimum_dtype(
+                self.layer.selected_label, raw_dtype
+            )
             self.node.cmap = DirectLabelVispyColormap(
-                use_selection=colormap.use_selection,
-                selection=colormap.selection,
+                use_selection=self.layer.show_selected_label,
+                selection=selection_texture,
                 scale=scale,
                 color_map_size=val_texture.shape[0],
                 multi=val_texture.shape[1] > 1,

--- a/src/napari/_vispy/layers/labels.py
+++ b/src/napari/_vispy/layers/labels.py
@@ -295,24 +295,30 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
             self.texture_data = color_texture
 
         elif not auto_mode:  # only for raw_dtype.itemsize > 2
-            color_dict = colormap._values_mapping_to_minimum_values_set()[1]
+            use_selection = self.layer.show_selected_label
+            selected_label = self.layer.selected_label
+            color_dict = colormap._values_mapping_to_minimum_values_set(
+                use_selection=use_selection, selection=selected_label
+            )[1]
             max_size = get_max_texture_sizes()[0]
             val_texture = build_textures_from_dict(color_dict, max_size)
 
-            dtype = _texture_dtype(
-                self.layer._direct_colormap._num_unique_colors + 2,
-                raw_dtype,
+            num_colors = (
+                2
+                if use_selection
+                else self.layer._direct_colormap._num_unique_colors + 2
             )
+            dtype = _texture_dtype(num_colors, raw_dtype)
             if issubclass(dtype.type, np.integer):
                 scale = np.iinfo(dtype).max
             else:  # float32 texture
                 scale = 1.0
 
             selection_texture = colormap._selection_as_minimum_dtype(
-                self.layer.selected_label, raw_dtype
+                selected_label, raw_dtype, use_selection=use_selection
             )
             self.node.cmap = DirectLabelVispyColormap(
-                use_selection=self.layer.show_selected_label,
+                use_selection=use_selection,
                 selection=selection_texture,
                 scale=scale,
                 color_map_size=val_texture.shape[0],

--- a/src/napari/_vispy/layers/labels.py
+++ b/src/napari/_vispy/layers/labels.py
@@ -297,8 +297,9 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
         elif not auto_mode:  # only for raw_dtype.itemsize > 2
             use_selection = self.layer.show_selected_label
             selected_label = self.layer.selected_label
+            selection = selected_label if use_selection else None
             color_dict = colormap._values_mapping_to_minimum_values_set(
-                use_selection=use_selection, selection=selected_label
+                selection=selection
             )[1]
             max_size = get_max_texture_sizes()[0]
             val_texture = build_textures_from_dict(color_dict, max_size)
@@ -316,9 +317,7 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
 
             # The shader only reads $selection when $use_selection is true.
             selection_texture = (
-                colormap._selection_as_minimum_dtype(
-                    selected_label, raw_dtype, use_selection=True
-                )
+                colormap._selection_as_minimum_dtype(selected_label, raw_dtype)
                 if use_selection
                 else 0
             )

--- a/src/napari/_vispy/layers/labels.py
+++ b/src/napari/_vispy/layers/labels.py
@@ -67,6 +67,9 @@ uniform vec2 LUT_shape;
 
 vec4 sample_label_color(float t) {
     t = t * $scale;
+    if (($use_selection) && ($selection != int(t + 0.5))) {
+        return vec4(0);
+    }
     return texture2D(
         texture2D_values,
         vec2(0.0, (t + 0.5) / $color_map_size)
@@ -81,6 +84,9 @@ uniform vec2 LUT_shape;
 
 vec4 sample_label_color(float t) {
     t = t * $scale;
+    if (($use_selection) && ($selection != int(t + 0.5))) {
+        return vec4(0);
+    }
     float row = mod(t, LUT_shape.x);
     float col = int(t / LUT_shape.x);
     return texture2D(
@@ -97,6 +103,8 @@ class LabelVispyColormap(VispyColormap):
         colormap: CyclicLabelColormap,
         view_dtype: np.dtype,
         raw_dtype: np.dtype,
+        use_selection: bool = False,
+        selection: int = 0,
     ):
         super().__init__(
             colors=['w', 'w'], controls=None, interpolation='zero'
@@ -116,12 +124,14 @@ class LabelVispyColormap(VispyColormap):
                 f'Cannot use dtype {view_dtype} with LabelVispyColormap'
             )
 
-        selection = colormap._selection_as_minimum_dtype(raw_dtype)
+        selection_texture = colormap._selection_as_minimum_dtype(
+            selection, raw_dtype
+        )
 
         self.glsl_map = (
             shader.replace('$color_map_size', str(len(colormap.colors)))
-            .replace('$use_selection', str(colormap.use_selection).lower())
-            .replace('$selection', str(selection))
+            .replace('$use_selection', str(use_selection).lower())
+            .replace('$selection', str(selection_texture))
         )
 
 
@@ -271,7 +281,11 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
                 colormap, view_dtype, raw_dtype
             )
             self.node.cmap = LabelVispyColormap(
-                colormap, view_dtype=view_dtype, raw_dtype=raw_dtype
+                colormap,
+                view_dtype=view_dtype,
+                raw_dtype=raw_dtype,
+                use_selection=self.layer.show_selected_label,
+                selection=self.layer.selected_label,
             )
             self.node.shared_program['texture2D_values'] = Texture2D(
                 color_texture,
@@ -294,9 +308,12 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
             else:  # float32 texture
                 scale = 1.0
 
+            selection_texture = colormap._selection_as_minimum_dtype(
+                self.layer.selected_label, raw_dtype
+            )
             self.node.cmap = DirectLabelVispyColormap(
-                use_selection=colormap.use_selection,
-                selection=colormap.selection,
+                use_selection=self.layer.show_selected_label,
+                selection=selection_texture,
                 scale=scale,
                 color_map_size=val_texture.shape[0],
                 multi=val_texture.shape[1] > 1,

--- a/src/napari/_vispy/layers/labels.py
+++ b/src/napari/_vispy/layers/labels.py
@@ -314,8 +314,13 @@ class VispyLabelsLayer(VispyScalarFieldBaseLayer):
             else:  # float32 texture
                 scale = 1.0
 
-            selection_texture = colormap._selection_as_minimum_dtype(
-                selected_label, raw_dtype, use_selection=use_selection
+            # The shader only reads $selection when $use_selection is true.
+            selection_texture = (
+                colormap._selection_as_minimum_dtype(
+                    selected_label, raw_dtype, use_selection=True
+                )
+                if use_selection
+                else 0
             )
             self.node.cmap = DirectLabelVispyColormap(
                 use_selection=use_selection,

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -1695,26 +1695,27 @@ def test_color_mapping_when_color_is_changed():
 
 
 def test_color_mapping_with_show_selected_label():
-    """Checks if the color mapping is computed correctly when show_selected_label is activated."""
+    """Layer-level get_color filters non-selected labels when show_selected_label is on."""
 
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
-    mapped_colors_all = layer.colormap.map(data)
+    original_colors = {label: layer.get_color(label) for label in range(1, 5)}
+    background_color = layer.colormap.map(layer.colormap.background_value)
 
     layer.show_selected_label = True
 
-    for selected_label in range(5):
+    for selected_label in range(1, 5):
         layer.selected_label = selected_label
-        label_mask = data == selected_label
-        mapped_colors = layer.colormap.map(data)
-
-        npt.assert_allclose(
-            mapped_colors[label_mask], mapped_colors_all[label_mask]
-        )
-        npt.assert_allclose(mapped_colors[np.logical_not(label_mask)], 0)
+        for label in range(1, 5):
+            color = layer.get_color(label)
+            if label == selected_label:
+                npt.assert_allclose(color, original_colors[label])
+            else:
+                npt.assert_allclose(color, background_color)
 
     layer.show_selected_label = False
-    assert np.allclose(layer.colormap.map(data), mapped_colors_all)
+    for label, color in original_colors.items():
+        npt.assert_allclose(layer.get_color(label), color)
 
 
 def test_color_mapping_when_seed_is_changed():
@@ -1936,3 +1937,90 @@ def test_view_dtype(visible, dtype):
 def test_view_dtype_int16(visible, dtype):
     layer = Labels(np.arange(25, dtype=dtype).reshape(5, 5), visible=visible)
     assert layer._slice.image.view.dtype == np.uint16
+
+
+def test_show_selected_label_persists_through_shuffle():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    layer.new_colormap(seed=42)
+
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 2
+
+
+def test_show_selected_label_persists_across_colormap_assign():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 3
+    layer.show_selected_label = True
+
+    layer.colormap = label_colormap(49, seed=0.7)
+
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 3
+
+
+def test_show_selected_label_persists_across_color_mode_round_trip():
+    """AUTO → DIRECT → AUTO via colormap setter preserves selection state."""
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 1
+    layer.show_selected_label = True
+
+    direct = DirectLabelColormap(
+        color_dict={1: 'red', 2: 'green', None: 'transparent'}
+    )
+    layer.colormap = direct
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 1
+
+    layer.colormap = layer._original_random_colormap
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 1
+
+
+def test_labels_constructor_accepts_show_selected_label():
+    layer = Labels(
+        np.zeros((4, 4), dtype=np.uint8),
+        show_selected_label=True,
+        selected_label=3,
+    )
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 3
+
+
+def test_get_state_round_trips_show_selected_label():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 4
+    layer.show_selected_label = True
+
+    state = layer._get_state()
+    assert state['show_selected_label'] is True
+    assert state['selected_label'] == 4
+
+    new_layer = Labels(**state)
+    assert new_layer.show_selected_label is True
+    assert new_layer.selected_label == 4
+
+
+def test_show_selected_label_survives_deepcopy():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    clone = copy.deepcopy(layer)
+    assert clone.show_selected_label is True
+    assert clone.selected_label == 2
+
+
+def test_show_selected_label_setter_fires_event_once():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    fired = []
+    layer.events.show_selected_label.connect(
+        lambda e: fired.append(e.show_selected_label)
+    )
+
+    layer.show_selected_label = True
+    layer.show_selected_label = False
+
+    assert fired == [True, False]

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -2845,17 +2845,6 @@ def test_negative_coord_meaning_follows_axis_role_via_n_edit_dims():
     assert not np.any(brush.data[-1])
 
 
-def test_show_selected_label_persists_through_shuffle():
-    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
-    layer.selected_label = 2
-    layer.show_selected_label = True
-
-    layer.new_colormap(seed=42)
-
-    assert layer.show_selected_label is True
-    assert layer.selected_label == 2
-
-
 def test_show_selected_label_persists_across_colormap_assign():
     layer = Labels(np.zeros((4, 4), dtype=np.uint8))
     layer.selected_label = 3
@@ -2933,7 +2922,9 @@ def test_show_selected_label_setter_fires_event_once():
 
 
 @pytest.mark.parametrize('use_direct', [False, True])
-def test_paint_respects_show_selected_label_in_texture_cache(use_direct):
+def test_paint_respects_show_selected_label_in_texture_cache(
+    use_direct, direct_colormap
+):
     """Painting on a non-numpy backend patches the texture view cache
     directly; the patch must honor the layer's selection filter.
 
@@ -2944,15 +2935,7 @@ def test_paint_respects_show_selected_label_in_texture_cache(use_direct):
     """
     data = zarr.zeros((10, 10), chunks=(5, 5), dtype=np.uint32)
     if use_direct:
-        cmap = DirectLabelColormap(
-            color_dict={
-                0: [0, 0, 0, 0],
-                2: [1, 0, 0, 1],
-                3: [0, 1, 0, 1],
-                None: [0, 0, 1, 1],
-            }
-        )
-        layer = Labels(data, colormap=cmap)
+        layer = Labels(data, colormap=direct_colormap)
     else:
         layer = Labels(data)
     layer.brush_size = 1
@@ -2966,7 +2949,7 @@ def test_paint_respects_show_selected_label_in_texture_cache(use_direct):
     assert not np.array_equal(layer._slice.image.view[5, 5], background)
 
     # Painting a non-selected label must be filtered to background.
-    layer.paint((8, 8), 3, refresh=False)
+    layer.paint((8, 8), 1, refresh=False)
     np.testing.assert_array_equal(layer._slice.image.view[8, 8], background)
 
 

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -2230,7 +2230,12 @@ def test_color_mapping_with_show_selected_label():
 
 
 def test_show_selected_label_preserved_after_shuffle():
-    """Shuffling colors must not silently disable show_selected_label."""
+    """Shuffling colors must not silently disable show_selected_label.
+
+    Regression test for the original drift bug (#8947): the layer owns
+    the selection state, so a colormap swap must leave it untouched and
+    the rendered slice must stay filtered.
+    """
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
     layer.selected_label = 2
@@ -2238,38 +2243,45 @@ def test_show_selected_label_preserved_after_shuffle():
 
     seen = {}
     layer.events.colormap.connect(
-        lambda e: seen.update(use_selection=layer.colormap.use_selection)
+        lambda e: seen.update(filtered=layer.show_selected_label)
     )
     layer.new_colormap(seed=0)
 
-    # Selection state must be set before `events.colormap` fires, so the
-    # vispy shader is rebuilt with the right `use_selection`.
-    assert seen['use_selection'] is True
-    # And it must stick on the final colormap.
-    assert layer.colormap.use_selection is True
-    assert layer.colormap.selection == 2
-    label_mask = data == 2
-    npt.assert_allclose(layer.colormap.map(data)[~label_mask], 0)
+    # Selection state must already be correct when `events.colormap`
+    # fires, so the vispy shader is rebuilt with the right filter.
+    assert seen['filtered'] is True
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 2
+    # The rendered slice honors the filter: non-selected labels get the
+    # background texture value.
+    displayed = layer._raw_to_displayed(data)
+    background = displayed[data == 0].ravel()[0]
+    assert np.all(displayed[data == 2] != background)
+    for value in (1, 3, 4):
+        assert np.all(displayed[data == value] == background)
 
 
 def test_shuffle_does_not_revive_stale_show_selected():
-    """Shuffling must reflect the layer's current show_selected_label state."""
+    """Shuffling must reflect the layer's current show_selected_label state.
+
+    Enable, shuffle, then disable. Before the layer owned the selection
+    state, the next shuffle would seed from a stale
+    `_original_random_colormap` and revive the filter (#8947).
+    """
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
     layer.selected_label = 2
 
-    # Enable, shuffle (detaches `_original_random_colormap` from the layer's
-    # mutations), then disable. Without the fix, the next shuffle would seed
-    # from the now-stale original and revive `use_selection=True`.
     layer.show_selected_label = True
     layer.new_colormap(seed=0)
     layer.show_selected_label = False
     layer.new_colormap(seed=1)
 
-    assert layer.colormap.use_selection is False
-    mapped = layer.colormap.map(data)
+    assert layer.show_selected_label is False
+    displayed = layer._raw_to_displayed(data)
+    background = displayed[data == 0].ravel()[0]
     for value in range(1, 5):
-        assert np.any(mapped[data == value] != 0)
+        assert np.all(displayed[data == value] != background)
 
 
 def test_color_mapping_when_seed_is_changed():
@@ -2918,3 +2930,57 @@ def test_show_selected_label_setter_fires_event_once():
     layer.show_selected_label = False
 
     assert fired == [True, False]
+
+
+@pytest.mark.parametrize('use_direct', [False, True])
+def test_paint_respects_show_selected_label_in_texture_cache(use_direct):
+    """Painting on a non-numpy backend patches the texture view cache
+    directly; the patch must honor the layer's selection filter.
+
+    Regression test for the interaction between layer-owned selection
+    state and the painting refactor's cache patching: painting a
+    non-selected label while ``show_selected_label`` is on must write the
+    filtered background value into the view cache, not the label's color.
+    """
+    data = zarr.zeros((10, 10), chunks=(5, 5), dtype=np.uint32)
+    if use_direct:
+        cmap = DirectLabelColormap(
+            color_dict={
+                0: [0, 0, 0, 0],
+                2: [1, 0, 0, 1],
+                3: [0, 1, 0, 1],
+                None: [0, 0, 1, 1],
+            }
+        )
+        layer = Labels(data, colormap=cmap)
+    else:
+        layer = Labels(data)
+    layer.brush_size = 1
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    background = np.copy(layer._slice.image.view[0, 0])
+
+    # Painting the selected label must show up in the view cache.
+    layer.paint((5, 5), 2, refresh=False)
+    assert not np.array_equal(layer._slice.image.view[5, 5], background)
+
+    # Painting a non-selected label must be filtered to background.
+    layer.paint((8, 8), 3, refresh=False)
+    np.testing.assert_array_equal(layer._slice.image.view[8, 8], background)
+
+
+def test_data_setitem_respects_show_selected_label_in_texture_cache():
+    """``data_setitem`` patches mapped values into the view cache; the
+    patch must honor the layer's selection filter."""
+    layer = Labels(np.zeros((10, 10), dtype=np.int32))
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    background = np.copy(layer._slice.image.view[0, 0])
+
+    layer.data_setitem((np.array([5]), np.array([5])), 2, refresh=False)
+    assert not np.array_equal(layer._slice.image.view[5, 5], background)
+
+    layer.data_setitem((np.array([8]), np.array([8])), 3, refresh=False)
+    np.testing.assert_array_equal(layer._slice.image.view[8, 8], background)

--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -2206,26 +2206,27 @@ def test_color_mapping_when_color_is_changed():
 
 
 def test_color_mapping_with_show_selected_label():
-    """Checks if the color mapping is computed correctly when show_selected_label is activated."""
+    """Layer-level get_color filters non-selected labels when show_selected_label is on."""
 
     data = np.arange(5, dtype=np.int32)[:, np.newaxis].repeat(5, axis=1)
     layer = Labels(data)
-    mapped_colors_all = layer.colormap.map(data)
+    original_colors = {label: layer.get_color(label) for label in range(1, 5)}
+    background_color = layer.colormap.map(layer.colormap.background_value)
 
     layer.show_selected_label = True
 
-    for selected_label in range(5):
+    for selected_label in range(1, 5):
         layer.selected_label = selected_label
-        label_mask = data == selected_label
-        mapped_colors = layer.colormap.map(data)
-
-        npt.assert_allclose(
-            mapped_colors[label_mask], mapped_colors_all[label_mask]
-        )
-        npt.assert_allclose(mapped_colors[np.logical_not(label_mask)], 0)
+        for label in range(1, 5):
+            color = layer.get_color(label)
+            if label == selected_label:
+                npt.assert_allclose(color, original_colors[label])
+            else:
+                npt.assert_allclose(color, background_color)
 
     layer.show_selected_label = False
-    assert np.allclose(layer.colormap.map(data), mapped_colors_all)
+    for label, color in original_colors.items():
+        npt.assert_allclose(layer.get_color(label), color)
 
 
 def test_show_selected_label_preserved_after_shuffle():
@@ -2830,3 +2831,90 @@ def test_negative_coord_meaning_follows_axis_role_via_n_edit_dims():
     brush.paint(coord, 1)
     assert np.any(brush.data[0])  # -1 clipped to the near edge
     assert not np.any(brush.data[-1])
+
+
+def test_show_selected_label_persists_through_shuffle():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    layer.new_colormap(seed=42)
+
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 2
+
+
+def test_show_selected_label_persists_across_colormap_assign():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 3
+    layer.show_selected_label = True
+
+    layer.colormap = label_colormap(49, seed=0.7)
+
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 3
+
+
+def test_show_selected_label_persists_across_color_mode_round_trip():
+    """AUTO → DIRECT → AUTO via colormap setter preserves selection state."""
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 1
+    layer.show_selected_label = True
+
+    direct = DirectLabelColormap(
+        color_dict={1: 'red', 2: 'green', None: 'transparent'}
+    )
+    layer.colormap = direct
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 1
+
+    layer.colormap = layer._original_random_colormap
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 1
+
+
+def test_labels_constructor_accepts_show_selected_label():
+    layer = Labels(
+        np.zeros((4, 4), dtype=np.uint8),
+        show_selected_label=True,
+        selected_label=3,
+    )
+    assert layer.show_selected_label is True
+    assert layer.selected_label == 3
+
+
+def test_get_state_round_trips_show_selected_label():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 4
+    layer.show_selected_label = True
+
+    state = layer._get_state()
+    assert state['show_selected_label'] is True
+    assert state['selected_label'] == 4
+
+    new_layer = Labels(**state)
+    assert new_layer.show_selected_label is True
+    assert new_layer.selected_label == 4
+
+
+def test_show_selected_label_survives_deepcopy():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    layer.selected_label = 2
+    layer.show_selected_label = True
+
+    clone = copy.deepcopy(layer)
+    assert clone.show_selected_label is True
+    assert clone.selected_label == 2
+
+
+def test_show_selected_label_setter_fires_event_once():
+    layer = Labels(np.zeros((4, 4), dtype=np.uint8))
+    fired = []
+    layer.events.show_selected_label.connect(
+        lambda e: fired.append(e.show_selected_label)
+    )
+
+    layer.show_selected_label = True
+    layer.show_selected_label = False
+
+    assert fired == [True, False]

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -165,9 +165,13 @@ class Labels(ScalarFieldBase):
         np.degrees if needed.
     scale : tuple of float
         Scale factors for the layer.
+    selected_label : int
+        Index of selected label. Can be greater than the current maximum label.
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
+    show_selected_label : bool
+        Whether to filter displayed labels to only the selected label.
     translate : tuple of float
         Translation values for the layer.
     units : tuple of str or pint.Unit, optional
@@ -334,7 +338,9 @@ class Labels(ScalarFieldBase):
         rendering='iso_categorical',
         rotate=None,
         scale=None,
+        selected_label=1,
         shear=None,
+        show_selected_label=False,
         translate=None,
         units=None,
         visible=True,
@@ -354,7 +360,7 @@ class Labels(ScalarFieldBase):
         )
         self._colormap = self._random_colormap
         self._color_mode = LabelColorMode.AUTO
-        self._show_selected_label = False
+        self._show_selected_label = show_selected_label
         self._contour = 0
 
         data = self._ensure_int_labels(data)
@@ -416,9 +422,7 @@ class Labels(ScalarFieldBase):
 
         self._iso_gradient_mode = IsoCategoricalGradientMode(iso_gradient_mode)
 
-        self._selected_label = 1
-        self.colormap.selection = self._selected_label
-        self.colormap.use_selection = self._show_selected_label
+        self._selected_label = selected_label
         self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self._updated_slice: tuple[slice, ...] | None = None
@@ -717,6 +721,8 @@ class Labels(ScalarFieldBase):
                 'data': self.data,
                 'features': self.features,
                 'colormap': self.colormap,
+                'selected_label': self.selected_label,
+                'show_selected_label': self.show_selected_label,
             }
         )
         return state
@@ -745,7 +751,6 @@ class Labels(ScalarFieldBase):
             self._prev_selected_label = self.selected_label
         else:
             self._prev_selected_label = None
-        self.colormap.selection = selected_label
         self._selected_label = selected_label
         self._selected_color = self.get_color(selected_label)
 
@@ -769,8 +774,6 @@ class Labels(ScalarFieldBase):
     @show_selected_label.setter
     def show_selected_label(self, show_selected):
         self._show_selected_label = show_selected
-        self.colormap.use_selection = show_selected
-        self.colormap.selection = self.selected_label
         self.events.show_selected_label(show_selected_label=show_selected)
         self.refresh(extent=False)
 
@@ -965,7 +968,11 @@ class Labels(ScalarFieldBase):
         if sliced_labels is None:
             sliced_labels = labels[data_slice]
 
-        return self.colormap._data_to_texture(sliced_labels)
+        return self.colormap._data_to_texture(
+            sliced_labels,
+            use_selection=self.show_selected_label,
+            selection=self.selected_label,
+        )
 
     def _update_thumbnail(self):
         """Update the thumbnail with current data and colormap.
@@ -999,6 +1006,8 @@ class Labels(ScalarFieldBase):
 
         downsampled = ndi.zoom(image, zoom_factor, prefilter=False, order=0)
         color_array = self.colormap.map(downsampled)
+        if self.show_selected_label:
+            color_array[downsampled != self.selected_label] = 0
         color_array[..., 3] *= self.opacity
 
         self.thumbnail = color_array
@@ -1502,7 +1511,11 @@ class Labels(ScalarFieldBase):
         else:
             # update data view
             self._slice.image.view[displayed_indices] = (
-                self.colormap._data_to_texture(visible_values)
+                self.colormap._data_to_texture(
+                    visible_values,
+                    use_selection=self.show_selected_label,
+                    selection=self.selected_label,
+                )
             )
 
         if self._updated_slice is None:

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -404,6 +404,9 @@ class Labels(ScalarFieldBase):
         self._colormap = self._random_colormap
         self._color_mode = LabelColorMode.AUTO
         self._show_selected_label = show_selected_label
+        # Set before super().__init__ because _slice_dtype reads it during
+        # the initial empty-slice construction.
+        self._selected_label = selected_label
         self._contour = 0
 
         data = self._ensure_int_labels(data)
@@ -473,7 +476,6 @@ class Labels(ScalarFieldBase):
 
         self._iso_gradient_mode = IsoCategoricalGradientMode(iso_gradient_mode)
 
-        self._selected_label = selected_label
         self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self._updated_slice: tuple[slice, ...] | None = None
@@ -492,7 +494,9 @@ class Labels(ScalarFieldBase):
     def _slice_dtype(self):
         """Calculate dtype of data view based on data dtype and current colormap"""
         return self.colormap._data_to_texture(
-            np.zeros(0, dtype=normalize_dtype(self.dtype))
+            np.zeros(0, dtype=normalize_dtype(self.dtype)),
+            use_selection=self.show_selected_label,
+            selection=self.selected_label,
         ).dtype
 
     def _post_init(self):
@@ -608,10 +612,6 @@ class Labels(ScalarFieldBase):
         new_cmap = shuffle_and_extend_colormap(
             self._original_random_colormap, seed
         )
-        # Sync from the layer (source of truth) before assignment, so
-        # `events.colormap` listeners observe the correct `use_selection`.
-        new_cmap.use_selection = self._show_selected_label
-        new_cmap.selection = self._selected_label
         self.colormap = new_cmap
         self._original_random_colormap = orig
 
@@ -2042,7 +2042,9 @@ class Labels(ScalarFieldBase):
 
         # Update texture view cache by compute new color only once
         new_color = self.colormap._data_to_texture(
-            np.array([new_label], dtype=visible_data.dtype)
+            np.array([new_label], dtype=visible_data.dtype),
+            use_selection=self.show_selected_label,
+            selection=self.selected_label,
         )[0]
 
         # Update cache in-place for changed pixels only

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -492,12 +492,24 @@ class Labels(ScalarFieldBase):
         self._staged_history: list[HistoryAtom]
         self._block_history: bool
 
-    def _slice_dtype(self):
-        """Calculate dtype of data view based on data dtype and current colormap"""
+    def _data_to_texture(self, values):
+        """Cast data to the texture dtype, applying the layer's selection state.
+
+        Single choke point for pairing ``colormap._data_to_texture`` with
+        the layer-owned ``show_selected_label`` / ``selected_label``; every
+        texture cast must go through here so no call site can forget the
+        selection kwargs.
+        """
         return self.colormap._data_to_texture(
-            np.zeros(0, dtype=normalize_dtype(self.dtype)),
+            values,
             use_selection=self.show_selected_label,
             selection=self.selected_label,
+        )
+
+    def _slice_dtype(self):
+        """Calculate dtype of data view based on data dtype and current colormap"""
+        return self._data_to_texture(
+            np.zeros(0, dtype=normalize_dtype(self.dtype))
         ).dtype
 
     def _post_init(self):
@@ -1039,11 +1051,7 @@ class Labels(ScalarFieldBase):
         if sliced_labels is None:
             sliced_labels = labels[data_slice]
 
-        return self.colormap._data_to_texture(
-            sliced_labels,
-            use_selection=self.show_selected_label,
-            selection=self.selected_label,
-        )
+        return self._data_to_texture(sliced_labels)
 
     def _update_thumbnail(self):
         """Update the thumbnail with current data and colormap.
@@ -2040,10 +2048,8 @@ class Labels(ScalarFieldBase):
             return
 
         # Update texture view cache by compute new color only once
-        new_color = self.colormap._data_to_texture(
-            np.array([new_label], dtype=visible_data.dtype),
-            use_selection=self.show_selected_label,
-            selection=self.selected_label,
+        new_color = self._data_to_texture(
+            np.array([new_label], dtype=visible_data.dtype)
         )[0]
 
         # Update cache in-place for changed pixels only
@@ -2208,12 +2214,8 @@ class Labels(ScalarFieldBase):
 
         if self.contour == 0:
             # update data view
-            self._slice.image.view[displayed_indices] = (
-                self.colormap._data_to_texture(
-                    visible_values,
-                    use_selection=self.show_selected_label,
-                    selection=self.selected_label,
-                )
+            self._slice.image.view[displayed_indices] = self._data_to_texture(
+                visible_values
             )
 
         self._accumulate_updated_slice(updated_slice)

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -205,9 +205,13 @@ class Labels(ScalarFieldBase):
         np.degrees if needed.
     scale : tuple of float
         Scale factors for the layer.
+    selected_label : int
+        Index of selected label. Can be greater than the current maximum label.
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
+    show_selected_label : bool
+        Whether to filter displayed labels to only the selected label.
     translate : tuple of float
         Translation values for the layer.
     units : tuple of str or pint.Unit, optional
@@ -378,7 +382,9 @@ class Labels(ScalarFieldBase):
         rendering='iso_categorical',
         rotate=None,
         scale=None,
+        selected_label=1,
         shear=None,
+        show_selected_label=False,
         translate=None,
         units=None,
         visible=True,
@@ -398,7 +404,7 @@ class Labels(ScalarFieldBase):
         )
         self._colormap = self._random_colormap
         self._color_mode = LabelColorMode.AUTO
-        self._show_selected_label = False
+        self._show_selected_label = show_selected_label
         self._contour = 0
 
         data = self._ensure_int_labels(data)
@@ -468,9 +474,7 @@ class Labels(ScalarFieldBase):
 
         self._iso_gradient_mode = IsoCategoricalGradientMode(iso_gradient_mode)
 
-        self._selected_label = 1
-        self.colormap.selection = self._selected_label
-        self.colormap.use_selection = self._show_selected_label
+        self._selected_label = selected_label
         self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self._updated_slice: tuple[slice, ...] | None = None
@@ -772,6 +776,8 @@ class Labels(ScalarFieldBase):
                 'data': self.data,
                 'features': self.features,
                 'colormap': self.colormap,
+                'selected_label': self.selected_label,
+                'show_selected_label': self.show_selected_label,
             }
         )
         return state
@@ -819,7 +825,6 @@ class Labels(ScalarFieldBase):
             self._prev_selected_label = self.selected_label
         else:
             self._prev_selected_label = None
-        self.colormap.selection = selected_label
         self._selected_label = selected_label
         self._selected_color = self.get_color(selected_label)
 
@@ -843,8 +848,6 @@ class Labels(ScalarFieldBase):
     @show_selected_label.setter
     def show_selected_label(self, show_selected):
         self._show_selected_label = show_selected
-        self.colormap.use_selection = show_selected
-        self.colormap.selection = self.selected_label
         self.events.show_selected_label(show_selected_label=show_selected)
         self.refresh(extent=False)
 
@@ -1036,7 +1039,11 @@ class Labels(ScalarFieldBase):
         if sliced_labels is None:
             sliced_labels = labels[data_slice]
 
-        return self.colormap._data_to_texture(sliced_labels)
+        return self.colormap._data_to_texture(
+            sliced_labels,
+            use_selection=self.show_selected_label,
+            selection=self.selected_label,
+        )
 
     def _update_thumbnail(self):
         """Update the thumbnail with current data and colormap.
@@ -1070,6 +1077,8 @@ class Labels(ScalarFieldBase):
 
         downsampled = ndi.zoom(image, zoom_factor, prefilter=False, order=0)
         color_array = self.colormap.map(downsampled)
+        if self.show_selected_label:
+            color_array[downsampled != self.selected_label] = 0
         color_array[..., 3] *= self.opacity
 
         self.thumbnail = color_array
@@ -2198,7 +2207,11 @@ class Labels(ScalarFieldBase):
         if self.contour == 0:
             # update data view
             self._slice.image.view[displayed_indices] = (
-                self.colormap._data_to_texture(visible_values)
+                self.colormap._data_to_texture(
+                    visible_values,
+                    use_selection=self.show_selected_label,
+                    selection=self.selected_label,
+                )
             )
 
         self._accumulate_updated_slice(updated_slice)

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -498,12 +498,13 @@ class Labels(ScalarFieldBase):
         Single choke point for pairing ``colormap._data_to_texture`` with
         the layer-owned ``show_selected_label`` / ``selected_label``; every
         texture cast must go through here so no call site can forget the
-        selection kwargs.
+        selection state.
         """
         return self.colormap._data_to_texture(
             values,
-            use_selection=self.show_selected_label,
-            selection=self.selected_label,
+            selection=self.selected_label
+            if self.show_selected_label
+            else None,
         )
 
     def _slice_dtype(self):

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -497,12 +497,13 @@ class Labels(ScalarFieldBase):
         Single choke point for pairing ``colormap._data_to_texture`` with
         the layer-owned ``show_selected_label`` / ``selected_label``; every
         texture cast must go through here so no call site can forget the
-        selection kwargs.
+        selection state.
         """
         return self.colormap._data_to_texture(
             values,
-            use_selection=self.show_selected_label,
-            selection=self.selected_label,
+            selection=self.selected_label
+            if self.show_selected_label
+            else None,
         )
 
     def _slice_dtype(self):

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -491,12 +491,24 @@ class Labels(ScalarFieldBase):
         self._staged_history: list[HistoryAtom]
         self._block_history: bool
 
-    def _slice_dtype(self):
-        """Calculate dtype of data view based on data dtype and current colormap"""
+    def _data_to_texture(self, values):
+        """Cast data to the texture dtype, applying the layer's selection state.
+
+        Single choke point for pairing ``colormap._data_to_texture`` with
+        the layer-owned ``show_selected_label`` / ``selected_label``; every
+        texture cast must go through here so no call site can forget the
+        selection kwargs.
+        """
         return self.colormap._data_to_texture(
-            np.zeros(0, dtype=normalize_dtype(self.dtype)),
+            values,
             use_selection=self.show_selected_label,
             selection=self.selected_label,
+        )
+
+    def _slice_dtype(self):
+        """Calculate dtype of data view based on data dtype and current colormap"""
+        return self._data_to_texture(
+            np.zeros(0, dtype=normalize_dtype(self.dtype))
         ).dtype
 
     def _post_init(self):
@@ -1038,11 +1050,7 @@ class Labels(ScalarFieldBase):
         if sliced_labels is None:
             sliced_labels = labels[data_slice]
 
-        return self.colormap._data_to_texture(
-            sliced_labels,
-            use_selection=self.show_selected_label,
-            selection=self.selected_label,
-        )
+        return self._data_to_texture(sliced_labels)
 
     def _update_thumbnail(self):
         """Update the thumbnail with current data and colormap.
@@ -2041,10 +2049,8 @@ class Labels(ScalarFieldBase):
             return
 
         # Update texture view cache by compute new color only once
-        new_color = self.colormap._data_to_texture(
-            np.array([new_label], dtype=visible_data.dtype),
-            use_selection=self.show_selected_label,
-            selection=self.selected_label,
+        new_color = self._data_to_texture(
+            np.array([new_label], dtype=visible_data.dtype)
         )[0]
 
         # Update cache in-place for changed pixels only
@@ -2209,12 +2215,8 @@ class Labels(ScalarFieldBase):
 
         if self.contour == 0:
             # update data view
-            self._slice.image.view[displayed_indices] = (
-                self.colormap._data_to_texture(
-                    visible_values,
-                    use_selection=self.show_selected_label,
-                    selection=self.selected_label,
-                )
+            self._slice.image.view[displayed_indices] = self._data_to_texture(
+                visible_values
             )
 
         self._accumulate_updated_slice(updated_slice)

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -405,6 +405,9 @@ class Labels(ScalarFieldBase):
         self._colormap = self._random_colormap
         self._color_mode = LabelColorMode.AUTO
         self._show_selected_label = show_selected_label
+        # Set before super().__init__ because _slice_dtype reads it during
+        # the initial empty-slice construction.
+        self._selected_label = selected_label
         self._contour = 0
 
         data = self._ensure_int_labels(data)
@@ -474,7 +477,6 @@ class Labels(ScalarFieldBase):
 
         self._iso_gradient_mode = IsoCategoricalGradientMode(iso_gradient_mode)
 
-        self._selected_label = selected_label
         self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self._updated_slice: tuple[slice, ...] | None = None
@@ -493,7 +495,9 @@ class Labels(ScalarFieldBase):
     def _slice_dtype(self):
         """Calculate dtype of data view based on data dtype and current colormap"""
         return self.colormap._data_to_texture(
-            np.zeros(0, dtype=normalize_dtype(self.dtype))
+            np.zeros(0, dtype=normalize_dtype(self.dtype)),
+            use_selection=self.show_selected_label,
+            selection=self.selected_label,
         ).dtype
 
     def _post_init(self):
@@ -609,10 +613,6 @@ class Labels(ScalarFieldBase):
         new_cmap = shuffle_and_extend_colormap(
             self._original_random_colormap, seed
         )
-        # Sync from the layer (source of truth) before assignment, so
-        # `events.colormap` listeners observe the correct `use_selection`.
-        new_cmap.use_selection = self._show_selected_label
-        new_cmap.selection = self._selected_label
         self.colormap = new_cmap
         self._original_random_colormap = orig
 
@@ -2041,7 +2041,9 @@ class Labels(ScalarFieldBase):
 
         # Update texture view cache by compute new color only once
         new_color = self.colormap._data_to_texture(
-            np.array([new_label], dtype=visible_data.dtype)
+            np.array([new_label], dtype=visible_data.dtype),
+            use_selection=self.show_selected_label,
+            selection=self.selected_label,
         )[0]
 
         # Update cache in-place for changed pixels only

--- a/src/napari/layers/labels/labels.py
+++ b/src/napari/layers/labels/labels.py
@@ -204,9 +204,13 @@ class Labels(ScalarFieldBase):
         np.degrees if needed.
     scale : tuple of float
         Scale factors for the layer.
+    selected_label : int
+        Index of selected label. Can be greater than the current maximum label.
     shear : 1-D array or n-D array
         Either a vector of upper triangular values, or an nD shear matrix with
         ones along the main diagonal.
+    show_selected_label : bool
+        Whether to filter displayed labels to only the selected label.
     translate : tuple of float
         Translation values for the layer.
     units : tuple of str or pint.Unit, optional
@@ -377,7 +381,9 @@ class Labels(ScalarFieldBase):
         rendering='iso_categorical',
         rotate=None,
         scale=None,
+        selected_label=1,
         shear=None,
+        show_selected_label=False,
         translate=None,
         units=None,
         visible=True,
@@ -397,7 +403,7 @@ class Labels(ScalarFieldBase):
         )
         self._colormap = self._random_colormap
         self._color_mode = LabelColorMode.AUTO
-        self._show_selected_label = False
+        self._show_selected_label = show_selected_label
         self._contour = 0
 
         data = self._ensure_int_labels(data)
@@ -467,9 +473,7 @@ class Labels(ScalarFieldBase):
 
         self._iso_gradient_mode = IsoCategoricalGradientMode(iso_gradient_mode)
 
-        self._selected_label = 1
-        self.colormap.selection = self._selected_label
-        self.colormap.use_selection = self._show_selected_label
+        self._selected_label = selected_label
         self._prev_selected_label = None
         self._selected_color = self.get_color(self._selected_label)
         self._updated_slice: tuple[slice, ...] | None = None
@@ -771,6 +775,8 @@ class Labels(ScalarFieldBase):
                 'data': self.data,
                 'features': self.features,
                 'colormap': self.colormap,
+                'selected_label': self.selected_label,
+                'show_selected_label': self.show_selected_label,
             }
         )
         return state
@@ -818,7 +824,6 @@ class Labels(ScalarFieldBase):
             self._prev_selected_label = self.selected_label
         else:
             self._prev_selected_label = None
-        self.colormap.selection = selected_label
         self._selected_label = selected_label
         self._selected_color = self.get_color(selected_label)
 
@@ -842,8 +847,6 @@ class Labels(ScalarFieldBase):
     @show_selected_label.setter
     def show_selected_label(self, show_selected):
         self._show_selected_label = show_selected
-        self.colormap.use_selection = show_selected
-        self.colormap.selection = self.selected_label
         self.events.show_selected_label(show_selected_label=show_selected)
         self.refresh(extent=False)
 
@@ -1035,7 +1038,11 @@ class Labels(ScalarFieldBase):
         if sliced_labels is None:
             sliced_labels = labels[data_slice]
 
-        return self.colormap._data_to_texture(sliced_labels)
+        return self.colormap._data_to_texture(
+            sliced_labels,
+            use_selection=self.show_selected_label,
+            selection=self.selected_label,
+        )
 
     def _update_thumbnail(self):
         """Update the thumbnail with current data and colormap.
@@ -1069,6 +1076,8 @@ class Labels(ScalarFieldBase):
 
         downsampled = ndi.zoom(image, zoom_factor, prefilter=False, order=0)
         color_array = self.colormap.map(downsampled)
+        if self.show_selected_label:
+            color_array[downsampled != self.selected_label] = 0
         color_array[..., 3] *= self.opacity
 
         self.thumbnail = color_array
@@ -2199,7 +2208,11 @@ class Labels(ScalarFieldBase):
         if self.contour == 0:
             # update data view
             self._slice.image.view[displayed_indices] = (
-                self.colormap._data_to_texture(visible_values)
+                self.colormap._data_to_texture(
+                    visible_values,
+                    use_selection=self.show_selected_label,
+                    selection=self.selected_label,
+                )
             )
 
         self._accumulate_updated_slice(updated_slice)

--- a/src/napari/utils/colormaps/_accelerated_cmap.py
+++ b/src/napari/utils/colormaps/_accelerated_cmap.py
@@ -189,7 +189,11 @@ else:
 
 
 def _labels_raw_to_texture_direct_numpy(
-    data: np.ndarray, direct_colormap: 'DirectLabelColormap'
+    data: np.ndarray,
+    direct_colormap: 'DirectLabelColormap',
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray:
     """Convert labels data to the data type used in the texture.
 
@@ -197,6 +201,8 @@ def _labels_raw_to_texture_direct_numpy(
 
     See `_cast_labels_data_to_texture_dtype_direct` for more details.
     """
+    if use_selection:
+        return (data == selection).astype(np.uint8)
     mapper = direct_colormap._array_map
     if any(x < 0 for x in direct_colormap.color_dict if x is not None):
         half_shape = mapper.shape[0] // 2 - 1
@@ -208,7 +214,11 @@ def _labels_raw_to_texture_direct_numpy(
 
 
 def _labels_raw_to_texture_direct_loop(
-    data: np.ndarray, direct_colormap: 'DirectLabelColormap'
+    data: np.ndarray,
+    direct_colormap: 'DirectLabelColormap',
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray:
     """
     Cast direct labels to the minimum type.
@@ -225,6 +235,9 @@ def _labels_raw_to_texture_direct_loop(
     np.ndarray
         The cast data array.
     """
+    if use_selection:
+        return (data == selection).astype(np.uint8)
+
     dkt = direct_colormap._get_typed_dict_mapping(data.dtype)
     target_dtype = minimum_dtype_for_labels(
         direct_colormap._num_unique_colors + 2
@@ -262,14 +275,23 @@ def zero_preserving_modulo_partsegcore(
 
 
 def labels_raw_to_texture_direct_partsegcore(
-    data: np.ndarray, direct_colormap: 'DirectLabelColormap'
+    data: np.ndarray,
+    direct_colormap: 'DirectLabelColormap',
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray:
-    iinfo = np.iinfo(data.dtype)
-    dkt = {
-        k: v
-        for k, v in direct_colormap._label_mapping_and_color_dict[0].items()
-        if k is None or iinfo.min <= k <= iinfo.max
-    }
+    if use_selection:
+        dkt = {None: 0, selection: 1}
+    else:
+        iinfo = np.iinfo(data.dtype)
+        dkt = {
+            k: v
+            for k, v in direct_colormap._label_mapping_and_color_dict[
+                0
+            ].items()
+            if k is None or iinfo.min <= k <= iinfo.max
+        }
     target_dtype = minimum_dtype_for_labels(
         direct_colormap._num_unique_colors + 2
     )

--- a/src/napari/utils/colormaps/_accelerated_cmap.py
+++ b/src/napari/utils/colormaps/_accelerated_cmap.py
@@ -192,8 +192,7 @@ def _labels_raw_to_texture_direct_numpy(
     data: np.ndarray,
     direct_colormap: 'DirectLabelColormap',
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.ndarray:
     """Convert labels data to the data type used in the texture.
 
@@ -201,7 +200,7 @@ def _labels_raw_to_texture_direct_numpy(
 
     See `_cast_labels_data_to_texture_dtype_direct` for more details.
     """
-    if use_selection:
+    if selection is not None:
         return (data == selection).astype(np.uint8)
     mapper = direct_colormap._array_map
     if any(x < 0 for x in direct_colormap.color_dict if x is not None):
@@ -217,8 +216,7 @@ def _labels_raw_to_texture_direct_loop(
     data: np.ndarray,
     direct_colormap: 'DirectLabelColormap',
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.ndarray:
     """
     Cast direct labels to the minimum type.
@@ -235,7 +233,7 @@ def _labels_raw_to_texture_direct_loop(
     np.ndarray
         The cast data array.
     """
-    if use_selection:
+    if selection is not None:
         return (data == selection).astype(np.uint8)
 
     dkt = direct_colormap._get_typed_dict_mapping(data.dtype)
@@ -278,10 +276,9 @@ def labels_raw_to_texture_direct_partsegcore(
     data: np.ndarray,
     direct_colormap: 'DirectLabelColormap',
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.ndarray:
-    if use_selection:
+    if selection is not None:
         dkt = {None: 0, selection: 1}
     else:
         iinfo = np.iinfo(data.dtype)

--- a/src/napari/utils/colormaps/_accelerated_cmap.py
+++ b/src/napari/utils/colormaps/_accelerated_cmap.py
@@ -197,8 +197,6 @@ def _labels_raw_to_texture_direct_numpy(
 
     See `_cast_labels_data_to_texture_dtype_direct` for more details.
     """
-    if direct_colormap.use_selection:
-        return (data == direct_colormap.selection).astype(np.uint8)
     mapper = direct_colormap._array_map
     if any(x < 0 for x in direct_colormap.color_dict if x is not None):
         half_shape = mapper.shape[0] // 2 - 1
@@ -227,9 +225,6 @@ def _labels_raw_to_texture_direct_loop(
     np.ndarray
         The cast data array.
     """
-    if direct_colormap.use_selection:
-        return (data == direct_colormap.selection).astype(np.uint8)
-
     dkt = direct_colormap._get_typed_dict_mapping(data.dtype)
     target_dtype = minimum_dtype_for_labels(
         direct_colormap._num_unique_colors + 2
@@ -269,17 +264,12 @@ def zero_preserving_modulo_partsegcore(
 def labels_raw_to_texture_direct_partsegcore(
     data: np.ndarray, direct_colormap: 'DirectLabelColormap'
 ) -> np.ndarray:
-    if direct_colormap.use_selection:
-        dkt = {None: 0, direct_colormap.selection: 1}
-    else:
-        iinfo = np.iinfo(data.dtype)
-        dkt = {
-            k: v
-            for k, v in direct_colormap._label_mapping_and_color_dict[
-                0
-            ].items()
-            if k is None or iinfo.min <= k <= iinfo.max
-        }
+    iinfo = np.iinfo(data.dtype)
+    dkt = {
+        k: v
+        for k, v in direct_colormap._label_mapping_and_color_dict[0].items()
+        if k is None or iinfo.min <= k <= iinfo.max
+    }
     target_dtype = minimum_dtype_for_labels(
         direct_colormap._num_unique_colors + 2
     )

--- a/src/napari/utils/colormaps/_tests/test_colormap.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap.py
@@ -269,13 +269,13 @@ def test_selection_fields_deprecation_shim(direct_label_colormap):
 
 
 def test_values_mapping_selection_shortcut(direct_label_colormap):
-    """With selection kwargs, the minimum-values-set mapping collapses to
+    """With a selection, the minimum-values-set mapping collapses to
     the 2-entry {background, selection} shortcut."""
     (
         label_mapping,
         color_dict,
     ) = direct_label_colormap._values_mapping_to_minimum_values_set(
-        use_selection=True, selection=2
+        selection=2
     )
 
     assert len(label_mapping) == 2

--- a/src/napari/utils/colormaps/_tests/test_colormap.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap.py
@@ -254,6 +254,20 @@ def test_direct_label_colormap_deepcopy_after_map(direct_label_colormap):
     assert cmap_copy._cache_mapping is not direct_label_colormap._cache_mapping
 
 
+def test_selection_fields_deprecation_shim(direct_label_colormap):
+    """Reading the removed selection fields warns and returns the old
+    defaults; writing raises with a pointer to the layer API."""
+    with pytest.warns(FutureWarning, match='show_selected_label'):
+        assert direct_label_colormap.use_selection is False
+    with pytest.warns(FutureWarning, match='selected_label'):
+        assert direct_label_colormap.selection == 0
+
+    with pytest.raises(AttributeError, match='show_selected_label'):
+        direct_label_colormap.use_selection = True
+    with pytest.raises(AttributeError, match='selected_label'):
+        direct_label_colormap.selection = 2
+
+
 def test_values_mapping_selection_shortcut(direct_label_colormap):
     """With selection kwargs, the minimum-values-set mapping collapses to
     the 2-entry {background, selection} shortcut."""
@@ -266,7 +280,6 @@ def test_values_mapping_selection_shortcut(direct_label_colormap):
 
     assert len(label_mapping) == 2
     assert len(color_dict) == 2
-
 
 
 @pytest.mark.usefixtures('_disable_jit')

--- a/src/napari/utils/colormaps/_tests/test_colormap.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap.py
@@ -254,22 +254,19 @@ def test_direct_label_colormap_deepcopy_after_map(direct_label_colormap):
     assert cmap_copy._cache_mapping is not direct_label_colormap._cache_mapping
 
 
-def test_direct_label_colormap_selection(direct_label_colormap):
-    direct_label_colormap.selection = 2
-    direct_label_colormap.use_selection = True
-
-    np.testing.assert_array_equal(
-        direct_label_colormap.map([0, 2, 7]),
-        np.array([[0, 0, 0, 0], [0, 1, 0, 1], [0, 0, 0, 0]]),
-    )
-
+def test_values_mapping_selection_shortcut(direct_label_colormap):
+    """With selection kwargs, the minimum-values-set mapping collapses to
+    the 2-entry {background, selection} shortcut."""
     (
         label_mapping,
         color_dict,
-    ) = direct_label_colormap._values_mapping_to_minimum_values_set()
+    ) = direct_label_colormap._values_mapping_to_minimum_values_set(
+        use_selection=True, selection=2
+    )
 
     assert len(label_mapping) == 2
     assert len(color_dict) == 2
+
 
 
 @pytest.mark.usefixtures('_disable_jit')
@@ -362,21 +359,6 @@ def test_label_colormap_map_with_uint8_values(dtype):
     npt.assert_array_equal(cmap.map(values), expected)
 
 
-@pytest.mark.parametrize('selection', [1, -1])
-@pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])
-def test_label_colormap_map_with_selection(selection, dtype):
-    cmap = colormap.CyclicLabelColormap(
-        colors=ColorArray(
-            np.array([[0, 0, 0, 0], [1, 0, 0, 1], [0, 1, 0, 1]])
-        ),
-        use_selection=True,
-        selection=selection,
-    )
-    values = np.array([0, selection, 2], dtype=np.int8)
-    expected = np.array([[0, 0, 0, 0], [1, 0, 0, 1], [0, 0, 0, 0]])
-    npt.assert_array_equal(cmap.map(values), expected)
-
-
 @pytest.mark.parametrize('background', [1, -1])
 @pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])
 def test_label_colormap_map_with_background(background, dtype):
@@ -449,26 +431,6 @@ def test_direct_colormap_with_no_selection():
     # Map multiple values
     mapped = cmap.map(np.array([1, 2]))
     npt.assert_array_equal(mapped, np.array([[1, 0, 0, 1], [0, 1, 0, 1]]))
-
-
-def test_direct_colormap_with_selection():
-    # Create a DirectLabelColormap with a simple color_dict and a selection
-    color_dict = {
-        1: np.array([1, 0, 0, 1]),
-        2: np.array([0, 1, 0, 1]),
-        None: np.array([0, 0, 0, 0]),
-    }
-    cmap = DirectLabelColormap(
-        color_dict=color_dict, use_selection=True, selection=1
-    )
-
-    # Map a single value
-    mapped = cmap.map(1)
-    npt.assert_array_equal(mapped, np.array([1, 0, 0, 1]))
-
-    # Map a value that is not the selection
-    mapped = cmap.map(2)
-    npt.assert_array_equal(mapped, np.array([0, 0, 0, 0]))
 
 
 def test_direct_colormap_with_invalid_values():
@@ -569,14 +531,6 @@ def test_direct_colormap_negative_values_numpy():
         np.array([-1, -2, 5], dtype=np.int8), cmap
     )
     npt.assert_array_equal(res, [1, 2, 0])
-
-    cmap.selection = -2
-    cmap.use_selection = True
-
-    res = _accelerated_cmap._labels_raw_to_texture_direct_numpy(
-        np.array([-1, -2, 5], dtype=np.int8), cmap
-    )
-    npt.assert_array_equal(res, [0, 1, 0])
 
 
 @pytest.mark.parametrize(

--- a/src/napari/utils/colormaps/_tests/test_colormap.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap.py
@@ -232,24 +232,6 @@ def test_direct_label_colormap_simple(direct_label_colormap):
     )
 
 
-def test_direct_label_colormap_selection(direct_label_colormap):
-    direct_label_colormap.selection = 2
-    direct_label_colormap.use_selection = True
-
-    np.testing.assert_array_equal(
-        direct_label_colormap.map([0, 2, 7]),
-        np.array([[0, 0, 0, 0], [0, 1, 0, 1], [0, 0, 0, 0]]),
-    )
-
-    (
-        label_mapping,
-        color_dict,
-    ) = direct_label_colormap._values_mapping_to_minimum_values_set()
-
-    assert len(label_mapping) == 2
-    assert len(color_dict) == 2
-
-
 @pytest.mark.usefixtures('_disable_jit')
 def test_cast_direct_labels_to_minimum_type(direct_label_colormap):
     data = np.arange(15, dtype=np.uint32)
@@ -340,21 +322,6 @@ def test_label_colormap_map_with_uint8_values(dtype):
     npt.assert_array_equal(cmap.map(values), expected)
 
 
-@pytest.mark.parametrize('selection', [1, -1])
-@pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])
-def test_label_colormap_map_with_selection(selection, dtype):
-    cmap = colormap.CyclicLabelColormap(
-        colors=ColorArray(
-            np.array([[0, 0, 0, 0], [1, 0, 0, 1], [0, 1, 0, 1]])
-        ),
-        use_selection=True,
-        selection=selection,
-    )
-    values = np.array([0, selection, 2], dtype=np.int8)
-    expected = np.array([[0, 0, 0, 0], [1, 0, 0, 1], [0, 0, 0, 0]])
-    npt.assert_array_equal(cmap.map(values), expected)
-
-
 @pytest.mark.parametrize('background', [1, -1])
 @pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])
 def test_label_colormap_map_with_background(background, dtype):
@@ -427,26 +394,6 @@ def test_direct_colormap_with_no_selection():
     # Map multiple values
     mapped = cmap.map(np.array([1, 2]))
     npt.assert_array_equal(mapped, np.array([[1, 0, 0, 1], [0, 1, 0, 1]]))
-
-
-def test_direct_colormap_with_selection():
-    # Create a DirectLabelColormap with a simple color_dict and a selection
-    color_dict = {
-        1: np.array([1, 0, 0, 1]),
-        2: np.array([0, 1, 0, 1]),
-        None: np.array([0, 0, 0, 0]),
-    }
-    cmap = DirectLabelColormap(
-        color_dict=color_dict, use_selection=True, selection=1
-    )
-
-    # Map a single value
-    mapped = cmap.map(1)
-    npt.assert_array_equal(mapped, np.array([1, 0, 0, 1]))
-
-    # Map a value that is not the selection
-    mapped = cmap.map(2)
-    npt.assert_array_equal(mapped, np.array([0, 0, 0, 0]))
 
 
 def test_direct_colormap_with_invalid_values():
@@ -547,14 +494,6 @@ def test_direct_colormap_negative_values_numpy():
         np.array([-1, -2, 5], dtype=np.int8), cmap
     )
     npt.assert_array_equal(res, [1, 2, 0])
-
-    cmap.selection = -2
-    cmap.use_selection = True
-
-    res = _accelerated_cmap._labels_raw_to_texture_direct_numpy(
-        np.array([-1, -2, 5], dtype=np.int8), cmap
-    )
-    npt.assert_array_equal(res, [0, 1, 0])
 
 
 @pytest.mark.parametrize(

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -198,8 +198,6 @@ class Colormap(EventedModel):
 
 
 class LabelColormapBase(Colormap):
-    use_selection: bool = False
-    selection: int = 0
     background_value: int = 0
     interpolation: Literal[ColormapInterpolationMode.ZERO] = Field(
         ColormapInterpolationMode.ZERO, frozen=True
@@ -219,23 +217,32 @@ class LabelColormapBase(Colormap):
     )
 
     @overload
-    def _data_to_texture(self, values: np.ndarray) -> np.ndarray: ...
+    def _data_to_texture(
+        self,
+        values: np.ndarray,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.ndarray: ...
 
     @overload
-    def _data_to_texture(self, values: np.integer) -> np.integer: ...
+    def _data_to_texture(
+        self,
+        values: np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.integer: ...
 
     def _data_to_texture(
-        self, values: np.ndarray | np.integer
+        self,
+        values: np.ndarray | np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> np.ndarray | np.integer:
         """Map input values to values for send to GPU."""
         raise NotImplementedError
-
-    def _cmap_without_selection(self) -> Self:
-        if self.use_selection:
-            cmap = self.__class__(**self.model_dump())
-            cmap.use_selection = False
-            return cmap
-        return self
 
     def _get_mapping_from_cache(
         self, data_dtype: np.dtype
@@ -267,11 +274,15 @@ class LabelColormapBase(Colormap):
         """Function that maps values to colors without selection or cache"""
         raise NotImplementedError
 
-    def _selection_as_minimum_dtype(self, dtype: np.dtype) -> int:
+    def _selection_as_minimum_dtype(
+        self, selection: int, dtype: np.dtype
+    ) -> int:
         """Treat selection as given dtype and calculate value with min dtype.
 
         Parameters
         ----------
+        selection : int
+            Label value the layer is filtering on.
         dtype : np.dtype
             The dtype to convert the selection to.
 
@@ -280,7 +291,7 @@ class LabelColormapBase(Colormap):
         int
             The selection converted.
         """
-        return int(self._data_to_texture(dtype.type(self.selection)))
+        return int(self._data_to_texture(dtype.type(selection)))
 
 
 class CyclicLabelColormap(LabelColormapBase):
@@ -292,11 +303,6 @@ class CyclicLabelColormap(LabelColormapBase):
         Colors to be used for mapping.
         For values above the number of colors,
         the colors will be cycled.
-    use_selection : bool
-        Whether map only selected label.
-        If `True` only selected label will be mapped to not transparent color.
-    selection : int
-        The selected label.
     background_value : int
         Which value should be treated as a background
         and mapped to transparent color.
@@ -334,16 +340,37 @@ class CyclicLabelColormap(LabelColormapBase):
         return int(self._data_to_texture(dtype.type(self.background_value)))
 
     @overload
-    def _data_to_texture(self, values: np.ndarray) -> np.ndarray: ...
+    def _data_to_texture(
+        self,
+        values: np.ndarray,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.ndarray: ...
 
     @overload
-    def _data_to_texture(self, values: np.integer) -> np.integer: ...
+    def _data_to_texture(
+        self,
+        values: np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.integer: ...
 
     def _data_to_texture(
-        self, values: np.ndarray | np.integer
+        self,
+        values: np.ndarray | np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> np.ndarray | np.integer:
         """Map input values to values for send to GPU."""
-        return _cast_labels_data_to_texture_dtype_auto(values, self)
+        return _cast_labels_data_to_texture_dtype_auto(
+            values,
+            self,
+            use_selection=use_selection,
+            selection=selection,
+        )
 
     def _map_without_cache(self, values) -> np.ndarray:
         texture_dtype_values = _accel_cmap.zero_preserving_modulo_numpy(
@@ -380,8 +407,6 @@ class CyclicLabelColormap(LabelColormapBase):
             mapped = mapper[values]
         else:
             mapped = self._map_without_cache(values)
-        if self.use_selection:
-            mapped[(values != self.selection)] = 0
 
         return np.reshape(mapped, original_shape + (4,))
 
@@ -413,11 +438,6 @@ class DirectLabelColormap(LabelColormapBase):
     color_dict: dict from int to (3,) or (4,) array
         The dictionary mapping labels to colors.
 
-    use_selection : bool
-        Whether to map only the selected label to a color.
-        If `True` only selected label will be not transparent.
-    selection : int
-        The selected label.
     colors : ColorArray
         Exist because of implementation details. Please do not use it.
     """
@@ -426,8 +446,6 @@ class DirectLabelColormap(LabelColormapBase):
         int | None,
         Annotated[np.ndarray, Field(default_factory=lambda: np.zeros(4))],
     ] = Field(default_factory=lambda: defaultdict(lambda: np.zeros(4)))
-    use_selection: bool = False
-    selection: int = 0
 
     def __init__(self, *args, **kwargs) -> None:
         if 'colors' not in kwargs and not args:
@@ -485,23 +503,37 @@ class DirectLabelColormap(LabelColormapBase):
             res = defaultdict(v.default_factory, res)
         return res
 
-    def _selection_as_minimum_dtype(self, dtype: np.dtype) -> int:
-        return int(
-            _cast_labels_data_to_texture_dtype_direct(
-                dtype.type(self.selection), self
-            )
-        )
+    @overload
+    def _data_to_texture(
+        self,
+        values: np.ndarray,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.ndarray: ...
 
     @overload
-    def _data_to_texture(self, values: np.ndarray) -> np.ndarray: ...
-
-    @overload
-    def _data_to_texture(self, values: np.integer) -> np.integer: ...
+    def _data_to_texture(
+        self,
+        values: np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.integer: ...
 
     def _data_to_texture(
-        self, values: np.ndarray | np.integer
+        self,
+        values: np.ndarray | np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> np.ndarray | np.integer:
-        """Map input values to values for send to GPU."""
+        """Map input values to values for send to GPU.
+
+        ``use_selection``/``selection`` are accepted for signature symmetry
+        with the cyclic colormap but ignored: direct-mode selection
+        filtering happens in the vispy shader, not in the texture data.
+        """
         return _cast_labels_data_to_texture_dtype_direct(values, self)
 
     def map(self, values: np.ndarray | np.integer | int) -> np.ndarray:
@@ -520,8 +552,6 @@ class DirectLabelColormap(LabelColormapBase):
         if isinstance(values, np.integer):
             values = int(values)
         if isinstance(values, int):
-            if self.use_selection and values != self.selection:
-                return np.array((0, 0, 0, 0))
             return self.color_dict.get(values, self.default_color)
         if isinstance(values, list | tuple):
             values = np.array(values)
@@ -534,18 +564,14 @@ class DirectLabelColormap(LabelColormapBase):
             values_cast = _accel_cmap.labels_raw_to_texture_direct(
                 values, self
             )
-            mapped = self._map_precast(values_cast, apply_selection=True)
-
-        if self.use_selection:
-            mapped[(values != self.selection)] = 0
+            mapped = self._map_precast(values_cast)
         return mapped
 
     def _map_without_cache(self, values: np.ndarray) -> np.ndarray:
-        cmap = self._cmap_without_selection()
-        cast = _accel_cmap.labels_raw_to_texture_direct(values, cmap)
-        return self._map_precast(cast, apply_selection=False)
+        cast = _accel_cmap.labels_raw_to_texture_direct(values, self)
+        return self._map_precast(cast)
 
-    def _map_precast(self, values, apply_selection) -> np.ndarray:
+    def _map_precast(self, values) -> np.ndarray:
         """Map values to colors.
 
         Parameters
@@ -565,7 +591,7 @@ class DirectLabelColormap(LabelColormapBase):
         where we already have cast values
         """
         mapped = np.zeros(values.shape + (4,), dtype=np.float32)
-        colors = self._values_mapping_to_minimum_values_set(apply_selection)[1]
+        colors = self._values_mapping_to_minimum_values_set()[1]
         for idx in np.ndindex(values.shape):
             value = values[idx]
             mapped[idx] = colors[value]
@@ -590,7 +616,7 @@ class DirectLabelColormap(LabelColormapBase):
             del self.__dict__['_array_map']
 
     def _values_mapping_to_minimum_values_set(
-        self, apply_selection=True
+        self,
     ) -> tuple[dict[int | None, int], dict[int, np.ndarray]]:
         """Create mapping from original values to minimum values set.
         To use minimum possible dtype for labels.
@@ -603,15 +629,6 @@ class DirectLabelColormap(LabelColormapBase):
             Mapping from new values to colors.
 
         """
-        if self.use_selection and apply_selection:
-            return {self.selection: 1, None: 0}, {
-                0: np.array((0, 0, 0, 0)),
-                1: self.color_dict.get(
-                    self.selection,
-                    self.default_color,
-                ),
-            }
-
         return self._label_mapping_and_color_dict
 
     @cached_property
@@ -771,6 +788,9 @@ def _convert_small_ints_to_unsigned(
 def _cast_labels_data_to_texture_dtype_auto(
     data: np.ndarray,
     colormap: CyclicLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray: ...
 
 
@@ -778,12 +798,18 @@ def _cast_labels_data_to_texture_dtype_auto(
 def _cast_labels_data_to_texture_dtype_auto(
     data: np.integer,
     colormap: CyclicLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.integer: ...
 
 
 def _cast_labels_data_to_texture_dtype_auto(
     data: np.ndarray | np.integer,
     colormap: CyclicLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray | np.integer:
     """Convert labels data to the data type used in the texture.
 
@@ -824,12 +850,16 @@ def _cast_labels_data_to_texture_dtype_auto(
 
     dtype = _accel_cmap.minimum_dtype_for_labels(num_colors + 1)
 
-    if colormap.use_selection:
+    if use_selection:
+        # Modulo hashing can map non-selected labels to the same texture
+        # index as the selection, which the shader would then render as
+        # the selection color. Zero non-selected pixels in the texture
+        # so the shader's filter check trivially excludes them.
         selection_in_texture = _accel_cmap.zero_preserving_modulo_numpy(
-            np.array([colormap.selection]), num_colors, dtype
+            np.array([selection]), num_colors, dtype
         )
         converted = np.where(
-            data_arr == colormap.selection, selection_in_texture, dtype.type(0)
+            data_arr == selection, selection_in_texture, dtype.type(0)
         )
     else:
         converted = zero_preserving_modulo_func(

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -19,7 +19,6 @@ from pydantic import (
     ValidationInfo,
     field_validator,
 )
-from typing_extensions import Self
 
 from napari.utils.color import ColorArray, ColorValue
 from napari.utils.colormaps import _accelerated_cmap as _accel_cmap
@@ -275,7 +274,11 @@ class LabelColormapBase(Colormap):
         raise NotImplementedError
 
     def _selection_as_minimum_dtype(
-        self, selection: int, dtype: np.dtype
+        self,
+        selection: int,
+        dtype: np.dtype,
+        *,
+        use_selection: bool = False,
     ) -> int:
         """Treat selection as given dtype and calculate value with min dtype.
 
@@ -285,13 +288,24 @@ class LabelColormapBase(Colormap):
             Label value the layer is filtering on.
         dtype : np.dtype
             The dtype to convert the selection to.
+        use_selection : bool
+            When True, the returned texture-index reflects the 2-entry
+            selection-shortcut mapping (always 1 for the selection),
+            matching what `_data_to_texture(..., use_selection=True)`
+            produces for the data texture.
 
         Returns
         -------
         int
             The selection converted.
         """
-        return int(self._data_to_texture(dtype.type(selection)))
+        return int(
+            self._data_to_texture(
+                dtype.type(selection),
+                use_selection=use_selection,
+                selection=selection,
+            )
+        )
 
 
 class CyclicLabelColormap(LabelColormapBase):
@@ -528,13 +542,13 @@ class DirectLabelColormap(LabelColormapBase):
         use_selection: bool = False,
         selection: int = 0,
     ) -> np.ndarray | np.integer:
-        """Map input values to values for send to GPU.
-
-        ``use_selection``/``selection`` are accepted for signature symmetry
-        with the cyclic colormap but ignored: direct-mode selection
-        filtering happens in the vispy shader, not in the texture data.
-        """
-        return _cast_labels_data_to_texture_dtype_direct(values, self)
+        """Map input values to values for send to GPU."""
+        return _cast_labels_data_to_texture_dtype_direct(
+            values,
+            self,
+            use_selection=use_selection,
+            selection=selection,
+        )
 
     def map(self, values: np.ndarray | np.integer | int) -> np.ndarray:
         """Map values to colors.
@@ -617,6 +631,9 @@ class DirectLabelColormap(LabelColormapBase):
 
     def _values_mapping_to_minimum_values_set(
         self,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> tuple[dict[int | None, int], dict[int, np.ndarray]]:
         """Create mapping from original values to minimum values set.
         To use minimum possible dtype for labels.
@@ -629,6 +646,14 @@ class DirectLabelColormap(LabelColormapBase):
             Mapping from new values to colors.
 
         """
+        if use_selection:
+            # Two-entry shortcut: pair with the 0/1 data short-circuit
+            # in `_labels_raw_to_texture_direct_*` so the texture stays
+            # tiny (one selection color + transparent).
+            return {selection: 1, None: 0}, {
+                0: np.array((0, 0, 0, 0)),
+                1: self.color_dict.get(selection, self.default_color),
+            }
         return self._label_mapping_and_color_dict
 
     @cached_property
@@ -874,18 +899,30 @@ def _cast_labels_data_to_texture_dtype_auto(
 
 @overload
 def _cast_labels_data_to_texture_dtype_direct(
-    data: np.ndarray, direct_colormap: DirectLabelColormap
+    data: np.ndarray,
+    direct_colormap: DirectLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray: ...
 
 
 @overload
 def _cast_labels_data_to_texture_dtype_direct(
-    data: np.integer, direct_colormap: DirectLabelColormap
+    data: np.integer,
+    direct_colormap: DirectLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.integer: ...
 
 
 def _cast_labels_data_to_texture_dtype_direct(
-    data: np.ndarray | np.integer, direct_colormap: DirectLabelColormap
+    data: np.ndarray | np.integer,
+    direct_colormap: DirectLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray | np.integer:
     """Convert labels data to the data type used in the texture.
 
@@ -924,10 +961,12 @@ def _cast_labels_data_to_texture_dtype_direct(
         return data
 
     if isinstance(data, np.integer):
-        mapper = direct_colormap._label_mapping_and_color_dict[0]
         target_dtype = _accel_cmap.minimum_dtype_for_labels(
             direct_colormap._num_unique_colors + 2
         )
+        if use_selection:
+            return target_dtype.type(1 if int(data) == selection else 0)
+        mapper = direct_colormap._label_mapping_and_color_dict[0]
         return target_dtype.type(
             mapper.get(int(data), _accel_cmap.MAPPING_OF_UNKNOWN_VALUE)
         )
@@ -935,7 +974,12 @@ def _cast_labels_data_to_texture_dtype_direct(
     original_shape = np.shape(data)
     array_data = np.atleast_1d(data)
     return np.reshape(
-        _accel_cmap.labels_raw_to_texture_direct(array_data, direct_colormap),
+        _accel_cmap.labels_raw_to_texture_direct(
+            array_data,
+            direct_colormap,
+            use_selection=use_selection,
+            selection=selection,
+        ),
         original_shape,
     )
 

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -203,6 +203,45 @@ class _RebuildableCache(dict):
         return type(self)()
 
 
+def _removed_selection_field(
+    name: str, layer_attr: str, *, default
+) -> property:
+    """Deprecation shim for a selection field removed from label colormaps.
+
+    Reading warns with ``FutureWarning`` and returns the old default;
+    writing raises ``AttributeError`` pointing to the Labels layer
+    attribute that owns the state now.
+    """
+
+    def getter(self):
+        warn(
+            trans._(
+                'LabelColormapBase.{name} was removed; label colormaps no'
+                ' longer carry selection state. Read layer.{layer_attr}'
+                ' instead.',
+                deferred=True,
+                name=name,
+                layer_attr=layer_attr,
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+        return default
+
+    def setter(self, value):
+        raise AttributeError(
+            trans._(
+                'LabelColormapBase.{name} was removed; label colormaps are'
+                ' immutable value objects. Set layer.{layer_attr} instead.',
+                deferred=True,
+                name=name,
+                layer_attr=layer_attr,
+            )
+        )
+
+    return property(getter, setter, doc=f'Removed: use layer.{layer_attr}.')
+
+
 class LabelColormapBase(Colormap):
     background_value: int = 0
     interpolation: Literal[ColormapInterpolationMode.ZERO] = Field(
@@ -224,56 +263,12 @@ class LabelColormapBase(Colormap):
         # TODO: ensure that this is actually needed
     )
 
-    @property
-    def use_selection(self) -> bool:
-        """Deprecated: selection filtering moved to the Labels layer."""
-        warn(
-            trans._(
-                'LabelColormapBase.use_selection was removed; label colormaps'
-                ' no longer carry selection state. Read'
-                ' layer.show_selected_label instead.',
-                deferred=True,
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return False
-
-    @use_selection.setter
-    def use_selection(self, value: bool) -> None:
-        raise AttributeError(
-            trans._(
-                'LabelColormapBase.use_selection was removed; label colormaps'
-                ' are immutable value objects. Set layer.show_selected_label'
-                ' instead.',
-                deferred=True,
-            )
-        )
-
-    @property
-    def selection(self) -> int:
-        """Deprecated: selection filtering moved to the Labels layer."""
-        warn(
-            trans._(
-                'LabelColormapBase.selection was removed; label colormaps no'
-                ' longer carry selection state. Read layer.selected_label'
-                ' instead.',
-                deferred=True,
-            ),
-            FutureWarning,
-            stacklevel=2,
-        )
-        return 0
-
-    @selection.setter
-    def selection(self, value: int) -> None:
-        raise AttributeError(
-            trans._(
-                'LabelColormapBase.selection was removed; label colormaps are'
-                ' immutable value objects. Set layer.selected_label instead.',
-                deferred=True,
-            )
-        )
+    use_selection = _removed_selection_field(
+        'use_selection', 'show_selected_label', default=False
+    )
+    selection = _removed_selection_field(
+        'selection', 'selected_label', default=0
+    )
 
     @overload
     def _data_to_texture(
@@ -635,10 +630,7 @@ class DirectLabelColormap(LabelColormapBase):
         if mapper is not None:
             mapped = mapper[values]
         else:
-            values_cast = _accel_cmap.labels_raw_to_texture_direct(
-                values, self
-            )
-            mapped = self._map_precast(values_cast)
+            mapped = self._map_without_cache(values)
         return mapped
 
     def _map_without_cache(self, values: np.ndarray) -> np.ndarray:

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -284,7 +284,11 @@ class LabelColormapBase(Colormap):
         raise NotImplementedError
 
     def _selection_as_minimum_dtype(
-        self, selection: int, dtype: np.dtype
+        self,
+        selection: int,
+        dtype: np.dtype,
+        *,
+        use_selection: bool = False,
     ) -> int:
         """Treat selection as given dtype and calculate value with min dtype.
 
@@ -294,13 +298,24 @@ class LabelColormapBase(Colormap):
             Label value the layer is filtering on.
         dtype : np.dtype
             The dtype to convert the selection to.
+        use_selection : bool
+            When True, the returned texture-index reflects the 2-entry
+            selection-shortcut mapping (always 1 for the selection),
+            matching what `_data_to_texture(..., use_selection=True)`
+            produces for the data texture.
 
         Returns
         -------
         int
             The selection converted.
         """
-        return int(self._data_to_texture(dtype.type(selection)))
+        return int(
+            self._data_to_texture(
+                dtype.type(selection),
+                use_selection=use_selection,
+                selection=selection,
+            )
+        )
 
 
 class CyclicLabelColormap(LabelColormapBase):
@@ -537,13 +552,13 @@ class DirectLabelColormap(LabelColormapBase):
         use_selection: bool = False,
         selection: int = 0,
     ) -> np.ndarray | np.integer:
-        """Map input values to values for send to GPU.
-
-        ``use_selection``/``selection`` are accepted for signature symmetry
-        with the cyclic colormap but ignored: direct-mode selection
-        filtering happens in the vispy shader, not in the texture data.
-        """
-        return _cast_labels_data_to_texture_dtype_direct(values, self)
+        """Map input values to values for send to GPU."""
+        return _cast_labels_data_to_texture_dtype_direct(
+            values,
+            self,
+            use_selection=use_selection,
+            selection=selection,
+        )
 
     def map(self, values: np.ndarray | np.integer | int) -> np.ndarray:
         """Map values to colors.
@@ -626,6 +641,9 @@ class DirectLabelColormap(LabelColormapBase):
 
     def _values_mapping_to_minimum_values_set(
         self,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> tuple[dict[int | None, int], dict[int, np.ndarray]]:
         """Create mapping from original values to minimum values set.
         To use minimum possible dtype for labels.
@@ -638,6 +656,14 @@ class DirectLabelColormap(LabelColormapBase):
             Mapping from new values to colors.
 
         """
+        if use_selection:
+            # Two-entry shortcut: pair with the 0/1 data short-circuit
+            # in `_labels_raw_to_texture_direct_*` so the texture stays
+            # tiny (one selection color + transparent).
+            return {selection: 1, None: 0}, {
+                0: np.array((0, 0, 0, 0)),
+                1: self.color_dict.get(selection, self.default_color),
+            }
         return self._label_mapping_and_color_dict
 
     @cached_property
@@ -883,18 +909,30 @@ def _cast_labels_data_to_texture_dtype_auto(
 
 @overload
 def _cast_labels_data_to_texture_dtype_direct(
-    data: np.ndarray, direct_colormap: DirectLabelColormap
+    data: np.ndarray,
+    direct_colormap: DirectLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray: ...
 
 
 @overload
 def _cast_labels_data_to_texture_dtype_direct(
-    data: np.integer, direct_colormap: DirectLabelColormap
+    data: np.integer,
+    direct_colormap: DirectLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.integer: ...
 
 
 def _cast_labels_data_to_texture_dtype_direct(
-    data: np.ndarray | np.integer, direct_colormap: DirectLabelColormap
+    data: np.ndarray | np.integer,
+    direct_colormap: DirectLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray | np.integer:
     """Convert labels data to the data type used in the texture.
 
@@ -933,10 +971,12 @@ def _cast_labels_data_to_texture_dtype_direct(
         return data
 
     if isinstance(data, np.integer):
-        mapper = direct_colormap._label_mapping_and_color_dict[0]
         target_dtype = _accel_cmap.minimum_dtype_for_labels(
             direct_colormap._num_unique_colors + 2
         )
+        if use_selection:
+            return target_dtype.type(1 if int(data) == selection else 0)
+        mapper = direct_colormap._label_mapping_and_color_dict[0]
         return target_dtype.type(
             mapper.get(int(data), _accel_cmap.MAPPING_OF_UNKNOWN_VALUE)
         )
@@ -944,7 +984,12 @@ def _cast_labels_data_to_texture_dtype_direct(
     original_shape = np.shape(data)
     array_data = np.atleast_1d(data)
     return np.reshape(
-        _accel_cmap.labels_raw_to_texture_direct(array_data, direct_colormap),
+        _accel_cmap.labels_raw_to_texture_direct(
+            array_data,
+            direct_colormap,
+            use_selection=use_selection,
+            selection=selection,
+        ),
         original_shape,
     )
 

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -275,8 +275,7 @@ class LabelColormapBase(Colormap):
         self,
         values: np.ndarray,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.ndarray: ...
 
     @overload
@@ -284,18 +283,21 @@ class LabelColormapBase(Colormap):
         self,
         values: np.integer,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.integer: ...
 
     def _data_to_texture(
         self,
         values: np.ndarray | np.integer,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.ndarray | np.integer:
-        """Map input values to values for send to GPU."""
+        """Map input values to values for send to GPU.
+
+        When ``selection`` is not None, values other than the selection are
+        mapped to the background texture value (the
+        ``Labels.show_selected_label`` filter).
+        """
         raise NotImplementedError
 
     def _get_mapping_from_cache(
@@ -329,13 +331,9 @@ class LabelColormapBase(Colormap):
         raise NotImplementedError
 
     def _selection_as_minimum_dtype(
-        self,
-        selection: int,
-        dtype: np.dtype,
-        *,
-        use_selection: bool = False,
+        self, selection: int, dtype: np.dtype
     ) -> int:
-        """Treat selection as given dtype and calculate value with min dtype.
+        """Texture value of the selected label while the filter is active.
 
         Parameters
         ----------
@@ -343,23 +341,16 @@ class LabelColormapBase(Colormap):
             Label value the layer is filtering on.
         dtype : np.dtype
             The dtype to convert the selection to.
-        use_selection : bool
-            When True, the returned texture-index reflects the 2-entry
-            selection-shortcut mapping (always 1 for the selection),
-            matching what `_data_to_texture(..., use_selection=True)`
-            produces for the data texture.
 
         Returns
         -------
         int
-            The selection converted.
+            The texture-index of the selection under the filtered mapping,
+            matching what `_data_to_texture(..., selection=selection)`
+            produces for the data texture.
         """
         return int(
-            self._data_to_texture(
-                dtype.type(selection),
-                use_selection=use_selection,
-                selection=selection,
-            )
+            self._data_to_texture(dtype.type(selection), selection=selection)
         )
 
 
@@ -413,8 +404,7 @@ class CyclicLabelColormap(LabelColormapBase):
         self,
         values: np.ndarray,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.ndarray: ...
 
     @overload
@@ -422,23 +412,18 @@ class CyclicLabelColormap(LabelColormapBase):
         self,
         values: np.integer,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.integer: ...
 
     def _data_to_texture(
         self,
         values: np.ndarray | np.integer,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.ndarray | np.integer:
         """Map input values to values for send to GPU."""
         return _cast_labels_data_to_texture_dtype_auto(
-            values,
-            self,
-            use_selection=use_selection,
-            selection=selection,
+            values, self, selection=selection
         )
 
     def _map_without_cache(self, values) -> np.ndarray:
@@ -577,8 +562,7 @@ class DirectLabelColormap(LabelColormapBase):
         self,
         values: np.ndarray,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.ndarray: ...
 
     @overload
@@ -586,23 +570,18 @@ class DirectLabelColormap(LabelColormapBase):
         self,
         values: np.integer,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.integer: ...
 
     def _data_to_texture(
         self,
         values: np.ndarray | np.integer,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> np.ndarray | np.integer:
         """Map input values to values for send to GPU."""
         return _cast_labels_data_to_texture_dtype_direct(
-            values,
-            self,
-            use_selection=use_selection,
-            selection=selection,
+            values, self, selection=selection
         )
 
     def map(self, values: np.ndarray | np.integer | int) -> np.ndarray:
@@ -684,8 +663,7 @@ class DirectLabelColormap(LabelColormapBase):
     def _values_mapping_to_minimum_values_set(
         self,
         *,
-        use_selection: bool = False,
-        selection: int = 0,
+        selection: int | None = None,
     ) -> tuple[dict[int | None, int], dict[int, np.ndarray]]:
         """Create mapping from original values to minimum values set.
         To use minimum possible dtype for labels.
@@ -698,7 +676,7 @@ class DirectLabelColormap(LabelColormapBase):
             Mapping from new values to colors.
 
         """
-        if use_selection:
+        if selection is not None:
             # Two-entry shortcut: pair with the 0/1 data short-circuit
             # in `_labels_raw_to_texture_direct_*` so the texture stays
             # tiny (one selection color + transparent).
@@ -866,8 +844,7 @@ def _cast_labels_data_to_texture_dtype_auto(
     data: np.ndarray,
     colormap: CyclicLabelColormap,
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.ndarray: ...
 
 
@@ -876,8 +853,7 @@ def _cast_labels_data_to_texture_dtype_auto(
     data: np.integer,
     colormap: CyclicLabelColormap,
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.integer: ...
 
 
@@ -885,8 +861,7 @@ def _cast_labels_data_to_texture_dtype_auto(
     data: np.ndarray | np.integer,
     colormap: CyclicLabelColormap,
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.ndarray | np.integer:
     """Convert labels data to the data type used in the texture.
 
@@ -927,7 +902,7 @@ def _cast_labels_data_to_texture_dtype_auto(
 
     dtype = _accel_cmap.minimum_dtype_for_labels(num_colors + 1)
 
-    if use_selection:
+    if selection is not None:
         # Modulo hashing can map non-selected labels to the same texture
         # index as the selection, which the shader would then render as
         # the selection color. Zero non-selected pixels in the texture
@@ -954,8 +929,7 @@ def _cast_labels_data_to_texture_dtype_direct(
     data: np.ndarray,
     direct_colormap: DirectLabelColormap,
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.ndarray: ...
 
 
@@ -964,8 +938,7 @@ def _cast_labels_data_to_texture_dtype_direct(
     data: np.integer,
     direct_colormap: DirectLabelColormap,
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.integer: ...
 
 
@@ -973,8 +946,7 @@ def _cast_labels_data_to_texture_dtype_direct(
     data: np.ndarray | np.integer,
     direct_colormap: DirectLabelColormap,
     *,
-    use_selection: bool = False,
-    selection: int = 0,
+    selection: int | None = None,
 ) -> np.ndarray | np.integer:
     """Convert labels data to the data type used in the texture.
 
@@ -1016,7 +988,7 @@ def _cast_labels_data_to_texture_dtype_direct(
         target_dtype = _accel_cmap.minimum_dtype_for_labels(
             direct_colormap._num_unique_colors + 2
         )
-        if use_selection:
+        if selection is not None:
             return target_dtype.type(1 if int(data) == selection else 0)
         mapper = direct_colormap._label_mapping_and_color_dict[0]
         return target_dtype.type(
@@ -1027,10 +999,7 @@ def _cast_labels_data_to_texture_dtype_direct(
     array_data = np.atleast_1d(data)
     return np.reshape(
         _accel_cmap.labels_raw_to_texture_direct(
-            array_data,
-            direct_colormap,
-            use_selection=use_selection,
-            selection=selection,
+            array_data, direct_colormap, selection=selection
         ),
         original_shape,
     )

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -205,8 +205,6 @@ class _RebuildableCache(dict):
 
 
 class LabelColormapBase(Colormap):
-    use_selection: bool = False
-    selection: int = 0
     background_value: int = 0
     interpolation: Literal[ColormapInterpolationMode.ZERO] = Field(
         ColormapInterpolationMode.ZERO, frozen=True
@@ -228,23 +226,32 @@ class LabelColormapBase(Colormap):
     )
 
     @overload
-    def _data_to_texture(self, values: np.ndarray) -> np.ndarray: ...
+    def _data_to_texture(
+        self,
+        values: np.ndarray,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.ndarray: ...
 
     @overload
-    def _data_to_texture(self, values: np.integer) -> np.integer: ...
+    def _data_to_texture(
+        self,
+        values: np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.integer: ...
 
     def _data_to_texture(
-        self, values: np.ndarray | np.integer
+        self,
+        values: np.ndarray | np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> np.ndarray | np.integer:
         """Map input values to values for send to GPU."""
         raise NotImplementedError
-
-    def _cmap_without_selection(self) -> Self:
-        if self.use_selection:
-            cmap = self.__class__(**self.model_dump())
-            cmap.use_selection = False
-            return cmap
-        return self
 
     def _get_mapping_from_cache(
         self, data_dtype: np.dtype
@@ -276,11 +283,15 @@ class LabelColormapBase(Colormap):
         """Function that maps values to colors without selection or cache"""
         raise NotImplementedError
 
-    def _selection_as_minimum_dtype(self, dtype: np.dtype) -> int:
+    def _selection_as_minimum_dtype(
+        self, selection: int, dtype: np.dtype
+    ) -> int:
         """Treat selection as given dtype and calculate value with min dtype.
 
         Parameters
         ----------
+        selection : int
+            Label value the layer is filtering on.
         dtype : np.dtype
             The dtype to convert the selection to.
 
@@ -289,7 +300,7 @@ class LabelColormapBase(Colormap):
         int
             The selection converted.
         """
-        return int(self._data_to_texture(dtype.type(self.selection)))
+        return int(self._data_to_texture(dtype.type(selection)))
 
 
 class CyclicLabelColormap(LabelColormapBase):
@@ -301,11 +312,6 @@ class CyclicLabelColormap(LabelColormapBase):
         Colors to be used for mapping.
         For values above the number of colors,
         the colors will be cycled.
-    use_selection : bool
-        Whether map only selected label.
-        If `True` only selected label will be mapped to not transparent color.
-    selection : int
-        The selected label.
     background_value : int
         Which value should be treated as a background
         and mapped to transparent color.
@@ -343,16 +349,37 @@ class CyclicLabelColormap(LabelColormapBase):
         return int(self._data_to_texture(dtype.type(self.background_value)))
 
     @overload
-    def _data_to_texture(self, values: np.ndarray) -> np.ndarray: ...
+    def _data_to_texture(
+        self,
+        values: np.ndarray,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.ndarray: ...
 
     @overload
-    def _data_to_texture(self, values: np.integer) -> np.integer: ...
+    def _data_to_texture(
+        self,
+        values: np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.integer: ...
 
     def _data_to_texture(
-        self, values: np.ndarray | np.integer
+        self,
+        values: np.ndarray | np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> np.ndarray | np.integer:
         """Map input values to values for send to GPU."""
-        return _cast_labels_data_to_texture_dtype_auto(values, self)
+        return _cast_labels_data_to_texture_dtype_auto(
+            values,
+            self,
+            use_selection=use_selection,
+            selection=selection,
+        )
 
     def _map_without_cache(self, values) -> np.ndarray:
         texture_dtype_values = _accel_cmap.zero_preserving_modulo_numpy(
@@ -389,8 +416,6 @@ class CyclicLabelColormap(LabelColormapBase):
             mapped = mapper[values]
         else:
             mapped = self._map_without_cache(values)
-        if self.use_selection:
-            mapped[(values != self.selection)] = 0
 
         return np.reshape(mapped, original_shape + (4,))
 
@@ -422,11 +447,6 @@ class DirectLabelColormap(LabelColormapBase):
     color_dict: dict from int to (3,) or (4,) array
         The dictionary mapping labels to colors.
 
-    use_selection : bool
-        Whether to map only the selected label to a color.
-        If `True` only selected label will be not transparent.
-    selection : int
-        The selected label.
     colors : ColorArray
         Exist because of implementation details. Please do not use it.
     """
@@ -435,8 +455,6 @@ class DirectLabelColormap(LabelColormapBase):
         int | None,
         Annotated[np.ndarray, Field(default_factory=lambda: np.zeros(4))],
     ] = Field(default_factory=lambda: defaultdict(lambda: np.zeros(4)))
-    use_selection: bool = False
-    selection: int = 0
 
     def __init__(self, *args, **kwargs) -> None:
         if 'colors' not in kwargs and not args:
@@ -494,23 +512,37 @@ class DirectLabelColormap(LabelColormapBase):
             res = defaultdict(v.default_factory, res)
         return res
 
-    def _selection_as_minimum_dtype(self, dtype: np.dtype) -> int:
-        return int(
-            _cast_labels_data_to_texture_dtype_direct(
-                dtype.type(self.selection), self
-            )
-        )
+    @overload
+    def _data_to_texture(
+        self,
+        values: np.ndarray,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.ndarray: ...
 
     @overload
-    def _data_to_texture(self, values: np.ndarray) -> np.ndarray: ...
-
-    @overload
-    def _data_to_texture(self, values: np.integer) -> np.integer: ...
+    def _data_to_texture(
+        self,
+        values: np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
+    ) -> np.integer: ...
 
     def _data_to_texture(
-        self, values: np.ndarray | np.integer
+        self,
+        values: np.ndarray | np.integer,
+        *,
+        use_selection: bool = False,
+        selection: int = 0,
     ) -> np.ndarray | np.integer:
-        """Map input values to values for send to GPU."""
+        """Map input values to values for send to GPU.
+
+        ``use_selection``/``selection`` are accepted for signature symmetry
+        with the cyclic colormap but ignored: direct-mode selection
+        filtering happens in the vispy shader, not in the texture data.
+        """
         return _cast_labels_data_to_texture_dtype_direct(values, self)
 
     def map(self, values: np.ndarray | np.integer | int) -> np.ndarray:
@@ -529,8 +561,6 @@ class DirectLabelColormap(LabelColormapBase):
         if isinstance(values, np.integer):
             values = int(values)
         if isinstance(values, int):
-            if self.use_selection and values != self.selection:
-                return np.array((0, 0, 0, 0))
             return self.color_dict.get(values, self.default_color)
         if isinstance(values, list | tuple):
             values = np.array(values)
@@ -543,18 +573,14 @@ class DirectLabelColormap(LabelColormapBase):
             values_cast = _accel_cmap.labels_raw_to_texture_direct(
                 values, self
             )
-            mapped = self._map_precast(values_cast, apply_selection=True)
-
-        if self.use_selection:
-            mapped[(values != self.selection)] = 0
+            mapped = self._map_precast(values_cast)
         return mapped
 
     def _map_without_cache(self, values: np.ndarray) -> np.ndarray:
-        cmap = self._cmap_without_selection()
-        cast = _accel_cmap.labels_raw_to_texture_direct(values, cmap)
-        return self._map_precast(cast, apply_selection=False)
+        cast = _accel_cmap.labels_raw_to_texture_direct(values, self)
+        return self._map_precast(cast)
 
-    def _map_precast(self, values, apply_selection) -> np.ndarray:
+    def _map_precast(self, values) -> np.ndarray:
         """Map values to colors.
 
         Parameters
@@ -574,7 +600,7 @@ class DirectLabelColormap(LabelColormapBase):
         where we already have cast values
         """
         mapped = np.zeros(values.shape + (4,), dtype=np.float32)
-        colors = self._values_mapping_to_minimum_values_set(apply_selection)[1]
+        colors = self._values_mapping_to_minimum_values_set()[1]
         for idx in np.ndindex(values.shape):
             value = values[idx]
             mapped[idx] = colors[value]
@@ -599,7 +625,7 @@ class DirectLabelColormap(LabelColormapBase):
             del self.__dict__['_array_map']
 
     def _values_mapping_to_minimum_values_set(
-        self, apply_selection=True
+        self,
     ) -> tuple[dict[int | None, int], dict[int, np.ndarray]]:
         """Create mapping from original values to minimum values set.
         To use minimum possible dtype for labels.
@@ -612,15 +638,6 @@ class DirectLabelColormap(LabelColormapBase):
             Mapping from new values to colors.
 
         """
-        if self.use_selection and apply_selection:
-            return {self.selection: 1, None: 0}, {
-                0: np.array((0, 0, 0, 0)),
-                1: self.color_dict.get(
-                    self.selection,
-                    self.default_color,
-                ),
-            }
-
         return self._label_mapping_and_color_dict
 
     @cached_property
@@ -780,6 +797,9 @@ def _convert_small_ints_to_unsigned(
 def _cast_labels_data_to_texture_dtype_auto(
     data: np.ndarray,
     colormap: CyclicLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray: ...
 
 
@@ -787,12 +807,18 @@ def _cast_labels_data_to_texture_dtype_auto(
 def _cast_labels_data_to_texture_dtype_auto(
     data: np.integer,
     colormap: CyclicLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.integer: ...
 
 
 def _cast_labels_data_to_texture_dtype_auto(
     data: np.ndarray | np.integer,
     colormap: CyclicLabelColormap,
+    *,
+    use_selection: bool = False,
+    selection: int = 0,
 ) -> np.ndarray | np.integer:
     """Convert labels data to the data type used in the texture.
 
@@ -833,12 +859,16 @@ def _cast_labels_data_to_texture_dtype_auto(
 
     dtype = _accel_cmap.minimum_dtype_for_labels(num_colors + 1)
 
-    if colormap.use_selection:
+    if use_selection:
+        # Modulo hashing can map non-selected labels to the same texture
+        # index as the selection, which the shader would then render as
+        # the selection color. Zero non-selected pixels in the texture
+        # so the shader's filter check trivially excludes them.
         selection_in_texture = _accel_cmap.zero_preserving_modulo_numpy(
-            np.array([colormap.selection]), num_colors, dtype
+            np.array([selection]), num_colors, dtype
         )
         converted = np.where(
-            data_arr == colormap.selection, selection_in_texture, dtype.type(0)
+            data_arr == selection, selection_in_texture, dtype.type(0)
         )
     else:
         converted = zero_preserving_modulo_func(

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -7,6 +7,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    NoReturn,
     cast,
     overload,
 )
@@ -203,43 +204,33 @@ class _RebuildableCache(dict):
         return type(self)()
 
 
-def _removed_selection_field(
-    name: str, layer_attr: str, *, default
-) -> property:
-    """Deprecation shim for a selection field removed from label colormaps.
+def _warn_removed_selection_field(name: str, layer_attr: str) -> None:
+    """Warn about reading a selection field removed from label colormaps."""
+    warn(
+        trans._(
+            'LabelColormapBase.{name} was removed; label colormaps no'
+            ' longer carry selection state. Read layer.{layer_attr}'
+            ' instead.',
+            deferred=True,
+            name=name,
+            layer_attr=layer_attr,
+        ),
+        FutureWarning,
+        stacklevel=3,
+    )
 
-    Reading warns with ``FutureWarning`` and returns the old default;
-    writing raises ``AttributeError`` pointing to the Labels layer
-    attribute that owns the state now.
-    """
 
-    def getter(self):
-        warn(
-            trans._(
-                'LabelColormapBase.{name} was removed; label colormaps no'
-                ' longer carry selection state. Read layer.{layer_attr}'
-                ' instead.',
-                deferred=True,
-                name=name,
-                layer_attr=layer_attr,
-            ),
-            FutureWarning,
-            stacklevel=2,
+def _raise_removed_selection_field(name: str, layer_attr: str) -> NoReturn:
+    """Raise for writing a selection field removed from label colormaps."""
+    raise AttributeError(
+        trans._(
+            'LabelColormapBase.{name} was removed; label colormaps are'
+            ' immutable value objects. Set layer.{layer_attr} instead.',
+            deferred=True,
+            name=name,
+            layer_attr=layer_attr,
         )
-        return default
-
-    def setter(self, value):
-        raise AttributeError(
-            trans._(
-                'LabelColormapBase.{name} was removed; label colormaps are'
-                ' immutable value objects. Set layer.{layer_attr} instead.',
-                deferred=True,
-                name=name,
-                layer_attr=layer_attr,
-            )
-        )
-
-    return property(getter, setter, doc=f'Removed: use layer.{layer_attr}.')
+    )
 
 
 class LabelColormapBase(Colormap):
@@ -263,12 +254,25 @@ class LabelColormapBase(Colormap):
         # TODO: ensure that this is actually needed
     )
 
-    use_selection = _removed_selection_field(
-        'use_selection', 'show_selected_label', default=False
-    )
-    selection = _removed_selection_field(
-        'selection', 'selected_label', default=0
-    )
+    @property
+    def use_selection(self) -> bool:
+        """Removed: read ``layer.show_selected_label`` instead."""
+        _warn_removed_selection_field('use_selection', 'show_selected_label')
+        return False
+
+    @use_selection.setter
+    def use_selection(self, value: bool) -> None:
+        _raise_removed_selection_field('use_selection', 'show_selected_label')
+
+    @property
+    def selection(self) -> int:
+        """Removed: read ``layer.selected_label`` instead."""
+        _warn_removed_selection_field('selection', 'selected_label')
+        return 0
+
+    @selection.setter
+    def selection(self, value: int) -> None:
+        _raise_removed_selection_field('selection', 'selected_label')
 
     @overload
     def _data_to_texture(

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -7,7 +7,6 @@ from typing import (
     Annotated,
     Any,
     Literal,
-    Self,
     cast,
     overload,
 )
@@ -224,6 +223,57 @@ class LabelColormapBase(Colormap):
         ignored_types=(cached_property,)
         # TODO: ensure that this is actually needed
     )
+
+    @property
+    def use_selection(self) -> bool:
+        """Deprecated: selection filtering moved to the Labels layer."""
+        warn(
+            trans._(
+                'LabelColormapBase.use_selection was removed; label colormaps'
+                ' no longer carry selection state. Read'
+                ' layer.show_selected_label instead.',
+                deferred=True,
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+        return False
+
+    @use_selection.setter
+    def use_selection(self, value: bool) -> None:
+        raise AttributeError(
+            trans._(
+                'LabelColormapBase.use_selection was removed; label colormaps'
+                ' are immutable value objects. Set layer.show_selected_label'
+                ' instead.',
+                deferred=True,
+            )
+        )
+
+    @property
+    def selection(self) -> int:
+        """Deprecated: selection filtering moved to the Labels layer."""
+        warn(
+            trans._(
+                'LabelColormapBase.selection was removed; label colormaps no'
+                ' longer carry selection state. Read layer.selected_label'
+                ' instead.',
+                deferred=True,
+            ),
+            FutureWarning,
+            stacklevel=2,
+        )
+        return 0
+
+    @selection.setter
+    def selection(self, value: int) -> None:
+        raise AttributeError(
+            trans._(
+                'LabelColormapBase.selection was removed; label colormaps are'
+                ' immutable value objects. Set layer.selected_label instead.',
+                deferred=True,
+            )
+        )
 
     @overload
     def _data_to_texture(

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -207,14 +207,8 @@ class _RebuildableCache(dict):
 def _warn_removed_selection_field(name: str, layer_attr: str) -> None:
     """Warn about reading a selection field removed from label colormaps."""
     warn(
-        trans._(
-            'LabelColormapBase.{name} was removed; label colormaps no'
-            ' longer carry selection state. Read layer.{layer_attr}'
-            ' instead.',
-            deferred=True,
-            name=name,
-            layer_attr=layer_attr,
-        ),
+        f'LabelColormapBase.{name} was removed; label colormaps no '
+        f'longer carry selection state. Read layer.{layer_attr} instead.',
         FutureWarning,
         stacklevel=3,
     )
@@ -223,13 +217,8 @@ def _warn_removed_selection_field(name: str, layer_attr: str) -> None:
 def _raise_removed_selection_field(name: str, layer_attr: str) -> NoReturn:
     """Raise for writing a selection field removed from label colormaps."""
     raise AttributeError(
-        trans._(
-            'LabelColormapBase.{name} was removed; label colormaps are'
-            ' immutable value objects. Set layer.{layer_attr} instead.',
-            deferred=True,
-            name=name,
-            layer_attr=layer_attr,
-        )
+        f'LabelColormapBase.{name} was removed; label colormaps are '
+        f'immutable value objects. Set layer.{layer_attr} instead.'
     )
 
 


### PR DESCRIPTION
# References and relevant issues

Closes #8965 (partially: the `show_selected_label` half). Supersedes #8967, which fixed the same bug by synchronization and is now closed in favor of this PR.

Related:
- #8947: the user-visible bug that started this (shuffle silently dropped the "show selected" filter). Merged; fixed one path.
- vispy/vispy#2663 and #6878 (HiLo): the "colormaps should be immutable" discussion this PR builds on, raised in review of #8967.
- #8699 (decoupling drawing label from display label): compatible, see below.

# Description

## The bug: `show_selected_label` state drift

`Labels` has a "show selected" mode that renders only the currently selected label and hides all others. Before this PR, the state for that mode was stored **twice**:

- on the layer: `Labels._show_selected_label` / `Labels._selected_label` (backing the public `layer.show_selected_label` / `layer.selected_label` API, the Qt checkbox, and the layer events), and
- on the colormap: `use_selection: bool` / `selection: int` Pydantic fields on `LabelColormapBase`, which is what the renderer actually read.

Nothing enforced that the two copies agree. Any code path that replaced or rebuilt the colormap without copying the layer state over (or vice versa) made them **drift** apart: the checkbox says filtering is on, but the canvas renders all labels, or the reverse. #8947 was exactly this: `new_colormap()` (color shuffle) built a fresh colormap with default `use_selection=False`, silently switching filtering off while the checkbox stayed checked. Review of that fix identified the same drift on at least four more paths (constructor with a user colormap, `layer.colormap = X` assignment, AUTO/DIRECT mode round-trip, `_get_state` round-trip).

Two directions were explored to fix the class of bug rather than individual paths:

- **#8967 (closed):** keep both copies, add synchronization at every seam where they can diverge.
- **This PR:** delete the colormap copy. The layer becomes the sole owner of the selection state, and the colormap becomes a pure, immutable value-to-color mapping, matching the vispy and matplotlib convention. Drift is impossible because there is nothing left to drift.

Concretely: the `use_selection` / `selection` fields are removed from `LabelColormapBase` (and subclasses), `colormap.map()` becomes pure, and the renderer receives the selection state from the layer at the texture-cast seam via a single keyword-only `selection: int | None = None` parameter (None means no filtering).

## Why this direction

1. **Resolves the drift bug by deletion, not synchronization.** All five known drift paths exist because there are two copies of the state. Removing the colormap copy removes the drift surface entirely; the sync approach has to defend every current and future seam by hand (the recent painting refactor #8636 added two new texture-cast sites, which is exactly how new drift paths appear).
2. **Matches the colormap-immutability convention.** `use_selection` / `selection` were the only mutable render-state fields on `LabelColormapBase`; with them gone, a label colormap is a static value-to-color mapping like everywhere else in the ecosystem (vispy removed mutable colormap setters in vispy/vispy#2663; matplotlib colormaps are effectively frozen). It also removes a sharing hazard: two layers handed the same colormap instance no longer fight over its selection state.
3. **Simplifies #8699.** That PR currently writes `self.colormap.selection = self._selected_display_label` in six places. With this PR landed, those writes have nothing to write to; `_selected_display_label` stays on the layer and is passed to `_data_to_texture` instead. The seam also widens naturally for multi-selection later: `selection: int | None` can become `int | frozenset[int] | None` without touching any call site, since all texture casts funnel through one layer-level method.
4. **Matches how the other layers already work.** `Colormap` has no `contrast_limits` or `gamma`; Image keeps its render state on the layer and treats the colormap as pure color data. Labels was the only layer storing per-layer render state inside its colormap, so this makes Labels consistent with the rest of napari, not just with vispy.
5. **Selection and colors change on different clocks.** `selected_label` changes at click frequency (the color picker changes it on every canvas click); colors change rarely. Keeping the hot state off the colormap means toggling the filter or picking a new label never invalidates the per-colormap caches (the dtype mapping cache and the numba typed.Dict that #9069 made deep-copy safe). Any design that bakes selection into the colormap object, including the "build a new frozen colormap per toggle" variant, churns those caches on every click.

## What changes structurally

### Layer (`labels.py`)

- A single `Labels._data_to_texture(values)` wrapper pairs the colormap cast with the layer's selection state; every texture cast site goes through it (`_slice_dtype`, `_raw_to_displayed`, and the texture view cache patch sites added by the painting refactor #8636), so painting while the filter is active patches the filtered value, the view buffer dtype matches the filtered conversion, and no future call site can forget the selection state.
- `Labels` gains `show_selected_label` and `selected_label` `__init__` kwargs; `_get_state` exposes both for round-tripping.
- `_update_thumbnail` applies a layer-side selection mask now that `colormap.map()` is pure.
- All `colormap.selection` / `colormap.use_selection` writes removed from `__init__`, `selected_label.setter`, `show_selected_label.setter`, and `new_colormap()`.

### Colormap (`utils/colormaps/colormap.py`, `_accelerated_cmap.py`)

- Pydantic fields `use_selection`, `selection` deleted from `LabelColormapBase` and `DirectLabelColormap`.
- `.map()` is now pure (no selection filtering).
- `_data_to_texture` and the cast helpers take `selection: int | None = None`; callers pass it at the seam. This preserves two CPU-side performance short-circuits that otherwise regress noticeably with selection on: the cyclic modulo-collision avoidance branch, and the direct-mode 2-entry texture shortcut paired with the data 0/1 mask.
- Deprecation shims replace the removed fields: reading `cmap.use_selection` / `cmap.selection` warns with `FutureWarning` and returns the old default; writing raises `AttributeError` pointing to `layer.show_selected_label` / `layer.selected_label`.

### Renderer (`_vispy/layers/labels.py`)

- `LabelVispyColormap` and `DirectLabelVispyColormap` take `use_selection` / `selection` as constructor arguments fed from the layer rather than reading them off the colormap. (The GLSL boundary keeps the two separate shader template values, since shaders have no None.)
- `direct_lookup_shader` and `direct_lookup_shader_many` gain the `$use_selection` / `$selection` filter that `auto_lookup_shader_uint{8,16}` already had. (Previously direct mode with itemsize > 2 relied on a CPU short-circuit, with no shader-level filter.)

## Trade-offs

The colormap-level API (`cmap.use_selection`, `cmap.selection`) is removed. Both names remain as deprecation shims (read warns and returns the old default, write raises with a pointer to the layer API), so external code fails loudly with a migration hint instead of silently losing behavior. A GitHub-wide code search for `layer.colormap.use_selection` and `.colormap.selection =` found no consumers outside napari itself, PR mirrors, and full napari forks (which vendor their own copy), so the shim should be a formality.

Assigning a colormap to a layer no longer "honors" any selection state the colormap object might carry (those fields don't exist anymore). The layer state always wins; the checkbox and rendering can't disagree.

## What this unblocks (out of scope here)

With selection state owned by the layer, the vispy layer could receive `selection` / `use_selection` as GLSL uniforms instead of shader template substitutions. Toggling the filter or picking a new label would then be O(1) on the GPU (no texture rebuild, no shader recompile) instead of the current full `_raw_to_displayed` pass. That is impossible while selection is baked into the colormap and texture; this PR is the prerequisite.

## Tests

Layer-level ownership tests in `test_labels.py` cover all the drift paths listed above, plus deepcopy and the single-event invariant:

- `test_show_selected_label_persists_across_colormap_assign`
- `test_show_selected_label_persists_across_color_mode_round_trip`
- `test_labels_constructor_accepts_show_selected_label`
- `test_get_state_round_trips_show_selected_label`
- `test_show_selected_label_survives_deepcopy`
- `test_show_selected_label_setter_fires_event_once`
- `test_show_selected_label_preserved_after_shuffle` and `test_shuffle_does_not_revive_stale_show_selected` (the #8947 regression tests, rewritten against layer state and rendered output instead of colormap fields)

New for the painting refactor (#8636) interaction:

- `test_paint_respects_show_selected_label_in_texture_cache` (auto and direct): painting on a non-numpy backend patches the texture view cache directly; painting a non-selected label while the filter is on must patch the filtered background value, not the label's color.
- `test_data_setitem_respects_show_selected_label_in_texture_cache`: same invariant for the `data_setitem` patch path.
- `test_selection_fields_deprecation_shim`: reads warn and return old defaults, writes raise.

`test_color_mapping_with_show_selected_label` was rewritten against the public `get_color` API since `colormap.map()` no longer filters.

## Performance

The renderer is on a hot path, so the refactor was benchmarked against `main` for `_raw_to_displayed` (1024x1024 int32, median of 9 runs):

| Configuration | main | this PR |
|---|---:|---:|
| cyclic, no selection | 2.96 ms | 3.25 ms |
| cyclic, with selection | 0.52 ms | 0.53 ms |
| direct, no selection | 1.57 ms | 1.55 ms |
| direct, with selection | 0.10 ms | 0.09 ms |

All paths within noise of `main`; no regressions. (Benchmarked before the rebase over #8636; the selection-threading at the cast sites is unchanged in kind.)

## Manual GUI verification

Verified interactively with four layers covering the touched paths (cyclic uint8, cyclic int32, direct int32 with a custom color dict, and a layer constructed with `show_selected_label=True`):

1. Toggle `show_selected`, shuffle colors. Filter persists; the selected label stays highlighted in its new color.
2. Toggle `show_selected`, then assign a fresh colormap from the console. Checkbox state is preserved.
3. AUTO to DIRECT to AUTO via the color mode combobox. Checkbox state preserved across both swaps.
4. `Labels(data, show_selected_label=True, selected_label=3)` reports and renders the filter immediately.
5. Painting while the filter is active: strokes with the selected label appear; strokes with a non-selected label stay hidden until the filter is turned off.

## Open questions for maintainers

- The #8965 thread initially leaned toward the opposite ownership direction ("depend on colormap attributes, sync on swap"). #8967 implemented that as a minimal sync fix and is now closed in favor of this PR, following the immutability argument from the #8967 review and vispy/vispy#2663. If maintainers prefer the sync direction after all, #8967 can be reopened, but it would need its own rebase over #8636.
