### PR TITLE
Stop using pickle when copying/pasting spatial features of layer

### DIFF
--- a/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
+++ b/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
@@ -22,20 +22,20 @@ from napari.utils.translations import trans
 __all__ = ('Q_LAYERLIST_CONTEXT_ACTIONS', 'is_valid_spatial_in_clipboard')
 
 
-def _numpy_to_list_mat_value(value: Any) -> Any:
+def _numpy_to_list_map_value(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return value.tolist()
     if isinstance(value, dict):
         return _numpy_to_list(value)
     if isinstance(value, list):
-        return [_numpy_to_list_mat_value(v) for v in value]
+        return [_numpy_to_list_map_value(v) for v in value]
     if isinstance(value, tuple):
-        return tuple(_numpy_to_list_mat_value(v) for v in value)
+        return tuple(_numpy_to_list_map_value(v) for v in value)
     return value
 
 
 def _numpy_to_list(d: dict) -> dict:
-    return {k: _numpy_to_list_mat_value(v) for k, v in d.items()}
+    return {k: _numpy_to_list_map_value(v) for k, v in d.items()}
 
 
 class UnitsEncoder(json.JSONEncoder):

--- a/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
+++ b/src/napari/_qt/_qapp_model/qactions/_layerlist_context.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import pickle
 from typing import Any
 
 import numpy as np
@@ -23,11 +22,20 @@ from napari.utils.translations import trans
 __all__ = ('Q_LAYERLIST_CONTEXT_ACTIONS', 'is_valid_spatial_in_clipboard')
 
 
+def _numpy_to_list_mat_value(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, dict):
+        return _numpy_to_list(value)
+    if isinstance(value, list):
+        return [_numpy_to_list_mat_value(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_numpy_to_list_mat_value(v) for v in value)
+    return value
+
+
 def _numpy_to_list(d: dict) -> dict:
-    for k, v in list(d.items()):
-        if isinstance(v, np.ndarray):
-            d[k] = v.tolist()
-    return d
+    return {k: _numpy_to_list_mat_value(v) for k, v in d.items()}
 
 
 class UnitsEncoder(json.JSONEncoder):
@@ -40,6 +48,24 @@ class UnitsEncoder(json.JSONEncoder):
 
 
 def _set_data_in_clipboard(data: dict) -> None:
+    """
+    This function is to set data in clipboard json encoded.
+
+    This method depends on the Qt to interact with the clipboard.
+
+    Based on python documentation about floating-point arithmetic
+    https://docs.python.org/3/tutorial/floatingpoint.html
+    The float.__repr__ method produces form that will be parsed to exactly
+    the same value. So this expression will be true eval(repr(value)) == value.
+    The eval(repr(value)) == value expression will be true for all values except
+    for those that are not representable in the float type.
+
+    Parameters
+    ----------
+    data: dict
+        dict with data to be copied to clipboard.
+
+    """
     data = _numpy_to_list(data)
     clip = QApplication.clipboard()
     if clip is None:
@@ -47,10 +73,8 @@ def _set_data_in_clipboard(data: dict) -> None:
         return
 
     d = json.dumps(data, cls=UnitsEncoder)
-    p = pickle.dumps(data)
     mime_data = QMimeData()
     mime_data.setText(d)
-    mime_data.setData('application/octet-stream', p)
 
     clip.setMimeData(mime_data)
 
@@ -108,8 +132,6 @@ def _get_spatial_from_clipboard() -> dict | None:
     if mime_data is None:  # pragma: no cover
         # we should never get here, but just in case
         return None
-    if mime_data.data('application/octet-stream'):
-        return pickle.loads(mime_data.data('application/octet-stream'))  # type: ignore[arg-type]
 
     return json.loads(mime_data.text())
 
@@ -117,7 +139,7 @@ def _get_spatial_from_clipboard() -> dict | None:
 def _paste_spatial_from_clipboard(ll: LayerList) -> None:
     try:
         loaded = _get_spatial_from_clipboard()
-    except (json.JSONDecodeError, pickle.UnpicklingError):
+    except json.JSONDecodeError:
         show_warning('Cannot parse clipboard data')
         return
     if loaded is None:
@@ -189,7 +211,7 @@ def _paste_spatial_from_clipboard(ll: LayerList) -> None:
 def is_valid_spatial_in_clipboard() -> bool:
     try:
         loaded = _get_spatial_from_clipboard()
-    except (json.JSONDecodeError, pickle.UnpicklingError):
+    except json.JSONDecodeError:
         return False
     if not isinstance(loaded, dict):
         return False


### PR DESCRIPTION
# References and relevant issues
Replaces #9140

# Description

As the `json` serialization of floats allows reproducing the same binary value during deserialization, there is no point in keeping using `pickle` that is known to be unsafe. 

Some binary form might be useful in the future if we want to pass more data. But as we want the spatial features to be pasteable to a text file, we don't need another serialization. 