### PR TITLE
New layer inherits axis labels when derived from another layer

### DIFF
--- a/src/napari/_app_model/actions/_file.py
+++ b/src/napari/_app_model/actions/_file.py
@@ -104,6 +104,7 @@ def _create_single_layer(
         rotate=source_layer.rotate,
         shear=source_layer.shear,
         units=source_layer.units,
+        axis_labels=source_layer.axis_labels,
         affine=source_layer.affine.affine_matrix,
     )
 

--- a/src/napari/components/_tests/test_viewer_model.py
+++ b/src/napari/components/_tests/test_viewer_model.py
@@ -1267,36 +1267,82 @@ def test_fit_to_view_handles_no_layers():
     assert viewer.camera.zoom > 0
 
 
-def test_new_layer_from_active_layer_inherits_axis_labels():
-    """new layer on a selected layer inherits its axis labels"""
+def test_new_shapes_points_axis_labels_inheritance_on_no_selection():
+    """New shapes/points layer created with no active layer gets default axis labels."""
     viewer = ViewerModel()
-    # test from selected image layer
+    viewer.add_image(np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c'))
+    viewer.layers.selection.active = None
+    new_shapes(viewer)
+    assert viewer.layers[-1].axis_labels == ('-3', '-2', '-1')
+    new_points(viewer)
+    assert viewer.layers[-1].axis_labels == ('-3', '-2', '-1')
+
+
+def test_new_shapes_points_axis_labels_inheritance_on_multi_selection():
+    """New shapes/points layer created with  multiple layers selected gets default axis labels."""
+    viewer = ViewerModel()
+    layer1 = viewer.add_image(np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c'))
+    layer2 = viewer.add_image(np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c'))
+    viewer.layers.selection = {layer1, layer2}
+    new_shapes(viewer)
+    assert viewer.layers[-1].axis_labels == ('-3', '-2', '-1')
+
+
+def test_new_shapes_points_axis_labels_inheritance_on_single_selection():
+    """New shapes/points layer created from a single selected layer inherits its axis labels."""
+    viewer = ViewerModel()
+    # test from image layer selection
     image_layer = viewer.add_image(
         np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c')
     )
     viewer.layers.selection.active = image_layer
-    viewer._new_labels()  # image→labels
-    assert viewer.layers[-1].axis_labels == ('a', 'b', 'c')
-    assert viewer.layers[-1].axis_labels == image_layer.axis_labels
     new_shapes(viewer)  # image→shapes
     assert viewer.layers[-1].axis_labels == ('a', 'b', 'c')
     assert viewer.layers[-1].axis_labels == image_layer.axis_labels
     new_points(viewer)  # image→points
     assert viewer.layers[-1].axis_labels == ('a', 'b', 'c')
     assert viewer.layers[-1].axis_labels == image_layer.axis_labels
-    # test from selected shapes layer
-    shape_layer = viewer.add_shapes(ndim=3, axis_labels=('z', 'y', 'x'))
-    viewer.layers.selection.active = shape_layer
-    viewer._new_labels()  # shapes→labels
+    # test from shapes layer selection (shapes→shapes)
+    shapes_layer = viewer.add_shapes(ndim=3, axis_labels=('z', 'y', 'x'))
+    viewer.layers.selection.active = shapes_layer
+    new_shapes(viewer)
     assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
-    assert viewer.layers[-1].axis_labels == shape_layer.axis_labels
-    new_shapes(viewer)  # shapes→shapes
-    assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
-    assert viewer.layers[-1].axis_labels == shape_layer.axis_labels
-    new_points(viewer)  # # shapes→points
-    assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
-    assert viewer.layers[-1].axis_labels == shape_layer.axis_labels
-    # test from unselected
+    assert viewer.layers[-1].axis_labels == shapes_layer.axis_labels
+
+
+def test_new_labels_axis_labels_inheritance_on_no_selection():
+    """New labels layer created with no active layer gets default axis labels."""
+    viewer = ViewerModel()
+    viewer.add_image(np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c'))
     viewer.layers.selection.active = None
-    new_shapes(viewer)  # unselected→shapes
+    viewer._new_labels()
+    assert viewer.layers[-1].axis_labels == ('-2', '-1')
+
+
+def test_new_labels_axis_labels_inheritance_on_multi_selection():
+    """New labels layer created with with multiple layers selected gets default axis labels."""
+    viewer = ViewerModel()
+    layer1 = viewer.add_image(np.zeros((2, 2)), axis_labels=('a', 'b'))
+    layer2 = viewer.add_image(np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c'))
+    viewer.layers.selection = {layer1, layer2}
+    viewer._new_labels()
     assert viewer.layers[-1].axis_labels == ('-3', '-2', '-1')
+
+
+def test_new_labels_axis_labels_inheritance_on_single_selection():
+    """New labels layer created from a single selected layer inherits its axis labels."""
+    viewer = ViewerModel()
+    # test from image layer selection (image→labels)
+    image_layer = viewer.add_image(
+        np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c')
+    )
+    viewer.layers.selection.active = image_layer
+    viewer._new_labels()
+    assert viewer.layers[-1].axis_labels == ('a', 'b', 'c')
+    assert viewer.layers[-1].axis_labels == image_layer.axis_labels
+    # test from shapes layer selection (shapes→labels)
+    shapes_layer = viewer.add_shapes(ndim=3, axis_labels=('z', 'y', 'x'))
+    viewer.layers.selection.active = shapes_layer
+    viewer._new_labels()
+    assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
+    assert viewer.layers[-1].axis_labels == shapes_layer.axis_labels

--- a/src/napari/components/_tests/test_viewer_model.py
+++ b/src/napari/components/_tests/test_viewer_model.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from npe2 import DynamicPlugin
 
+from napari._app_model.actions._file import new_points, new_shapes
 from napari._tests.utils import (
     count_warning_events,
     good_layer_data,
@@ -1264,3 +1265,38 @@ def test_fit_to_view_handles_no_layers():
     np.testing.assert_allclose(viewer.camera.center, (0, 255.5, 255.5))
     np.testing.assert_allclose(viewer.camera.angles, (0, 0, 0))
     assert viewer.camera.zoom > 0
+
+
+def test_new_layer_from_active_layer_inherits_axis_labels():
+    """new layer on a selected layer inherits its axis labels"""
+    viewer = ViewerModel()
+    # test from selected image layer
+    image_layer = viewer.add_image(
+        np.zeros((2, 2, 2)), axis_labels=('a', 'b', 'c')
+    )
+    viewer.layers.selection.active = image_layer
+    viewer._new_labels()  # image→labels
+    assert viewer.layers[-1].axis_labels == ('a', 'b', 'c')
+    assert viewer.layers[-1].axis_labels == image_layer.axis_labels
+    new_shapes(viewer)  # image→shapes
+    assert viewer.layers[-1].axis_labels == ('a', 'b', 'c')
+    assert viewer.layers[-1].axis_labels == image_layer.axis_labels
+    new_points(viewer)  # image→points
+    assert viewer.layers[-1].axis_labels == ('a', 'b', 'c')
+    assert viewer.layers[-1].axis_labels == image_layer.axis_labels
+    # test from selected shapes layer
+    shape_layer = viewer.add_shapes(ndim=3, axis_labels=('z', 'y', 'x'))
+    viewer.layers.selection.active = shape_layer
+    viewer._new_labels()  # shapes→labels
+    assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
+    assert viewer.layers[-1].axis_labels == shape_layer.axis_labels
+    new_shapes(viewer)  # shapes→shapes
+    assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
+    assert viewer.layers[-1].axis_labels == shape_layer.axis_labels
+    new_points(viewer)  # # shapes→points
+    assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
+    assert viewer.layers[-1].axis_labels == shape_layer.axis_labels
+    # test from unselected
+    viewer.layers.selection.active = None
+    new_shapes(viewer)  # unselected→shapes
+    assert viewer.layers[-1].axis_labels == ('-3', '-2', '-1')

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -715,12 +715,13 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             dtype_str = get_settings().application.new_labels_dtype
             empty_labels = np.zeros(shape, dtype=dtype_str)
             active = self.layers.selection.active
+            axis_labels = active.axis_labels if active is not None else None
             layer = Labels(
                 data=empty_labels,
                 translate=np.array(corner),
                 scale=scale,
                 units=units,
-                axis_labels=active.axis_labels if active is not None else None,
+                axis_labels=axis_labels,
             )
         else:
             layer = Labels(

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -696,6 +696,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
                 rotate=base_layer.rotate,
                 shear=base_layer.shear,
                 units=base_layer.units,
+                axis_labels=base_layer.axis_labels,
                 affine=base_layer.affine,
                 name=base_layer.name + ' - Labels',
             )
@@ -713,11 +714,13 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             ]
             dtype_str = get_settings().application.new_labels_dtype
             empty_labels = np.zeros(shape, dtype=dtype_str)
+            active = self.layers.selection.active
             layer = Labels(
                 data=empty_labels,
                 translate=np.array(corner),
                 scale=scale,
                 units=units,
+                axis_labels=active.axis_labels if active is not None else None,
             )
         else:
             layer = Labels(


### PR DESCRIPTION
# References and relevant issues
Related to #9285 - step 2.

# Description
This PR allows a new layer derived from a selected layer to inherit its axis labels (e.g. "new layer from selected" in the GUI).

Implemented for 3 different cases:
a. any layer → shapes/points layer
b. image/labels layer (ScalarFieldBase) → labels layer
c. shapes/points layer → labels layer

When more than one layer is selected, the new layer falls back to default numeric labels.

Added test asserts the new layer's axis labels match the source's or fall back to default if there is no selection.