### PR TITLE
Fix auto_contrast button state initialization

### DIFF
--- a/src/napari/_qt/layer_controls/widgets/qt_contrast_limits.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_contrast_limits.py
@@ -346,6 +346,7 @@ class AutoScaleButtons(QWidget):
 
         self.auto_btn = QPushButton('continuous')
         self.auto_btn.setCheckable(True)
+        self.auto_btn.setChecked(layer.auto_contrast)
         self.auto_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.once_btn.clicked.connect(lambda: self.auto_btn.setChecked(False))
         connect_no_arg(self.once_btn.clicked, layer, 'reset_contrast_limits')


### PR DESCRIPTION
# References and relevant issues
Follow up to PR #9271

# Description
This fixes that the auto_contrast button is toggled on when adding an image with auto_contrast via `viewer.add_image(image, auto_contrast=True)`
