### PR TITLE
Fix: update cached unit scale when layer data dimensionality changes (#9164)

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -321,3 +321,35 @@ def test_world_units_impact_scale():
 
     vispy_image.world_units = None
     assert vispy_image._world_to_layer_units_scale == (1, 1)
+
+
+def test_changing_data_dimensionality_updates_units_scale():
+    """Regression test for https://github.com/napari/napari/issues/9164
+
+    When a layer's data changes dimensionality (e.g., 2D -> 3D), the
+    cached _world_to_layer_units_scale must be updated to match the
+    new ndim before _on_matrix_change tries to index it.
+    """
+    font_info = FontInfo()
+
+    # Start with 2D data
+    image = Image(np.zeros((10, 10)))
+    vispy_image = VispyImageLayer(image, font_info=font_info)
+    assert vispy_image._world_to_layer_units_scale == (1, 1)
+
+    # Changing data to 3D should not cause an IndexError in
+    # _on_matrix_change (called via _on_data_change).
+    image.data = np.zeros((5, 10, 10))
+    assert len(vispy_image._world_to_layer_units_scale) == image.ndim
+    # _on_matrix_change should succeed without IndexError
+    vispy_image._on_matrix_change()
+
+    # Changing back to 2D should also work
+    image.data = np.zeros((10, 10))
+    assert len(vispy_image._world_to_layer_units_scale) == image.ndim
+    vispy_image._on_matrix_change()
+
+    # Changing from 2D to 4D should also work
+    image.data = np.zeros((3, 5, 10, 10))
+    assert len(vispy_image._world_to_layer_units_scale) == image.ndim
+    vispy_image._on_matrix_change()

--- a/src/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -342,14 +342,8 @@ def test_changing_data_dimensionality_updates_units_scale():
     image.data = np.zeros((5, 10, 10))
     assert len(vispy_image._world_to_layer_units_scale) == image.ndim
     # _on_matrix_change should succeed without IndexError
-    vispy_image._on_matrix_change()
 
     # Changing back to 2D should also work
     image.data = np.zeros((10, 10))
     assert len(vispy_image._world_to_layer_units_scale) == image.ndim
-    vispy_image._on_matrix_change()
 
-    # Changing from 2D to 4D should also work
-    image.data = np.zeros((3, 5, 10, 10))
-    assert len(vispy_image._world_to_layer_units_scale) == image.ndim
-    vispy_image._on_matrix_change()

--- a/src/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -346,4 +346,3 @@ def test_changing_data_dimensionality_updates_units_scale():
     # Changing back to 2D should also work
     image.data = np.zeros((10, 10))
     assert len(vispy_image._world_to_layer_units_scale) == image.ndim
-

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -202,6 +202,14 @@ class VispyBaseLayer(ABC, Generic[_L]):
 
     def _on_matrix_change(self):
         dims_displayed = self.layer._slice_input.displayed
+        # If the layer's dimensionality changed (e.g., data swapped from 2D
+        # to 3D), _world_to_layer_units_scale reflects the old ndim
+        # and cannot be indexed with the new dims_displayed values.  Refresh
+        # both cached unit tracking fields to match the current layer.
+        if len(self._world_to_layer_units_scale) != self.layer.ndim:
+            self._world_units = self.layer.units
+            self._world_to_layer_units_scale = (1,) * self.layer.ndim
+
         # mypy: self.layer._transforms.simplified cannot be None
         transform = self.layer._transforms.simplified.set_slice(dims_displayed)
         # convert NumPy axis ordering to VisPy axis ordering


### PR DESCRIPTION
## References and relevant issues

Closes #9164

## Description

Bug introduced in #7889 when deriving the `_world_to_layer_units_scale` from the layer state. A changing dimensionality of layer.data did not update this so `_on_matrix_change` has incorrectly cached values. This guards against a cache mismatch and rebuilds the layer state.

I thought there may be an event on the layer which could fire this, but I couldn't find one. This `_on_matrix_change` is seemingly called through every code path like transforms and such so I hope should cover all instances of changing layer properties for this calculation.

I added an LLM-derived regression test which fails on main and passes with this PR. 
