### PR TITLE
Fix: adapt frame box upper bound to data size (allow >6-digit indices)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -506,5 +506,10 @@ authors:
   affiliation: Institute of Cell Biology, University of Bern, Switzerland
   orcid: https://orcid.org/0000-0002-3956-9363
   alias: hinderling
+- given-names: Mikkel
+  family-names: Roald-Arbøl
+  affiliation: University of Bonn
+  orcid: https://orcid.org/0000-0002-9998-0058
+  alias: roaldarbol
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/src/napari/_qt/widgets/_tests/test_qt_dims_2.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims_2.py
@@ -36,6 +36,21 @@ def test_slice_labels(qtbot):
     assert dims.point[0] == 8
 
 
+def test_slice_label_validator_fits_large_dims(qtbot):
+    """The frame box must accept indices for stacks with >6 digits, see #3795."""
+    dims = Dims(ndim=2)
+    dims.set_range(0, (0, 2_000_000, 1))
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+
+    label_edit = view.slider_widgets[0].curslice_label
+    # a 7-digit index is valid for this stack and must be accepted
+    assert label_edit.validator().top() >= 1_999_999
+    label_edit.setText('1500000')
+    label_edit.editingFinished.emit()
+    assert dims.point[0] == 1_500_000
+
+
 def test_not_playing_after_ndim_changes(qt_dims, qtbot):
     """See https://github.com/napari/napari/issues/3998"""
     qt_dims.dims.ndim = 3

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -263,9 +263,7 @@ class QtDimSliderWidget(QWidget):
             self.slider.setSingleStep(1)
             self.slider.setPageStep(1)
             self.slider.setValue(self.dims.current_step[self.axis])
-            self.curslice_label.validator().setTop(
-                10 ** len(str(nsteps + 1))
-            )
+            self.curslice_label.validator().setTop(10 ** len(str(nsteps + 1)))
             self.totslice_label.setText(str(nsteps))
             self.totslice_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
             self._update_slice_labels()

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -264,7 +264,7 @@ class QtDimSliderWidget(QWidget):
             self.slider.setPageStep(1)
             self.slider.setValue(self.dims.current_step[self.axis])
             self.curslice_label.validator().setTop(
-                10 ** (len(str(nsteps)) + 1)
+                10 ** len(str(nsteps + 1))
             )
             self.totslice_label.setText(str(nsteps))
             self.totslice_label.setAlignment(Qt.AlignmentFlag.AlignLeft)

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -263,7 +263,9 @@ class QtDimSliderWidget(QWidget):
             self.slider.setSingleStep(1)
             self.slider.setPageStep(1)
             self.slider.setValue(self.dims.current_step[self.axis])
-            self.curslice_label.validator().setTop(10 ** (len(str(nsteps)) + 1))
+            self.curslice_label.validator().setTop(
+                10 ** (len(str(nsteps)) + 1)
+            )
             self.totslice_label.setText(str(nsteps))
             self.totslice_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
             self._update_slice_labels()

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -83,7 +83,8 @@ class QtDimSliderWidget(QWidget):
         # editingFinished event (the user is expected to change the value)...
         # which is confusing to the user, so instead we use an IntValidator
         # that makes sure the user can only enter integers, but we do our own
-        # value validation in self.change_slice
+        # value validation in self._set_slice_from_label. The upper bound is
+        # updated to fit the data in self._update_range (see #3795).
         self.curslice_label.setValidator(QIntValidator(0, 999999))
 
         self.curslice_label.editingFinished.connect(self._set_slice_from_label)
@@ -262,6 +263,7 @@ class QtDimSliderWidget(QWidget):
             self.slider.setSingleStep(1)
             self.slider.setPageStep(1)
             self.slider.setValue(self.dims.current_step[self.axis])
+            self.curslice_label.validator().setTop(10 ** (len(str(nsteps)) + 1))
             self.totslice_label.setText(str(nsteps))
             self.totslice_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
             self._update_slice_labels()


### PR DESCRIPTION
# References and relevant issues

Closes #3795.

# Description

This PR fixes a slider bug that put a cap on the max. frame that could be input to the slider value box. It also provides a regression test. 

The main addition is this line:
```python
self.curslice_label.validator().setTop(10 ** (len(str(nsteps)) + 1))
```
that responsively sets the upper bound an order of magnitude higher than the number of frames, so it always remains possible to write higher values - if they are specified higher than the max. number of frames, theit still automatically snaps to the max frame number. @TimMonko does this look alright - and I decided not to add a docstring above this line, but happy to do so if it helps. :-)

I don't have a large enough file to test on this device, so I'll test it tomorrow at work.


I used Claude Code to help with the PR, but all chatter is by me. :-)


