### PR TITLE
Disable part of test matrix to increase runner availability during sprints/hackathon

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -83,9 +83,9 @@ jobs:
       python_version: ${{ matrix.python }}
       platform: ${{ matrix.platform }}
       qt_backend: ${{ matrix.backend }}
-      min_req: ${{ matrix.MIN_REQ }}
+#      min_req: ${{ matrix.MIN_REQ }}
       coverage: cov
-      tox_extras: ${{ matrix.tox_extras }}
+#      tox_extras: ${{ matrix.tox_extras }}
 
   test_pip_install:
     name: pip install

--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -51,33 +51,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest]
-        python: ["3.11", "3.12", "3.13", "3.14"]
-        backend: [pyqt5]
-        include:
-          - python: "3.11"
-            platform: macos-15
-            backend: pyqt5
-          # test with minimum specified requirements
-          - python: "3.11"
-            platform: ubuntu-22.04
-            backend: pyqt5
-            MIN_REQ: 1
-          # test without any Qt backends
-          - python: "3.11"
-            platform: ubuntu-22.04
-            backend: headless
-          - python: "3.14"
-            platform: ubuntu-latest
-            backend: pyqt6
-            tox_extras: "testing_extra"
-          - python: "3.12"
-            platform: ubuntu-latest
-            backend: pyside6
-            tox_extras: "testing_extra"
-          - python: "3.14"
-            platform: ubuntu-24.04-arm
-            backend: pyqt6
+        platform: [ubuntu-latest] #, windows-latest]
+        python: ["3.13"] #, "3.12", "3.13", "3.14"]
+        backend: [pyqt6]
+#        include:
+#          - python: "3.11"
+#            platform: macos-15
+#            backend: pyqt5
+#          # test with minimum specified requirements
+#          - python: "3.11"
+#            platform: ubuntu-22.04
+#            backend: pyqt5
+#            MIN_REQ: 1
+#          # test without any Qt backends
+#          - python: "3.11"
+#            platform: ubuntu-22.04
+#            backend: headless
+#          - python: "3.14"
+#            platform: ubuntu-latest
+#            backend: pyqt6
+#            tox_extras: "testing_extra"
+#          - python: "3.12"
+#            platform: ubuntu-latest
+#            backend: pyside6
+#            tox_extras: "testing_extra"
+#          - python: "3.14"
+#            platform: ubuntu-24.04-arm
+#            backend: pyqt6
 
     with:
       python_version: ${{ matrix.python }}


### PR DESCRIPTION
# References and relevant issues


# Description

Limit the number of tests executed after the merge to avoid getting stuck with PRs during sprints and hackathons.

It should be reverted after the napari European hackathon.  
