### PR TITLE
Fixes #9247 - Shapes highlight outline leaking onto adjacent slices

### DIFF
--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2741,3 +2741,45 @@ def test_default_features_not_changed_when_selected_data_changes():
     np.testing.assert_equal(
         shape.feature_defaults.values[0][1], origin_values[0][1]
     )
+
+
+def test_outline_not_drawn_off_slice():
+    """Highlight outline of a shape is only drawn on the shape's own slice.
+
+    Regression: ``_outline_shapes`` used the shape's in-plane vertices without
+    checking the viewed slice, so a selected or hovered shape drew a thin
+    highlight outline on adjacent slices even though its face mesh (correctly
+    slice-gated) was hidden there. Both the selection path and the hover-only
+    path are exercised, on and off the shape's slice.
+    """
+    on_slice = Dims(
+        ndim=3, ndisplay=2, range=((0, 5, 1),) * 3, point=(0, 0, 0)
+    )
+    off_slice = Dims(
+        ndim=3, ndisplay=2, range=((0, 5, 1),) * 3, point=(1, 0, 0)
+    )
+    # A single polygon living entirely on slice z=0 of a 3-D layer.
+    layer = Shapes(
+        [[(0, 0, 0), (0, 0, 10), (0, 10, 10), (0, 10, 0)]],
+        shape_type='polygon',
+    )
+
+    # On the shape's own slice, both an active selection and a bare hover
+    # (no selection) draw the outline.
+    layer._slice_dims(on_slice)
+    layer.selected_data = {0}
+    layer._value = (None, None)
+    assert layer._outline_shapes()[0] is not None  # selection path
+    layer.selected_data = set()
+    layer._value = (0, None)
+    assert layer._outline_shapes()[0] is not None  # hover-only path
+
+    # Stepping to an adjacent slice hides the face; neither path may outline.
+    layer._slice_dims(off_slice)
+    assert not layer._data_view._displayed[0]
+    layer.selected_data = {0}
+    layer._value = (None, None)
+    assert layer._outline_shapes() == (None, None)  # selection path
+    layer.selected_data = set()
+    layer._value = (0, None)
+    assert layer._outline_shapes() == (None, None)  # hover-only path

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2533,6 +2533,11 @@ class Shapes(Layer):
     def _outline_shapes(self):
         """Find outlines of any selected or hovered shapes.
 
+        Only shapes on the currently viewed slice are outlined. The outline
+        geometry is built from in-plane vertices and is not slice-aware, so a
+        selected or hovered shape sitting on another slice would otherwise draw
+        its highlight over the viewed slice.
+
         Returns
         -------
         vertices : None | np.ndarray
@@ -2550,17 +2555,18 @@ class Shapes(Layer):
             if value in self.selected_data:
                 value = None
 
+            index = list(self.selected_data)
+            if value is not None:
+                index.append(value)
+            # Keep only shapes on the current slice (see docstring). Drop the
+            # rest so an off-slice selection/hover does not leak a highlight.
+            index = sorted(i for i in index if self._data_view._displayed[i])
+            if not index:
+                return None, None
+
             if value in self._outlines_cache:
                 centers, offsets, triangles = self._outlines_cache[value]
             else:
-                if len(self.selected_data) > 0:
-                    index = list(self.selected_data)
-                    if value is not None:
-                        index.append(value)
-                    index.sort()
-                else:
-                    index = value
-
                 centers, offsets, triangles = self._data_view.outline(index)
                 self._outlines_cache[self._value[0]] = (
                     centers,


### PR DESCRIPTION
The selection/hover highlight outline was built from a shape's in-plane edge vertices without checking the viewed slice. That geometry carries no out-of-plane coordinate, so a selected or hovered shape sitting on one slice kept drawing its outline on every other slice, even though the shape's face mesh is correctly hidden off-slice by the `_update_displayed` slice-key test. In practice a finished, still-selected polygon left a thin highlight outline on adjacent slices while scrubbing.

Filter the selected/hovered indices through `_data_view._displayed` before constructing the outline, and return no outline when nothing on the current slice remains. This mirrors the slice gating the sibling highlight paths already do — `_compute_vertices_and_box` via `displayed_vertices` and `interaction_box` via `_data_view._displayed[i]`. The filter runs before the outline-cache lookup so it holds regardless of cache state.

Add a regression test covering both the selection and hover-only paths, on and off the shape's slice.


Reviewed-By: Codex (gpt-5.6-terra, reasoning effort high)

# References and relevant issues
Fixes #9247 

# Description
Bug fix. The contour visible on first slice was not drawn on second slice - it is an artifact

<img width="850" height="707" alt="napari_shape_outline_bug_1" src="https://github.com/user-attachments/assets/fc785bce-1e2b-4ccc-a46a-615c0babe943" />
<img width="852" height="705" alt="napari_shape_outline_bug_2" src="https://github.com/user-attachments/assets/631c022a-97b7-4fb5-9616-a8431f85eece" />

