### PR TITLE
Add tests to check if all mehod to create image have consistent signatures

### DIFF
--- a/src/napari/_tests/test_view_layers.py
+++ b/src/napari/_tests/test_view_layers.py
@@ -14,6 +14,8 @@ from docstring_parser.numpydoc import parse as parse_docstring
 import napari
 from napari import Viewer, layers as module
 from napari._tests.utils import check_viewer_functioning
+from napari.layers import Image
+from napari.utils._test_utils import validate_match_signature
 from napari.utils.misc import camel_to_snake
 
 layers = []
@@ -181,3 +183,11 @@ def test_imshow_with_viewer(qtbot, make_napari_viewer):
     view = viewer.window._qt_viewer
     check_viewer_functioning(viewer, view, data, ndim)
     viewer.close()
+
+
+def test_add_image_consistency():
+    validate_match_signature(
+        Image,
+        napari.imshow,
+        {'channel_axis', 'title', 'show', 'viewer', 'ndisplay', 'order'},
+    )

--- a/src/napari/components/_tests/test_viewer_model.py
+++ b/src/napari/components/_tests/test_viewer_model.py
@@ -18,6 +18,7 @@ from napari.layers.shapes._tests.conftest import (
     ten_four_corner,  # noqa: F401
 )  # import to not put this data in top level conftest.py
 from napari.settings import get_settings
+from napari.utils._test_utils import validate_match_signature
 from napari.utils.colormaps import AVAILABLE_COLORMAPS, Colormap
 from napari.utils.events.event import WarningEmitter
 
@@ -1349,3 +1350,9 @@ def test_new_labels_axis_labels_inheritance_on_single_selection():
     viewer._new_labels()
     assert viewer.layers[-1].axis_labels == ('z', 'y', 'x')
     assert viewer.layers[-1].axis_labels == shapes_layer.axis_labels
+
+
+def test_add_image_consistency():
+    validate_match_signature(
+        Image, ViewerModel.add_image, {'self', 'channel_axis'}
+    )

--- a/src/napari/utils/_test_utils.py
+++ b/src/napari/utils/_test_utils.py
@@ -3,6 +3,7 @@ File with things that are useful for testing, but not to be fixtures
 """
 
 import inspect
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -72,6 +73,47 @@ def validate_kwargs_sorted(func):
     ]
     assert kwargs_list == sorted(kwargs_list), (
         'Keyword arguments are not sorted in function signature'
+    )
+
+
+def validate_match_signature(
+    func: Callable,
+    other_func: Callable,
+    additional_params: set[str] | None = None,
+):
+    """
+    Check if the signature of other_func matches the signature of func,
+    allowing for additional parameters in other_func.
+
+    It raises an AssertionError if the signatures do not match.
+    with information abourt all mismatches.
+
+    Parameters
+    ----------
+    func : Callable
+        The function whose signature is to be matched.
+    other_func : Callable
+        The function whose signature is to be checked against func.
+    additional_params : set[str], optional
+        A set of parameter names that are allowed to be present in other_func but not in func.
+        If None, no additional parameters are allowed.
+    """
+    sig1 = inspect.signature(func)
+    sig2 = inspect.signature(other_func)
+
+    if additional_params is None:
+        additional_params = set()
+
+    desired_params = set(sig1.parameters.keys()) | additional_params
+    actual_params = set(sig2.parameters.keys())
+    missed_params = desired_params - actual_params
+    extra_params = actual_params - desired_params
+
+    assert not missed_params, (
+        f'Function {other_func.__name__} is missing parameters: {", ".join(missed_params)}'
+    )
+    assert not extra_params, (
+        f'Function {other_func.__name__} has extra parameters: {", ".join(extra_params)}'
     )
 
 

--- a/src/napari/utils/_test_utils.py
+++ b/src/napari/utils/_test_utils.py
@@ -80,7 +80,7 @@ def validate_match_signature(
     func: Callable,
     other_func: Callable,
     additional_params: set[str] | None = None,
-):
+) -> None:
     """
     Check if the signature of other_func matches the signature of func,
     allowing for additional parameters in other_func.


### PR DESCRIPTION
# References and relevant issues


# Description

To avoid future problems with updates of signatures. 

Currently check only names. Once we add types, we should add checking of types too. 
