### PR TITLE
Enh: Selectable text in ConfirmCloseDialog

### DIFF
--- a/src/napari/_qt/dialogs/_tests/test_confirm_close_dialog.py
+++ b/src/napari/_qt/dialogs/_tests/test_confirm_close_dialog.py
@@ -1,4 +1,5 @@
-from qtpy.QtWidgets import QDialog
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QDialog, QLabel
 
 from napari._qt.dialogs.confirm_close_dialog import ConfirmCloseDialog
 from napari.settings import get_settings
@@ -42,3 +43,14 @@ def test_create_window_close(qtbot):
     dialog.close_btn.click()
     assert dialog.result() == QDialog.DialogCode.Accepted
     assert get_settings().application.confirm_close_window
+
+
+def test_text_is_selectable(qtbot):
+    dialog = ConfirmCloseDialog(
+        None, close_app=False, extra_info='napari-worker'
+    )
+    qtbot.addWidget(dialog)
+    label = dialog.findChild(QLabel)
+    flags = label.textInteractionFlags()
+    assert flags & Qt.TextInteractionFlag.TextSelectableByMouse
+    assert flags & Qt.TextInteractionFlag.TextSelectableByKeyboard

--- a/src/napari/_qt/dialogs/confirm_close_dialog.py
+++ b/src/napari/_qt/dialogs/confirm_close_dialog.py
@@ -1,3 +1,4 @@
+from qtpy.QtCore import Qt
 from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -64,7 +65,12 @@ class ConfirmCloseDialog(QDialog):
         layout2 = QHBoxLayout()
         layout2.addWidget(icon_label)
         layout3 = QVBoxLayout()
-        layout3.addWidget(QLabel(text))
+        text_label = QLabel(text)
+        text_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+            | Qt.TextInteractionFlag.TextSelectableByKeyboard
+        )
+        layout3.addWidget(text_label)
         layout3.addWidget(self.do_not_ask)
         layout2.addLayout(layout3)
         layout4 = QHBoxLayout()


### PR DESCRIPTION
# References and relevant issues

While working on #8658 I tried to close napari while the worker was running, this leads to a Modal dialog with a warning, however, the text was not selectable and I wanted to copy and paste. 
This is not the first time I've wanted to copy/paste this text.

# Description

Sets the `Qlabel` text of the `ConfirmCloseDialog` to be interactable with mouse and keyboard.
Now text can be copy/pasted. While the message is useful, someone using a plugin for example may see this as a very cryptic message and wish to share. This will help users like myself to share the message in the box to ask questions -- where before this prevented me from knowing what was really happening. 

<img width="1116" height="432" alt="image" src="https://github.com/user-attachments/assets/fb87dedd-b509-44c8-bb65-1f8e5b2a94c0" />

