### PR TITLE
Make tensorstore optional dependency of `test_labels` again

### DIFF
--- a/src/napari/layers/labels/_tests/test_labels.py
+++ b/src/napari/layers/labels/_tests/test_labels.py
@@ -3,7 +3,7 @@ import itertools
 import time
 from collections import defaultdict
 from dataclasses import dataclass
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 import dask.array as da
 import numpy as np
@@ -1518,7 +1518,13 @@ def test_large_label_values():
     assert len(np.unique(mapped.reshape((-1, 4)), axis=0)) == 4
 
 
-if parse_version(version('tensorstore')) > parse_version('0.1.42'):
+try:
+    tensorstore_version = version('tensorstore')
+except PackageNotFoundError:
+    tensorstore_version = '0.0.0'
+
+
+if parse_version(tensorstore_version) > parse_version('0.1.42'):
     driver = [(2, 'zarr'), (3, 'zarr3')]
     ZARR_V3 = True
 else:


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/npe2/pull/486

# Description

In #9134 I made the trnsorstore a mandatory dependency of the `test_labels` test, as importlib.metadata raises an exception if it does not find the package. 

However, this causes an error in npe2 tests where tensorstore is not available. Sample stack trace from npe2 tests below. 

```python
Run pytest -W 'ignore::DeprecationWarning' src/napari/plugins src/napari/settings src/napari/layers src/napari/components
  pytest -W 'ignore::DeprecationWarning' src/napari/plugins src/napari/settings src/napari/layers src/napari/components
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.13.14/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.13.14/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.14/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.14/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.14/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.13.14/x64/lib
============================= test session starts ==============================
platform linux -- Python 3.13.14, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/runner/work/npe2/npe2/napari-from-github
configfile: pyproject.toml
plugins: npe2-0.1.dev1+gcc2ce8033, napari-plugin-engine-0.2.1, zarr-3.2.1, napari-0.8.1.dev1+g4b40dd60e, pretty-1.3.0, hypothesis-6.156.7
collected 2255 items / 1 error / 1 skipped

==================================== ERRORS ====================================
_______ ERROR collecting src/napari/layers/labels/_tests/test_labels.py ________
ImportError while importing test module '/home/runner/work/npe2/npe2/napari-from-github/src/napari/layers/labels/_tests/test_labels.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.13.14/x64/lib/python3.13/importlib/metadata/__init__.py:407: in from_name
    return next(iter(cls.discover(name=name)))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   StopIteration

During handling of the above exception, another exception occurred:
/opt/hostedtoolcache/Python/3.13.14/x64/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/napari/layers/labels/_tests/test_labels.py:1521: in <module>
    if parse_version(version('tensorstore')) > parse_version('0.1.42'):
                     ^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.13.14/x64/lib/python3.13/importlib/metadata/__init__.py:987: in version
    return distribution(distribution_name).version
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.13.14/x64/lib/python3.13/importlib/metadata/__init__.py:960: in distribution
    return Distribution.from_name(distribution_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.13.14/x64/lib/python3.13/importlib/metadata/__init__.py:409: in from_name
    raise PackageNotFoundError(name)
E   importlib.metadata.PackageNotFoundError: No package metadata was found for tensorstore
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
Results (14.30s):
         1 skipped
         1 error

```

This PR puts the version check behind a try/except to make npe2 CI green again.