### PR TITLE
move features table widget command to the Metadata menu

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -557,5 +557,9 @@ authors:
   affiliation: European Spallation Source
   orcid: https://orcid.org/0000-0002-0969-0437
   alias: mriduls
+- given-names: Bas
+  family-names: Bloemsaat
+  affiliation: QStarsIT
+  alias: basbloemsaat
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/src/napari_builtins/builtins.yaml
+++ b/src/napari_builtins/builtins.yaml
@@ -331,6 +331,7 @@ contributions:
       display_name: Features table widget
 
   menus:
+    napari/layers/metadata:
+      - command: napari.widgets.features_table
     napari/layers/measure:
       - command: napari.toggle_shape_measures
-      - command: napari.widgets.features_table

--- a/src/napari_builtins/builtins.yaml
+++ b/src/napari_builtins/builtins.yaml
@@ -331,7 +331,6 @@ contributions:
       display_name: Features table widget
 
   menus:
-    napari/layers/visualize:
-      - command: napari.widgets.features_table
     napari/layers/measure:
       - command: napari.toggle_shape_measures
+      - command: napari.widgets.features_table


### PR DESCRIPTION
# References and relevant issues

Closes #8659 

# Description

This PR moves the features table widget from the "visualize" menu to the "metadata" menu.

