### PR TITLE
Fix problem with ignoring annotation when drag and drop

### DIFF
--- a/src/napari/utils/io.py
+++ b/src/napari/utils/io.py
@@ -190,7 +190,8 @@ def execute_python_code(code: str, script_path: str | Path = '') -> None:
             # code will be executed with `exec(code, namespace)`, set `__name__` to `builtins`.
             # Set `__main__` to execute `if __name__ == '__main__':` blocks
             script_namespace['__name__'] = '__main__'
-            exec(code, script_namespace)
+            code_obj = compile(code, script_path, 'exec', dont_inherit=True)
+            exec(code_obj, script_namespace)
             _add_variables_to_viewer_console(
                 _SCRIPT_NAMESPACES[script_path], patched_viewer
             )


### PR DESCRIPTION
# References and relevant issues
https://napari.zulipchat.com/#narrow/channel/212875-general/topic/Drag.20n.20drop.20.2B.20magicgui.20doesn.27t.20work.20properly/with/606936662

# Description

It shows that `exec` inherits `from __future__ import annotations` from `napari.utils.io` that leads to `magicgui` resolve annotation to `ForwardRef` and ignores it when creating a widget. 

Use `compile` with `dont_inherit=True` allow to work around it. 

The ultimate solution will be to fix magicgui to work with it, but this allows it to work in the next release. 