### PR TITLE
Use numpy io methods for pass data in clipboard

### DIFF
--- a/src/napari/_qt/_qapp_model/_tests/test_qaction_layer.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_qaction_layer.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import numpy as np
 import numpy.testing as npt
 import pytest
-from PyQt6.QtCore import QMimeData
+from qtpy.QtCore import QMimeData
 from qtpy.QtWidgets import QApplication
 
 from napari._qt._qapp_model.qactions._layerlist_context import (

--- a/src/napari/_qt/_qapp_model/_tests/test_qaction_layer.py
+++ b/src/napari/_qt/_qapp_model/_tests/test_qaction_layer.py
@@ -1,11 +1,14 @@
+from io import BytesIO
 from unittest.mock import Mock
 
 import numpy as np
 import numpy.testing as npt
 import pytest
+from PyQt6.QtCore import QMimeData
 from qtpy.QtWidgets import QApplication
 
 from napari._qt._qapp_model.qactions._layerlist_context import (
+    SPATIAL_MIME_KEY,
     _copy_affine_to_clipboard,
     _copy_rotate_to_clipboard,
     _copy_scale_to_clipboard,
@@ -13,6 +16,7 @@ from napari._qt._qapp_model.qactions._layerlist_context import (
     _copy_spatial_to_clipboard,
     _copy_translate_to_clipboard,
     _copy_units_to_clipboard,
+    _get_spatial_from_clipboard,
     _paste_spatial_from_clipboard,
     is_valid_spatial_in_clipboard,
 )
@@ -145,6 +149,26 @@ def test_copy_units_to_clipboard(layer_list):
         layer_list['l3'].units, get_units_from_name(('pixel', 'pixel'))
     )
     npt.assert_array_equal(layer_list['l2'].scale, (1, 1))
+
+
+@pytest.mark.parametrize(
+    ('binary', 'expected'), [(True, [2, 2]), (False, [1, 1])]
+)
+def test_copy_numpy_overwrite(qapp, binary, expected):
+    """Test if a value from a binary buffer overwrites a value from a text buffer."""
+    text_data = '{"units": ["nm", "nm"], "scale": [1, 1]}'
+    buffer = BytesIO()
+    np.savez(buffer, scale=np.array([2, 2]))
+    buffer.seek(0)
+
+    qapp.clipboard().setMimeData(QMimeData())
+    qapp.clipboard().mimeData().setText(text_data)
+    qapp.clipboard().mimeData().setData(SPATIAL_MIME_KEY, buffer.getvalue())
+
+    res = _get_spatial_from_clipboard(binary=binary)
+    assert res is not None
+    assert 'units' in res
+    npt.assert_array_equal(res['scale'], expected)
 
 
 @pytest.mark.usefixtures('qtbot')

--- a/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
+++ b/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
@@ -23,12 +23,13 @@ from napari.utils.translations import trans
 
 __all__ = ('Q_LAYERLIST_CONTEXT_ACTIONS', 'is_valid_spatial_in_clipboard')
 
+SPATIAL_MIME_KEY = 'application/x-napari-layer-spatial-npz'
+
 
 def _numpy_to_list(d: dict) -> dict:
-    for k, v in list(d.items()):
-        if isinstance(v, np.ndarray):
-            d[k] = v.tolist()
-    return d
+    return {
+        k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in d.items()
+    }
 
 
 class UnitsEncoder(json.JSONEncoder):
@@ -46,10 +47,10 @@ def _set_data_in_clipboard(data: dict) -> None:
         show_warning('Cannot access clipboard')
         return
 
-    data_ = _numpy_to_list(data)
-    json_data = json.dumps(data_, cls=UnitsEncoder)
+    json_data = _numpy_to_list(data)
+    json_data = json.dumps(json_data, cls=UnitsEncoder)
 
-    numpy_data = {k: v for k, v in data_.items() if isinstance(v, np.ndarray)}
+    numpy_data = {k: v for k, v in data.items() if isinstance(v, np.ndarray)}
     # maybe change to MessagePack in future
     buffer = BytesIO()
     np.savez(buffer, **numpy_data, allow_pickle=False)
@@ -57,9 +58,7 @@ def _set_data_in_clipboard(data: dict) -> None:
     byte_representation = buffer.getvalue()
     mime_data = QMimeData()
     mime_data.setText(json_data)
-    mime_data.setData(
-        'application/x-napari-layer-spatial-npz', byte_representation
-    )
+    mime_data.setData(SPATIAL_MIME_KEY, byte_representation)
 
     clip.setMimeData(mime_data)
 
@@ -118,9 +117,9 @@ def _get_spatial_from_clipboard(binary: bool = True) -> dict | None:
         # we should never get here, but just in case
         return None
     numpy_data = {}
-    if mime_data.data('application/x-napari-layer-spatial-npz') and binary:
+    if mime_data.data(SPATIAL_MIME_KEY) and binary:
         buff = BytesIO(
-            bytes(mime_data.data('application/x-napari-layer-spatial-npz'))  # type: ignore[call-overload]
+            bytes(mime_data.data(SPATIAL_MIME_KEY))  # type: ignore[call-overload]
         )
         numpy_data = np.load(buff, allow_pickle=False)
 

--- a/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
+++ b/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import pickle
+from io import BytesIO
 from typing import Any
 
 import numpy as np
@@ -40,17 +41,24 @@ class UnitsEncoder(json.JSONEncoder):
 
 
 def _set_data_in_clipboard(data: dict) -> None:
-    data = _numpy_to_list(data)
     clip = QApplication.clipboard()
     if clip is None:
         show_warning('Cannot access clipboard')
         return
 
-    d = json.dumps(data, cls=UnitsEncoder)
-    p = pickle.dumps(data)
+    data_ = _numpy_to_list(data)
+    json_data = json.dumps(data_, cls=UnitsEncoder)
+
+    numpy_data = {k: v for k, v in data_.items() if isinstance(v, np.ndarray)}
+    buffer = BytesIO()
+    np.savez(buffer, **numpy_data, allow_pickle=False)
+
+    byte_representation = buffer.getvalue()
     mime_data = QMimeData()
-    mime_data.setText(d)
-    mime_data.setData('application/octet-stream', p)
+    mime_data.setText(json_data)
+    mime_data.setData(
+        'application/x-napari-layer-spatial-npz', byte_representation
+    )
 
     clip.setMimeData(mime_data)
 
@@ -99,7 +107,7 @@ def _copy_units_to_clipboard(layer: Layer) -> None:
     _set_data_in_clipboard({'units': layer.units})
 
 
-def _get_spatial_from_clipboard() -> dict | None:
+def _get_spatial_from_clipboard(binary=True) -> dict | None:
     clip = QApplication.clipboard()
     if clip is None:
         return None
@@ -108,10 +116,19 @@ def _get_spatial_from_clipboard() -> dict | None:
     if mime_data is None:  # pragma: no cover
         # we should never get here, but just in case
         return None
-    if mime_data.data('application/octet-stream'):
-        return pickle.loads(mime_data.data('application/octet-stream'))  # type: ignore[arg-type]
+    numpy_data = {}
+    if mime_data.data('application/x-napari-layer-spatial-npz') and binary:
+        buff = BytesIO(
+            bytes(mime_data.data('application/x-napari-layer-spatial-npz'))
+        )
+        numpy_data = np.load(buff, allow_pickle=False)  # type: ignore[arg-type]
 
-    return json.loads(mime_data.text())
+    json_data: dict = json.loads(mime_data.text())
+    if not isinstance(json_data, dict):
+        return None
+    if numpy_data:
+        json_data.update(**numpy_data)
+    return json_data
 
 
 def _paste_spatial_from_clipboard(ll: LayerList) -> None:
@@ -188,8 +205,8 @@ def _paste_spatial_from_clipboard(ll: LayerList) -> None:
 
 def is_valid_spatial_in_clipboard() -> bool:
     try:
-        loaded = _get_spatial_from_clipboard()
-    except (json.JSONDecodeError, pickle.UnpicklingError):
+        loaded = _get_spatial_from_clipboard(binary=False)
+    except json.JSONDecodeError:
         return False
     if not isinstance(loaded, dict):
         return False

--- a/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
+++ b/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
@@ -50,6 +50,7 @@ def _set_data_in_clipboard(data: dict) -> None:
     json_data = json.dumps(data_, cls=UnitsEncoder)
 
     numpy_data = {k: v for k, v in data_.items() if isinstance(v, np.ndarray)}
+    # maybe change to MessagePack in future
     buffer = BytesIO()
     np.savez(buffer, **numpy_data, allow_pickle=False)
 

--- a/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
+++ b/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
@@ -108,7 +108,7 @@ def _copy_units_to_clipboard(layer: Layer) -> None:
     _set_data_in_clipboard({'units': layer.units})
 
 
-def _get_spatial_from_clipboard(binary=True) -> dict | None:
+def _get_spatial_from_clipboard(binary: bool = True) -> dict | None:
     clip = QApplication.clipboard()
     if clip is None:
         return None
@@ -120,9 +120,9 @@ def _get_spatial_from_clipboard(binary=True) -> dict | None:
     numpy_data = {}
     if mime_data.data('application/x-napari-layer-spatial-npz') and binary:
         buff = BytesIO(
-            bytes(mime_data.data('application/x-napari-layer-spatial-npz'))
+            bytes(mime_data.data('application/x-napari-layer-spatial-npz'))  # type: ignore[call-overload]
         )
-        numpy_data = np.load(buff, allow_pickle=False)  # type: ignore[arg-type]
+        numpy_data = np.load(buff, allow_pickle=False)
 
     json_data: dict = json.loads(mime_data.text())
     if not isinstance(json_data, dict):

--- a/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
+++ b/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
@@ -48,7 +48,7 @@ def _set_data_in_clipboard(data: dict) -> None:
         return
 
     json_data = _numpy_to_list(data)
-    json_data = json.dumps(json_data, cls=UnitsEncoder)
+    json_data_str = json.dumps(json_data, cls=UnitsEncoder)
 
     numpy_data = {k: v for k, v in data.items() if isinstance(v, np.ndarray)}
     # maybe change to MessagePack in future
@@ -57,7 +57,7 @@ def _set_data_in_clipboard(data: dict) -> None:
 
     byte_representation = buffer.getvalue()
     mime_data = QMimeData()
-    mime_data.setText(json_data)
+    mime_data.setText(json_data_str)
     mime_data.setData(SPATIAL_MIME_KEY, byte_representation)
 
     clip.setMimeData(mime_data)


### PR DESCRIPTION
# References and relevant issues


# Description

Instead of pickle module use `numpy.savez` and `numpy.load` to pass data through the clipboard without losing float precision. 

This method do not need additional dependency. We discussed the use of MessagePack in the future (https://msgpack.org/) but as it is an additional dependency, we need to be more careful.  


If it works, I think it will be easy to implement #7568 in a similar way. 


