### PR TITLE
Fix overlay test failing when canvas is not avaiable

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -13,6 +13,7 @@ from napari.utils.interactions import (
 
 @pytest.mark.usefixtures('qapp')
 def test_vispy_labels_polygon_overlay(make_napari_viewer):
+    # see #9262 for why we need make_napari_viewer
     viewer = make_napari_viewer()
 
     labels_polygon = LabelsPolygonOverlay()

--- a/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -3,7 +3,6 @@ import pytest
 
 from napari._vispy.overlays.labels_polygon import VispyLabelsPolygonOverlay
 from napari._vispy.utils.qt_font import FontInfo
-from napari.components import ViewerModel
 from napari.components.overlays import LabelsPolygonOverlay
 from napari.layers.labels._labels_key_bindings import complete_polygon
 from napari.utils.interactions import (
@@ -13,8 +12,8 @@ from napari.utils.interactions import (
 
 
 @pytest.mark.usefixtures('qapp')
-def test_vispy_labels_polygon_overlay():
-    viewer = ViewerModel()
+def test_vispy_labels_polygon_overlay(make_napari_viewer):
+    viewer = make_napari_viewer()
 
     labels_polygon = LabelsPolygonOverlay()
 


### PR DESCRIPTION
# References and relevant issues
See failure at https://github.com/napari/napari/actions/runs/30098939384/job/89533057150?pr=8935.

# Description
Not clear why this happens now, but this was already a bug in the test: the canvas needs to be initialized. It just used to pass due to some previous test leaving the GL context alive. This explicitly creates a napari viewer to ensure the canvas is there.
