### PR TITLE
MAINT: Remove deprecated ScaleBar.unit

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari._vispy.utils.qt_font import FontInfo
@@ -39,12 +38,4 @@ def test_scale_bar_inconsistent_units_default_to_pixel(
     assert vispy_scale_bar._unit.units.dimensionless
     img1.units = ('um', 'um')
     vispy_scale_bar._on_unit_change()
-    assert vispy_scale_bar._unit.units == 'micrometer'
-    with pytest.warns(
-        FutureWarning,
-        match='Setting unit on the ScaleBar model is deprecated.',
-    ):
-        model.unit = 's'
-    vispy_scale_bar._on_unit_change()
-    # this has no effect now, it should not change
     assert vispy_scale_bar._unit.units == 'micrometer'

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -43,7 +43,6 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.overlay.events.box_color.connect(self._on_rendering_change)
         self.overlay.events.font_size.connect(self._on_font_size_change)
         self.overlay.events.ticks.connect(self._on_rendering_change)
-        self.overlay.events.unit.connect(self._on_unit_change)
         self.overlay.events.length.connect(self._on_size_or_zoom_change)
         self.overlay.events.visible.connect(self._on_rendering_change)
 

--- a/src/napari/components/_tests/test_scale_bar.py
+++ b/src/napari/components/_tests/test_scale_bar.py
@@ -7,8 +7,7 @@ def test_scale_bar():
     assert scale_bar is not None
 
 
-def test_scale_bar_fixed_length_and_units():
+def test_scale_bar_fixed_length():
     """Test creating scale bar object with fixed length"""
     scale_bar = ScaleBarOverlay(length=50)
     assert scale_bar.length == 50
-    assert scale_bar.unit is None

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -1,7 +1,5 @@
 """Scale bar model."""
 
-import warnings
-
 from pydantic import Field
 
 from napari.components.overlays.base import CanvasOverlay
@@ -51,26 +49,3 @@ class ScaleBarOverlay(CanvasOverlay):
     ticks: bool = True
     font_size: float = 10
     length: float | None = None
-
-    @property
-    def unit(self) -> None:
-        warnings.warn(
-            'ScaleBar.unit is deprecated and now always returns None. '
-            'This attribute will be removed in 0.9.0.\n'
-            'Units are instead computed from the layers in the layerlist. '
-            'Use `Layer.units` to set units for each layer.',
-            category=FutureWarning,
-            stacklevel=4,
-        )
-        return None
-
-    @unit.setter
-    def unit(self, value: str | None) -> None:
-        warnings.warn(
-            'Setting unit on the ScaleBar model is deprecated and no longer has any effect. '
-            'This attribute will be removed in 0.9.0.\n'
-            'Units are instead computed from the layers in the layerlist. '
-            'Use `Layer.units` to set units for each layer.',
-            category=FutureWarning,
-            stacklevel=4,
-        )


### PR DESCRIPTION
# References and relevant issues

Fixes https://github.com/napari/napari/issues/9124

# Description

I used https://github.com/napari/napari/pull/9029 to get an idea what to remove here.


