### PR TITLE
Set `Shapes._value`to `None, None` on delete of shape

### DIFF
--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2686,7 +2686,9 @@ def test_remove_shape_that_is_value(remove: list[int]):
         ],
         shape_type='polygon',
     )
+    layer.events.highlight.connect(layer._outline_shapes)
     layer._value = (1, None)
+    layer.selected_data = {1}
 
     layer.remove(remove)
 

--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2674,3 +2674,21 @@ def test_finish_drawing_called_when_is_creating():
         layer.mode = 'select'
         mock_finish.assert_called_once()
     assert not layer._is_creating
+
+
+@pytest.mark.parametrize('remove', [[0], [1], [2], [1, 2]])
+def test_remove_shape_that_is_value(remove: list[int]):
+    layer = Shapes(
+        [
+            [(0, 0), (1, 1), (1, 0)],
+            [(0, 0), (1, 1), (0, 1)],
+            [(0, 0), (-1, -1), (-1, 0)],
+        ],
+        shape_type='polygon',
+    )
+    layer._value = (1, None)
+
+    layer.remove(remove)
+
+    assert len(layer.data) > 0
+    assert layer._value == (None, None)

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2833,12 +2833,7 @@ class Shapes(Layer):
             )
             self._data_view.remove_multiple(to_remove)
 
-            if self._value[0] in to_remove:
-                self._value = (None, None)
-            elif self._value[0] is not None:
-                indices_removed = np.array(indices) < self._value[0]
-                offset = np.sum(indices_removed)
-                self._value = (self._value[0] - offset, None)
+            self._value = (None, None)
 
             if len(self.data) == 0 and self.selected_data:
                 self.selected_data.clear()

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2836,7 +2836,7 @@ class Shapes(Layer):
             if self._value[0] in to_remove:
                 self._value = (None, None)
             elif self._value[0] is not None:
-                indices_removed = np.array(indices) < self._value
+                indices_removed = np.array(indices) < self._value[0]
                 offset = np.sum(indices_removed)
                 self._value = (self._value[0] - offset, None)
 


### PR DESCRIPTION
# References and relevant issues

# Description

The remove function of shapes is calling `_finish_drawing` function

https://github.com/napari/napari/blob/abe68275c99d6aa6eef0d9610c3ed73147101dd0/src/napari/layers/shapes/shapes.py#L2877

that set `self._value` to `None, None`

https://github.com/napari/napari/blob/abe68275c99d6aa6eef0d9610c3ed73147101dd0/src/napari/layers/shapes/shapes.py#L2712

So calculating of `self._value` is useless. 


