### PR TITLE
fix (typing): add typing and fix mypy error in `qt_symbol_combobox.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -659,7 +659,6 @@ module = [
     'napari._qt.layer_controls.widgets._labels.qt_render_control',
     'napari._qt.layer_controls.widgets._labels.qt_display_selected_label_checkbox',
     'napari._qt.layer_controls.widgets._points.qt_current_size_slider',
-    'napari._qt.layer_controls.widgets._points.qt_symbol_combobox',
     'napari._qt.layer_controls.widgets._points.qt_border_color',
     'napari._qt.layer_controls.widgets.qt_colormap_control',
     'napari._qt.layer_controls.widgets.qt_contrast_limits',

--- a/src/napari/_qt/layer_controls/widgets/_points/qt_symbol_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_points/qt_symbol_combobox.py
@@ -13,7 +13,7 @@ from napari.layers.points._points_constants import (
 from napari.utils.translations import trans
 
 
-class QtSymbolComboBoxControl(QtWidgetControlsBase):
+class QtSymbolComboBoxControl(QtWidgetControlsBase):  # type: ignore[metaclass]
     """
     Class that wraps the connection of events/signals between the current symbol
     layer attribute and Qt widgets.
@@ -33,6 +33,8 @@ class QtSymbolComboBoxControl(QtWidgetControlsBase):
         Label for the current symbol chooser widget.
     """
 
+    _layer: Points
+
     def __init__(self, parent: QWidget, layer: Points) -> None:
         super().__init__(parent, layer)
         # Setup layer
@@ -49,13 +51,12 @@ class QtSymbolComboBoxControl(QtWidgetControlsBase):
             )
         )
         current_index = 0
-        for index, (symbol_string, text) in enumerate(
+        for index, (symbol_enum, text) in enumerate(
             SYMBOL_TRANSLATION.items()
         ):
-            symbol_string = symbol_string.value
-            sym_cb.addItem(text, symbol_string)
+            sym_cb.addItem(text, symbol_enum.value)
 
-            if symbol_string == self._layer.current_symbol:
+            if symbol_enum == self._layer.current_symbol:
                 current_index = index
 
         sym_cb.setCurrentIndex(current_index)

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -26,6 +26,7 @@ from napari.layers.points._points_constants import (
     Mode,
     PointsProjectionMode,
     Shading,
+    Symbol,
 )
 from napari.layers.points._points_mouse_bindings import add, highlight, select
 from napari.layers.points._points_utils import (
@@ -914,12 +915,12 @@ class Points(Layer):
         self.events.highlight()
 
     @property
-    def current_symbol(self) -> int | float:
-        """float: symbol of marker for the next added point."""
+    def current_symbol(self) -> Symbol:
+        """Symbol: symbol of marker for the next added point."""
         return self._current_symbol
 
     @current_symbol.setter
-    def current_symbol(self, symbol: None | float) -> None:
+    def current_symbol(self, symbol: str | Symbol) -> None:
         symbol = coerce_symbols(np.array([symbol]))[0]
         self._current_symbol = symbol
         if self._update_properties and len(self.selected_data) > 0:


### PR DESCRIPTION
Towards #8120 
# References and relevant issues

# Description

- in this we are adding typing hints in `qt_symbol_combobox.py`



