### PR TITLE
Fix get_status for RGB images in 3D display mode

### DIFF
--- a/src/napari/layers/_scalar_field/scalar_field.py
+++ b/src/napari/layers/_scalar_field/scalar_field.py
@@ -748,7 +748,10 @@ class ScalarFieldBase(Layer, ABC):
             # data are always consistent (data_level and the slice
             # can be temporarily out of sync).
             im_slice = self._slice.image.raw
-            slice_shape = np.array(im_slice.shape)
+            # note we remove the potential rgb channel dimension if present
+            # but this doesn't need to be removed from level_shapes because
+            # it's already done
+            slice_shape = np.array(im_slice.shape)[: len(dims_displayed)]
             level0_shape = np.array(self.level_shapes[0])
             ds = level0_shape[dims_displayed] / slice_shape
             start_point = start_point[dims_displayed] / ds

--- a/src/napari/layers/_scalar_field/scalar_field.py
+++ b/src/napari/layers/_scalar_field/scalar_field.py
@@ -748,9 +748,8 @@ class ScalarFieldBase(Layer, ABC):
             # data are always consistent (data_level and the slice
             # can be temporarily out of sync).
             im_slice = self._slice.image.raw
-            # note we remove the potential rgb channel dimension if present
-            # but this doesn't need to be removed from level_shapes because
-            # it's already done
+            # Use only the displayed spatial dims; an RGB slice carries a
+            # trailing channel axis that is absent from level_shapes.
             slice_shape = np.array(im_slice.shape)[: len(dims_displayed)]
             level0_shape = np.array(self.level_shapes[0])
             ds = level0_shape[dims_displayed] / slice_shape

--- a/src/napari/layers/image/_tests/test_multiscale.py
+++ b/src/napari/layers/image/_tests/test_multiscale.py
@@ -352,6 +352,18 @@ def test_value():
     np.testing.assert_allclose(value, (2, data[2][0, 0]))
 
 
+def test_value_rgb():
+    """Test getting the value of the rgb data at the current coordinates."""
+    shapes = [(40, 20, 3), (20, 10, 3), (10, 5, 3)]
+    np.random.seed(0)
+    data = [np.random.random(s) for s in shapes]
+    layer = Image(data, multiscale=True, rgb=True)
+    value = layer.get_value((0,) * 2)
+    assert layer.data_level == 2
+    assert value[0] == 2
+    np.testing.assert_allclose(value[1], data[2][0, 0])
+
+
 def test_corner_value():
     """Test getting the value of the data at the new position."""
     shapes = [(40, 20), (20, 10), (10, 5)]

--- a/src/napari/layers/image/_tests/test_volume.py
+++ b/src/napari/layers/image/_tests/test_volume.py
@@ -155,6 +155,16 @@ def test_value():
     assert value == data[0, 0, 0]
 
 
+def test_value_rgb():
+    """Test getting the value of the rgb data at the current coordinates."""
+    np.random.seed(0)
+    data = np.random.random((10, 15, 20, 3))
+    layer = Image(data, rgb=True)
+    layer._slice_dims(Dims(ndim=3, ndisplay=3))
+    value = layer.get_value((0,) * 3)
+    assert value == data[0, 0, 0]
+
+
 def test_message():
     """Test converting value and coords to message."""
     np.random.seed(0)

--- a/src/napari/layers/image/_tests/test_volume.py
+++ b/src/napari/layers/image/_tests/test_volume.py
@@ -162,7 +162,7 @@ def test_value_rgb():
     layer = Image(data, rgb=True)
     layer._slice_dims(Dims(ndim=3, ndisplay=3))
     value = layer.get_value((0,) * 3)
-    assert value == data[0, 0, 0]
+    np.testing.assert_array_equal(value, data[0, 0, 0])
 
 
 def test_message():


### PR DESCRIPTION
# References and relevant issues
- closes #9120
- zulip: https://napari.zulipchat.com/#narrow/channel/270578-reviews/topic/broken.203D.20rgb/with/607165724

# Description
Strip the rgb channel dimension if present.
