### PR TITLE
Fix typing problem by provide strict version of _BaseEventedItemModel.getItem

### DIFF
--- a/src/napari/_qt/containers/_base_item_model.py
+++ b/src/napari/_qt/containers/_base_item_model.py
@@ -294,6 +294,15 @@ class _BaseEventedItemModel(QAbstractItemModel, Generic[ItemType]):
         """
         return self._root[index.row()] if index.isValid() else self._root
 
+    def getItemStrict(self, index: QModelIndex) -> ItemType:
+        """Return python object for a given `QModelIndex`.
+
+        An invalid `QModelIndex` will raise an IndexError.
+        """
+        if not index.isValid():
+            raise IndexError('Invalid index')
+        return self._root[index.row()]
+
     def _process_event(self, event: Any) -> None:
         # for subclasses to handle ItemType-specific data
         pass

--- a/src/napari/_qt/containers/qt_axis_model.py
+++ b/src/napari/_qt/containers/qt_axis_model.py
@@ -104,7 +104,7 @@ class QtAxisListModel(QtListModel[AxisModel]):
     ) -> Any:
         if not index.isValid():
             return None
-        axis = self.getItem(index)
+        axis = self.getItemStrict(index)
         if role == Qt.ItemDataRole.DisplayRole:
             return str(axis)
         if role == Qt.ItemDataRole.TextAlignmentRole:
@@ -123,7 +123,7 @@ class QtAxisListModel(QtListModel[AxisModel]):
         value: Any,
         role: int = Qt.ItemDataRole.EditRole,
     ) -> bool:
-        axis = self.getItem(index)
+        axis = self.getItemStrict(index)
         if role == Qt.ItemDataRole.CheckStateRole:
             axis.rollable = Qt.CheckState(value) == Qt.CheckState.Checked
         elif role == Qt.ItemDataRole.EditRole:


### PR DESCRIPTION
# References and relevant issues

https://github.com/napari/napari/pull/9167#issuecomment-5078812747

# Description

Provide a stricter version of `_BaseEventedItemModel.getItem` that will raise an exception on an invalid index. 
