### PR TITLE
Remove task label from Task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,6 @@
 name: "\U0001F9F0 Task"
 about: Maintenance, follow-ups, and other defined to-do items
 title: ''
-labels: task
 assignees: ''
 
 ---


### PR DESCRIPTION
# References and relevant issues

Today's triage-party https://hackmd.io/@napari/triage/edit

# Description

Removes the task label from the issue template, since we discussed that this acts as an uninformative label. It used to be helpful for searching generally by label types, but now there is the ability to search by no label and a Type field for issues.
