### PR TITLE
Fix half-voxel offset

### DIFF
--- a/src/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -3,6 +3,7 @@ import sys
 
 import numpy as np
 import pytest
+from packaging.version import parse as parse_version
 from qtpy import QT_VERSION
 from qtpy.QtCore import QPoint, Qt
 from qtpy.QtWidgets import QApplication
@@ -82,7 +83,7 @@ def test_toggle_axes_scale_bar_attr(
 
 @skip_local_popups
 @pytest.mark.skipif(
-    QT_VERSION == '6.9.0',
+    parse_version(QT_VERSION) >= parse_version('6.9.0'),
     reason='bug in Qt with maximized windows, https://bugreports.qt.io/browse/QTBUG-135844',
 )
 @pytest.mark.flaky(
@@ -135,7 +136,7 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
     reruns=2, reruns_delay=250, condition=sys.platform == 'darwin'
 )  # sometimes fails on macos CI
 @pytest.mark.skipif(
-    QT_VERSION == '6.9.0',
+    parse_version(QT_VERSION) >= parse_version('6.9.0'),
     reason='bug in Qt with maximized windows, https://bugreports.qt.io/browse/QTBUG-135844',
 )
 @pytest.mark.qt_log_level_fail('WARNING')

--- a/src/napari/_qt/_qapp_model/_tests/test_view_menu.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_view_menu.py
@@ -3,7 +3,6 @@ import sys
 
 import numpy as np
 import pytest
-from packaging.version import parse as parse_version
 from qtpy import QT_VERSION
 from qtpy.QtCore import QPoint, Qt
 from qtpy.QtWidgets import QApplication
@@ -83,7 +82,7 @@ def test_toggle_axes_scale_bar_attr(
 
 @skip_local_popups
 @pytest.mark.skipif(
-    parse_version(QT_VERSION) >= parse_version('6.9.0'),
+    QT_VERSION == '6.9.0',
     reason='bug in Qt with maximized windows, https://bugreports.qt.io/browse/QTBUG-135844',
 )
 @pytest.mark.flaky(
@@ -136,7 +135,7 @@ def test_toggle_fullscreen_from_normal(make_napari_viewer, qtbot):
     reruns=2, reruns_delay=250, condition=sys.platform == 'darwin'
 )  # sometimes fails on macos CI
 @pytest.mark.skipif(
-    parse_version(QT_VERSION) >= parse_version('6.9.0'),
+    QT_VERSION == '6.9.0',
     reason='bug in Qt with maximized windows, https://bugreports.qt.io/browse/QTBUG-135844',
 )
 @pytest.mark.qt_log_level_fail('WARNING')

--- a/src/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -268,6 +268,41 @@ def test_node_origin_is_consistent_with_multiscale(
     np.testing.assert_array_equal(high_res_origin, low_res_origin)
 
 
+def test_3d_multiscale_half_voxel_uses_rendered_level():
+    """The 3D half-voxel offset must use the rendered level, not the coarsest.
+
+    A deep pyramid (e.g. 10 levels) has coarsest downsample_factors of
+    512. If the offset always used the coarsest level, rendering level 0
+    would apply a ~256-voxel ghost translation — far off-screen. The fix
+    uses data_level so the offset tracks whichever level is displayed.
+    """
+    # 3-level 3D pyramid: level 0 = 64^3, level 1 = 32^3, level 2 = 16^3
+    data = [
+        np.zeros((64, 64, 64)),
+        np.zeros((32, 32, 32)),
+        np.zeros((16, 16, 16)),
+    ]
+    image = Image(data)
+    vispy_image = VispyImageLayer(image, font_info=FontInfo())
+
+    image._slice_dims(Dims(ndim=3, ndisplay=3))
+
+    # Render the finest level (downsample factor 1)
+    image._data_level = 0
+    vispy_image._on_matrix_change()
+    translate_fine = vispy_image.node.transform.matrix[-1, :3].copy()
+
+    # Render the coarsest level (downsample factor 4)
+    image._data_level = 2
+    vispy_image._on_matrix_change()
+    translate_coarse = vispy_image.node.transform.matrix[-1, :3].copy()
+
+    # Level 0 has downsample factor 1 → half-voxel offset = 0.
+    # The old bug applied the coarsest offset (4-1)/2 = 1.5 to every
+    # level, so translate_fine would have been [1.5, 1.5, 1.5] too.
+    npt.assert_array_almost_equal(translate_fine, [0, 0, 0])
+
+
 def test_world_units_impact_scale():
     nm = get_application_registry().nm
     font_info = FontInfo()

--- a/src/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -302,6 +302,9 @@ def test_3d_multiscale_half_voxel_uses_rendered_level():
     # level, so translate_fine would have been [1.5, 1.5, 1.5] too.
     npt.assert_array_almost_equal(translate_fine, [0, 0, 0])
 
+    # Level 2 has downsample factor 4 → half-voxel offset = (4-1)/2 = 1.5
+    npt.assert_array_almost_equal(translate_coarse, [1.5, 1.5, 1.5])
+
 
 def test_world_units_impact_scale():
     nm = get_application_registry().nm

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -230,18 +230,13 @@ class VispyBaseLayer(ABC, Generic[_L]):
             # offset is mapped to world units with the layer scale.
             layer_scale = np.asarray(self.layer.scale)[dims_displayed][::-1]
             data_level: int = getattr(self.layer, 'data_level', 0)
-            translate += (
-                (
-                    # displayed dimensions, order inverted to match VisPy,
-                    # then adjust by half a pixel per downscale level
-                    self.layer.downsample_factors[data_level][dims_displayed][
-                        ::-1
-                    ]
-                    - 1
-                )
-                / 2
-                * layer_scale
-            )
+            # grab the downscale factors for this level
+            level_factors = self.layer.downsample_factors[data_level]
+            # keep only the displayed factors, then invert to match VisPy
+            # axis ordering
+            displayed_downsample = level_factors[dims_displayed][::-1]
+            # finally, adjust translate by half a pixel per downscale level
+            translate += (displayed_downsample - 1) / 2 * layer_scale
 
         # Embed in the top left corner of a 4x4 affine matrix
         affine_matrix = np.eye(4)

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -234,9 +234,9 @@ class VispyBaseLayer(ABC, Generic[_L]):
                 (
                     # displayed dimensions, order inverted to match VisPy,
                     # then adjust by half a pixel per downscale level
-                    self.layer.downsample_factors[data_level][
-                        dims_displayed
-                    ][::-1]
+                    self.layer.downsample_factors[data_level][dims_displayed][
+                        ::-1
+                    ]
                     - 1
                 )
                 / 2

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -229,11 +229,12 @@ class VispyBaseLayer(ABC, Generic[_L]):
             # sub-volume tiles) can select any level. The data-space
             # offset is mapped to world units with the layer scale.
             layer_scale = np.asarray(self.layer.scale)[dims_displayed][::-1]
+            data_level: int = getattr(self.layer, 'data_level', 0)
             translate += (
                 (
                     # displayed dimensions, order inverted to match VisPy,
                     # then adjust by half a pixel per downscale level
-                    self.layer.downsample_factors[self.layer.data_level][
+                    self.layer.downsample_factors[data_level][
                         dims_displayed
                     ][::-1]
                     - 1

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -224,13 +224,23 @@ class VispyBaseLayer(ABC, Generic[_L]):
             and self.layer.multiscale
             and hasattr(self.layer, 'downsample_factors')
         ):
-            # The last downsample factor is used because we only ever show the
-            # last/lowest multi-scale level for 3D.
+            # Use the rendered level's downsample factor: 3D shows the
+            # lowest level by default, but locked_data_level (and 3D
+            # sub-volume tiles) can select any level. The data-space
+            # offset is mapped to world units with the layer scale.
+            layer_scale = np.asarray(self.layer.scale)[dims_displayed][::-1]
             translate += (
-                # displayed dimensions, order inverted to match VisPy, then
-                # adjust by half a pixel per downscale level
-                self.layer.downsample_factors[-1][dims_displayed][::-1] - 1
-            ) / 2
+                (
+                    # displayed dimensions, order inverted to match VisPy,
+                    # then adjust by half a pixel per downscale level
+                    self.layer.downsample_factors[self.layer.data_level][
+                        dims_displayed
+                    ][::-1]
+                    - 1
+                )
+                / 2
+                * layer_scale
+            )
 
         # Embed in the top left corner of a 4x4 affine matrix
         affine_matrix = np.eye(4)


### PR DESCRIPTION
# References and relevant issues

- Related to https://github.com/napari/napari/issues/6320 (TY @psobolewskiPhD)
- Found during 3D multiscale rendering investigation in https://github.com/kephale/napari/tree/progressive-loading-rebase
- There were some flaky CI issues that I've fixed in #9074

# Description

Fixes a half-voxel offset bug in 3D multiscale rendering where the offset was always computed from the **coarsest** pyramid level (`downsample_factors[-1]`) instead of the **currently rendered** level (`downsample_factors[data_level]`).

For a deep pyramid (e.g. 10 levels with a 512× coarsest downsample), rendering level 0 would apply a ~256-voxel ghost translation — shifting the volume far off-screen. This was masked when only the coarsest level was ever displayed, but
becomes visible with `locked_data_level` or any workflow that renders a finer level in 3D.

**Changes:**
- Use `data_level` instead of `-1` to index into `downsample_factors`, so the offset tracks whichever level is actually displayed
- Multiply the data-space offset by the layer scale to correctly map to world units
- Add a regression test that verifies the finest level (downsample factor 1) produces a zero offset, not the coarsest level's offset