### PR TITLE
[Shapes] In remove(), update the index of self._value et al to account for the data being removed

### DIFF
--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -1551,6 +1551,75 @@ def test_removing_selected_shapes():
     )
 
 
+def test_removing_selected_shapes_clears_cached_shape_references():
+    """Regression test for https://github.com/napari/napari/issues/9019.
+
+    Removing a shape that is referenced by _value must not crash _outline_shapes
+    when the highlight event fires mid-removal. Without the fix this raises
+    IndexError because _outline_shapes accesses the already-deleted shape index.
+    _value and _moving_value are also reset unconditionally by _finish_drawing(),
+    but _value_stored is only cleaned up by the explicit renumber call.
+    """
+    layer = Shapes(np.random.random((2, 4, 2)))
+    # Connect _outline_shapes directly to reproduce the production crash path:
+    # remove() → selected_data.clear() → _set_highlight → events.highlight
+    layer.events.highlight.connect(layer._outline_shapes)
+    layer.selected_data = {1}
+    layer._value = (1, None)
+    layer._value_stored = (1, None)
+    layer._moving_value = (1, None)
+
+    layer.remove_selected()  # raises IndexError without the fix
+
+    assert layer._value == (None, None)
+    assert layer._value_stored == (None, None)
+    assert layer._moving_value == (None, None)
+
+
+def test_renumber_shape_reference():
+    """Unit tests for _renumber_shape_reference covering all three code paths."""
+    removed = np.array([1, 3, 5])
+
+    # None input is a no-op
+    assert Shapes._renumber_shape_reference((None, None), removed) == (
+        None,
+        None,
+    )
+
+    # Shape was removed → cleared
+    assert Shapes._renumber_shape_reference((3, None), removed) == (None, None)
+
+    # Shape survives before any removed index → index unchanged
+    assert Shapes._renumber_shape_reference((0, None), removed) == (0, None)
+
+    # Shape survives after some removed indices → index decremented by offset
+    # Shape 6 survives; 3 indices below it were removed → becomes index 3
+    assert Shapes._renumber_shape_reference((6, 2), removed) == (3, 2)
+
+
+def test_removing_shape_renumbers_cached_hover_reference():
+    """When a shape before the hovered one is deleted, the hover index must
+    be renumbered before events.highlight fires.
+
+    Without the fix, _value still holds the original index (2) after shape 1
+    is removed. Since only indices 0 and 1 remain, _outline_shapes would call
+    _data_view.outline(2) and raise an IndexError.
+    """
+    layer = Shapes(np.random.random((3, 4, 2)))
+    captured_values = []
+    layer.events.highlight.connect(
+        lambda: captured_values.append(layer._value)
+    )
+
+    layer._value = (2, None)  # hovering over the last shape
+    layer.selected_data = {1}  # select the middle shape to delete
+    layer.remove_selected()  # without the fix: IndexError in _outline_shapes
+
+    # The highlight callback must have seen the renumbered index:
+    # shape 2 shifted to index 1 after shape 1 was removed.
+    assert (1, None) in captured_values
+
+
 def test_popping_shapes():
     """Test popping shapes."""
     np.random.seed(0)

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2820,7 +2820,8 @@ class Shapes(Layer):
         indices : List[int]
             List of indices of shapes to remove from the layer.
         """
-        to_remove = sorted(indices, reverse=True)
+        sorted_indices = sorted(indices)
+        to_remove = sorted_indices[::-1]
 
         if len(indices) > 0:
             self.events.data(
@@ -2832,13 +2833,26 @@ class Shapes(Layer):
                 vertex_indices=((),),
             )
             self._data_view.remove_multiple(to_remove)
+            indices_array = np.array(sorted_indices)
+            # Update cached hover/move references before any selection change
+            # fires events.highlight → _outline_shapes. _value and
+            # _moving_value are also reset by _finish_drawing() below, but
+            # _value_stored is not, so all three are updated here.
+            self._value = self._renumber_shape_reference(
+                self._value, indices_array
+            )
+            self._value_stored = self._renumber_shape_reference(
+                self._value_stored, indices_array
+            )
+            self._moving_value = self._renumber_shape_reference(
+                self._moving_value, indices_array
+            )
 
             if len(self.data) == 0 and self.selected_data:
                 self.selected_data.clear()
             elif self.selected_data:
                 selected_not_removed = self.selected_data - set(indices)
                 if selected_not_removed:
-                    indices_array = np.array(to_remove[::-1])
                     remaining_selected = np.fromiter(
                         selected_not_removed,
                         dtype=np.intp,
@@ -2868,6 +2882,34 @@ class Shapes(Layer):
             )
             self.events.features()
         self._finish_drawing()
+
+    @staticmethod
+    def _renumber_shape_reference(
+        value: tuple[int | None, int | None], removed_indices: np.ndarray
+    ) -> tuple[int | None, int | None]:
+        """Update a cached shape reference after removing shapes.
+
+        Parameters
+        ----------
+        value : tuple[int | None, int | None]
+            A ``(shape_index, vertex_index)`` pair to update.
+        removed_indices : np.ndarray
+            Sorted ascending array of shape indices that were removed.
+
+        Returns
+        -------
+        tuple[int | None, int | None]
+            ``(None, None)`` if the referenced shape was removed; otherwise
+            the renumbered ``(shape_index, vertex_index)`` pair accounting for
+            the shift introduced by the removed shapes.
+        """
+        shape_index, vertex_index = value
+        if shape_index is None:
+            return value
+        pos = np.searchsorted(removed_indices, shape_index)
+        if pos < len(removed_indices) and removed_indices[pos] == shape_index:
+            return (None, None)
+        return (shape_index - pos, vertex_index)
 
     def remove_selected(self) -> None:
         """Remove any selected shapes."""


### PR DESCRIPTION
# References and relevant issues
Closes: #9019 

# Description
This PR is primarily by Copilot using Claude, having been given the issue #9019

It essentially implements the approach from Points.remove() written by Kevin to update cached references:
https://github.com/napari/napari/blob/8faae44d5147891396e5436ff26982595d7dfe01/src/napari/layers/points/points.py#L2026-L2035

There is one small change which you can see in the helper: np.searchsorted is used, as a few lines below in Shapes.remove -- it's more performant. Claude suggested making a new PR with the same change to Points.remove() but I'm not sure it's worth it.

I tested locally and I think the fix makes sense, but  happy to close if someone wants to implement a different fix for this annoying bug.

