### PR TITLE
UI: Add back the space between the arrow and 'activity'

### DIFF
--- a/src/napari/_qt/dialogs/qt_activity_dialog.py
+++ b/src/napari/_qt/dialogs/qt_activity_dialog.py
@@ -40,7 +40,7 @@ class ActivityToggleItem(QWidget):
         )
         self._activityBtn.setArrowType(Qt.ArrowType.UpArrow)
         self._activityBtn.setIconSize(QSize(11, 11))
-        self._activityBtn.setText('activity')
+        self._activityBtn.setText(' activity')
         self._activityBtn.setCheckable(True)
 
         self._inProgressIndicator = QLabel('in progress...', self)


### PR DESCRIPTION
# References and relevant issues
From: https://github.com/napari/napari/pull/8935#discussion_r3676411188

# Description
Adds back the space between the Up arrow and the word 'activity' in the status bar (bottom right).