### PR TITLE
fix: change the order of edge/face color and border

### DIFF
--- a/src/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/src/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -193,17 +193,6 @@ class QtShapesControls(QtLayerControls):
         self.button_grid.setColumnStretch(0, 1)
         self.button_grid.setSpacing(4)
 
-        # Setup widgets controls
-        self._edge_width_slider_control = QtEdgeWidthSliderControl(self, layer)
-        self._add_widget_controls(self._edge_width_slider_control)
-        self._edge_color_control = QtEdgeColorControl(
-            self,
-            layer,
-            tooltip=trans._(
-                'Click to set the edge color of currently selected shapes and any added afterwards'
-            ),
-        )
-        self._add_widget_controls(self._edge_color_control)
         self._face_color_control = QtFaceColorControl(
             self,
             layer,
@@ -212,6 +201,18 @@ class QtShapesControls(QtLayerControls):
             ),
         )
         self._add_widget_controls(self._face_color_control)
+
+        # Setup widgets controls
+        self._edge_width_slider_control = QtEdgeWidthSliderControl(self, layer)
+        self._edge_color_control = QtEdgeColorControl(
+            self,
+            layer,
+            tooltip=trans._(
+                'Click to set the edge color of currently selected shapes and any added afterwards'
+            ),
+        )
+        self._add_widget_controls(self._edge_color_control)
+        self._add_widget_controls(self._edge_width_slider_control)
         self._text_visibility_control = QtTextVisibilityControl(self, layer)
         self._add_widget_controls(self._text_visibility_control)
 

--- a/src/napari/_qt/layer_controls/qt_shapes_controls.py
+++ b/src/napari/_qt/layer_controls/qt_shapes_controls.py
@@ -193,6 +193,7 @@ class QtShapesControls(QtLayerControls):
         self.button_grid.setColumnStretch(0, 1)
         self.button_grid.setSpacing(4)
 
+        # Setup widgets controls
         self._face_color_control = QtFaceColorControl(
             self,
             layer,
@@ -200,9 +201,6 @@ class QtShapesControls(QtLayerControls):
                 'Click to set the face color of currently selected shapes and any added afterwards.'
             ),
         )
-        self._add_widget_controls(self._face_color_control)
-
-        # Setup widgets controls
         self._edge_width_slider_control = QtEdgeWidthSliderControl(self, layer)
         self._edge_color_control = QtEdgeColorControl(
             self,
@@ -211,6 +209,7 @@ class QtShapesControls(QtLayerControls):
                 'Click to set the edge color of currently selected shapes and any added afterwards'
             ),
         )
+        self._add_widget_controls(self._face_color_control)
         self._add_widget_controls(self._edge_color_control)
         self._add_widget_controls(self._edge_width_slider_control)
         self._text_visibility_control = QtTextVisibilityControl(self, layer)


### PR DESCRIPTION
# References and relevant issues

Fix https://github.com/napari/napari/issues/9057

# Description

Change the order of face color and edge color/ border 
<img width="377" height="456" alt="Screenshot 2026-07-19 at 11 40 40" src="https://github.com/user-attachments/assets/d1c78112-1c49-4dc5-839e-878e4c038606" />


- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation
  (open a PR on the docs repository (https://github.com/napari/docs) if relevant!)
- I have added tests that prove my fix is effective or that my feature works
- If an API has been modified, I have added a `.. versionadded::` or `.. versionchanged::`
  directive to the appropriate docstring (For more information see
  [the Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions)).
