### PR TITLE
Move the layer lock to group with link/unlink in layer list context menu

### DIFF
--- a/src/napari/_app_model/actions/_layerlist_context_actions.py
+++ b/src/napari/_app_model/actions/_layerlist_context_actions.py
@@ -175,17 +175,6 @@ LAYERLIST_CONTEXT_ACTIONS: list[Action] = [
         ],
     ),
     Action(
-        id='napari.layer.toggle_lock',
-        title=trans._('Toggle lock'),
-        callback=_layer_actions._toggle_lock,
-        menus=[
-            {
-                'id': MenuId.LAYERLIST_CONTEXT,
-                'group': MenuGroup.NAVIGATION,
-            }
-        ],
-    ),
-    Action(
         id='napari.layer.link_selected_layers',
         title=trans._('Link Layers'),
         callback=_layer_actions._link_selected_layers,
@@ -206,6 +195,12 @@ LAYERLIST_CONTEXT_ACTIONS: list[Action] = [
         title=trans._('Select Linked Layers'),
         callback=_layer_actions._select_linked_layers,
         enablement=LLSCK.num_unselected_linked_layers,
+        menus=[LAYERCTX_LINK],
+    ),
+    Action(
+        id='napari.layer.toggle_lock',
+        title=trans._('Toggle lock'),
+        callback=_layer_actions._toggle_lock,
         menus=[LAYERCTX_LINK],
     ),
     Action(


### PR DESCRIPTION
# References and relevant issues

Closes #9005 

# Description

Moves the toggle lock in the context menu from the top, with visibility, to the bottom, to group with the suggested link/unlink:
<img width="417" height="155" alt="image" src="https://github.com/user-attachments/assets/a32cc27b-9d2e-4d61-b15f-7629eb976700" />




