### PR TITLE
Add information about PyQt5 deprecation

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -245,7 +245,7 @@ class _QtMainWindow(QMainWindow):
 
         if SHOW_QT_WARNING:
             show_warning(
-                'The support for PyQt5 backend is deprecated and will be removed on fall of 2026'
+                'napari support for the PyQt5 backend is deprecated and will be removed in fall of 2026'
             )
 
             SHOW_QT_WARNING = False

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -105,6 +105,7 @@ if TYPE_CHECKING:
 _sentinel = object()
 
 SHOW_QT_WARNING = QT5
+# a variable to check if we run with PyQt5 backend. As we dropped PySide it is enough to check Qt version
 
 del QT5
 

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -22,6 +22,7 @@ from typing import (
 )
 from weakref import WeakValueDictionary
 
+from qtpy import QT5
 from qtpy.QtCore import (
     QEvent,
     QEventLoop,
@@ -85,7 +86,7 @@ from napari.utils.misc import (
     in_python_repl,
     running_as_constructor_app,
 )
-from napari.utils.notifications import Notification
+from napari.utils.notifications import Notification, show_warning
 from napari.utils.task_status import Status, TaskStatusManager
 from napari.utils.theme import _themes, get_system_theme
 from napari.utils.translations import trans
@@ -103,6 +104,9 @@ if TYPE_CHECKING:
 
 _sentinel = object()
 
+SHOW_QT_WARNING = QT5
+
+del QT5
 
 MenuStr = Literal[
     'file_menu',
@@ -227,6 +231,8 @@ class _QtMainWindow(QMainWindow):
 
     def showEvent(self, event: QShowEvent):
         """Override to handle window state changes."""
+        global SHOW_QT_WARNING
+
         settings = get_settings()
         # if event loop is not running, we don't want to start the thread
         # If event loop is running, the loopLevel will be above 0
@@ -235,6 +241,14 @@ class _QtMainWindow(QMainWindow):
             and QApplication.instance().thread().loopLevel()
         ):
             self.status_thread.start()
+
+        if SHOW_QT_WARNING:
+            show_warning(
+                'The support for PyQt5 backend is deprecated and will be removed on fall of 2026'
+            )
+
+            SHOW_QT_WARNING = False
+
         super().showEvent(event)
 
     def enterEvent(self, a0):

--- a/src/napari/utils/_testsupport.py
+++ b/src/napari/utils/_testsupport.py
@@ -163,7 +163,11 @@ def mock_app_model():
 
 @pytest.fixture(autouse=True)
 def _disable_qt_warnings(monkeypatch):
-    monkeypatch.setattr('napari._qt.qt_main_window.SHOW_QT_WARNING', False)
+    try:
+        from napari._qt import qt_main_window
+    except ImportError:
+        return
+    monkeypatch.setattr(qt_main_window, 'SHOW_QT_WARNING', False)
 
 
 @pytest.fixture

--- a/src/napari/utils/_testsupport.py
+++ b/src/napari/utils/_testsupport.py
@@ -161,6 +161,11 @@ def mock_app_model():
             init_qactions.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _disable_qt_warnings(monkeypatch):
+    monkeypatch.setattr('napari._qt.qt_main_window.SHOW_QT_WARNING', False)
+
+
 @pytest.fixture
 def make_napari_viewer(
     qtbot,


### PR DESCRIPTION
# References and relevant issues

# Description

Qt5 has reached end-of-life status. We fixed our bundle to use Qt6 instead of Qt 5 and dropped PySide2. 

Keeping PyQt5 support complicates the CI matrix and introduces additional maintenance costs, but there might still be plugins/scripts that depend on Qt5. 

This PR adds a gentle notification to give the user time to fix the code before we remove support for PyQt5. 