### PR TITLE
gitignore various agent related file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,42 @@ src/napari/resources/icons/_themes/
 tools/perfmon/*/traces-*.json
 
 github_cache.sqlite
+
+# ─── Agentic coding ───
+# Local overrides & personal instruction variants
+CLAUDE*.md
+AGENTS*.md
+RULES*.md
+*PLAN*.md
+*.prompt.md
+*.local.md
+*instructions.md
+
+# Agent tool state directories
+.claude/
+.windsurf/
+.aider*
+.continue/
+.codeium/
+
+# Agent skill definitions, prompts & agents, catches also the .github/ path
+*/skills/
+*/prompts/
+*/agents/
+
+# Agent session transcripts, logs, scratch
+.agent/
+.agent-workspace/
+.agent-scratch/
+agent-logs/
+*.session.json
+*.transcript.*
+
+# MCP configs (frequently contain tokens/credentials)
+*.mcp.local.json
+
+# Agent caches / embeddings / vector stores
+.agent-cache/
+.context-cache/
+.embeddings/
+.vectorstore/


### PR DESCRIPTION
# References and relevant issues

Peter's suggestion after I commited like AGENTS.md or PLAN.md to #9104: https://github.com/napari/napari/pull/9104#issuecomment-4856901261
based on https://github.com/zarr-developers/zarr-python/pull/4041

# Description

Starting with the zarr agentic gitignore from above, I modified this to catch more files especially from my own experience using Copilot within VSCode.
I added some more wildcards characters to hit more folders (like `github/agents/`) or `copilot-instructions.md` without having to write out all the paths.
I'm less familiar with the other toolings, but the zarr gitignore seems to be sufficiently tailored to all those other harnesses.
