### PR TITLE
fix: action binding the `new-label` tooltips  with shortcuts

### DIFF
--- a/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_labels_layer.py
@@ -230,7 +230,7 @@ def test_label_button_adds_new_label(make_labels_controls):
     layer, qtctrl = make_labels_controls()
     expected = int(layer.data.max()) + 1
     layer.selected_label = 1
-    qtctrl._label_control.new_label_button.click()
+    qtctrl._label_control._on_button_click()
     assert layer.selected_label == expected
 
 
@@ -239,5 +239,5 @@ def test_label_button_no_change_if_reached_at_max(make_labels_controls):
     layer, qtctrl = make_labels_controls()
     layer.selected_label = int(layer.data.max()) + 1
     before = layer.selected_label
-    qtctrl._label_control.new_label_button.click()
+    qtctrl._label_control._on_button_click()
     assert layer.selected_label == before

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -17,6 +17,7 @@ from napari.layers import Labels
 from napari.layers.labels._labels_key_bindings import new_label
 from napari.layers.labels._labels_utils import get_dtype
 from napari.utils._dtype import get_dtype_limits
+from napari.utils.action_manager import action_manager
 from napari.utils.events import disconnect_events
 from napari.utils.translations import trans
 
@@ -154,9 +155,7 @@ class QtLabelControl(QtWidgetControlsBase):
         self.new_label_button = QPushButton()
         self.new_label_button.setText(trans._('new'))
         self.new_label_button.setObjectName('newLabelButton')
-        self.new_label_button.setToolTip(
-            trans._('Add a new label with the next highest unused value')
-        )
+        action_manager.bind_button('napari:new_label', self.new_label_button)
         self.new_label_button.clicked.connect(self._on_button_click)
 
         self.label_color_label = QtWrappedLabel(trans._('label:'))


### PR DESCRIPTION
# References and relevant issues

Fix #9227  and follow up of #9215 

# Description

- Add shortcut to the tooltip of new label
<img width="684" height="444" alt="Screenshot 2026-07-19 at 10 18 23" src="https://github.com/user-attachments/assets/5e11afa0-e023-4666-801e-1341aba387f0" />



- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- I have added tests that prove my fix is effective or that my feature works
- If an API has been modified, I have added a `.. versionadded::` or `.. versionchanged::`
  directive to the appropriate docstring (For more information see
  [the Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions)).
