### PR TITLE
UX: Indicate web links in Help menu with ↗ (unicode character)

### DIFF
--- a/src/napari/_qt/_qapp_model/qactions/_help.py
+++ b/src/napari/_qt/_qapp_model/qactions/_help.py
@@ -68,13 +68,13 @@ Q_HELP_ACTIONS: list[Action] = [
     ),
     Action(
         id='napari.window.help.getting_started',
-        title='Getting started',
+        title='Getting started ↗',
         callback=partial(web_open, url=HELP_URLS['getting_started']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id='napari.window.help.tutorials',
-        title='Tutorials',
+        title='Tutorials ↗',
         callback=partial(web_open, url=HELP_URLS['tutorials']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
@@ -87,25 +87,25 @@ Q_HELP_ACTIONS: list[Action] = [
     ),
     Action(
         id='napari.window.help.layers_guide',
-        title='Using Layers Guides',
+        title='Using Layers Guides ↗',
         callback=partial(web_open, url=HELP_URLS['layers_guide']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id='napari.window.help.examples',
-        title='Examples Gallery',
+        title='Examples Gallery ↗',
         callback=partial(web_open, url=HELP_URLS['examples_gallery']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id='napari.window.help.plugins',
-        title='Extend with Plugins',
+        title='Extend with Plugins ↗',
         callback=partial(web_open, url=HELP_URLS['plugins']),
         menus=[{'id': MenuId.MENUBAR_HELP}],
     ),
     Action(
         id='napari.window.help.release_notes',
-        title='Release Notes',
+        title='Release Notes ↗',
         callback=partial(web_open, url=HELP_URLS['release_notes']),
         menus=[
             {
@@ -117,7 +117,7 @@ Q_HELP_ACTIONS: list[Action] = [
     ),
     Action(
         id='napari.window.help.github_issue',
-        title='Report an issue on GitHub',
+        title='Report an issue on GitHub ↗',
         callback=partial(web_open, url=HELP_URLS['github_issue']),
         menus=[
             {
@@ -129,13 +129,13 @@ Q_HELP_ACTIONS: list[Action] = [
     ),
     Action(
         id='napari.window.help.contribute',
-        title='Contribute to napari',
+        title='Contribute to napari ↗',
         callback=partial(web_open, url=HELP_URLS['contribute']),
         menus=[{'id': MenuId.MENUBAR_HELP, 'group': MenuGroup.NAVIGATION}],
     ),
     Action(
         id='napari.window.help.homepage',
-        title='napari homepage',
+        title='napari homepage ↗',
         callback=partial(web_open, url=HELP_URLS['homepage']),
         menus=[{'id': MenuId.MENUBAR_HELP, 'group': MenuGroup.NAVIGATION}],
     ),


### PR DESCRIPTION
# References and relevant issues
Realized when reviewing https://github.com/napari/napari/pull/9290

# Description
Our Help menu includes a lot of links to external resources, but also a few things that stay within napari -- with more to come (e.g. #92090 ). The web links thus far are not clearly marked. A user may prefer to first open something internal vs. a browser/webpage. A user may not have internet access, so then knowing what resources are unavailable can also be useful.
So in this PR I just add the arrow unicode character ↗ to the ones that are links. I did some googling and it seems reasonable. Other options would be an emoji, but that might create issues on non-macOS systems, so just sticking with a basic unicode character was the best choice.

How it looks on macOS:
<img width="482" height="332" alt="image" src="https://github.com/user-attachments/assets/a6a7c988-b843-4dcc-ba34-1da7e4be2277" />
