### PR TITLE
In vispy overalys use **kwargs instead of synchronizing signature

### DIFF
--- a/src/napari/_vispy/overlays/axes.py
+++ b/src/napari/_vispy/overlays/axes.py
@@ -1,12 +1,17 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from vispy.visuals.text.text import FontManager
 
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispySceneOverlay
 from napari._vispy.visuals.axes import Axes
-from napari.components.overlays import AxesOverlay
 from napari.utils.theme import get_theme
+
+if TYPE_CHECKING:
+    from vispy.visuals.text.text import FontManager
+
+    from napari.components.overlays import AxesOverlay
 
 
 class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):

--- a/src/napari/_vispy/overlays/axes.py
+++ b/src/napari/_vispy/overlays/axes.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 from vispy.visuals.text.text import FontManager
 
@@ -11,15 +13,14 @@ class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):
     """Axes indicating world coordinate origin and orientation."""
 
     overlay: AxesOverlay
+    node: Axes
 
     def __init__(
         self,
         *,
-        viewer,
-        overlay,
-        parent=None,
         font_manager: FontManager | None = None,
         font_family: str = 'OpenSans',
+        **kwargs: Any,
     ) -> None:
         self._scale = 1.0
 
@@ -28,11 +29,9 @@ class VispyAxesOverlay(ViewerOverlayMixin, VispySceneOverlay):
 
         super().__init__(
             node=Axes(font_manager=font_manager, font_family=font_family),
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
             font_manager=font_manager,
             font_family=font_family,
+            **kwargs,
         )
         self.overlay.events.colored.connect(self._on_data_change)
         self.overlay.events.dashed.connect(self._on_data_change)

--- a/src/napari/_vispy/overlays/base.py
+++ b/src/napari/_vispy/overlays/base.py
@@ -203,26 +203,17 @@ class VispySceneOverlay(VispyBaseOverlay):
 
     overlay: SceneOverlay
 
-    def __init__(
-        self, *, overlay, viewer, node, parent=None, **kwargs
-    ) -> None:
-        super().__init__(
-            overlay=overlay, viewer=viewer, node=node, parent=parent, **kwargs
-        )
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.node.transform = MatrixTransform()
 
 
 class LayerOverlayMixin:
     layer: Layer
+    overlay: Overlay
 
-    def __init__(
-        self, *, overlay, layer: Layer, viewer, node, parent=None, **kwargs
-    ) -> None:
+    def __init__(self, *, layer: Layer, **kwargs) -> None:
         super().__init__(
-            node=node,
-            overlay=overlay,
-            viewer=viewer,
-            parent=parent,
             **kwargs,
         )
         self.layer = layer

--- a/src/napari/_vispy/overlays/bounding_box.py
+++ b/src/napari/_vispy/overlays/bounding_box.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from napari._vispy.overlays.base import LayerOverlayMixin, VispySceneOverlay
 from napari._vispy.visuals.bounding_box import BoundingBox
-from napari.components.overlays import BoundingBoxOverlay
-from napari.layers._scalar_field import ScalarFieldBase
+
+if TYPE_CHECKING:
+    from napari.components.overlays import BoundingBoxOverlay
+    from napari.layers._scalar_field import ScalarFieldBase
 
 
 class VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):

--- a/src/napari/_vispy/overlays/bounding_box.py
+++ b/src/napari/_vispy/overlays/bounding_box.py
@@ -1,38 +1,23 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 
-from napari import Viewer
 from napari._vispy.overlays.base import LayerOverlayMixin, VispySceneOverlay
 from napari._vispy.visuals.bounding_box import BoundingBox
 from napari.components.overlays import BoundingBoxOverlay
 from napari.layers._scalar_field import ScalarFieldBase
 
-if TYPE_CHECKING:
-    from vispy.scene import ViewBox
-
 
 class VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
     overlay: BoundingBoxOverlay
     layer: ScalarFieldBase
+    node: BoundingBox
 
-    def __init__(
-        self,
-        *,
-        layer: ScalarFieldBase,
-        viewer: Viewer,
-        overlay: BoundingBoxOverlay,
-        parent: ViewBox | None = None,
-        **kwargs: Any,
-    ) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(
             node=BoundingBox(),
-            layer=layer,
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
             **kwargs,
         )
         self.layer.events.set_data.connect(self._on_bounds_change)

--- a/src/napari/_vispy/overlays/brush_circle.py
+++ b/src/napari/_vispy/overlays/brush_circle.py
@@ -7,7 +7,6 @@ from vispy.scene.visuals import Compound, Ellipse
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
 from napari.components.overlays.brush_circle import BrushCircleOverlay
 from napari.utils.events import Event
-from napari.viewer import Viewer
 
 if TYPE_CHECKING:
     from vispy.scene import ViewBox
@@ -19,8 +18,6 @@ class VispyBrushCircleOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     def __init__(
         self,
         *,
-        viewer: Viewer,
-        overlay: BrushCircleOverlay,
         parent: ViewBox | None = None,
         **kwargs: Any,
     ) -> None:
@@ -39,8 +36,6 @@ class VispyBrushCircleOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
         super().__init__(
             node=Compound([self._white_circle, self._black_circle]),
-            viewer=viewer,
-            overlay=overlay,
             parent=parent,
             **kwargs,
         )

--- a/src/napari/_vispy/overlays/brush_circle.py
+++ b/src/napari/_vispy/overlays/brush_circle.py
@@ -5,11 +5,12 @@ from typing import TYPE_CHECKING, Any
 from vispy.scene.visuals import Compound, Ellipse
 
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
-from napari.components.overlays.brush_circle import BrushCircleOverlay
-from napari.utils.events import Event
 
 if TYPE_CHECKING:
     from vispy.scene import ViewBox
+
+    from napari.components.overlays.brush_circle import BrushCircleOverlay
+    from napari.utils.events import Event
 
 
 class VispyBrushCircleOverlay(ViewerOverlayMixin, VispyCanvasOverlay):

--- a/src/napari/_vispy/overlays/brush_circle.py
+++ b/src/napari/_vispy/overlays/brush_circle.py
@@ -7,8 +7,6 @@ from vispy.scene.visuals import Compound, Ellipse
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
 
 if TYPE_CHECKING:
-    from vispy.scene import ViewBox
-
     from napari.components.overlays.brush_circle import BrushCircleOverlay
     from napari.utils.events import Event
 
@@ -16,12 +14,7 @@ if TYPE_CHECKING:
 class VispyBrushCircleOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     overlay: BrushCircleOverlay
 
-    def __init__(
-        self,
-        *,
-        parent: ViewBox | None = None,
-        **kwargs: Any,
-    ) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self._white_circle = Ellipse(
             center=(0, 0),
             color=(0, 0, 0, 0.0),
@@ -37,7 +30,6 @@ class VispyBrushCircleOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
         super().__init__(
             node=Compound([self._white_circle, self._black_circle]),
-            parent=parent,
             **kwargs,
         )
 
@@ -53,8 +45,10 @@ class VispyBrushCircleOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.reset()
 
         # manually connect this once and get the correct canvas
-        if parent is not None:
-            parent.scene.canvas.events.mouse_move.connect(self._on_mouse_move)
+        if self.node.parent is not None:
+            self.node.parent.scene.canvas.events.mouse_move.connect(
+                self._on_mouse_move
+            )
 
     def _on_position_change(self, event: Event | None = None) -> None:
         self._set_position(self.overlay.position)

--- a/src/napari/_vispy/overlays/colorbar.py
+++ b/src/napari/_vispy/overlays/colorbar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -15,11 +15,9 @@ from napari.utils.colormaps.colormap_utils import (
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike
-    from vispy.scene import Node
     from vispy.visuals.text.text import FontManager
 
-    from napari.components import ViewerModel
-    from napari.components.overlays import ColorBarOverlay, Overlay
+    from napari.components.overlays import ColorBarOverlay
     from napari.layers import Image, Layer, Surface
     from napari.utils.colormaps import Colormap
 
@@ -74,20 +72,16 @@ class VispyColorBarOverlay(LayerOverlayMixin, VispyCanvasOverlay):
         self,
         *,
         layer: Layer,
-        viewer: ViewerModel,
-        overlay: Overlay,
-        parent: Node | None = None,
         font_manager: FontManager | None = None,
         font_family: str = 'OpenSans',
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             node=ColorBar(font_manager=font_manager, font_family=font_family),
             layer=layer,
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
             font_manager=font_manager,
             font_family=font_family,
+            **kwargs,
         )
         self.layer: Layer
         self.x_size = 50

--- a/src/napari/_vispy/overlays/colorbar.py
+++ b/src/napari/_vispy/overlays/colorbar.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from napari._vispy.overlays.base import LayerOverlayMixin, VispyCanvasOverlay
 from napari._vispy.visuals.colorbar import ColorBar
-from napari.layers.utils.color_manager import ColorManager
 from napari.settings import get_settings
 from napari.utils.colormaps.colormap_utils import (
     _coerce_contrast_limits,
@@ -19,6 +18,7 @@ if TYPE_CHECKING:
 
     from napari.components.overlays import ColorBarOverlay
     from napari.layers import Image, Layer, Surface
+    from napari.layers.utils.color_manager import ColorManager
     from napari.utils.colormaps import Colormap
 
 

--- a/src/napari/_vispy/overlays/interaction_box.py
+++ b/src/napari/_vispy/overlays/interaction_box.py
@@ -1,9 +1,16 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from napari._vispy.overlays.base import LayerOverlayMixin, VispySceneOverlay
 from napari._vispy.visuals.interaction_box import InteractionBox
-from napari.components.overlays import SelectionBoxOverlay, TransformBoxOverlay
 from napari.layers.base._base_constants import InteractionBoxHandle
+
+if TYPE_CHECKING:
+    from napari.components.overlays import (
+        SelectionBoxOverlay,
+        TransformBoxOverlay,
+    )
 
 
 class _VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):

--- a/src/napari/_vispy/overlays/interaction_box.py
+++ b/src/napari/_vispy/overlays/interaction_box.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from napari._vispy.overlays.base import LayerOverlayMixin, VispySceneOverlay
 from napari._vispy.visuals.interaction_box import InteractionBox
 from napari.components.overlays import SelectionBoxOverlay, TransformBoxOverlay
@@ -5,17 +7,10 @@ from napari.layers.base._base_constants import InteractionBoxHandle
 
 
 class _VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
-    def __init__(
-        self, *, layer, viewer, overlay, parent=None, **kwargs
-    ) -> None:
-        super().__init__(
-            node=InteractionBox(),
-            layer=layer,
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
-            **kwargs,
-        )
+    node: InteractionBox
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(node=InteractionBox(), **kwargs)
         self.layer.events.set_data.connect(self._on_visible_change)
 
     def _on_bounds_change(self):
@@ -36,16 +31,8 @@ class _VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
 class VispySelectionBoxOverlay(_VispyBoundingBoxOverlay):
     overlay: SelectionBoxOverlay
 
-    def __init__(
-        self, *, layer, viewer, overlay, parent=None, **kwargs
-    ) -> None:
-        super().__init__(
-            layer=layer,
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
-            **kwargs,
-        )
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.overlay.events.bounds.connect(self._on_bounds_change)
         self.overlay.events.handles.connect(self._on_bounds_change)
         self.overlay.events.selected_handle.connect(self._on_bounds_change)
@@ -67,16 +54,8 @@ class VispySelectionBoxOverlay(_VispyBoundingBoxOverlay):
 class VispyTransformBoxOverlay(_VispyBoundingBoxOverlay):
     overlay: TransformBoxOverlay
 
-    def __init__(
-        self, *, layer, viewer, overlay, parent=None, **kwargs
-    ) -> None:
-        super().__init__(
-            layer=layer,
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
-            **kwargs,
-        )
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.layer.events.scale.connect(self._on_bounds_change)
         self.layer.events.translate.connect(self._on_bounds_change)
         self.layer.events.rotate.connect(self._on_bounds_change)

--- a/src/napari/_vispy/overlays/interaction_box.py
+++ b/src/napari/_vispy/overlays/interaction_box.py
@@ -8,6 +8,7 @@ from napari.layers.base._base_constants import InteractionBoxHandle
 
 if TYPE_CHECKING:
     from napari.components.overlays import (
+        SceneOverlay,
         SelectionBoxOverlay,
         TransformBoxOverlay,
     )
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 
 class _VispyBoundingBoxOverlay(LayerOverlayMixin, VispySceneOverlay):
     node: InteractionBox
+    overlay: SceneOverlay
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(node=InteractionBox(), **kwargs)

--- a/src/napari/_vispy/overlays/labels_polygon.py
+++ b/src/napari/_vispy/overlays/labels_polygon.py
@@ -5,7 +5,6 @@ from vispy.scene.visuals import Compound, Line, Markers, Polygon
 
 from napari._vispy.overlays.base import LayerOverlayMixin, VispySceneOverlay
 from napari.components.overlays import LabelsPolygonOverlay
-from napari.components.viewer_model import ViewerModel
 from napari.layers import Labels
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
@@ -39,15 +38,7 @@ class VispyLabelsPolygonOverlay(LayerOverlayMixin, VispySceneOverlay):
     layer: Labels
     overlay: LabelsPolygonOverlay
 
-    def __init__(
-        self,
-        *,
-        layer: Labels,
-        viewer: ViewerModel,
-        overlay: LabelsPolygonOverlay,
-        parent=None,
-        **kwargs,
-    ):
+    def __init__(self, **kwargs):
         points = [(0, 0), (1, 1)]
 
         self._nodes_kwargs = {
@@ -68,10 +59,6 @@ class VispyLabelsPolygonOverlay(LayerOverlayMixin, VispySceneOverlay):
 
         super().__init__(
             node=Compound([self._polygon, self._nodes, self._line]),
-            layer=layer,
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
             **kwargs,
         )
 

--- a/src/napari/_vispy/overlays/labels_polygon.py
+++ b/src/napari/_vispy/overlays/labels_polygon.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from vispy.scene.visuals import Compound, Line, Markers, Polygon
 
 from napari._vispy.overlays.base import LayerOverlayMixin, VispySceneOverlay
-from napari.components.overlays import LabelsPolygonOverlay
-from napari.layers import Labels
 from napari.layers.labels._labels_constants import Mode
 from napari.layers.labels._labels_utils import mouse_event_to_labels_coordinate
 from napari.settings import get_settings
+
+if TYPE_CHECKING:
+    from napari.components.overlays import LabelsPolygonOverlay
+    from napari.layers import Labels
 
 
 def _only_when_enabled(callback):
@@ -169,6 +173,8 @@ class VispyLabelsPolygonOverlay(LayerOverlayMixin, VispySceneOverlay):
     @_only_when_enabled
     def _on_mouse_press(self, layer, event):
         pos = self._get_mouse_coordinates(event)
+        if pos is None:
+            return
         dims_displayed = self._dims_displayed
 
         if event.button == 1:  # left mouse click

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -3,37 +3,33 @@ from __future__ import annotations
 import bisect
 from decimal import Decimal
 from math import floor, log
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pint
 
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
 from napari._vispy.visuals.scale_bar import ScaleBar
-from napari.components.overlays import Overlay, ScaleBarOverlay
+from napari.components.overlays import ScaleBarOverlay
 from napari.settings import get_settings
 from napari.utils._units import PREFERRED_VALUES
 
 if TYPE_CHECKING:
-    from vispy.scene import ViewBox
     from vispy.visuals.text.text import FontManager
-
-    from napari.components import ViewerModel
 
 
 class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     """Scale bar in world coordinates."""
 
     overlay: ScaleBarOverlay
+    node: ScaleBar
 
     def __init__(
         self,
         *,
-        viewer: ViewerModel,
-        overlay: Overlay,
-        parent: ViewBox | None = None,
         font_manager: FontManager | None = None,
         font_family: str = 'OpenSans',
+        **kwargs: Any,
     ) -> None:
         self._target_length = 150.0
         self._current_length = 150.0
@@ -42,11 +38,9 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
         super().__init__(
             node=ScaleBar(font_manager=font_manager, font_family=font_family),
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
             font_manager=font_manager,
             font_family=font_family,
+            **kwargs,
         )
 
         self.overlay.events.color.connect(self._on_rendering_change)

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -10,12 +10,13 @@ import pint
 
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
 from napari._vispy.visuals.scale_bar import ScaleBar
-from napari.components.overlays import ScaleBarOverlay
 from napari.settings import get_settings
 from napari.utils._units import PREFERRED_VALUES
 
 if TYPE_CHECKING:
     from vispy.visuals.text.text import FontManager
+
+    from napari.components.overlays import ScaleBarOverlay
 
 
 class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from napari._vispy.overlays.base import (
     LayerOverlayMixin,
     ViewerOverlayMixin,
@@ -8,14 +12,28 @@ from napari.components._viewer_constants import CanvasPosition
 from napari.components.overlays import TextOverlay
 from napari.settings import get_settings
 
+if TYPE_CHECKING:
+    from vispy.visuals.text.text import FontManager
+
 
 class _VispyBaseTextOverlay(VispyCanvasOverlay):
     """Base class for vispy text overlays."""
 
     overlay: TextOverlay
+    node: Text
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        font_manager: FontManager | None = None,
+        font_family: str = 'OpenSans',
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
+            font_manager=font_manager,
+            font_family=font_family,
+            **kwargs,
+        )
 
         self.node.font_size = self.overlay.font_size
         self.node.anchors = ('left', 'bottom')
@@ -27,6 +45,9 @@ class _VispyBaseTextOverlay(VispyCanvasOverlay):
 
         get_settings().appearance.events.theme.connect(self._on_color_change)
         self.viewer.events.theme.connect(self._on_color_change)
+
+        self._connect_events()
+        self.reset()
 
     def _connect_events(self):
         pass
@@ -97,29 +118,11 @@ class _VispyBaseTextOverlay(VispyCanvasOverlay):
 
 
 class _VispyViewerTextOverlay(ViewerOverlayMixin, _VispyBaseTextOverlay):
-    def __init__(self, **kwargs):
-        font_manager = kwargs.get('font_manager')
-        font_family = kwargs.get('font_family', 'OpenSans')
-        super().__init__(
-            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
-            **kwargs,
-        )
-
-        self._connect_events()
-        self.reset()
+    pass
 
 
 class _VispyLayerTextOverlay(LayerOverlayMixin, _VispyBaseTextOverlay):
-    def __init__(self, **kwargs):
-        font_manager = kwargs.get('font_manager')
-        font_family = kwargs.get('font_family', 'OpenSans')
-        super().__init__(
-            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
-            **kwargs,
-        )
-
-        self._connect_events()
-        self.reset()
+    pass
 
 
 class VispyTextOverlay(_VispyViewerTextOverlay):

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -123,6 +123,8 @@ class _VispyViewerTextOverlay(ViewerOverlayMixin, _VispyBaseTextOverlay):
 
 
 class _VispyLayerTextOverlay(LayerOverlayMixin, _VispyBaseTextOverlay):
+    overlay: TextOverlay
+
     def __init__(
         self,
         font_manager: FontManager | None = None,

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -23,18 +23,8 @@ class _VispyBaseTextOverlay(VispyCanvasOverlay):
     overlay: TextOverlay
     node: Text
 
-    def __init__(
-        self,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(
-            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
-            font_manager=font_manager,
-            font_family=font_family,
-            **kwargs,
-        )
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
 
         self.node.font_size = self.overlay.font_size
         self.node.anchors = ('left', 'bottom')
@@ -46,9 +36,6 @@ class _VispyBaseTextOverlay(VispyCanvasOverlay):
 
         get_settings().appearance.events.theme.connect(self._on_color_change)
         self.viewer.events.theme.connect(self._on_color_change)
-
-        self._connect_events()
-        self.reset()
 
     def _connect_events(self):
         pass
@@ -119,11 +106,37 @@ class _VispyBaseTextOverlay(VispyCanvasOverlay):
 
 
 class _VispyViewerTextOverlay(ViewerOverlayMixin, _VispyBaseTextOverlay):
-    pass
+    def __init__(
+        self,
+        font_manager: FontManager | None = None,
+        font_family: str = 'OpenSans',
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
+            font_manager=font_manager,
+            font_family=font_family,
+            **kwargs,
+        )
+        self._connect_events()
+        self.reset()
 
 
 class _VispyLayerTextOverlay(LayerOverlayMixin, _VispyBaseTextOverlay):
-    pass
+    def __init__(
+        self,
+        font_manager: FontManager | None = None,
+        font_family: str = 'OpenSans',
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            node=Text(pos=(0, 0), font_manager=font_manager, face=font_family),
+            font_manager=font_manager,
+            font_family=font_family,
+            **kwargs,
+        )
+        self._connect_events()
+        self.reset()
 
 
 class VispyTextOverlay(_VispyViewerTextOverlay):

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -9,11 +9,12 @@ from napari._vispy.overlays.base import (
 )
 from napari._vispy.visuals.text import Text
 from napari.components._viewer_constants import CanvasPosition
-from napari.components.overlays import TextOverlay
 from napari.settings import get_settings
 
 if TYPE_CHECKING:
     from vispy.visuals.text.text import FontManager
+
+    from napari.components.overlays import TextOverlay
 
 
 class _VispyBaseTextOverlay(VispyCanvasOverlay):

--- a/src/napari/_vispy/overlays/welcome.py
+++ b/src/napari/_vispy/overlays/welcome.py
@@ -13,33 +13,28 @@ from napari._vispy.visuals.welcome import Welcome
 from napari.settings import get_settings
 
 if TYPE_CHECKING:
-    from vispy.scene import Node
     from vispy.util.event import Event
     from vispy.visuals.text.text import FontManager
 
-    from napari.components import ViewerModel
     from napari.components.overlays import WelcomeOverlay
 
 
 class VispyWelcomeOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     overlay: WelcomeOverlay
+    node: Welcome
 
     def __init__(
         self,
         *,
-        viewer: ViewerModel,
-        overlay: WelcomeOverlay,
         font_manager: FontManager | None = None,
         font_family: str = 'OpenSans',
-        parent: Node | None = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             node=Welcome(font_manager=font_manager, face=font_family),
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
             font_manager=font_manager,
             font_family=font_family,
+            **kwargs,
         )
         self.viewer.events.theme.connect(self._on_theme_change)
         self.viewer.layers.events.inserted.connect(self._on_visible_change)

--- a/src/napari/_vispy/overlays/zoom.py
+++ b/src/napari/_vispy/overlays/zoom.py
@@ -9,10 +9,7 @@ from napari._vispy.visuals.interaction_box import InteractionBox
 from napari.settings import get_settings
 
 if TYPE_CHECKING:
-    from vispy.visuals.text.text import FontManager
-
     from napari.components.overlays import ZoomOverlay
-    from napari.components.viewer_model import ViewerModel
     from napari.utils.events import Event
 
 
@@ -20,23 +17,10 @@ class VispyZoomOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     """Zoom box overlay.."""
 
     overlay: ZoomOverlay
+    node: InteractionBox
 
-    def __init__(
-        self,
-        viewer: ViewerModel,
-        overlay: ZoomOverlay,
-        parent: Optional[Any] = None,
-        font_manager: FontManager | None = None,
-        font_family: str = 'OpenSans',
-    ):
-        super().__init__(
-            node=InteractionBox(),
-            viewer=viewer,
-            overlay=overlay,
-            parent=parent,
-            font_manager=font_manager,
-            font_family=font_family,
-        )
+    def __init__(self, **kwargs: Any):
+        super().__init__(node=InteractionBox(), **kwargs)
 
         self.overlay.events.position.connect(self._on_position_change)
 
@@ -48,7 +32,9 @@ class VispyZoomOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.node._highlight_width = (
             settings.appearance.highlight.highlight_thickness
         )
-        self.node._edge_color = settings.appearance.highlight.highlight_color
+        self.node._edge_color = tuple(
+            settings.appearance.highlight.highlight_color
+        )  # type: ignore[assignment]
 
         top_left, bot_right = self.overlay.position
         self.node.set_data(

--- a/src/napari/_vispy/visuals/bounding_box.py
+++ b/src/napari/_vispy/visuals/bounding_box.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
 from itertools import product
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from vispy.scene.visuals import Compound, Line
 
 from napari._vispy.visuals.markers import Markers
+from napari.utils.color import ColorValue
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from vispy.visuals.line import LineVisual
 
 
 class BoundingBox(Compound):
@@ -34,24 +42,26 @@ class BoundingBox(Compound):
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._line_color = 'red'
-        self._line_thickness = 2
-        self._marker_color = (1, 1, 1, 1)
-        self._marker_size = 1
+        self._line_color = ColorValue('red')
+        self._line_thickness = 2.0
+        self._marker_color = ColorValue((1, 1, 1, 1))
+        self._marker_size = 1.0
 
         super().__init__(
             [Line(antialias=True), Markers(antialias=0)], *args, **kwargs
         )
 
     @property
-    def lines(self):
+    def lines(self) -> LineVisual:
         return self._subvisuals[0]
 
     @property
-    def markers(self):
+    def markers(self) -> Markers:
         return self._subvisuals[1]
 
-    def set_bounds(self, bounds):
+    def set_bounds(
+        self, bounds: Sequence[Sequence[float] | None] | np.ndarray
+    ) -> None:
         """Update the bounding box based on a layer's bounds."""
         if any(b is None for b in bounds):
             return

--- a/src/napari/_vispy/visuals/interaction_box.py
+++ b/src/napari/_vispy/visuals/interaction_box.py
@@ -43,7 +43,7 @@ class InteractionBox(Compound):
         self._highlight_width = 2
         # squares for corners, diamonds for midpoints, disc for rotation handle
         self._marker_symbol = ['square'] * 4 + ['diamond'] * 4 + ['disc']
-        self._edge_color = (0, 0, 1, 1)
+        self._edge_color = (0.0, 0.0, 1.0, 1.0)
 
         super().__init__(
             [Line(antialias=True), Markers(antialias=0)], *args, **kwargs

--- a/src/napari/_vispy/visuals/welcome.py
+++ b/src/napari/_vispy/visuals/welcome.py
@@ -42,7 +42,7 @@ def _load_logo() -> np.ndarray:
 
 
 class Welcome(Node):
-    def __init__(self, font_manager: FontManager, face: str) -> None:
+    def __init__(self, font_manager: FontManager | None, face: str) -> None:
         self.logo_coords = _load_logo()
         super().__init__()
 

--- a/src/napari/settings/_appearance.py
+++ b/src/napari/settings/_appearance.py
@@ -18,12 +18,14 @@ class HighlightSettings(EventedModel):
         ge=1,
         le=10,
     )
-    highlight_color: list[float] = Field(
-        [0.0, 0.6, 1.0, 1.0],
-        title=trans._('Highlight color'),
-        description=trans._(
-            'Select the highlight color when hovering over shapes/points.'
-        ),
+    highlight_color: list[float] = (
+        Field(  # TODO: fix type annotation to tuple[float, float, float, float],
+            [0.0, 0.6, 1.0, 1.0],
+            title=trans._('Highlight color'),
+            description=trans._(
+                'Select the highlight color when hovering over shapes/points.'
+            ),
+        )
     )
 
 


### PR DESCRIPTION
# References and relevant issues

extracted from #8770

# Description

This PR is to simplify overlays code. We do not use them directly outside tests – just use helper functions. 
So use `**kwargs` instead of editing multiple signatures each time we modify some of the base class. 

This PR also move multiple imports into TYPE_CHECKING block. 