### PR TITLE
[Maint] Remove unneeded _set_highlight calls in Shapes key and mouse binds

### DIFF
--- a/src/napari/layers/shapes/_shapes_key_bindings.py
+++ b/src/napari/layers/shapes/_shapes_key_bindings.py
@@ -186,7 +186,6 @@ def select_shapes_in_slice(layer: Shapes) -> None:
                     deferred=True,
                 )
             )
-    layer._set_highlight()
 
 
 @register_shapes_action(trans._('Delete any selected shapes'))

--- a/src/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -90,7 +90,6 @@ def select(layer: Shapes, event: MouseEvent) -> Generator[None, None, None]:
                 layer.selected_data = {shape_under_cursor}
         else:
             layer.selected_data = set()
-    layer._set_highlight()
 
     # we don't update the thumbnail unless a shape has been moved
     update_thumbnail = False
@@ -143,7 +142,6 @@ def select(layer: Shapes, event: MouseEvent) -> Generator[None, None, None]:
     elif layer._is_selecting:
         layer.selected_data = layer._data_view.shapes_in_box(layer._drag_box)
         layer._is_selecting = False
-        layer._set_highlight()
 
     layer._is_moving = False
     layer._drag_start = None
@@ -322,10 +320,9 @@ def initiate_polygon_draw(
     layer._is_creating = True
     data = np.array([coordinates, coordinates])
     layer.add(data, shape_type='path', gui=True)
-    layer.selected_data = Selection({layer.nshapes - 1})
     layer._value = (layer.nshapes - 1, 1)
     layer._moving_value = copy(layer._value)
-    layer._set_highlight()
+    layer.selected_data = Selection({layer.nshapes - 1})
 
 
 def add_path_polygon_lasso(


### PR DESCRIPTION
# References and relevant issues
Followup noticed in https://github.com/napari/napari/pull/8375

# Description
Shapes `_on_selection_changed` already triggers `_set_highlight`, which is connected to `_selected_data.events.items_changed`. 
The `selected_data.setter` uses `replace_selection` so the event will be emitted -- this is from the psygnal change in https://github.com/napari/napari/pull/8332 and https://github.com/napari/napari/pull/8297
So these manual calls in the bindings are un-needed. They don't have a big cost, because there is a check in `_set_highlight` using equality checks, but still.

Tested locally that things work as expected.