### PR TITLE
Fix cross layer in multiple viewer example to use line vectors.

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -539,5 +539,10 @@ authors:
   affiliation: University of Bonn
   orcid: https://orcid.org/0000-0002-9998-0058
   alias: roaldarbol
+- given-names: Filippo Maria
+  family-names: Castelli
+  affiliation: Delta Tribe SRL
+  orcid: https://orcid.org/0000-0001-8170-8905
+  alias: filippocastelli
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/examples/multiple_viewer_widget.py
+++ b/examples/multiple_viewer_widget.py
@@ -174,7 +174,7 @@ class CrossWidget(QCheckBox):
     def _update_ndim(self, event):
         if self.layer in self.viewer.layers:
             self.viewer.layers.remove(self.layer)
-        self.layer = Vectors(name='.cross', ndim=event.value)
+        self.layer = Vectors(name='.cross', ndim=event.value, vector_style='line')
         self.layer.edge_width = 1.5
         self.update_cross()
 


### PR DESCRIPTION
Vectors default to triangle style, which made the crosshair look like arrows.
# References and relevant issues
Closes #9212
# Description
Bug fix for the `multiple_viewer_widget` example.
The `CrossWidget` builds a `Vectors` layer for the crosshair but did not set `vector_style`. Vectors default to `'triangle'`, so the cross rendered as filled triangles that look like arrows instead of a line crosshair.
This PR sets `vector_style='line'` when creating the layer so the crosshair displays as intended.
```python
self.layer = Vectors(name='.cross', ndim=event.value, vector_style='line')