### PR TITLE
ci: trigger dependency check on PR edits

### DIFF
--- a/.github/workflows/pr_dependency.yml
+++ b/.github/workflows/pr_dependency.yml
@@ -2,6 +2,7 @@
 name: "PR Dependency Check"
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, edited ]
   issue_comment:
     types: [ created ]
 


### PR DESCRIPTION
closes #9082
# References and relevant issues

# Description
- GitHub already triggers `opened`, `synchronize`, `reopened` by default  (https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)

> > Can you write in your own words what this ultimately means? 
> 
> sure, like before adding `types` github triggers `opened`, `synchronize`, `reopened` by default and we have added one extra option to trigger `edited` (this tag from docs)
> 
> > What does adding edited do? 
> 
> It triggers when pull request is edited
> 
> >Can we just add edited or does this than squash all the defaults?
> 
> I also thought for this but after looking into this(i searched) i got to know once we define types, github only listen to the types which are in the list.
> 
> 
> ahh 😀 , i don't know if i explained clearly, please correct me if i need improvement. Thanks

_Originally posted by @Aniketsy in https://github.com/napari/napari/issues/9084#issuecomment-4781980064_
            

