### PR TITLE
Remove unnecessary ``FutureWarning`` ignore for ``test_layers_save_svg``

### DIFF
--- a/src/napari/components/_tests/test_layers_list.py
+++ b/src/napari/components/_tests/test_layers_list.py
@@ -432,10 +432,6 @@ def test_layers_save_selected(builtins, tmpdir, layer_data_and_types):
 
 
 # the layers fixture is defined in napari/conftest.py
-# TODO: this warning filter can be removed when a new version
-# of napari-svg includes the following PR:
-# https://github.com/napari/napari-svg/pull/38
-@pytest.mark.filterwarnings('ignore:edge_:FutureWarning')
 def test_layers_save_svg(tmpdir, layers, napari_svg_name):
     """Test saving all layer data to an svg."""
     pm = npe2.PluginManager.instance()


### PR DESCRIPTION
# References and relevant issues
Closes #8428.

# Description
This PR removes an unnecessary ``FutureWarning`` ignore in the ``test_layers_save_svg`` from ``test_layers_list.py`` (deleting the ``@pytest.mark.filterwarnings('ignore:edge_:FutureWarning'`` directive).

As hinted in #8428, this warning is no longer raised.
I was able to confirm this locally: No warning is raised after removing the ``pytest`` mark when running the command : 

`pytest -W ignore::DeprecationWarning -s .\src\napari\components\_tests\test_layers_list.py -k test_layers_save_svg`

(``DeprecationWarning`` has to be ignored, since some of them are coming from ``pydantic`` when running this particular test).