### PR TITLE
TST: parameterizing with iterables is deprecated in pytest

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -548,5 +548,10 @@ authors:
   family-names: Coussoux
   affiliation: Synopsys, Inc.
   alias: ecoussoux-ansys
+- given-names: Mridul
+  family-names: Seth
+  affiliation: European Spallation Source
+  orcid: https://orcid.org/0000-0002-0969-0437
+  alias: mriduls
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/src/napari/_vispy/_tests/test_vispy_image_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_image_layer.py
@@ -15,7 +15,7 @@ from napari.components.viewer_model import ViewerModel
 from napari.layers import Image
 
 
-@pytest.mark.parametrize('order', permutations((0, 1, 2)))
+@pytest.mark.parametrize('order', list(permutations((0, 1, 2))))
 def test_3d_slice_of_2d_image_with_order(order):
     """See https://github.com/napari/napari/issues/4926
 
@@ -31,7 +31,7 @@ def test_3d_slice_of_2d_image_with_order(order):
     np.testing.assert_array_equal((4, 4, 1), scene_size)
 
 
-@pytest.mark.parametrize('order', permutations((0, 1, 2)))
+@pytest.mark.parametrize('order', list(permutations((0, 1, 2))))
 def test_2d_slice_of_3d_image_with_order(order):
     """See https://github.com/napari/napari/issues/4926
 
@@ -47,7 +47,7 @@ def test_2d_slice_of_3d_image_with_order(order):
     np.testing.assert_array_equal((8, 8, 0), scene_size)
 
 
-@pytest.mark.parametrize('order', permutations((0, 1, 2)))
+@pytest.mark.parametrize('order', list(permutations((0, 1, 2))))
 def test_3d_slice_of_3d_image_with_order(order):
     """See https://github.com/napari/napari/issues/4926
 
@@ -63,7 +63,7 @@ def test_3d_slice_of_3d_image_with_order(order):
     np.testing.assert_array_equal((8, 8, 8), scene_size)
 
 
-@pytest.mark.parametrize('order', permutations((0, 1, 2, 3)))
+@pytest.mark.parametrize('order', list(permutations((0, 1, 2, 3))))
 def test_3d_slice_of_4d_image_with_order(order):
     """See https://github.com/napari/napari/issues/4926
 

--- a/src/napari/components/_tests/test_camera.py
+++ b/src/napari/components/_tests/test_camera.py
@@ -111,14 +111,25 @@ def test_calculate_view_direction_nd():
 
 @pytest.mark.parametrize(
     ('orientation', 'expected_handedness'),
-    zip(
-        # Could do this but the order is not locally visible, so we explicitly
-        # order the strings so we can think about handedness locally.
-        # product(DepthAxisOrientation, VerticalAxisOrientation, HorizontalAxisOrientation),
-        product(['towards', 'away'], ['down', 'up'], ['right', 'left']),
-        # hardcoded after running once
-        ['right', 'left', 'left', 'right', 'left', 'right', 'right', 'left'],
-        strict=False,
+    list(
+        zip(
+            # Could do this but the order is not locally visible, so we explicitly
+            # order the strings so we can think about handedness locally.
+            # product(DepthAxisOrientation, VerticalAxisOrientation, HorizontalAxisOrientation),
+            product(['towards', 'away'], ['down', 'up'], ['right', 'left']),
+            # hardcoded after running once
+            [
+                'right',
+                'left',
+                'left',
+                'right',
+                'left',
+                'right',
+                'right',
+                'left',
+            ],
+            strict=False,
+        )
     ),
 )
 def test_handedness(orientation, expected_handedness):

--- a/src/napari/layers/utils/_tests/test_text_manager.py
+++ b/src/napari/layers/utils/_tests/test_text_manager.py
@@ -755,7 +755,7 @@ def test_compute_text_coords(ndim, ndisplay, translation):
     np.testing.assert_equal(text_coords, expected_coords)
 
 
-@pytest.mark.parametrize(('order'), permutations((0, 1, 2)))
+@pytest.mark.parametrize(('order'), list(permutations((0, 1, 2))))
 def test_compute_text_coords_with_3D_data_2D_display(order):
     """See https://github.com/napari/napari/issues/5111"""
     num_points = 3

--- a/src/napari/utils/colormaps/_tests/test_color_to_array.py
+++ b/src/napari/utils/colormaps/_tests/test_color_to_array.py
@@ -27,7 +27,7 @@ WARN_MESSAGE = (
 
 @pytest.mark.parametrize(
     ('colors', 'true_colors'),
-    zip(single_color_options, single_colors_as_array, strict=True),
+    list(zip(single_color_options, single_colors_as_array, strict=True)),
 )
 def test_oned_points(colors, true_colors):
     np.testing.assert_array_equal(true_colors, transform_color(colors))
@@ -35,7 +35,7 @@ def test_oned_points(colors, true_colors):
 
 @pytest.mark.parametrize(
     ('color', 'true_color', 'warn_message'),
-    zip(COLORS, TRUE_COLORS, WARN_MESSAGE, strict=True),
+    list(zip(COLORS, TRUE_COLORS, WARN_MESSAGE, strict=True)),
 )
 def test_warns_but_parses(color, true_color, warn_message):
     """Test collection of colors that raise a warning but do not return
@@ -48,7 +48,7 @@ def test_warns_but_parses(color, true_color, warn_message):
 
 @pytest.mark.parametrize(
     ('colors', 'true_colors'),
-    zip(two_color_options, two_colors_as_array, strict=False),
+    list(zip(two_color_options, two_colors_as_array, strict=False)),
 )
 def test_twod_points(colors, true_colors):
     np.testing.assert_array_equal(true_colors, transform_color(colors))

--- a/src/napari/utils/colormaps/_tests/test_colormap_utils.py
+++ b/src/napari/utils/colormaps/_tests/test_colormap_utils.py
@@ -23,7 +23,7 @@ FIRST_COLORS = [
 
 
 @pytest.mark.parametrize(
-    ('index', 'expected'), enumerate(FIRST_COLORS, start=1)
+    ('index', 'expected'), list(enumerate(FIRST_COLORS, start=1))
 )
 def test_label_colormap(index, expected):
     """Test the label colormap.


### PR DESCRIPTION
# References and relevant issues

Fixes https://github.com/napari/napari/issues/9190

# Description

Parameterizing with iterables is deprecated and will be removed in pytest 10 https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators




