### PR TITLE
Disable interaction with vispy.gloo in test_vispy_labels_polygon_overlay

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -16,7 +16,7 @@ from napari.utils.interactions import (
 def patch_gloo_set_state(monkeypatch):
     monkeypatch.setattr('vispy.visuals.polygon.set_state', lambda *args: None)
 
-
+# see https://github.com/napari/napari/pull/9262
 @pytest.mark.usefixtures('patch_gloo_set_state')
 @pytest.mark.usefixtures('qapp')
 def test_vispy_labels_polygon_overlay():

--- a/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -12,6 +12,12 @@ from napari.utils.interactions import (
 )
 
 
+@pytest.fixture
+def patch_gloo_set_state(monkeypatch):
+    monkeypatch.setattr('vispy.visuals.polygon.set_state', lambda *args: None)
+
+
+@pytest.mark.usefixtures('patch_gloo_set_state')
 @pytest.mark.usefixtures('qapp')
 def test_vispy_labels_polygon_overlay():
     viewer = ViewerModel()

--- a/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -14,7 +14,9 @@ from napari.utils.interactions import (
 
 @pytest.fixture
 def patch_gloo_set_state(monkeypatch):
-    monkeypatch.setattr('vispy.visuals.polygon.set_state', lambda *args: None)
+    monkeypatch.setattr(
+        'vispy.visuals.polygon.set_state', lambda *args, **kwargs: None
+    )
 
 
 # see https://github.com/napari/napari/pull/9262

--- a/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_labels_polygon_overlay.py
@@ -16,6 +16,7 @@ from napari.utils.interactions import (
 def patch_gloo_set_state(monkeypatch):
     monkeypatch.setattr('vispy.visuals.polygon.set_state', lambda *args: None)
 
+
 # see https://github.com/napari/napari/pull/9262
 @pytest.mark.usefixtures('patch_gloo_set_state')
 @pytest.mark.usefixtures('qapp')


### PR DESCRIPTION
# References and relevant issues

alternative to #9262

# Description

Disable the set_state call from polygons. 
