### PR TITLE
deprecate setting dims axis labels in examples

### DIFF
--- a/examples/latlon-data-with-map.py
+++ b/examples/latlon-data-with-map.py
@@ -40,14 +40,12 @@ boundsWgsMap = gpd.GeoSeries(gpd.GeoDataFrame(geometry=gpd.points_from_xy([bg_ex
 viewer = napari.Viewer()
 viewer.camera.orientation2d=('up','right')
 viewer.floating_axes.visible=True
-viewer.dims.axis_labels=('lat','lon')
 viewer.window.add_plugin_dock_widget('napari', 'Features table widget')
 
 # add the downloaded background map as an image layer, with the correct translation and scale to match the lat/lon coordinates
-viewer.add_image(bg_map[:,:,:3][::-1], name='background', opacity=0.9, rgb=True,
+viewer.add_image(bg_map[:,:,:3][::-1], name='background', opacity=0.9, rgb=True, axis_labels=('lat','lon'),
                    translate=(boundsWgsMap[1], boundsWgsMap[0]),
                    scale=((boundsWgsMap[3]-boundsWgsMap[1])/bg_map.shape[0], (boundsWgsMap[2]-boundsWgsMap[0])/bg_map.shape[1])
-
                   )
 
 # add the points of interest as a points layer, using some of the features for coloring
@@ -59,7 +57,8 @@ points_layer = viewer.add_points(
     border_width=0.4,
     face_color='stars',
     face_colormap='reds',
-    size=0.002, name='POI'
+    size=0.002, name='POI',
+    axis_labels=('lat','lon'),
 )
 
 if __name__ == '__main__':

--- a/examples/xarray-latlon-timeseries.py
+++ b/examples/xarray-latlon-timeseries.py
@@ -68,7 +68,7 @@ air_layer = viewer.add_image(
         **get_scale_translate(airtemp, 'air'),
         colormap='viridis',
         blending='additive',
-        contrast_limits=(-23 + 273, 32 + 273),  # data are in degrees Kelvin,
+        contrast_limits=(-23 + 273, 32 + 273),  # data are in degrees Kelvin
         axis_labels=sst.sst.dims
         )
 

--- a/examples/xarray-latlon-timeseries.py
+++ b/examples/xarray-latlon-timeseries.py
@@ -58,9 +58,9 @@ viewer, sst_layer = napari.imshow(
         name='sea surface temp',
         **get_scale_translate(sst, 'sst'),
         colormap='magma',
+        axis_labels=sst.sst.dims,
         )
 viewer.scale_bar.visible = True
-viewer.dims.axis_labels = sst.sst.dims
 
 air_layer = viewer.add_image(
         airtemp.air,
@@ -68,7 +68,8 @@ air_layer = viewer.add_image(
         **get_scale_translate(airtemp, 'air'),
         colormap='viridis',
         blending='additive',
-        contrast_limits=(-23 + 273, 32 + 273),  # data are in degrees Kelvin
+        contrast_limits=(-23 + 273, 32 + 273),  # data are in degrees Kelvin,
+        axis_labels=sst.sst.dims
         )
 
 viewer.layers.units = ('hour', 'degrees', 'degrees')


### PR DESCRIPTION
# References and relevant issues
Related to #9285 - step 4.>1.

# Description
Drop setting dims.axis_labels in examples. Substituted with setting axis labels directly to layers.