### PR TITLE
Mnt: Block qt6 6.11.0, 6.11.1 due to dock widget and resizing bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,9 @@ pyside6 = [
     "PySide6 > 6.7, !=6.11.1"  # Qt 6.11.1 causes dock widget and layout resizing problems
 ]
 pyqt6 = [
-    "PyQt6 > 6.5, !=6.11.1",  # Qt 6.11.1 causes dock widget and layout resizing problems
-    "PyQt6 != 6.6.1 ; platform_system == 'Darwin'"
+    "PyQt6 > 6.5",
+    "PyQt6 != 6.6.1 ; platform_system == 'Darwin'",
+    "pyqt6-qt6 != 6.11.1"  # Qt 6.11.1 causes dock widget and layout resizing problems
 ]
 pyside = [
     "napari[pyside6]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,10 @@ Documentation = "https://napari.org"
 
 [project.optional-dependencies]
 pyside6 = [
-    "PySide6 > 6.7"
+    "PySide6 > 6.7, !=6.11.1"  # Qt 6.11.1 causes dock widget and layout resizing problems
 ]
 pyqt6 = [
-    "PyQt6 > 6.5",
+    "PyQt6 > 6.5, !=6.11.1",  # Qt 6.11.1 causes dock widget and layout resizing problems
     "PyQt6 != 6.6.1 ; platform_system == 'Darwin'"
 ]
 pyside = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,12 +95,12 @@ Documentation = "https://napari.org"
 
 [project.optional-dependencies]
 pyside6 = [
-    "PySide6 > 6.7, !=6.11.1"  # Qt 6.11.1 causes dock widget and layout resizing problems
+    "PySide6 > 6.7, !=6.11.0, !=6.11.1"  # Qt 6.11.1 causes dock widget and layout resizing problems
 ]
 pyqt6 = [
     "PyQt6 > 6.5",
     "PyQt6 != 6.6.1 ; platform_system == 'Darwin'",
-    "pyqt6-qt6 != 6.11.1"  # Qt 6.11.1 causes dock widget and layout resizing problems
+    "pyqt6-qt6 !=6.11.0, !=6.11.1"  # Qt 6.11.1 causes dock widget and layout resizing problems
 ]
 pyside = [
     "napari[pyside6]"

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -412,13 +412,13 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.1
+pyside6==6.11.0
     # via
     #   -r resources/constraints/version_denylist.txt
     #   napari (pyproject.toml)
-pyside6-addons==6.11.1
+pyside6-addons==6.11.0
     # via pyside6
-pyside6-essentials==6.11.1
+pyside6-essentials==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -509,7 +509,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.1
+shiboken6==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -540,7 +540,6 @@ tomli==2.4.1
     # via
     #   build
     #   npe2
-    #   pyside6
     #   pytest
 tomli-w==1.2.0
     # via npe2
@@ -572,6 +571,7 @@ typer==0.26.4
 typing-extensions==4.15.0
     # via
     #   napari (pyproject.toml)
+    #   aiohttp
     #   aiosignal
     #   app-model
     #   exceptiongroup

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -404,8 +404,10 @@ pyproject-hooks==1.2.0
     # via build
 pyqt6==6.11.0
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.1
-    # via pyqt6
+pyqt6-qt6==6.11.0
+    # via
+    #   napari (pyproject.toml)
+    #   pyqt6
 pyqt6-sip==13.11.1
     # via pyqt6
 pyrect==0.2.0

--- a/resources/constraints/constraints_py3.10.txt
+++ b/resources/constraints/constraints_py3.10.txt
@@ -402,9 +402,9 @@ pyperclip==1.11.0
     # via mouseinfo
 pyproject-hooks==1.2.0
     # via build
-pyqt6==6.11.0
+pyqt6==6.10.2
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.0
+pyqt6-qt6==6.10.2
     # via
     #   napari (pyproject.toml)
     #   pyqt6
@@ -414,13 +414,13 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.0
+pyside6==6.10.3
     # via
     #   -r resources/constraints/version_denylist.txt
     #   napari (pyproject.toml)
-pyside6-addons==6.11.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.11.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -511,7 +511,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -407,13 +407,13 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.1
+pyside6==6.11.0
     # via
     #   -r resources/constraints/version_denylist.txt
     #   napari (pyproject.toml)
-pyside6-addons==6.11.1
+pyside6-addons==6.11.0
     # via pyside6
-pyside6-essentials==6.11.1
+pyside6-essentials==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -501,7 +501,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.1
+shiboken6==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -558,6 +558,7 @@ typer==0.26.4
 typing-extensions==4.15.0
     # via
     #   napari (pyproject.toml)
+    #   aiohttp
     #   aiosignal
     #   app-model
     #   flexcache

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -397,9 +397,9 @@ pyperclip==1.11.0
     # via mouseinfo
 pyproject-hooks==1.2.0
     # via build
-pyqt6==6.11.0
+pyqt6==6.10.2
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.0
+pyqt6-qt6==6.10.2
     # via
     #   napari (pyproject.toml)
     #   pyqt6
@@ -409,13 +409,13 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.0
+pyside6==6.10.3
     # via
     #   -r resources/constraints/version_denylist.txt
     #   napari (pyproject.toml)
-pyside6-addons==6.11.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.11.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -503,7 +503,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -399,8 +399,10 @@ pyproject-hooks==1.2.0
     # via build
 pyqt6==6.11.0
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.1
-    # via pyqt6
+pyqt6-qt6==6.11.0
+    # via
+    #   napari (pyproject.toml)
+    #   pyqt6
 pyqt6-sip==13.11.1
     # via pyqt6
 pyrect==0.2.0

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -394,9 +394,9 @@ pyperclip==1.11.0
     # via mouseinfo
 pyproject-hooks==1.2.0
     # via build
-pyqt6==6.11.0
+pyqt6==6.10.2
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.0
+pyqt6-qt6==6.10.2
     # via
     #   napari (pyproject.toml)
     #   pyqt6
@@ -406,11 +406,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.0
+pyside6==6.10.3
     # via napari (pyproject.toml)
-pyside6-addons==6.11.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.11.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -498,7 +498,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -396,8 +396,10 @@ pyproject-hooks==1.2.0
     # via build
 pyqt6==6.11.0
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.1
-    # via pyqt6
+pyqt6-qt6==6.11.0
+    # via
+    #   napari (pyproject.toml)
+    #   pyqt6
 pyqt6-sip==13.11.1
     # via pyqt6
 pyrect==0.2.0

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -404,11 +404,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.1
+pyside6==6.11.0
     # via napari (pyproject.toml)
-pyside6-addons==6.11.1
+pyside6-addons==6.11.0
     # via pyside6
-pyside6-essentials==6.11.1
+pyside6-essentials==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -496,7 +496,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.1
+shiboken6==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -553,6 +553,7 @@ typer==0.26.4
 typing-extensions==4.15.0
     # via
     #   napari (pyproject.toml)
+    #   aiohttp
     #   aiosignal
     #   app-model
     #   flexcache

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -697,8 +697,10 @@ pyproject-hooks==1.2.0
     # via build
 pyqt6==6.11.0
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.1
-    # via pyqt6
+pyqt6-qt6==6.11.0
+    # via
+    #   napari (pyproject.toml)
+    #   pyqt6
 pyqt6-sip==13.11.1
     # via pyqt6
 pyrect==0.2.0

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -695,9 +695,9 @@ pyperclip==1.11.0
     # via mouseinfo
 pyproject-hooks==1.2.0
     # via build
-pyqt6==6.11.0
+pyqt6==6.10.2
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.0
+pyqt6-qt6==6.10.2
     # via
     #   napari (pyproject.toml)
     #   pyqt6
@@ -707,11 +707,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.0
+pyside6==6.10.3
     # via napari (pyproject.toml)
-pyside6-addons==6.11.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.11.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -841,7 +841,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -705,11 +705,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.1
+pyside6==6.11.0
     # via napari (pyproject.toml)
-pyside6-addons==6.11.1
+pyside6-addons==6.11.0
     # via pyside6
-pyside6-essentials==6.11.1
+pyside6-essentials==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -839,7 +839,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.1
+shiboken6==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -991,6 +991,7 @@ typer==0.26.4
 typing-extensions==4.15.0
     # via
     #   napari (pyproject.toml)
+    #   aiohttp
     #   aiosignal
     #   anyio
     #   app-model

--- a/resources/constraints/constraints_py3.12_examples.txt
+++ b/resources/constraints/constraints_py3.12_examples.txt
@@ -489,8 +489,10 @@ pyproject-hooks==1.2.0
     # via build
 pyqt6==6.11.0
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.1
-    # via pyqt6
+pyqt6-qt6==6.11.0
+    # via
+    #   napari (pyproject.toml)
+    #   pyqt6
 pyqt6-sip==13.11.1
     # via pyqt6
 pyrect==0.2.0

--- a/resources/constraints/constraints_py3.12_examples.txt
+++ b/resources/constraints/constraints_py3.12_examples.txt
@@ -487,9 +487,9 @@ pyperclip==1.11.0
     # via mouseinfo
 pyproject-hooks==1.2.0
     # via build
-pyqt6==6.11.0
+pyqt6==6.10.2
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.0
+pyqt6-qt6==6.10.2
     # via
     #   napari (pyproject.toml)
     #   pyqt6
@@ -499,11 +499,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.0
+pyside6==6.10.3
     # via napari (pyproject.toml)
-pyside6-addons==6.11.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.11.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -608,7 +608,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.12_examples.txt
+++ b/resources/constraints/constraints_py3.12_examples.txt
@@ -497,11 +497,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.1
+pyside6==6.11.0
     # via napari (pyproject.toml)
-pyside6-addons==6.11.1
+pyside6-addons==6.11.0
     # via pyside6
-pyside6-essentials==6.11.1
+pyside6-essentials==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -606,7 +606,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.1
+shiboken6==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -686,6 +686,7 @@ typer==0.26.4
 typing-extensions==4.15.0
     # via
     #   napari (pyproject.toml)
+    #   aiohttp
     #   aiosignal
     #   app-model
     #   beautifulsoup4

--- a/resources/constraints/constraints_py3.13.txt
+++ b/resources/constraints/constraints_py3.13.txt
@@ -394,9 +394,9 @@ pyperclip==1.11.0
     # via mouseinfo
 pyproject-hooks==1.2.0
     # via build
-pyqt6==6.11.0
+pyqt6==6.10.2
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.0
+pyqt6-qt6==6.10.2
     # via
     #   napari (pyproject.toml)
     #   pyqt6
@@ -406,11 +406,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.0
+pyside6==6.10.3
     # via napari (pyproject.toml)
-pyside6-addons==6.11.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.11.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -498,7 +498,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.13.txt
+++ b/resources/constraints/constraints_py3.13.txt
@@ -396,8 +396,10 @@ pyproject-hooks==1.2.0
     # via build
 pyqt6==6.11.0
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.1
-    # via pyqt6
+pyqt6-qt6==6.11.0
+    # via
+    #   napari (pyproject.toml)
+    #   pyqt6
 pyqt6-sip==13.11.1
     # via pyqt6
 pyrect==0.2.0

--- a/resources/constraints/constraints_py3.13.txt
+++ b/resources/constraints/constraints_py3.13.txt
@@ -404,11 +404,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.1
+pyside6==6.11.0
     # via napari (pyproject.toml)
-pyside6-addons==6.11.1
+pyside6-addons==6.11.0
     # via pyside6
-pyside6-essentials==6.11.1
+pyside6-essentials==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -496,7 +496,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.1
+shiboken6==6.11.0
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.14.txt
+++ b/resources/constraints/constraints_py3.14.txt
@@ -394,9 +394,9 @@ pyperclip==1.11.0
     # via mouseinfo
 pyproject-hooks==1.2.0
     # via build
-pyqt6==6.11.0
+pyqt6==6.10.2
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.0
+pyqt6-qt6==6.10.2
     # via
     #   napari (pyproject.toml)
     #   pyqt6
@@ -406,11 +406,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.0
+pyside6==6.10.3
     # via napari (pyproject.toml)
-pyside6-addons==6.11.0
+pyside6-addons==6.10.3
     # via pyside6
-pyside6-essentials==6.11.0
+pyside6-essentials==6.10.3
     # via
     #   pyside6
     #   pyside6-addons
@@ -498,7 +498,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.0
+shiboken6==6.10.3
     # via
     #   pyside6
     #   pyside6-addons

--- a/resources/constraints/constraints_py3.14.txt
+++ b/resources/constraints/constraints_py3.14.txt
@@ -396,8 +396,10 @@ pyproject-hooks==1.2.0
     # via build
 pyqt6==6.11.0
     # via napari (pyproject.toml)
-pyqt6-qt6==6.11.1
-    # via pyqt6
+pyqt6-qt6==6.11.0
+    # via
+    #   napari (pyproject.toml)
+    #   pyqt6
 pyqt6-sip==13.11.1
     # via pyqt6
 pyrect==0.2.0

--- a/resources/constraints/constraints_py3.14.txt
+++ b/resources/constraints/constraints_py3.14.txt
@@ -404,11 +404,11 @@ pyrect==0.2.0
     # via pygetwindow
 pyscreeze==1.0.1
     # via pyautogui
-pyside6==6.11.1
+pyside6==6.11.0
     # via napari (pyproject.toml)
-pyside6-addons==6.11.1
+pyside6-addons==6.11.0
     # via pyside6
-pyside6-essentials==6.11.1
+pyside6-essentials==6.11.0
     # via
     #   pyside6
     #   pyside6-addons
@@ -496,7 +496,7 @@ setuptools==81.0.0
     # via torch
 shellingham==1.5.4
     # via typer
-shiboken6==6.11.1
+shiboken6==6.11.0
     # via
     #   pyside6
     #   pyside6-addons


### PR DESCRIPTION
# References and relevant issues

xref #9054 

Zulip discussion: https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E7.2E1.20-.20pop.20out.20widget.20bug.20on.20Qt.206.2E11.2E1.20.28latest.29/with/602196289

# Description

This blocks Qt 6.11.1 versions because of docking issues detailed in #9054. Carlos and I worked on this at today's community meeting. We blocked this Qt version for both pyside6 and pyqt6-qt6 (because pyqt6 is still just at 6.11.0) in pyproject.toml

Then we used the following:
`tools/compile_constraints.sh pyside6`
`tools/compile_constraints.sh pyqt6-qt6`

Update: I've opted to also block 6.11.0
I do think, in the case of critical functionality aka the GUI, we should probably err on the side of conservative. Especially because there's not like computational/speed benefits or somethign that we lose

## Alternatively

1. `Qt < 6.11` <- the absolute safest pin, but I really don't like upper pins, they seem to be actively working on it.
2. `Qt !=6.11.0, !=6.11.1` also more conservative, and maybe the safe play. But in all my time debugging #8898 and today while debugging 6.11.0 never caused issues, and is the reason I haven't adopted it (or an upper pin)
