### PR TITLE
Fix scale bar unit guessing logic and deprecate scale_bar.unit

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari.components import ViewerModel
@@ -28,7 +29,15 @@ def test_scale_bar_inconsistent_units_default_to_pixel(
     )
     model = ScaleBarOverlay()
     vispy_scale_bar = VispyScaleBarOverlay(overlay=model, viewer=viewer_model)
-    assert vispy_scale_bar._unit.units == 'pixel'
+    # dimensionless when inconsistent
+    assert vispy_scale_bar._unit.units.dimensionless
     img1.units = ('um', 'um')
     vispy_scale_bar._on_unit_change()
     assert vispy_scale_bar._unit.units == 'micrometer'
+    with pytest.warns(
+        FutureWarning,
+        match='Setting unit on the ScaleBar model is deprecated.',
+    ):
+        model.unit = 's'
+    vispy_scale_bar._on_unit_change()
+    assert vispy_scale_bar._unit.units == 'second'

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -67,7 +67,9 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         if self.viewer.layers.units is not None:
             unit = self.viewer.layers.units[self.viewer.dims.displayed[-1]]
         else:
-            unit = pint.get_application_registry()(self.overlay.unit)
+            unit = (
+                pint.get_application_registry()(self.overlay.unit) or 'pixel'
+            )
         self._unit = unit * 1  # convert unit to quantity
         self._on_size_or_zoom_change(force=True)
 

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -67,8 +67,8 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         if self.viewer.layers.units is not None:
             unit = self.viewer.layers.units[self.viewer.dims.displayed[-1]]
         else:
-            unit = (
-                pint.get_application_registry()(self.overlay.unit) or 'pixel'
+            unit = pint.get_application_registry()(
+                self.overlay.unit or 'pixel'
             )
         self._unit = unit * 1  # convert unit to quantity
         self._on_size_or_zoom_change(force=True)

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -64,12 +64,12 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.reset()
 
     def _on_unit_change(self):
-        if self.viewer.layers.units is not None:
+        if self.overlay.unit is not None:
+            unit = pint.get_application_registry()(self.overlay.unit)
+        elif self.viewer.layers.units is not None:
             unit = self.viewer.layers.units[self.viewer.dims.displayed[-1]]
         else:
-            unit = pint.get_application_registry()(
-                self.overlay.unit or 'pixel'
-            )
+            unit = 'pixel'
         self._unit = unit * 1  # convert unit to quantity
         self._on_size_or_zoom_change(force=True)
 

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -64,12 +64,14 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.reset()
 
     def _on_unit_change(self):
+        # NOTE: this is also called by VispyCanvas when layer units are updated
+        #       so it doesn't need to be connected to events for that
         if self.overlay.unit is not None:
             unit = pint.get_application_registry()(self.overlay.unit)
         elif self.viewer.layers.units is not None:
             unit = self.viewer.layers.units[self.viewer.dims.displayed[-1]]
         else:
-            unit = pint.get_application_registry()('pixel')
+            unit = pint.get_application_registry()('dimensionless')
         self._unit = unit * 1  # convert unit to quantity
         self._on_size_or_zoom_change(force=True)
 

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import bisect
+import warnings
 from decimal import Decimal
 from math import floor, log
 from typing import TYPE_CHECKING, Any
@@ -70,7 +71,20 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         if self.overlay.unit is not None:
             unit = pint.get_application_registry()(self.overlay.unit)
         elif self.viewer.layers.units is not None:
-            unit = self.viewer.layers.units[self.viewer.dims.displayed[-1]]
+            units = np.array(self.viewer.layers.units)[
+                list(self.viewer.dims.displayed)
+            ]
+            if any(
+                u.dimensionality != units[0].dimensionality for u in units[1:]
+            ):
+                dim_repr = tuple(str(d.dimensionality) for d in units)
+                warnings.warn(
+                    f'Displayed dimensions have mismatched dimensionality {dim_repr}. '
+                    'The scale bar will only use the unit from the last displayed axis.',
+                    category=RuntimeWarning,
+                    stacklevel=2,
+                )
+            unit = units[-1]
         else:
             unit = pint.get_application_registry()('dimensionless')
         self._unit = unit * 1  # convert unit to quantity

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -58,6 +58,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.viewer.camera.events.zoom.connect(self._on_size_or_zoom_change)
         self.viewer.events.theme.connect(self._on_rendering_change)
         self.viewer.dims.events.order.connect(self._on_unit_change)
+        self.viewer.dims.events.ndisplay.connect(self._on_unit_change)
 
         get_settings().appearance.events.theme.connect(
             self._on_rendering_change

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -69,7 +69,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         elif self.viewer.layers.units is not None:
             unit = self.viewer.layers.units[self.viewer.dims.displayed[-1]]
         else:
-            unit = 'pixel'
+            unit = pint.get_application_registry()('pixel')
         self._unit = unit * 1  # convert unit to quantity
         self._on_size_or_zoom_change(force=True)
 

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -56,6 +56,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
         self.viewer.camera.events.zoom.connect(self._on_size_or_zoom_change)
         self.viewer.events.theme.connect(self._on_rendering_change)
+        self.viewer.dims.events.order.connect(self._on_unit_change)
 
         get_settings().appearance.events.theme.connect(
             self._on_rendering_change

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import bisect
-import warnings
 from decimal import Decimal
 from math import floor, log
 from typing import TYPE_CHECKING, Any
@@ -13,6 +12,7 @@ from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
 from napari._vispy.visuals.scale_bar import ScaleBar
 from napari.settings import get_settings
 from napari.utils._units import PREFERRED_VALUES
+from napari.utils.notifications import show_warning
 
 if TYPE_CHECKING:
     from vispy.visuals.text.text import FontManager
@@ -79,11 +79,9 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
                 u.dimensionality != units[0].dimensionality for u in units[1:]
             ):
                 dim_repr = tuple(str(d.dimensionality) for d in units)
-                warnings.warn(
+                show_warning(
                     f'Displayed dimensions have mismatched dimensionality {dim_repr}. '
                     'The scale bar will only use the unit from the last displayed axis.',
-                    category=RuntimeWarning,
-                    stacklevel=2,
                 )
             unit = units[-1]
         else:

--- a/src/napari/components/_tests/test_scale_bar.py
+++ b/src/napari/components/_tests/test_scale_bar.py
@@ -11,4 +11,4 @@ def test_scale_bar_fixed_length_and_units():
     """Test creating scale bar object with fixed length"""
     scale_bar = ScaleBarOverlay(length=50)
     assert scale_bar.length == 50
-    assert scale_bar.unit == 'pixel'
+    assert scale_bar.unit is None

--- a/src/napari/components/overlays/base.py
+++ b/src/napari/components/overlays/base.py
@@ -26,10 +26,10 @@ class Overlay(EventedModel):
         The rendering order of the overlay: lower numbers get rendered first.
     """
 
-    model_config = EventedModel.model_config | ConfigDict(
+    model_config = EventedModel.model_config | ConfigDict(  # type: ignore[typeddict-unknown-key]
         validate_assignment=True,
-        allow_property_setters=True,  # type: ignore[typeddict-unknown-key]
-        guess_property_dependencies=True,  # type: ignore[typeddict-unknown-key]
+        allow_property_setters=True,
+        guess_property_dependencies=True,
     )
 
     visible: bool = False

--- a/src/napari/components/overlays/base.py
+++ b/src/napari/components/overlays/base.py
@@ -28,8 +28,8 @@ class Overlay(EventedModel):
 
     model_config = EventedModel.model_config | ConfigDict(
         validate_assignment=True,
-        allow_property_setters=True,
-        guess_property_dependencies=True,
+        allow_property_setters=True,  # type: ignore[typeddict-unknown-key]
+        guess_property_dependencies=True,  # type: ignore[typeddict-unknown-key]
     )
 
     visible: bool = False

--- a/src/napari/components/overlays/base.py
+++ b/src/napari/components/overlays/base.py
@@ -27,7 +27,9 @@ class Overlay(EventedModel):
     """
 
     model_config = EventedModel.model_config | ConfigDict(
-        validate_assignment=True
+        validate_assignment=True,
+        allow_property_setters=True,
+        guess_property_dependencies=True,
     )
 
     visible: bool = False

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -58,7 +58,7 @@ class ScaleBarOverlay(CanvasOverlay):
         return self._unit
 
     @unit.setter
-    def unit(self, value: str | None):
+    def unit(self, value: str | None) -> None:
         if value is not None:
             warnings.warn(
                 'Setting unit on the ScaleBar model is deprecated. Units will instead be computed from '

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -53,7 +53,7 @@ class ScaleBarOverlay(CanvasOverlay):
     color: ColorValue = Field(default_factory=lambda: ColorValue([1, 0, 1, 1]))
     ticks: bool = True
     font_size: float = 10
-    _unit: str | None = PrivateAttr(default='pixel')
+    _unit: str | None = PrivateAttr(default=None)
     length: float | None = None
 
     @property
@@ -62,10 +62,13 @@ class ScaleBarOverlay(CanvasOverlay):
 
     @unit.setter
     def unit(self, value: str | None):
-        warnings.warn(
-            'Setting unit from the scale_bar is deprecated. Starting in 0.9.0, units will be '
-            'computed from the layers present in the viewer instead.',
-            category=FutureWarning,
-            stacklevel=2,
-        )
+        if value is not None:
+            warnings.warn(
+                'Setting unit on the ScaleBar model is deprecated. Units are instead computed from '
+                'the layers in the layerlist. To silence this warning, leave scale_bar unit as `None`, '
+                'and use `Layer.units` to set units for each layer. Starting in v0.8.0, ScaleBar.unit '
+                'will do nothing. Starting from v0.9.0, it will be removed and raise an exception.',
+                category=FutureWarning,
+                stacklevel=4,
+            )
         self._unit = value

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -1,6 +1,8 @@
 """Scale bar model."""
 
-from pydantic import Field
+import warnings
+
+from pydantic import Field, PrivateAttr
 
 from napari.components.overlays.base import CanvasOverlay
 from napari.utils.color import ColorValue
@@ -51,5 +53,19 @@ class ScaleBarOverlay(CanvasOverlay):
     color: ColorValue = Field(default_factory=lambda: ColorValue([1, 0, 1, 1]))
     ticks: bool = True
     font_size: float = 10
-    unit: str | None = 'pixel'
+    _unit: str | None = PrivateAttr(default='pixel')
     length: float | None = None
+
+    @property
+    def unit(self) -> str | None:
+        return self._unit
+
+    @unit.setter
+    def unit(self, value: str | None):
+        warnings.warn(
+            'Setting unit from the scale_bar is deprecated. Starting in 0.9.0, units will be '
+            'computed from the layers present in the viewer instead.',
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        self._unit = value

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -33,9 +33,6 @@ class ScaleBarOverlay(CanvasOverlay):
     box_color : Optional[str | array-like]
         Background box color.
         See ``ColorValue.validate`` for supported values.
-    unit : Optional[str]
-        Unit to be used by the scale bar, equivalent to 1 pixel. Can be a quantity
-        such as "10 nm". The value can be set to `None` to display no units.
     length : Optional[float]
         Fixed length of the scale bar in physical units. If set to `None`,
         it is determined automatically based on zoom level.
@@ -64,11 +61,13 @@ class ScaleBarOverlay(CanvasOverlay):
     def unit(self, value: str | None):
         if value is not None:
             warnings.warn(
-                'Setting unit on the ScaleBar model is deprecated. Units are instead computed from '
+                'Setting unit on the ScaleBar model is deprecated. Units will instead be computed from '
                 'the layers in the layerlist. To silence this warning, leave scale_bar unit as `None`, '
-                'and use `Layer.units` to set units for each layer. Starting in v0.8.0, ScaleBar.unit '
-                'will do nothing. Starting from v0.9.0, it will be removed and raise an exception.',
+                'and use `Layer.units` to set units for each layer. Starting in v0.8.0, setting '
+                'ScaleBar.unit will no longer have an effect. Starting from v0.9.0, it will be '
+                'removed and raise an exception.',
                 category=FutureWarning,
                 stacklevel=4,
             )
         self._unit = value
+        self.events.unit(self._unit)


### PR DESCRIPTION
# References and relevant issues
- https://github.com/napari/napari/pull/8900#issuecomment-4266950277 and following conversation
- https://github.com/napari/napari/pull/8907#discussion_r3302388250

# Description
This PR deprecates `ScaleBar.unit`'s setter. The idea is to have this property fully computed based on the layers in the layerlist, and not settable. I chose a two-step deprecation, but open to better suggestions!

As part of this, I also fixed the unit guessing to be more in line with expectations: if unit is unset, guess from layers. If it's set, send a warning and use the provided one.
