### PR TITLE
Add `locked_data_level` to `add_image()` signature

### DIFF
--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -1077,6 +1077,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         interpolation2d='nearest',
         interpolation3d='linear',
         iso_threshold=None,
+        locked_data_level=None,
         metadata=None,
         multiscale=None,
         name=None,
@@ -1169,6 +1170,11 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             Same as 'interpolation2d' but for 3D rendering.
         iso_threshold : float or list of float
             Threshold for isosurface.
+        locked_data_level : int, optional
+            Lock the multiscale resolution level to a specific index. When set,
+            forces rendering at the given multiscale level instead of automatic
+            level selection based on the viewport. Set to ``None`` (default) to
+            use automatic selection.
         metadata : dict or list of dict
             Layer metadata.
         multiscale : bool
@@ -1240,6 +1246,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             'colormap': colormap,
             'contrast_limits': contrast_limits,
             'gamma': gamma,
+            'locked_data_level': locked_data_level,
             'interpolation2d': interpolation2d,
             'interpolation3d': interpolation3d,
             'rendering': rendering,

--- a/src/napari/layers/_scalar_field/_tests/test_scalar_field.py
+++ b/src/napari/layers/_scalar_field/_tests/test_scalar_field.py
@@ -241,6 +241,17 @@ class TestLockedDataLevel:
         assert layer.locked_data_level is None
 
 
+def test_locked_data_level_constructor():
+    """locked_data_level can be set via the Image constructor."""
+    data = _make_multiscale_3d()
+    layer = Image(data, multiscale=True, locked_data_level=2)
+    assert layer.locked_data_level == 2
+
+    # Default (None) should also be safe
+    layer2 = Image(data, multiscale=True)
+    assert layer2.locked_data_level is None
+
+
 def _draw_layer(layer, shape_threshold=(800, 600)):
     """Call ``_update_draw`` with a viewport that sees the full data extent."""
     displayed = layer._slice_input.displayed

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -140,6 +140,11 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
     rendering : str
         Rendering mode used by vispy. Must be one of our supported
         modes.
+    locked_data_level : int, optional
+        Lock the multiscale resolution level to a specific index. When set,
+        forces rendering at the given multiscale level instead of automatic
+        level selection based on the viewport. Set to ``None`` (default) to
+        use automatic selection.
     rgb : bool, optional
         Whether the image is RGB or RGBA if rgb. If not
         specified by user, but the last dimension of the data has length 3 or 4,
@@ -270,6 +275,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         interpolation2d: InterpolationStr = 'nearest',
         interpolation3d: InterpolationStr = 'linear',
         iso_threshold: float | None = None,
+        locked_data_level: int | None = None,
         metadata: dict | None = None,
         multiscale: bool | None = None,
         name: str | None = None,
@@ -351,6 +357,9 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
             self._iso_threshold = cmin + (cmax - cmin) / 2
         else:
             self._iso_threshold = iso_threshold
+
+        if locked_data_level is not None:
+            self.locked_data_level = locked_data_level
 
     @property
     def rendering(self) -> str:

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -114,6 +114,11 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         Same as 'interpolation2d' but for 3D rendering.
     iso_threshold : float
         Threshold for isosurface.
+    locked_data_level : int, optional
+        Lock the multiscale resolution level to a specific index. When set,
+        forces rendering at the given multiscale level instead of automatic
+        level selection based on the viewport. Set to ``None`` (default) to
+        use automatic selection.
     metadata : dict
         Layer metadata.
     multiscale : bool
@@ -140,11 +145,6 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
     rendering : str
         Rendering mode used by vispy. Must be one of our supported
         modes.
-    locked_data_level : int, optional
-        Lock the multiscale resolution level to a specific index. When set,
-        forces rendering at the given multiscale level instead of automatic
-        level selection based on the viewport. Set to ``None`` (default) to
-        use automatic selection.
     rgb : bool, optional
         Whether the image is RGB or RGBA if rgb. If not
         specified by user, but the last dimension of the data has length 3 or 4,

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -422,6 +422,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
                 'iso_threshold': self.iso_threshold,
                 'attenuation': self.attenuation,
                 'gamma': self.gamma,
+                'locked_data_level': self.locked_data_level,
                 'data': self.data,
                 'custom_interpolation_kernel_2d': self.custom_interpolation_kernel_2d,
             }

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -411,6 +411,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
             {
                 'rgb': self.rgb,
                 'multiscale': self.multiscale,
+                'locked_data_level': self.locked_data_level,
                 'auto_contrast': self.auto_contrast,
                 'colormap': self.colormap.model_dump(),
                 'contrast_limits': self.contrast_limits,
@@ -422,7 +423,6 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
                 'iso_threshold': self.iso_threshold,
                 'attenuation': self.attenuation,
                 'gamma': self.gamma,
-                'locked_data_level': self.locked_data_level,
                 'data': self.data,
                 'custom_interpolation_kernel_2d': self.custom_interpolation_kernel_2d,
             }

--- a/src/napari/view_layers.py
+++ b/src/napari/view_layers.py
@@ -95,6 +95,7 @@ def imshow(
     interpolation2d=...,
     interpolation3d=...,
     iso_threshold=...,
+    locked_data_level=...,
     metadata=...,
     multiscale=...,
     name=...,
@@ -137,6 +138,7 @@ def imshow(
     interpolation2d=...,
     interpolation3d=...,
     iso_threshold=...,
+    locked_data_level=...,
     metadata=...,
     multiscale=...,
     name=...,
@@ -178,6 +180,7 @@ def imshow(
     interpolation2d='nearest',
     interpolation3d='linear',
     iso_threshold=None,
+    locked_data_level=None,
     metadata=None,
     multiscale=None,
     name=None,
@@ -272,6 +275,11 @@ def imshow(
         Same as 'interpolation2d' but for 3D rendering.
     iso_threshold : float or list of float
         Threshold for isosurface.
+    locked_data_level : int, optional
+        Lock the multiscale resolution level to a specific index. When set,
+        forces rendering at the given multiscale level instead of automatic
+        level selection based on the viewport. Set to ``None`` (default) to
+        use automatic selection.
     metadata : dict or list of dict
         Layer metadata.
     multiscale : bool
@@ -354,6 +362,7 @@ def imshow(
         rendering=rendering,
         depiction=depiction,
         iso_threshold=iso_threshold,
+        locked_data_level=locked_data_level,
         attenuation=attenuation,
         auto_contrast=auto_contrast,
         name=name,


### PR DESCRIPTION
# References and relevant issues

[#general > should &#96;locked_data_level&#96; be an &#96;add_image&#96; argument?](https://napari.zulipchat.com/#narrow/channel/212875-general/topic/should.20.60locked_data_level.60.20be.20an.20.60add_image.60.20argument.3F/with/609566708)
follow-up #8917 

# Description

`locked_data_level` (which is awesome) was not manually added to `add_image()`, which is a special case that is not auto-generated.
This adds the parameter to the signature for both the `Image` class and `ViewerModel`
