### PR TITLE
Remove stretch from features table widget layout

### DIFF
--- a/src/napari_builtins/_qt/features_table.py
+++ b/src/napari_builtins/_qt/features_table.py
@@ -769,7 +769,6 @@ class FeaturesTable(QWidget):
         self.layout().addWidget(self.join_toggle)
         self.layout().addWidget(self.save)
         self.layout().addWidget(self.table)
-        self.layout().addStretch()
 
         self.toggle.toggled.connect(self._on_editable_change)
         self.join_toggle.toggled.connect(self._on_join_change)


### PR DESCRIPTION
# Description
I'm not sure why we added this stretch initially, but I can't see a reason to keep it at the moment. I'm always annoyed that the table takes up half the space instead of all of it, even when there's more entries...

```sh
python examples/features_table_widget.py
```

main:
<img width="1090" height="659" alt="image" src="https://github.com/user-attachments/assets/2e2fdd89-9935-4fc0-91db-8fd89d136012" />

PR:
<img width="1090" height="659" alt="image" src="https://github.com/user-attachments/assets/dcad6b35-2b94-4cf4-8138-9cfdbe1bea39" />

