### PR TITLE
Fix sync slicing when toggling to 3D with auto contrast

### DIFF
--- a/src/napari/layers/image/_tests/test_image.py
+++ b/src/napari/layers/image/_tests/test_image.py
@@ -999,6 +999,20 @@ def test_adjust_contrast_limits_range_set_data():
     )
 
 
+def test_ndisplay_3_auto_contrast():
+    """Ensure toggle to 3D display with with continuous contrast.
+
+    Regression test for https://github.com/napari/napari/issues/7152
+    """
+    data = np.ones((10, 20, 20))
+    layer = Image(data)
+    layer._keep_auto_contrast = True
+
+    layer._slice_dims(Dims(ndim=3, ndisplay=2))
+    # switch to ndisplay=3
+    layer._slice_dims(Dims(ndim=3, ndisplay=3))
+
+
 def test_thick_slice_multiscale():
     data = np.ones((5, 5, 5)) * np.arange(5).reshape(-1, 1, 1)
     data_zoom = data.repeat(2, 0).repeat(2, 1).repeat(2, 2)

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -707,6 +707,7 @@ class _ImageSlicingState(ScalarFieldSlicingState):
         WARNING: This is a hack.
         Will be removed as we want to go into multi canvas mode.
         """
+        super()._update_slice_response(response)
         if self.layer._keep_auto_contrast:
             data = response.image.raw
             input_data = data[-1] if self.layer.multiscale else data
@@ -715,7 +716,6 @@ class _ImageSlicingState(ScalarFieldSlicingState):
                 rgb=self.layer.rgb,
                 dtype=self.layer.dtype,
             )
-        super()._update_slice_response(response)
         if self.layer._should_calc_clims:
             self.layer.reset_contrast_limits_range()
             self.layer.reset_contrast_limits()


### PR DESCRIPTION
# References and relevant issues
Closes #7152 

# Description
https://github.com/napari/napari/pull/6537 added auto-contrast contrast calculations to _update_slice_response, but it was inserted *prior* to `super()._update_slice_response(response)`. 
This means that the thumbnail code runs before the slice response is updated and you have a desync.
This PR just moves `super()._update_slice_response(response)` before the contrast calculations and adds a regression test that fails on main by passes with this fix.