### PR TITLE
Add ``example`` to ``allowed_labels`` in ``check_labels`` job of ``label_and_milestone_checker.yml`` workflow

### DIFF
--- a/.github/workflows/label_and_milestone_checker.yml
+++ b/.github/workflows/label_and_milestone_checker.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          allowed_labels="bugfix feature documentation performance enhancement maintenance"
+          allowed_labels="bugfix feature documentation performance enhancement maintenance example"
 
           labels="$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}" --jq '.labels[].name' || true)"
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -544,5 +544,9 @@ authors:
   affiliation: Delta Tribe SRL
   orcid: https://orcid.org/0000-0001-8170-8905
   alias: filippocastelli
+- given-names: Edouard
+  family-names: Coussoux
+  affiliation: Synopsys, Inc.
+  alias: ecoussoux-ansys
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause


### PR DESCRIPTION
# References and relevant issues
Closes #8657.

# Description
This PR is adding the ``example`` label to the list of ``allowed_labels`` in the ``check_labels`` job of the ``label_and_milestone_checker.yml`` workflow.
This way ``example`` will become an acceptable label for ready-to-merge PRs, as desired in #8657.