### PR TITLE
update dims axis labels from layers axis labels

### DIFF
--- a/src/napari/_tests/test_viewer.py
+++ b/src/napari/_tests/test_viewer.py
@@ -517,6 +517,11 @@ def test_dims_axis_labels_match_layerlist(make_napari_viewer, qtbot):
     assert viewer.dims.axis_labels == ('z', 'y', 'x')
 
     # Lower-dim, annotated layer doesn't override the longer labels
+    # This is different from test_axis_labels_after_data because in that
+    # case we are overwriting result of
+    # `viewer.dims.axis_labels = ('z', 'y', 'x')`, whereas in this case
+    # `viewer.dims.axis_labels` is only ever set dynamically from the layer
+    # list.
     viewer.add_image(np.random.random((4, 5)), axis_labels=('i', 'j'))
     assert viewer.dims.axis_labels == viewer.layers.axis_labels
     assert viewer.dims.axis_labels == ('z', 'y', 'x')

--- a/src/napari/_tests/test_viewer.py
+++ b/src/napari/_tests/test_viewer.py
@@ -499,4 +499,29 @@ def test_axis_labels_after_data(make_napari_viewer, qtbot):
     data_labels = ('i', 'j')
     assert data_labels != original_labels
     _ = viewer.add_image(np.random.random((10, 12)), axis_labels=data_labels)
-    assert viewer.dims.axis_labels == original_labels
+    assert viewer.dims.axis_labels == ('z', 'i', 'j')
+
+
+def test_dims_axis_labels_match_layerlist(make_napari_viewer, qtbot):
+    """
+    Check viewer.dims.axis_labels reflect layers.axis_labels."""
+    viewer = make_napari_viewer()
+
+    # Default indices on empty viewer
+    assert viewer.dims.axis_labels == viewer.layers.axis_labels
+    assert viewer.dims.axis_labels == ('-2', '-1')
+
+    # Annotated layer propagates to dims
+    viewer.add_image(np.random.random((3, 4, 5)), axis_labels=('z', 'y', 'x'))
+    assert viewer.dims.axis_labels == viewer.layers.axis_labels
+    assert viewer.dims.axis_labels == ('z', 'y', 'x')
+
+    # Lower-dim, annotated layer doesn't override the longer labels
+    viewer.add_image(np.random.random((4, 5)), axis_labels=('i', 'j'))
+    assert viewer.dims.axis_labels == viewer.layers.axis_labels
+    assert viewer.dims.axis_labels == ('z', 'y', 'x')
+
+    # Higher-dim, unannotated layer doesn't override the annotated labels
+    viewer.add_image(np.random.random((2, 3, 4, 5)))
+    assert viewer.dims.axis_labels == viewer.layers.axis_labels
+    assert viewer.dims.axis_labels == ('-4', 'z', 'y', 'x')

--- a/src/napari/components/_tests/test_layers_list.py
+++ b/src/napari/components/_tests/test_layers_list.py
@@ -805,6 +805,7 @@ def test_remove_selected_all_locked():
     ],
 )
 def test_layerlist_axis_labels(
+    # layer specs: list of (shape, axis_labels) tuples for image layers
     layer_specs: list[tuple[tuple[int, ...], tuple[str, ...] | None]],
     expected_labels: tuple[str, ...],
     expected_ndim: int,

--- a/src/napari/components/_tests/test_layers_list.py
+++ b/src/napari/components/_tests/test_layers_list.py
@@ -779,3 +779,42 @@ def test_remove_selected_all_locked():
     layers.selection = {layer}
     layers.remove_selected()
     assert len(layers) == 1
+
+
+@pytest.mark.parametrize(
+    ('layer_specs', 'expected_labels', 'expected_ndim'),
+    [
+        ([], ('-2', '-1'), 2),  # no layers
+        ([((5, 5), None)], ('-2', '-1'), 2),  # unnanotated single layer
+        ([((5, 5), ('y', 'x'))], ('y', 'x'), 2),  # annotated single layer
+        (
+            [((2, 3, 4, 5), None), ((4, 5), ('y', 'x'))],
+            ('-4', '-3', 'y', 'x'),
+            4,
+        ),  # single annotated wins and is aligned
+        (
+            [((3, 4, 5), ('z', 'y', 'x')), ((4, 5), ('a', 'b'))],
+            ('z', 'y', 'x'),
+            3,
+        ),  # longest annotated wins
+        (
+            [((4, 5), ('y0', 'x0')), ((4, 5), ('y1', 'x1'))],
+            ('y1', 'x1'),
+            2,
+        ),  # topmost equally long annotated wins
+    ],
+)
+def test_layerlist_axis_labels(
+    layer_specs: list[tuple[tuple[int, ...], tuple[str, ...] | None]],
+    expected_labels: tuple[str, ...],
+    expected_ndim: int,
+):
+    """
+    Check that axis labels are set properly.
+    """
+    layers = LayerList(
+        Image(np.zeros(shape), axis_labels=labels)
+        for shape, labels in layer_specs
+    )
+    assert layers.axis_labels == expected_labels
+    assert layers.ndim == expected_ndim

--- a/src/napari/components/layerlist.py
+++ b/src/napari/components/layerlist.py
@@ -654,6 +654,41 @@ class LayerList(SelectableEventedList[Layer]):
         """
         return max((layer.ndim for layer in self), default=2)
 
+    def _is_axis_annotated(self, axis_labels: tuple[str, ...]) -> bool:
+        """Return True if axis labels for given layer are annotated.
+
+        Axis labels are annotated when they do not match the default indices.
+        """
+        not_annotated = tuple(str(i) for i in range(-len(axis_labels), 0))
+        return axis_labels != not_annotated
+
+    def _find_longest_annotated(self) -> tuple[str, ...]:
+        """Return the annotated axis labels spanning the most dimensions.
+
+        Returns () when no layer is annotated. When more are equally long,
+        the most recent layer wins.
+        """
+        annotated_list = [
+            layer.axis_labels
+            for layer in self
+            if self._is_axis_annotated(layer.axis_labels)
+        ][::-1]
+        return max(annotated_list, key=len, default=())
+
+    @property
+    def axis_labels(self) -> tuple[str, ...]:
+        """Axis labels for the layer list.
+
+        Uses the labels from the layer with the longest annotated axis labels.
+        Missing axes annotations fall back to default indices.
+        """
+        axis_labels = [str(i) for i in range(-self.ndim, 0)]
+        labels = self._find_longest_annotated()
+        offset = self.ndim - len(labels)
+        for idx, label in enumerate(labels):
+            axis_labels[offset + idx] = label
+        return tuple(axis_labels)
+
     def _link_layers(
         self,
         method: str,

--- a/src/napari/components/layerlist.py
+++ b/src/napari/components/layerlist.py
@@ -654,14 +654,6 @@ class LayerList(SelectableEventedList[Layer]):
         """
         return max((layer.ndim for layer in self), default=2)
 
-    def _is_axis_annotated(self, axis_labels: tuple[str, ...]) -> bool:
-        """Return True if axis labels for given layer are annotated.
-
-        Axis labels are annotated when they do not match the default indices.
-        """
-        not_annotated = tuple(str(i) for i in range(-len(axis_labels), 0))
-        return axis_labels != not_annotated
-
     def _find_longest_annotated(self) -> tuple[str, ...]:
         """Return the annotated axis labels spanning the most dimensions.
 
@@ -671,7 +663,7 @@ class LayerList(SelectableEventedList[Layer]):
         annotated_list = [
             layer.axis_labels
             for layer in self
-            if self._is_axis_annotated(layer.axis_labels)
+            if not layer._has_default_axis_labels()
         ][::-1]
         return max(annotated_list, key=len, default=())
 

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -797,6 +797,17 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             self.camera.mouse_zoom = active_layer.mouse_zoom
             self.update_status_from_cursor()
 
+    def _merge_dims_and_layers_axis_labels(self) -> tuple[str, ...]:
+        """Combine layerlist axis labels onto the current dims labels.
+
+        Replaces dims axis label at indices where layers axis labels exist.
+        """
+        updated_axis_labels = list(self.dims.axis_labels)
+        for pos, label in enumerate(self.layers.axis_labels):
+            if label != str(pos - self.dims.ndim):
+                updated_axis_labels[pos] = label
+        return tuple(updated_axis_labels)
+
     def _on_layers_change(self):
         if len(self.layers) == 0:
             self.dims.ndim = 2
@@ -807,6 +818,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             self.dims.ndim = len(ranges)
             self.dims.range = ranges
             self.dims.units = self.layers.units
+            self.dims.axis_labels = self._merge_dims_and_layers_axis_labels()
 
         new_dim = self.dims.ndim
         dim_diff = new_dim - len(self.cursor.position)
@@ -969,6 +981,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         layer.events.rotate.connect(self._on_layers_change)
         layer.events.shear.connect(self._on_layers_change)
         layer.events.affine.connect(self._on_layers_change)
+        layer.events.axis_labels.connect(self._on_layers_change)
         layer.events.name.connect(self.layers._update_name)
         layer.events.reload.connect(self._on_layer_reload)
         if hasattr(layer.events, 'mode'):

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -1035,6 +1035,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         if self._transforms['data2physical'].axis_labels != prev:
             self.events.axis_labels()
 
+    def _has_default_axis_labels(self) -> bool:
+        """Return True if axis labels are the default indices."""
+        default_labels = tuple(str(i) for i in range(-self.ndim, 0))
+        return self.axis_labels == default_labels
+
     @property
     def units(self) -> tuple[pint.Unit, ...]:
         """List of units for the layer."""


### PR DESCRIPTION
# References and relevant issues

Closes #906
Closes #8452

Related to #1144

# Description
This PR is a quick fix so viewer.dims.axis_labels get picked from layers axis_labels. E.g. if dataset has labeled axes like (t, c, z, y, x), these will be reflected in the dims sliders instead of the default numeric placeholders. 

1. It adds axis_labels to LayerList to aggregate labels from all layers.
- the annotated layer with the most dimensions wins
- if more equally long (same ndims) are annotated, the topmost (most recent) wins (or you pref the other order?) -> re-ordering them in the GUI would change which ones win
2. It updates viewer.dims.axis_labels with those from the LayerList.
- change to axis labels is triggered on change in layers (ViewerModel._on_layers_change)
- annotations are merged, but priority is annotated layer > annotated dims (e.g. if dims labels are a,b,c and annotated layer y,x, will resolve to a,y,x)

Tests cover the LayerList aggregation rules and the dims↔layers axis labels merging.

## Future plans
As discussed with @TimMonko and @jni , follow-up work could:
- deprecate option to set the viewer.dims.axis_labels
- allow inheriting axis labels when deriving a layer from another (e.g. "new layer from selected" in the GUI)
- align layers by axis label (e.g. a zyx and a tyx layer should combine into tzyx).