### PR TITLE
Enable coverage annotation in PR changes view

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,3 +36,6 @@ codecov:
 comment:
   require_changes: true  # if true: only post the PR comment if coverage changes
   after_n_builds: 1
+
+github_checks:
+  annotations: true


### PR DESCRIPTION
# References and relevant issues

https://docs.codecov.com/docs/codecovyml-reference#turn-on-github_checks-annotations-github-users-only

# Description

To not need to open the coverage report but see missed lines in GitHub lines.

It will not show coverage changes outside the edited code. 
