### PR TITLE
Fix hidden grids when stride is not abs(1)

### DIFF
--- a/src/napari/components/_tests/test_grid.py
+++ b/src/napari/components/_tests/test_grid.py
@@ -159,13 +159,13 @@ def test_hidden_layers_with_large_stride():
         mock_layer(visible=False),
     ]
     # stride=3 → ceil(4/3)=2 grid squares → (1, 2) shape
-    assert grid.actual_shape(layers_mixed) == (1, 2)
+    assert grid.actual_shape(layers_mixed) == (1, 1)
     # Every layer gets a grid position (visibility ignored for stride >= 2)
     # Stride=3 packs 3 layers in cell 0, then 1 layer in cell 1
     assert grid.position(0, layers_mixed) == (0, 0)
-    assert grid.position(1, layers_mixed) == (0, 0)
+    assert grid.position(1, layers_mixed) == (-1, -1)
     assert grid.position(2, layers_mixed) == (0, 0)
-    assert grid.position(3, layers_mixed) == (0, 1)
+    assert grid.position(3, layers_mixed) == (-1, -1)
 
 
 def test_contents_at_with_hidden_layers():
@@ -230,10 +230,48 @@ def test_effective_indices():
     assert grid._effective_indices(layers_mixed) == [0, 2]
     # stride >= 2 → all layers regardless of visibility
     grid.stride = 2
-    assert grid._effective_indices(layers_mixed) == [0, 1, 2]
+    assert grid._effective_indices(layers_mixed) == [0, 2]
     grid.stride = 3
-    assert grid._effective_indices(layers_mixed) == [0, 1, 2]
+    assert grid._effective_indices(layers_mixed) == [0, 2]
     # Empty layers → empty list
     assert grid._effective_indices([]) == []
     # None → empty list
     assert grid._effective_indices() == []
+
+def test_hidden_layers_with_stride_equal_visible_count():
+    """Test stride=n with n visible + invisible layers ->  shape (1, 1).
+    
+    Regression test: stride=n with exactly n visible layers and
+    one or more invisible layers should produce a single viewbox.
+    """
+    grid = GridCanvas(enabled=True, stride=2)
+    layers = [
+        mock_layer(visible=True),
+        mock_layer(visible=True),
+        mock_layer(visible=False),
+        mock_layer(visible=False),
+    ]
+    # Both visible layers are in group 0 (indices 0,1)
+    # Group 1 (index 2) is entirely invisible -> not counted
+    assert grid.actual_shape(layers) == (1, 1)
+    assert grid.position(0, layers) == (0, 0)
+    assert grid.position(1, layers) == (0, 0)
+    assert grid.position(2, layers) == (-1, -1)
+
+    # Alternate visibility test
+    layers_alt = [
+        mock_layer(visible=True),
+        mock_layer(visible=False),
+        mock_layer(visible=True),
+        mock_layer(visible=False),
+        mock_layer(visible=True),
+        mock_layer(visible=False),
+    ]
+  
+    assert grid.actual_shape(layers_alt) == (2, 2)
+    assert grid.position(0, layers_alt) == (0, 0)
+    assert grid.position(1, layers_alt) == (-1, -1)
+    assert grid.position(2, layers_alt) == (0, 1)
+    assert grid.position(3, layers_alt) == (-1, -1)
+    assert grid.position(4, layers_alt) == (1, 0)
+    assert grid.position(5, layers_alt) == (-1, -1)

--- a/src/napari/components/_tests/test_grid.py
+++ b/src/napari/components/_tests/test_grid.py
@@ -238,9 +238,10 @@ def test_effective_indices():
     # None → empty list
     assert grid._effective_indices() == []
 
+
 def test_hidden_layers_with_stride_equal_visible_count():
     """Test stride=n with n visible + invisible layers ->  shape (1, 1).
-    
+
     Regression test: stride=n with exactly n visible layers and
     one or more invisible layers should produce a single viewbox.
     """
@@ -267,7 +268,7 @@ def test_hidden_layers_with_stride_equal_visible_count():
         mock_layer(visible=True),
         mock_layer(visible=False),
     ]
-  
+
     assert grid.actual_shape(layers_alt) == (2, 2)
     assert grid.position(0, layers_alt) == (0, 0)
     assert grid.position(1, layers_alt) == (-1, -1)

--- a/src/napari/components/grid.py
+++ b/src/napari/components/grid.py
@@ -137,13 +137,17 @@ class GridCanvas(EventedModel):
         # Compute viewbox index based on stride and effective indices
         viewbox = index // abs(self.stride)
         # build a sorted list of occupied stride groups
-        occupied_groups = sorted({i // abs(self.stride) for i in effective_indices})
+        occupied_groups = sorted(
+            {i // abs(self.stride) for i in effective_indices}
+        )
 
         # Map the viewbox to a linear position in the grid, depending on the stride direction
         if self.stride > 0:
             linear_pos = occupied_groups.index(viewbox)
         else:
-            linear_pos = len(occupied_groups) - 1 - occupied_groups.index(viewbox)
+            linear_pos = (
+                len(occupied_groups) - 1 - occupied_groups.index(viewbox)
+            )
 
         adj_i = linear_pos % (n_row * n_column)
         i_row = adj_i // n_column

--- a/src/napari/components/grid.py
+++ b/src/napari/components/grid.py
@@ -78,17 +78,22 @@ class GridCanvas(EventedModel):
             return (1, 1)
 
         n_row, n_column = self.shape
-        n_grid_squares = np.ceil(
-            len(self._effective_indices(layers)) / abs(self.stride)
+
+        # Compute the number of occupied stride groups, which is the number of
+        # viewboxes that will be used to display the layers in the grid.
+        effective = self._effective_indices(layers)
+        stride = abs(self.stride)
+        occupied_groups = np.ceil(
+            len({i // stride for i in effective})
         ).astype(int)
 
         if n_row == -1 and n_column == -1:
-            n_column = np.ceil(np.sqrt(n_grid_squares)).astype(int)
-            n_row = np.ceil(n_grid_squares / n_column).astype(int)
+            n_column = np.ceil(np.sqrt(occupied_groups)).astype(int)
+            n_row = np.ceil(occupied_groups / n_column).astype(int)
         elif n_row == -1:
-            n_row = np.ceil(n_grid_squares / n_column).astype(int)
+            n_row = np.ceil(occupied_groups / n_column).astype(int)
         elif n_column == -1:
-            n_column = np.ceil(n_grid_squares / n_row).astype(int)
+            n_column = np.ceil(occupied_groups / n_row).astype(int)
 
         n_row = max(1, n_row)
         n_column = max(1, n_column)
@@ -129,16 +134,21 @@ class GridCanvas(EventedModel):
         n_row, n_column = self.actual_shape(layers)
 
         # Adjust for forward or reverse ordering
-        adj_i = (
-            effective_indices.index(index)
-            if self.stride > 0
-            else len(effective_indices) - effective_indices.index(index) - 1
-        )
+        # Compute viewbox index based on stride and effective indices
+        viewbox = index // abs(self.stride)
+        # build a sorted list of occupied stride groups
+        occupied_groups = sorted({i // abs(self.stride) for i in effective_indices})
 
-        adj_i = adj_i // abs(self.stride)
-        adj_i = adj_i % (n_row * n_column)
+        # Map the viewbox to a linear position in the grid, depending on the stride direction
+        if self.stride > 0:
+            linear_pos = occupied_groups.index(viewbox)
+        else:
+            linear_pos = len(occupied_groups) - 1 - occupied_groups.index(viewbox)
+
+        adj_i = linear_pos % (n_row * n_column)
         i_row = adj_i // n_column
         i_column = adj_i % n_column
+
         # convert to python int from np int
         return (int(i_row), int(i_column))
 
@@ -256,8 +266,4 @@ class GridCanvas(EventedModel):
         """Return a list of original layer indices that are "active" in the grid."""
         if layers is None:
             return []
-        if abs(self.stride) >= 2:
-            return list(range(len(layers)))
-        if abs(self.stride) == 1:
-            return [i for i, layer in enumerate(layers) if layer.visible]
-        return list(range(len(layers)))
+        return [i for i, layer in enumerate(layers) if layer.visible]


### PR DESCRIPTION
# References and relevant issues
 Closes Issue #9305
 From the PR #9244, Followup: do this even when stride is not abs(1)! 
The major issues are: 
1. When stride = 2, Layers =3 (1 hidden ; 2 visible) , grid shape = (1,2) where it should be (1,1)
2. Alternating visible and hidden layers should result in grid shape = (2,2)

# Description
This PR fixes these in grid mode by building a sorted list of occupied groups and adds tests for previous failure cases. 

