### PR TITLE
Add units to Dims docstring and clarify Layer.units

### DIFF
--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -44,6 +44,9 @@ class Dims(EventedModel):
         Tuple of ordering the dimensions, where the last dimensions are rendered.
     axis_labels : tuple of str
         Tuple of labels for each dimension.
+    units : tuple of pint.Unit, optional
+        Shared world units for each dimension.
+        If ``None``, no additional unit conversion is applied.
     last_used : int
         Dimension which was last interacted with.
 
@@ -66,6 +69,9 @@ class Dims(EventedModel):
         Tuple of ordering the dimensions, where the last dimensions are rendered.
     axis_labels : tuple of str
         Tuple of labels for each dimension.
+    units : tuple of pint.Unit or None
+        Shared world units for each dimension.
+        If ``None``, no additional unit conversion is applied.
     last_used : int
         Dimension which was last used.
         Tuple the slider position for each dims slider, in world coordinates.

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -488,8 +488,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         of a viewer.
     visible : bool
         Whether the layer visual is currently being displayed.
-    units: tuple of pint.Unit
+    units : tuple of pint.Unit
         Units of the layer data in world coordinates.
+        If not explicitly set, these default to pixel.
     z_index : int
         Depth of the layer visual relative to other visuals in the scenecanvas.
 


### PR DESCRIPTION
# References and relevant issues

Obeserved while investigating https://github.com/ome/napari-ome-zarr/pull/149

# Description

1. adds `units` to Dims docstring, because it was missing
2. clarifies that default `Layer.units` when `None` result in `'pixel'` units.
