### PR TITLE
Block pydantic==2.14.0a1 in `--pre` tests

### DIFF
--- a/resources/constraints/version_denylist.txt
+++ b/resources/constraints/version_denylist.txt
@@ -5,5 +5,5 @@ tensorstore!=0.1.38,!=0.1.72
 ipykernel!=7.0.0a0,!=7.0.0a1
 wrapt!=1.17.0 # problem with macOS intel
 zarr!=3.0.0b3,!=3.0.0b2,!=3.0.0rc1
-pydantic!=2.11.0a2,!=2.11.0a1
+pydantic!=2.11.0a2,!=2.11.0a1,!=2.14.0a1
 pytest-qt!=4.5.0 ; python_version <= '3.10' # pyside2 support


### PR DESCRIPTION
# References and relevant issues

https://github.com/pyapp-kit/psygnal/issues/417
closes #9008 

# Description

I found that there is incompatibility between pydantic 2.14.0a1 and psygnal. We cannot easily solve this on our side.

So, the solution is to block this version of pydantic. 

If next alpha makes similar problems, we need to patch psygnal and/or report to pydantic. 