### PR TITLE
Improve slider handle conspicuity by using theme's `current` color for active dim 

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -435,6 +435,11 @@ authors:
   family-names: Saveur
   orcid: https://orcid.org/0009-0002-6410-4063
   alias: Tommaati
+- given-names: Matthias Christian
+  family-names: Schabel
+  affiliation: Oregon Health & Science University
+  orcid: https://orcid.org/0000-0002-3183-7212
+  alias: matthiasschabel
 - given-names: Gabriel
   family-names: Selzer
   affiliation: University of Wisconsin-Madison

--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -216,7 +216,7 @@ PlaneNormalButtons QPushButton {
 /* ------------- DimsSliders --------- */
 
 QtDimSliderWidget > QScrollBar::handle[last_used=true]:horizontal {
-    background: {{ highlight }};
+    background: {{ current }};
 }
 
 QtDimSliderWidget > QScrollBar:left-arrow:horizontal {

--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -338,6 +338,27 @@ def test_slider_press_updates_last_used(qtbot):
             assert view.dims.last_used == 0
 
 
+def test_last_used_style_property_set_at_creation(qtbot):
+    """The active slider is marked from the start, not only after a change.
+
+    The ``last_used`` event only fires on a change, so with the default
+    ``last_used == 0`` freshly created sliders never got the style property
+    and the active slider opened unhighlighted.
+    """
+    view = QtDims(Dims(ndim=4))
+    qtbot.addWidget(view)
+
+    assert view.dims.last_used == 0
+    assert [
+        widg.slider.property('last_used') for widg in view.slider_widgets
+    ] == [True, False, False, False]
+
+    view.dims.last_used = 1
+    assert [
+        widg.slider.property('last_used') for widg in view.slider_widgets
+    ] == [False, True, False, False]
+
+
 @pytest.mark.skipif(
     os.environ.get('CI') and platform == 'win32',
     reason='not working in windows VM',

--- a/src/napari/_qt/widgets/qt_dims.py
+++ b/src/napari/_qt/widgets/qt_dims.py
@@ -133,9 +133,7 @@ class QtDims(QWidget):
             if self._displayed_sliders[i]:
                 self._update_slider()
         # Freshly created sliders have no `last_used` style property yet, and
-        # the `last_used` event only fires on a change — when it is already at
-        # its default (0) no event arrives and the active slider is never
-        # marked, so it opens unhighlighted.
+        # the `last_used` event only fires on a change
         self._on_last_used_changed()
         self.stop()
 

--- a/src/napari/_qt/widgets/qt_dims.py
+++ b/src/napari/_qt/widgets/qt_dims.py
@@ -132,6 +132,11 @@ class QtDims(QWidget):
             self._update_range()
             if self._displayed_sliders[i]:
                 self._update_slider()
+        # Freshly created sliders have no `last_used` style property yet, and
+        # the `last_used` event only fires on a change — when it is already at
+        # its default (0) no event arrives and the active slider is never
+        # marked, so it opens unhighlighted.
+        self._on_last_used_changed()
         self.stop()
 
     def _resize_axis_labels(self):


### PR DESCRIPTION
# Description

Which dims slider is *active* (the one the keyboard focus shortcuts and arrow keys drive) is indicated by painting its handle with the theme's `highlight` color instead of `secondary`. Those two colors differ by a 1.16:1 contrast ratio in the dark theme (1.07:1 in light) — it is sort-of visible, but just barely.

This PR paints the active handle with the theme's `current` color instead — the color already used for the selected layer — so the active slider reuses napari's existing "this one is selected" visual language, in both built-in themes and any custom theme.

It also fixes the indicator never appearing at startup: the `last_used` style property was only set from the model's change event, so with the default `last_used == 0` freshly created sliders were never marked, and nothing was highlighted until the first focus change or slider press. `_update_nsliders` now applies the property after building the sliders (regression test added).

**Screenshots** (dark/light, before/after — active slider is `TimePoint`):

<img width="596" height="60" alt="dims_dark_before" src="https://github.com/user-attachments/assets/622c5b80-94c1-4965-b47b-46dede743664" />
<img width="596" height="60" alt="dims_dark_after" src="https://github.com/user-attachments/assets/78832dc6-aea2-491f-bd33-1d47d9d5e186" />
<img width="596" height="60" alt="dims_light_before" src="https://github.com/user-attachments/assets/272b8afa-135e-4007-802c-a7d41102878b" />
<img width="596" height="60" alt="dims_light_after" src="https://github.com/user-attachments/assets/0d8b7333-5c14-4130-a19b-46e2bd52e178" />

One conspicuity note: `current` is nearly isoluminant with the inactive `secondary` handles (1.15:1 dark, 1.09:1 light), so the distinction is carried almost entirely by hue. That is still a big improvement, but a luminance cue such as a `text`-colored border on the active handle makes it even more apparent.
