### PR TITLE
Remove `str_to_rgb`

### DIFF
--- a/src/napari/utils/_tests/test_misc.py
+++ b/src/napari/utils/_tests/test_misc.py
@@ -19,7 +19,6 @@ from napari.utils.misc import (
     human_readable_size,
     is_iterable,
     pick_equality_operator,
-    str_to_rgb,
 )
 
 ITERABLE = (0, 1, 2)
@@ -268,19 +267,6 @@ def test_ensure_list_of_layer_data_tuple(input_data, expected):
 )
 def test_is_iterable(data, expected):
     assert is_iterable(data) == expected
-
-
-def test_str_to_rgb_warns_and_parses():
-    with pytest.warns(FutureWarning, match='str_to_rgb is deprecated'):
-        assert str_to_rgb('rgb(1, 2, 3)') == [1, 2, 3]
-
-
-def test_str_to_rgb_raises_on_invalid_input():
-    with (
-        pytest.warns(FutureWarning, match='str_to_rgb is deprecated'),
-        pytest.raises(ValueError, match=r"arg not in format 'rgb\(x,y,z\)'"),
-    ):
-        str_to_rgb('not-rgb')
 
 
 @pytest.mark.parametrize(

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -93,26 +93,6 @@ def in_python_repl() -> bool:
     )
 
 
-def str_to_rgb(arg: str) -> list[int]:
-    """Convert an rgb string 'rgb(x,y,z)' to a list of ints [x,y,z].
-
-    .. deprecated:: 0.7.1
-        `str_to_rgb` is deprecated and will be removed in a future release.
-        Please migrate away from this utility. The function currently
-        retains its behavior but will warn on use.
-    """
-    warnings.warn(
-        'napari.utils.misc.str_to_rgb is deprecated in 0.7.1 and will be removed in 0.8.0 release.',
-        FutureWarning,
-        stacklevel=2,
-    )
-
-    match = re.match(r'rgb\((\d+),\s*(\d+),\s*(\d+)\)', arg)
-    if match is None:
-        raise ValueError("arg not in format 'rgb(x,y,z)'")
-    return list(map(int, match.groups()))
-
-
 def ensure_iterable(
     arg: None | str | Enum | float | list | npt.NDArray,
 ):


### PR DESCRIPTION
# References and relevant issues
#9129
# Description
in napari/utils/misc.py,str_to_rgb is not covered, and does not seem to be used since https://github.com/napari/napari/pull/2542.



