### PR TITLE
fix: add minimum value to grid mode strides to allow negative strides

### DIFF
--- a/src/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/src/napari/_qt/widgets/qt_viewer_buttons.py
@@ -721,6 +721,9 @@ class QtViewerButtons(QFrame):
 
         grid_stride.setObjectName('gridStrideBox')
         grid_stride.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        # Magic number to allow for negative strides, but not too large to be unreasonable.
+        # 1000 is arbitrary.
+        grid_stride.setMinimum(-1000)
         grid_stride.setProhibitValue(0)
         grid_stride.setValue(self.viewer.grid.stride)
         grid_stride.valueChanged.connect(self._update_grid_stride)


### PR DESCRIPTION
# References and relevant issues

This issue is part of #9199, the strides were not going negative values and it was setting to 0, which was not the expected behaviour.

# Description

<img width="409" height="848" alt="Screenshot 2026-07-19 at 13 26 46" src="https://github.com/user-attachments/assets/8e4627b3-10c3-4555-94e9-faa7b50eec80" />



