### PR TITLE
feat: add `new` label button to the labels controls

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -539,5 +539,9 @@ authors:
   affiliation: University of Bonn
   orcid: https://orcid.org/0000-0002-9998-0058
   alias: roaldarbol
+- given-names: Revathy
+  family-names: Venugopal
+  affiliation: Synopsys, Inc.
+  alias: revathyvenugopal162
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -215,3 +215,28 @@ def test_iso_gradient_mode_with_rendering(make_labels_controls):
     assert not qtctrl._render_control.iso_gradient_combobox.isEnabled()
     layer.rendering = LabelsRendering.ISO_CATEGORICAL
     assert qtctrl._render_control.iso_gradient_combobox.isEnabled()
+
+
+def test_label_button_exists(make_labels_controls):
+    """Test that the new label button exists."""
+    layer, qtctrl = make_labels_controls()
+    layer.data = np.random.randint(5, size=(10, 15), dtype=np.uint8)
+    assert qtctrl._label_control.new_label_button is not None
+    assert qtctrl._label_control.new_label_button.button.text() == 'new'
+
+
+def test_label_button_adds_new_label(make_labels_controls):
+    """Test that clicking the new label button sets selected_label to max + 1."""
+    layer, qtctrl = make_labels_controls()
+    expected = int(layer.data.max()) + 1
+    qtctrl._label_control.new_label_button.button.click()
+    assert layer.selected_label == expected
+
+
+def test_label_button_no_change_if_reached_at_max(make_labels_controls):
+    """Test that clicking again when already at max+1 does not change selected_label."""
+    layer, qtctrl = make_labels_controls()
+    layer.selected_label = int(layer.data.max()) + 1
+    before = layer.selected_label
+    qtctrl._label_control.new_label_button.button.click()
+    assert layer.selected_label == before

--- a/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -229,6 +229,7 @@ def test_label_button_adds_new_label(make_labels_controls):
     """Test that clicking the new label button sets selected_label to max + 1."""
     layer, qtctrl = make_labels_controls()
     expected = int(layer.data.max()) + 1
+    layer.selected_label = 1
     qtctrl._label_control.new_label_button.click()
     assert layer.selected_label == expected
 

--- a/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -222,14 +222,14 @@ def test_label_button_exists(make_labels_controls):
     layer, qtctrl = make_labels_controls()
     layer.data = np.random.randint(5, size=(10, 15), dtype=np.uint8)
     assert qtctrl._label_control.new_label_button is not None
-    assert qtctrl._label_control.new_label_button.button.text() == 'new'
+    assert qtctrl._label_control.new_label_button.text() == 'new'
 
 
 def test_label_button_adds_new_label(make_labels_controls):
     """Test that clicking the new label button sets selected_label to max + 1."""
     layer, qtctrl = make_labels_controls()
     expected = int(layer.data.max()) + 1
-    qtctrl._label_control.new_label_button.button.click()
+    qtctrl._label_control.new_label_button.click()
     assert layer.selected_label == expected
 
 
@@ -238,5 +238,5 @@ def test_label_button_no_change_if_reached_at_max(make_labels_controls):
     layer, qtctrl = make_labels_controls()
     layer.selected_label = int(layer.data.max()) + 1
     before = layer.selected_label
-    qtctrl._label_control.new_label_button.button.click()
+    qtctrl._label_control.new_label_button.click()
     assert layer.selected_label == before

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -103,31 +103,6 @@ class QtColorBox(QWidget):
         super().closeEvent(event)
 
 
-class QtNewLabel(QWidget):
-    """A widget that shows a button to add a new label to the label layer.
-
-    Parameters
-    ----------
-    parent : qtpy.QtWidgets.QWidget
-        An instance of QWidget that will be used as the parent for this widget.
-    layer : napari.layers.Labels
-        An instance of a napari Labels layer.
-    """
-
-    def __init__(self, parent: QWidget, layer: Labels) -> None:
-        super().__init__(None)
-        self._layer = layer
-        self.button = QPushButton(trans._('new'), self)
-        self.button.setToolTip(
-            trans._('Add a new label with the next highest unused level')
-        )
-        self.button.clicked.connect(self._on_button_click)
-
-    def _on_button_click(self):
-        """Add a new label to the label layer when the button is clicked."""
-        new_label(self._layer)
-
-
 class QtLabelControl(QtWidgetControlsBase):
     """
     Class that wraps the connection of events/signals between the current label
@@ -160,7 +135,6 @@ class QtLabelControl(QtWidgetControlsBase):
 
         # Setup widgets
         self.selection_spinbox = QLargeIntSpinBox()
-        self.new_label_button = QtNewLabel(self, self._layer)
         dtype_lims = get_dtype_limits(get_dtype(layer))
         self.selection_spinbox.setRange(*dtype_lims)
         self.selection_spinbox.setValue(self._layer.selected_label)
@@ -175,6 +149,13 @@ class QtLabelControl(QtWidgetControlsBase):
                 'setValue',
             )
         )
+        self.new_label_button = QPushButton()
+        self.new_label_button.setText(trans._('new'))
+        self.new_label_button.setFixedWidth(40)
+        self.new_label_button.setToolTip(
+            trans._('Add a new label with the next highest unused level')
+        )
+        self.new_label_button.clicked.connect(self._on_button_click)
 
         self.label_color_label = QtWrappedLabel(trans._('label:'))
         self.label_color = QWidget()
@@ -209,6 +190,10 @@ class QtLabelControl(QtWidgetControlsBase):
     def disconnect_widget_controls(self) -> None:
         self.colorbox.disconnect_widget_controls()
         super().disconnect_widget_controls()
+
+    def _on_button_click(self):
+        """Add a new label to the label layer when the button is clicked."""
+        new_label(self._layer)
 
     def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
         return [(self.label_color_label, self.label_color)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -155,7 +155,7 @@ class QtLabelControl(QtWidgetControlsBase):
         self.new_label_button.setText(trans._('new'))
         self.new_label_button.setObjectName('newLabelButton')
         self.new_label_button.setToolTip(
-            trans._('Add a new label with the next highest unused level')
+            trans._('Add a new label with the next highest unused value')
         )
         self.new_label_button.clicked.connect(self._on_button_click)
 
@@ -194,7 +194,7 @@ class QtLabelControl(QtWidgetControlsBase):
         super().disconnect_widget_controls()
 
     def _on_button_click(self):
-        """Add a new label to the label layer when the button is clicked."""
+        """Select a new label for the labels layer when the button is clicked."""
         new_label(self._layer)
 
     def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -151,7 +151,6 @@ class QtLabelControl(QtWidgetControlsBase):
         )
         self.new_label_button = QPushButton()
         self.new_label_button.setText(trans._('new'))
-        self.new_label_button.setFixedWidth(40)
         self.new_label_button.setToolTip(
             trans._('Add a new label with the next highest unused level')
         )
@@ -163,9 +162,9 @@ class QtLabelControl(QtWidgetControlsBase):
         color_layout.setContentsMargins(0, 2, 0, 1)
         color_layout.setSpacing(4)
         self.colorbox = QtColorBox(layer)
-        color_layout.addWidget(self.colorbox)
-        color_layout.addWidget(self.selection_spinbox)
-        color_layout.addWidget(self.new_label_button)
+        color_layout.addWidget(self.colorbox, 0)
+        color_layout.addWidget(self.selection_spinbox, 1)
+        color_layout.addWidget(self.new_label_button, 0)
         self.label_color.setLayout(color_layout)
         self.label_color.setProperty('foreground', 'true')
 

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -126,6 +126,8 @@ class QtLabelControl(QtWidgetControlsBase):
     selection_spinbox : superqt.QLargeIntSpinBox
         Widget to select a specific label by its index.
         N.B. cannot represent labels > 2**53.
+    new_label_button : qtpy.QtWidgets.QPushButton
+        Button to add a new label to the label layer.
     """
 
     def __init__(self, parent: QWidget, layer: Labels) -> None:
@@ -151,6 +153,7 @@ class QtLabelControl(QtWidgetControlsBase):
         )
         self.new_label_button = QPushButton()
         self.new_label_button.setText(trans._('new'))
+        self.new_label_button.setObjectName('newLabelButton')
         self.new_label_button.setToolTip(
             trans._('Add a new label with the next highest unused level')
         )

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -3,6 +3,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor, QPainter
 from qtpy.QtWidgets import (
     QHBoxLayout,
+    QPushButton,
     QWidget,
 )
 from superqt import QLargeIntSpinBox
@@ -13,6 +14,7 @@ from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
 )
 from napari._qt.utils import attr_to_settr, qt_signals_blocked
 from napari.layers import Labels
+from napari.layers.labels._labels_key_bindings import new_label
 from napari.layers.labels._labels_utils import get_dtype
 from napari.utils._dtype import get_dtype_limits
 from napari.utils.events import disconnect_events
@@ -101,6 +103,31 @@ class QtColorBox(QWidget):
         super().closeEvent(event)
 
 
+class QtNewLabel(QWidget):
+    """A widget that shows a button to add a new label to the label layer.
+
+    Parameters
+    ----------
+    parent : qtpy.QtWidgets.QWidget
+        An instance of QWidget that will be used as the parent for this widget.
+    layer : napari.layers.Labels
+        An instance of a napari Labels layer.
+    """
+
+    def __init__(self, parent: QWidget, layer: Labels) -> None:
+        super().__init__(None)
+        self._layer = layer
+        self.button = QPushButton(trans._('new'), self)
+        self.button.setToolTip(
+            trans._('Add a new label with the next highest unused level')
+        )
+        self.button.clicked.connect(self._on_button_click)
+
+    def _on_button_click(self):
+        """Add a new label to the label layer when the button is clicked."""
+        new_label(self._layer)
+
+
 class QtLabelControl(QtWidgetControlsBase):
     """
     Class that wraps the connection of events/signals between the current label
@@ -133,6 +160,7 @@ class QtLabelControl(QtWidgetControlsBase):
 
         # Setup widgets
         self.selection_spinbox = QLargeIntSpinBox()
+        self.new_label_button = QtNewLabel(self, self._layer)
         dtype_lims = get_dtype_limits(get_dtype(layer))
         self.selection_spinbox.setRange(*dtype_lims)
         self.selection_spinbox.setValue(self._layer.selected_label)
@@ -152,9 +180,11 @@ class QtLabelControl(QtWidgetControlsBase):
         self.label_color = QWidget()
         color_layout = QHBoxLayout()
         color_layout.setContentsMargins(0, 2, 0, 1)
+        color_layout.setSpacing(4)
         self.colorbox = QtColorBox(layer)
         color_layout.addWidget(self.colorbox)
         color_layout.addWidget(self.selection_spinbox)
+        color_layout.addWidget(self.new_label_button)
         self.label_color.setLayout(color_layout)
         self.label_color.setProperty('foreground', 'true')
 

--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -190,6 +190,10 @@ QtColorBox {
 QtLayerControls > QComboBox, QtLayerControls > QLabel, QtLayerControls, QtPlaneControls > QLabeledSlider > QAbstractSpinBox {
   color: {{ text }};
 }
+QPushButton#newLabelButton {
+  min-height: 12px;
+  max-height: 12px;
+}
 
 SliderLabel {
   background-color: {{ darken(background, 15) }};

--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -227,7 +227,7 @@ QtDimSliderWidget > QLineEdit {
   background-color: {{ background }};
 }
 
-/* ------------- QtModal (Grid, Play, nDisplay, Roll --------- */
+/* ------------- QtModal (Grid, Play, nDisplay, Roll) --------- */
 
 #QtModalPopup {
   /* required for rounded corners to not have background color */


### PR DESCRIPTION
# References and relevant issues

Adds a New label button to the label row in the Labels layer controls panel, next to the selected-label spinbox. Clicking the button replicates the M keybinding -> it sets `selected_label` to `max(data+1)`, making it easy to start painting with a fresh label without using the keyboard.

fixes #8833

# Description

- `qt_label_color.py`
   - Add a `new_label_button` button and a click handler for this button
   - Integrates this button to the label color , along with the spin box
- `test_qt_labels_layer.py
   - tests verifying the button exists and correctly updates 
<img width="840" height="751" alt="Screenshot 2026-07-18 at 12 41 41" src="https://github.com/user-attachments/assets/19dc4afe-e0aa-4a65-a13f-a692485176a6" />
<img width="796" height="719" alt="Screenshot 2026-07-18 at 12 40 59" src="https://github.com/user-attachments/assets/28f19ce4-c61c-40e3-8523-d0346e0f9658" />



- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- I have added tests that prove my fix is effective or that my feature works
- If an API has been modified, I have added a `.. versionadded::` or `.. versionchanged::`
  directive to the appropriate docstring (For more information see
  [the Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions)).


