### PR TITLE
Update recommended Python version in README from 3.11 to 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In the `File` menu, select `Open Sample` and select a sample image to get starte
 For a full installation, we recommend installing napari into a virtual environment, like this:
 
 ```sh
-conda create -y -n napari-env -c conda-forge python=3.11
+conda create -y -n napari-env -c conda-forge python=3.13
 conda activate napari-env
 python -m pip install "napari[all]"
 ```


### PR DESCRIPTION
## References and relevant issues

Closes: #9222

## Description
Updates the recommended Python version in the README conda install example from 3.11 to 3.13 so new installs follow a current supported release.

