### PR TITLE
Expose Shapes drawing state as public API: `is_creating` and `drawing_started`/`drawing_finished` events

### DIFF
--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2741,3 +2741,49 @@ def test_default_features_not_changed_when_selected_data_changes():
     np.testing.assert_equal(
         shape.feature_defaults.values[0][1], origin_values[0][1]
     )
+
+
+def test_is_creating_tracks_draw_window_and_is_edge_triggered():
+    """is_creating mirrors the draw window; events fire only on a transition."""
+    layer = Shapes()
+    started, finished = Mock(), Mock()
+    layer.events.drawing_started.connect(started)
+    layer.events.drawing_finished.connect(finished)
+
+    assert layer.is_creating is False
+    layer._is_creating = False  # same value: no event
+    started.assert_not_called()
+
+    layer._is_creating = True
+    assert layer.is_creating is True
+    started.assert_called_once()
+    layer._is_creating = True  # repeat: still once
+    started.assert_called_once()
+    finished.assert_not_called()
+
+    layer._is_creating = False
+    assert layer.is_creating is False
+    finished.assert_called_once()
+    layer._is_creating = False  # repeat: still once
+    finished.assert_called_once()
+
+
+@pytest.mark.parametrize('mode', ['add_polygon', 'add_path'])
+def test_drawing_events_multivertex_lifecycle(mode):
+    """A multi-vertex draw starts on the first vertex and finishes once."""
+    from napari.layers.shapes import _shapes_mouse_bindings as mb
+
+    layer = Shapes()
+    layer.mode = mode
+    started, finished = Mock(), Mock()
+    layer.events.drawing_started.connect(started)
+    layer.events.drawing_finished.connect(finished)
+
+    mb.initiate_polygon_draw(layer, np.array([10.0, 10.0]))
+    assert layer.is_creating is True
+    started.assert_called_once()
+    finished.assert_not_called()
+
+    layer._finish_drawing()
+    assert layer.is_creating is False
+    finished.assert_called_once()

--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2811,7 +2811,6 @@ def test_outline_not_drawn_off_slice():
 
 
 def test_is_creating_tracks_draw_window_and_is_edge_triggered():
-    """is_creating mirrors the draw window; events fire only on a transition."""
     layer = Shapes()
     started, finished = Mock(), Mock()
     layer.events.drawing_started.connect(started)
@@ -2835,13 +2834,11 @@ def test_is_creating_tracks_draw_window_and_is_edge_triggered():
     finished.assert_called_once()
 
 
-@pytest.mark.parametrize('mode', ['add_polygon', 'add_path'])
-def test_drawing_events_multivertex_lifecycle(mode):
-    """A multi-vertex draw starts on the first vertex and finishes once."""
+def test_drawing_events_multivertex_lifecycle():
     from napari.layers.shapes import _shapes_mouse_bindings as mb
 
     layer = Shapes()
-    layer.mode = mode
+    layer.mode = 'add_polygon'
     started, finished = Mock(), Mock()
     layer.events.drawing_started.connect(started)
     layer.events.drawing_finished.connect(finished)

--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2810,44 +2810,25 @@ def test_outline_not_drawn_off_slice():
     assert layer._outline_shapes() == (None, None)  # hover-only path
 
 
-def test_is_creating_tracks_draw_window_and_is_edge_triggered():
+def test_is_creating_is_edge_triggered():
     layer = Shapes()
     started, finished = Mock(), Mock()
     layer.events.drawing_started.connect(started)
     layer.events.drawing_finished.connect(finished)
-
     assert layer.is_creating is False
+
     layer._is_creating = False  # same value: no event
     started.assert_not_called()
 
     layer._is_creating = True
     assert layer.is_creating is True
     started.assert_called_once()
-    layer._is_creating = True  # repeat: still once
+    layer._is_creating = True
     started.assert_called_once()
     finished.assert_not_called()
 
     layer._is_creating = False
     assert layer.is_creating is False
     finished.assert_called_once()
-    layer._is_creating = False  # repeat: still once
-    finished.assert_called_once()
-
-
-def test_drawing_events_multivertex_lifecycle():
-    from napari.layers.shapes import _shapes_mouse_bindings as mb
-
-    layer = Shapes()
-    layer.mode = 'add_polygon'
-    started, finished = Mock(), Mock()
-    layer.events.drawing_started.connect(started)
-    layer.events.drawing_finished.connect(finished)
-
-    mb.initiate_polygon_draw(layer, np.array([10.0, 10.0]))
-    assert layer.is_creating is True
-    started.assert_called_once()
-    finished.assert_not_called()
-
-    layer._finish_drawing()
-    assert layer.is_creating is False
+    layer._is_creating = False
     finished.assert_called_once()

--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2808,3 +2808,49 @@ def test_outline_not_drawn_off_slice():
     layer.selected_data = set()
     layer._value = (0, None)
     assert layer._outline_shapes() == (None, None)  # hover-only path
+
+
+def test_is_creating_tracks_draw_window_and_is_edge_triggered():
+    """is_creating mirrors the draw window; events fire only on a transition."""
+    layer = Shapes()
+    started, finished = Mock(), Mock()
+    layer.events.drawing_started.connect(started)
+    layer.events.drawing_finished.connect(finished)
+
+    assert layer.is_creating is False
+    layer._is_creating = False  # same value: no event
+    started.assert_not_called()
+
+    layer._is_creating = True
+    assert layer.is_creating is True
+    started.assert_called_once()
+    layer._is_creating = True  # repeat: still once
+    started.assert_called_once()
+    finished.assert_not_called()
+
+    layer._is_creating = False
+    assert layer.is_creating is False
+    finished.assert_called_once()
+    layer._is_creating = False  # repeat: still once
+    finished.assert_called_once()
+
+
+@pytest.mark.parametrize('mode', ['add_polygon', 'add_path'])
+def test_drawing_events_multivertex_lifecycle(mode):
+    """A multi-vertex draw starts on the first vertex and finishes once."""
+    from napari.layers.shapes import _shapes_mouse_bindings as mb
+
+    layer = Shapes()
+    layer.mode = mode
+    started, finished = Mock(), Mock()
+    layer.events.drawing_started.connect(started)
+    layer.events.drawing_finished.connect(finished)
+
+    mb.initiate_polygon_draw(layer, np.array([10.0, 10.0]))
+    assert layer.is_creating is True
+    started.assert_called_once()
+    finished.assert_not_called()
+
+    layer._finish_drawing()
+    assert layer.is_creating is False
+    finished.assert_called_once()

--- a/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -1376,13 +1376,9 @@ def test_drag_start_selection(
     assert layer._drag_start is None
 
 
-@pytest.mark.parametrize('shape_type', ['rectangle', 'ellipse', 'line'])
-def test_add_simple_shape_drawing_events(
-    shape_type, create_known_shapes_layer
-):
-    """A press/drag/release draw emits exactly one started and one finished."""
+def test_add_simple_shape_drawing_events(create_known_shapes_layer):
     layer, _, known_non_shape = create_known_shapes_layer
-    layer.mode = f'add_{shape_type}'
+    layer.mode = 'add_rectangle'
 
     started, finished = Mock(), Mock()
     layer.events.drawing_started.connect(started)

--- a/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -1374,3 +1374,36 @@ def test_drag_start_selection(
         pytest.fail('Unreachable code')
     assert layer._drag_box is None
     assert layer._drag_start is None
+
+
+@pytest.mark.parametrize('shape_type', ['rectangle', 'ellipse', 'line'])
+def test_add_simple_shape_drawing_events(
+    shape_type, create_known_shapes_layer
+):
+    """A press/drag/release draw emits exactly one started and one finished."""
+    layer, _, known_non_shape = create_known_shapes_layer
+    layer.mode = f'add_{shape_type}'
+
+    started, finished = Mock(), Mock()
+    layer.events.drawing_started.connect(started)
+    layer.events.drawing_finished.connect(finished)
+
+    event = read_only_mouse_event(type='mouse_press', position=known_non_shape)
+    mouse_press_callbacks(layer, event)
+    # the start boundary is the press, not the release
+    assert layer.is_creating is True
+    started.assert_called_once()
+    finished.assert_not_called()
+
+    end = [40, 60]
+    event = read_only_mouse_event(
+        type='mouse_move', is_dragging=True, position=end
+    )
+    mouse_move_callbacks(layer, event)
+
+    event = read_only_mouse_event(type='mouse_release', position=end)
+    mouse_release_callbacks(layer, event)
+
+    assert layer.is_creating is False
+    started.assert_called_once()
+    finished.assert_called_once()

--- a/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -1022,6 +1022,10 @@ def test_is_creating_is_false_on_creation(mode, create_known_shapes_layer):
     def is_creating_is_False(event):
         assert not event.source._is_creating
 
+    started, finished = Mock(), Mock()
+    layer.events.drawing_started.connect(started)
+    layer.events.drawing_finished.connect(finished)
+
     assert not layer._is_creating
     layer.events.set_data.connect(is_creating_is_True)
 
@@ -1044,6 +1048,8 @@ def test_is_creating_is_false_on_creation(mode, create_known_shapes_layer):
     mouse_double_click_callbacks(layer, end_click)
 
     assert not layer._is_creating
+    started.assert_called_once()
+    finished.assert_called_once()
 
 
 @pytest.mark.parametrize('mode', ['select', 'direct'])
@@ -1374,32 +1380,3 @@ def test_drag_start_selection(
         pytest.fail('Unreachable code')
     assert layer._drag_box is None
     assert layer._drag_start is None
-
-
-def test_add_simple_shape_drawing_events(create_known_shapes_layer):
-    layer, _, known_non_shape = create_known_shapes_layer
-    layer.mode = 'add_rectangle'
-
-    started, finished = Mock(), Mock()
-    layer.events.drawing_started.connect(started)
-    layer.events.drawing_finished.connect(finished)
-
-    event = read_only_mouse_event(type='mouse_press', position=known_non_shape)
-    mouse_press_callbacks(layer, event)
-    # the start boundary is the press, not the release
-    assert layer.is_creating is True
-    started.assert_called_once()
-    finished.assert_not_called()
-
-    end = [40, 60]
-    event = read_only_mouse_event(
-        type='mouse_move', is_dragging=True, position=end
-    )
-    mouse_move_callbacks(layer, event)
-
-    event = read_only_mouse_event(type='mouse_release', position=end)
-    mouse_release_callbacks(layer, event)
-
-    assert layer.is_creating is False
-    started.assert_called_once()
-    finished.assert_called_once()

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -257,6 +257,12 @@ class Shapes(Layer):
         List of currently selected shapes.
     nshapes : int
         Total number of shapes.
+    is_creating : bool
+        Read-only flag, ``True`` while a shape is being drawn -- from drawing
+        initiation until the shape is finished or cancelled. The
+        ``drawing_started`` and ``drawing_finished`` events fire at its
+        boundaries. Unlike ``mode`` (which stays on an ``add_*`` value before,
+        during and after a draw) this tracks the actual construction window.
     mode : Mode
         Interactive mode. The normal, default mode is PAN_ZOOM, which
         allows for normal interactivity with the canvas.
@@ -518,6 +524,8 @@ class Shapes(Layer):
             highlight=Event,
             features=Event,
             feature_defaults=Event,
+            drawing_started=Event,
+            drawing_finished=Event,
         )
 
         # Flag set to false to block thumbnail refresh
@@ -575,7 +583,7 @@ class Shapes(Layer):
         self._is_selecting = False
         self._drag_box = None
         self._drag_box_stored = None
-        self._is_creating = False
+        self._private_is_creating = False
         self._clipboard: dict[str, Shapes] = {}
         self._outlines_cache: dict[
             int | None, tuple[np.ndarray, np.ndarray, np.ndarray]
@@ -1301,6 +1309,37 @@ class Shapes(Layer):
         if value:
             assert self._moving_coordinates is not None
         self._private_is_moving = value
+
+    @property
+    def is_creating(self) -> bool:
+        """bool: whether a shape is currently being drawn.
+
+        ``True`` from the moment a new shape's construction begins until it is
+        finished or cancelled. ``drawing_started`` fires before the initial
+        geometry is added to the layer, so a listener reacting to it should not
+        assume the new shape is already in ``data``. Unlike ``mode``, which
+        stays on an ``add_*`` value before, during and after a draw, this
+        tracks the actual construction window. The ``drawing_started`` and
+        ``drawing_finished`` events fire at its boundaries.
+        """
+        return self._is_creating
+
+    @property
+    def _is_creating(self) -> bool:
+        return self._private_is_creating
+
+    @_is_creating.setter
+    def _is_creating(self, value: bool) -> None:
+        # Edge-triggered: only a real transition fires, so listeners see one
+        # event per draw rather than one per assignment.
+        value = bool(value)
+        if value == self._private_is_creating:
+            return
+        self._private_is_creating = value
+        if value:
+            self.events.drawing_started()
+        else:
+            self.events.drawing_finished()
 
     def _set_color(self, color, attribute: str):
         """Set the face_color or edge_color property

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -257,11 +257,8 @@ class Shapes(Layer):
     nshapes : int
         Total number of shapes.
     is_creating : bool
-        Read-only flag, ``True`` while a shape is being drawn -- from drawing
-        initiation until the shape is finished or cancelled. The
-        ``drawing_started`` and ``drawing_finished`` events fire at its
-        boundaries. Unlike ``mode`` (which stays on an ``add_*`` value before,
-        during and after a draw) this tracks the actual construction window.
+        Read-only flag, ``True`` while a shape is being drawn. The
+        ``drawing_started`` and ``drawing_finished`` events fire at its edges.
     mode : Mode
         Interactive mode. The normal, default mode is PAN_ZOOM, which
         allows for normal interactivity with the canvas.
@@ -1322,13 +1319,8 @@ class Shapes(Layer):
     def is_creating(self) -> bool:
         """bool: whether a shape is currently being drawn.
 
-        ``True`` from the moment a new shape's construction begins until it is
-        finished or cancelled. ``drawing_started`` fires before the initial
-        geometry is added to the layer, so a listener reacting to it should not
-        assume the new shape is already in ``data``. Unlike ``mode``, which
-        stays on an ``add_*`` value before, during and after a draw, this
-        tracks the actual construction window. The ``drawing_started`` and
-        ``drawing_finished`` events fire at its boundaries.
+        ``drawing_started`` fires before the new shape's initial geometry is
+        added to the layer, so a listener must not assume it is in ``data``.
 
         .. versionadded:: 0.10.0
         """
@@ -1340,8 +1332,6 @@ class Shapes(Layer):
 
     @_is_creating.setter
     def _is_creating(self, value: bool) -> None:
-        # Edge-triggered: only a real transition fires, so listeners see one
-        # event per draw rather than one per assignment.
         value = bool(value)
         if value == self._private_is_creating:
             return

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -256,6 +256,12 @@ class Shapes(Layer):
         List of currently selected shapes.
     nshapes : int
         Total number of shapes.
+    is_creating : bool
+        Read-only flag, ``True`` while a shape is being drawn -- from drawing
+        initiation until the shape is finished or cancelled. The
+        ``drawing_started`` and ``drawing_finished`` events fire at its
+        boundaries. Unlike ``mode`` (which stays on an ``add_*`` value before,
+        during and after a draw) this tracks the actual construction window.
     mode : Mode
         Interactive mode. The normal, default mode is PAN_ZOOM, which
         allows for normal interactivity with the canvas.
@@ -517,6 +523,8 @@ class Shapes(Layer):
             highlight=Event,
             features=Event,
             feature_defaults=Event,
+            drawing_started=Event,
+            drawing_finished=Event,
         )
 
         # Flag set to false to block thumbnail refresh
@@ -574,7 +582,7 @@ class Shapes(Layer):
         self._is_selecting = False
         self._drag_box = None
         self._drag_box_stored = None
-        self._is_creating = False
+        self._private_is_creating = False
         self._clipboard: dict[str, Shapes] = {}
         self._outlines_cache: dict[
             int | None, tuple[np.ndarray, np.ndarray, np.ndarray]
@@ -1309,6 +1317,37 @@ class Shapes(Layer):
         if value:
             assert self._moving_coordinates is not None
         self._private_is_moving = value
+
+    @property
+    def is_creating(self) -> bool:
+        """bool: whether a shape is currently being drawn.
+
+        ``True`` from the moment a new shape's construction begins until it is
+        finished or cancelled. ``drawing_started`` fires before the initial
+        geometry is added to the layer, so a listener reacting to it should not
+        assume the new shape is already in ``data``. Unlike ``mode``, which
+        stays on an ``add_*`` value before, during and after a draw, this
+        tracks the actual construction window. The ``drawing_started`` and
+        ``drawing_finished`` events fire at its boundaries.
+        """
+        return self._is_creating
+
+    @property
+    def _is_creating(self) -> bool:
+        return self._private_is_creating
+
+    @_is_creating.setter
+    def _is_creating(self, value: bool) -> None:
+        # Edge-triggered: only a real transition fires, so listeners see one
+        # event per draw rather than one per assignment.
+        value = bool(value)
+        if value == self._private_is_creating:
+            return
+        self._private_is_creating = value
+        if value:
+            self.events.drawing_started()
+        else:
+            self.events.drawing_finished()
 
     def _set_color(self, color, attribute: str):
         """Set the face_color or edge_color property

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -263,6 +263,10 @@ class Shapes(Layer):
         ``drawing_started`` and ``drawing_finished`` events fire at its
         boundaries. Unlike ``mode`` (which stays on an ``add_*`` value before,
         during and after a draw) this tracks the actual construction window.
+
+        .. versionadded:: 0.9.0
+            ``is_creating`` and the ``drawing_started`` / ``drawing_finished``
+            events were added in 0.9.0.
     mode : Mode
         Interactive mode. The normal, default mode is PAN_ZOOM, which
         allows for normal interactivity with the canvas.
@@ -1321,6 +1325,8 @@ class Shapes(Layer):
         stays on an ``add_*`` value before, during and after a draw, this
         tracks the actual construction window. The ``drawing_started`` and
         ``drawing_finished`` events fire at its boundaries.
+
+        .. versionadded:: 0.9.0
         """
         return self._is_creating
 

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -1329,6 +1329,8 @@ class Shapes(Layer):
         stays on an ``add_*`` value before, during and after a draw, this
         tracks the actual construction window. The ``drawing_started`` and
         ``drawing_finished`` events fire at its boundaries.
+
+        .. versionadded:: 0.10.0
         """
         return self._is_creating
 


### PR DESCRIPTION
# References and relevant issues

Closes #9208.
Related: #9277, a pre-existing `remove_selected()` crash mid-draw that reproduces on `main` without this PR.

# Description

`mode` can't tell you whether a shape is under construction: the layer sits on an `add_*` value before, during and after a draw, so the only thing tracking the actual window is the private `Shapes._is_creating`, and applications end up reading it.

This adds a read-only `Shapes.is_creating` and `drawing_started`/`drawing_finished` events at its boundaries. `_is_creating` becomes an event-firing property over `_private_is_creating`, following the `_is_moving` pattern already in this class, and is edge-triggered so a listener sees one event per draw rather than one per assignment.

What napari should *do* when the view changes mid-draw is the policy question in #9207, not proposed here.
