### PR TITLE
docs: correct move_multiple dest_index description in EventedList

### DIFF
--- a/src/napari/utils/events/containers/_evented_list.py
+++ b/src/napari/utils/events/containers/_evented_list.py
@@ -256,8 +256,10 @@ class EventedList(TypedMutableSequence[_T]):
         dest_index : int, optional
             The destination index.  All sources will be inserted before this
             index (in pre-move space), by default 0... which has the effect of
-            "bringing to front" everything in ``sources``, or acting as a
-            "reorder" method if ``sources`` contains all indices.
+            moving everything in ``sources`` to the beginning of the list
+            (for a ``LayerList`` this is the bottom of the layer stack, since
+            the last layer is rendered on top), or acting as a "reorder"
+            method if ``sources`` contains all indices.
 
         Returns
         -------


### PR DESCRIPTION
# References and relevant issues

Closes #6482

# Description

The `dest_index` parameter docstring for `EventedList.move_multiple` (inherited by `LayerList`) described the default `dest_index=0` as "bringing to front" everything in `sources`. That phrasing is misleading: index 0 is the beginning of the list, and for a `LayerList` the beginning is the bottom of the visual layer stack (the last layer is rendered on top). As reported in #6482, the default actually moves layers to the back, not the front.

This updates the docstring text to describe the behavior accurately and notes the `LayerList` stacking implication. No code behavior changes.
