### PR TITLE
Reorder font-family declaration in console QSS

### DIFF
--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -118,7 +118,7 @@ QtConsole > QTextEdit {
   color: {{ text }};
   selection-background-color: {{ highlight }};
   margin: 10px;
-  font-family: monospace, Menlo, Consolas, "Ubuntu Mono", "Roboto Mono", "DejaVu Sans Mono";
+  font-family: Menlo, Consolas, "Ubuntu Mono", "Roboto Mono", "DejaVu Sans Mono", monospace;
   font-size: {{ font_size }};
   border: 1px solid {{ console }};
 }


### PR DESCRIPTION
# References and relevant issues
For a while I've been getting the following warning when opening the console:
```
WARNING: Populating font family aliases took 157 ms. Replace uses of missing font family "Monospace" with one that exists to avoid this cost.
22:56:38 : WARNING : MainThread : Populating font family aliases took 157 ms. Replace uses of missing font family "Monospace" with one that exists to avoid this cost.
```
I did some digging and it's related to the qss lookup handling.

# Description
This is a tiny revert of a regression from https://github.com/napari/napari/pull/8927

By sorting the generic alias to the end, a real font should always be used first which should be faster.
I tested locally and this does resolve the issue on macOS: no warning and the console opens faster.
(I still get the debugger warning but that's a different issue).
Note: QSS differs from CSS in the way that aliases are handled. There are no QSS generic aliases in Qt.
