### PR TITLE
Bump vispy to 0.16.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "toolz>=0.11.0",
     "tqdm>=4.56.0",
     "typing_extensions>=4.12",
-    "vispy>=0.16.1,<0.17",
+    "vispy>=0.16.2,<0.17",
     "wrapt>=1.13.3",
 ]
 dynamic = [

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -602,7 +602,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.3.3
     # via napari (pyproject.toml)
-vispy==0.16.1
+vispy==0.16.2
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -586,7 +586,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.3.3
     # via napari (pyproject.toml)
-vispy==0.16.1
+vispy==0.16.2
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -580,7 +580,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.3.3
     # via napari (pyproject.toml)
-vispy==0.16.1
+vispy==0.16.2
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -1031,7 +1031,7 @@ uvicorn==0.47.0
     # via sphinx-autobuild
 virtualenv==21.3.3
     # via napari (pyproject.toml)
-vispy==0.16.1
+vispy==0.16.2
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.12_examples.txt
+++ b/resources/constraints/constraints_py3.12_examples.txt
@@ -716,7 +716,7 @@ urllib3==2.7.0
     #   requests
 virtualenv==21.3.3
     # via napari (pyproject.toml)
-vispy==0.16.1
+vispy==0.16.2
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.13.txt
+++ b/resources/constraints/constraints_py3.13.txt
@@ -578,7 +578,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.3.3
     # via napari (pyproject.toml)
-vispy==0.16.1
+vispy==0.16.2
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.14.txt
+++ b/resources/constraints/constraints_py3.14.txt
@@ -578,7 +578,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.3.3
     # via napari (pyproject.toml)
-vispy==0.16.1
+vispy==0.16.2
     # via
     #   napari (pyproject.toml)
     #   napari-svg


### PR DESCRIPTION
# Description
Bump vispy dependency to the just released v0.16.2. While not strictly necessary, this brings in some stuff which I think is worth bumping for. Most relevant for us:

- @psobolewskyPhD's performance improvements on startup (https://github.com/vispy/vispy/pull/2744 and https://github.com/vispy/vispy/pull/2726) which together should save us ~350ms on launch (part of #8689)
- fix some text quirks by @TimMonko (https://github.com/vispy/vispy/pull/2728)
- depth buffer fix on gridlines (https://github.com/vispy/vispy/pull/2748) which should give us the final touch for #7827

