### PR TITLE
Fix: Restore tooltip symbol QSS after #9003

### DIFF
--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -450,6 +450,36 @@ QtVersionLabel {
   font-size: {{ increase(font_size, 6) }};
 }
 
+/* ------------- Help tooltip labels --------- */
+#error_label, #success_label, #help_label, #righthand_label, #lefthand_label {
+  max-width: 18px;
+  max-height: 18px;
+  min-width: 18px;
+  min-height: 18px;
+  margin: 0px;
+  margin-left: 1px;
+  padding: 2px;
+}
+#error_label {
+  image: url("theme_{{ id }}:/warning.svg");
+}
+
+#success_label {
+  image: url("theme_{{ id }}:/check.svg");
+}
+
+#help_label {
+  image: url("theme_{{ id }}:/help_50.svg");
+}
+
+#righthand_label {
+  image: url("theme_{{ id }}:/righthand_50.svg");
+}
+
+#lefthand_label {
+  image: url("theme_{{ id }}:/lefthand_50.svg");
+}
+
 /* ------------- Narrow scrollbar for qtlayer list --------- */
 
 QtListView QScrollBar:vertical {

--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -451,7 +451,7 @@ QtVersionLabel {
 }
 
 /* ------------- Help tooltip labels --------- */
-#error_label, #success_label, #help_label, #righthand_label, #lefthand_label {
+#error_label, #help_label, #righthand_label, #lefthand_label {
   max-width: 18px;
   max-height: 18px;
   min-width: 18px;
@@ -462,10 +462,6 @@ QtVersionLabel {
 }
 #error_label {
   image: url("theme_{{ id }}:/warning.svg");
-}
-
-#success_label {
-  image: url("theme_{{ id }}:/check.svg");
 }
 
 #help_label {


### PR DESCRIPTION
# References and relevant issues

#9003 removed Plugin Manager related QSS but this snuck in between them (presumably because they were introduced originally with the manager)
Closes #9150

# Description

Restores QSS removed in #9003. But, drops `#help_label` because its not used in prod.

<img width="624" height="369" alt="image" src="https://github.com/user-attachments/assets/0153f4ef-c32d-4cb5-ace2-6a400ef0f12d" />
