### PR TITLE
fix(typing): resolve mypy errors for `qt_widget_controls_base`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -633,7 +633,6 @@ module = [
     'napari._qt.layer_controls.qt_surface_controls',
     'napari._qt.layer_controls.qt_tracks_controls',
     'napari._qt.layer_controls.qt_vectors_controls',
-    'napari._qt.layer_controls.widgets.qt_widget_controls_base',
     'napari._qt.layer_controls.widgets.qt_face_color',
     'napari._qt.layer_controls.widgets.qt_opacity_blending_controls',
     'napari._qt.layer_controls.widgets.qt_text_visibility',

--- a/src/napari/_qt/layer_controls/widgets/qt_histogram_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_histogram_control.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     )
 
 
-class QtHistogramControl(QtWidgetControlsBase):  # type: ignore[metaclass]
+class QtHistogramControl(QtWidgetControlsBase):
     """
     Histogram control widget for Image layers.
 

--- a/src/napari/_qt/layer_controls/widgets/qt_multiscale_level_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_multiscale_level_control.py
@@ -37,11 +37,7 @@ def _format_level_label(
     return f'{index}: {shape_str} ({size_str})'
 
 
-# MetaWidgetControlsBase merges type(QObject) and type(ABC) at runtime,
-# but mypy cannot verify this is safe.
-class QtMultiscaleLevelControl(  # type: ignore[metaclass]
-    QtWidgetControlsBase,
-):
+class QtMultiscaleLevelControl(QtWidgetControlsBase):
     """Widget to manually select which multiscale level to render.
 
     Shows a combobox with "Auto" plus one entry per resolution level.

--- a/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
@@ -55,10 +55,9 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         # Setup layer
         self._layer = layer
         # Track registered callbacks (defined via `attr_to_settr` for example)
-        # so it is possible to disconnect them when the widget is being closed/deleted
-        # TODO: what are the possible input types of the callbacks?
-        # maybe Any should do the trick?
-        self._callbacks: list[Callable[[], None]] = []
+        # so it is possible to disconnect them when the widget is being closed/deleted.
+        # Arguments of callbacks are hard to track; Any is the best we can do here.
+        self._callbacks: list[Callable[[Any], None]] = []
 
     @abstractmethod
     def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:

--- a/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
@@ -1,10 +1,24 @@
-from abc import ABC, abstractmethod
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtWidgets import QLabel, QWidget
 
 from napari.layers.base.base import Layer
 from napari.utils.events import disconnect_events
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    MetaBase = ABCMeta
+
+else:
+
+    class MetaBase(type(QObject), ABCMeta):
+        pass
 
 
 class QtWrappedLabel(QLabel):
@@ -13,7 +27,7 @@ class QtWrappedLabel(QLabel):
     to the right and vertically centered by default.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.setWordWrap(True)
         self.setAlignment(
@@ -21,11 +35,7 @@ class QtWrappedLabel(QLabel):
         )
 
 
-class MetaWidgetControlsBase(type(ABC), type(QObject)):
-    pass
-
-
-class QtWidgetControlsBase(QObject, ABC, metaclass=MetaWidgetControlsBase):
+class QtWidgetControlsBase(QObject, metaclass=MetaBase):
     """
     Base class that defines base methods for wrapper classes that do the
     connection of events/signals between layer attributes and Qt widgets.
@@ -46,7 +56,9 @@ class QtWidgetControlsBase(QObject, ABC, metaclass=MetaWidgetControlsBase):
         self._layer = layer
         # Track registered callbacks (defined via `attr_to_settr` for example)
         # so it is possible to disconnect them when the widget is being closed/deleted
-        self._callbacks = []
+        # TODO: what are the possible input types of the callbacks?
+        # maybe Any should do the trick?
+        self._callbacks: list[Callable[[], None]] = []
 
     @abstractmethod
     def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:

--- a/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
@@ -13,11 +13,11 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
 
-    MetaBase = ABCMeta
+    _QtABCMeta = ABCMeta
 
 else:
 
-    class MetaBase(type(QObject), ABCMeta):
+    class _QtABCMeta(type(QObject), ABCMeta):
         pass
 
 
@@ -35,7 +35,7 @@ class QtWrappedLabel(QLabel):
         )
 
 
-class QtWidgetControlsBase(QObject, metaclass=MetaBase):
+class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
     """
     Base class that defines base methods for wrapper classes that do the
     connection of events/signals between layer attributes and Qt widgets.


### PR DESCRIPTION
# References and relevant issues

Towards #8120
Helper for #9182 and #9183

# Description

While reviewing #9182 and #9183 I realized that this is the typical problem of declaring Qt objects as base metaclasses.

With some input from claude on how to make `mypy` happy, the latter now sees as base metaclass `ABCMeta` at type checking time, while at runtime is the actual metaclass leveraging `type(QObject)`. So we lie, but it's a white lie.

For posterity, ran the following command to check the file individually:

```
uv run --no-project mypy --config-file pyproject.toml --pretty --show-error-codes src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
```



