### PR TITLE
fix(dims): seed per-axis playback settings from preferences instead of binding to them

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_dims_slider.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims_slider.py
@@ -1,5 +1,7 @@
 from napari._qt.widgets.qt_dims import QtDims, QtDimSliderWidget
 from napari.components import Dims
+from napari.settings import get_settings
+from napari.settings._constants import LoopMode
 
 
 def test_same_margin_popup(qtbot):
@@ -30,3 +32,155 @@ def test_move_margin_popup(qtbot):
     assert slider.margins_popup.right_slider.value() == dims.margin_right[0]
     slider.margins_popup.left_slider.setValue(1)
     assert slider.margins_popup.left_slider.value() == dims.margin_left[0]
+
+
+def test_playback_settings_seed_from_preferences(qtbot):
+    """A new slider starts at the playback settings from the preferences."""
+    settings = get_settings()
+    settings.application.playback_fps = 27
+    settings.application.playback_mode = LoopMode.ONCE
+
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider: QtDimSliderWidget = view.slider_widgets[0]
+
+    assert slider.fps == 27
+    assert slider.loop_mode == LoopMode.ONCE
+
+
+def test_preference_change_keeps_per_axis_override(qtbot):
+    """Changing the preference must not stomp an axis's own playback speed.
+
+    Each slider owns its fps, set per axis from the play button's popup, so a
+    later preference change is a new default rather than an edict: it applies
+    to sliders created afterwards and leaves existing overrides alone.
+    """
+    settings = get_settings()
+    settings.application.playback_fps = 10
+
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider: QtDimSliderWidget = view.slider_widgets[0]
+
+    slider.fps = 30  # as the popup does
+    settings.application.playback_fps = 15
+
+    assert slider.fps == 30
+
+
+def test_popup_restore_defaults_resets_playback_settings(qtbot):
+    """The popup's "restore defaults" re-reads the preference for that axis."""
+    settings = get_settings()
+    settings.application.playback_fps = 10
+    settings.application.playback_mode = LoopMode.LOOP
+
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider: QtDimSliderWidget = view.slider_widgets[0]
+
+    slider.fps = 30
+    slider.loop_mode = LoopMode.ONCE
+
+    slider.play_button.reset_button.click()
+
+    assert slider.fps == 10
+    assert slider.loop_mode == LoopMode.LOOP
+
+
+def test_popup_restore_defaults_resets_only_its_own_axis(qtbot):
+    """Restoring one axis's playback settings leaves the other axes alone."""
+    settings = get_settings()
+    settings.application.playback_fps = 10
+
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    first: QtDimSliderWidget = view.slider_widgets[0]
+    second: QtDimSliderWidget = view.slider_widgets[1]
+
+    first.fps = 30
+    second.fps = 45
+
+    first.play_button.reset_button.click()
+
+    assert first.fps == 10
+    assert second.fps == 45
+
+
+def test_popup_restore_defaults_restores_reverse_playback(qtbot):
+    """A negative preference fps restores as reverse playback."""
+    settings = get_settings()
+    settings.application.playback_fps = -12
+
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider: QtDimSliderWidget = view.slider_widgets[0]
+
+    slider.fps = 30
+
+    slider.play_button.reset_button.click()
+
+    assert slider.fps == -12
+    assert slider.play_button.reverse_check.isChecked()
+
+
+def test_popup_restore_defaults_announces_fps_once(qtbot):
+    """Reset publishes the default speed only, never an intermediate one.
+
+    Reversing direction and changing magnitude are one edit. Announcing the
+    new direction against the old magnitude would hand a running animation
+    (which follows ``fps_changed``) a speed the user never chose.
+    """
+    settings = get_settings()
+    settings.application.playback_fps = -12
+
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    slider: QtDimSliderWidget = view.slider_widgets[0]
+
+    slider.fps = 30
+
+    announced = []
+    slider.fps_changed.connect(announced.append)
+    slider.play_button.reset_button.click()
+
+    assert announced == [-12]
+
+
+def test_preferences_reset_then_popup_restore_defaults(qtbot):
+    """The full workflow this change is about.
+
+    "Restore Defaults" in preferences restores the preference and leaves the
+    per-axis overrides alone; the popup's own button is what re-reads it.
+    """
+    settings = get_settings()
+    settings.application.playback_fps = 24
+    settings.application.playback_mode = LoopMode.ONCE
+    default_fps = settings.application._defaults['playback_fps']
+    default_mode = settings.application._defaults['playback_mode']
+
+    dims = Dims(ndim=3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+    first: QtDimSliderWidget = view.slider_widgets[0]
+    second: QtDimSliderWidget = view.slider_widgets[1]
+    assert first.fps == 24  # seeded from the preference
+
+    first.fps = 30  # as the popup does
+    settings.reset()
+
+    # the preference went back to its default; the axes did not move
+    assert settings.application.playback_fps == default_fps
+    assert first.fps == 30
+    assert second.fps == 24
+
+    first.play_button.reset_button.click()
+
+    assert first.fps == default_fps
+    assert first.loop_mode == default_mode
+    assert second.fps == 24  # still untouched

--- a/src/napari/_qt/widgets/_tests/test_qt_dims_slider.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims_slider.py
@@ -34,153 +34,52 @@ def test_move_margin_popup(qtbot):
     assert slider.margins_popup.left_slider.value() == dims.margin_left[0]
 
 
-def test_playback_settings_seed_from_preferences(qtbot):
-    """A new slider starts at the playback settings from the preferences."""
+def test_playback_settings_seed_sliders_but_do_not_bind_them(qtbot):
     settings = get_settings()
-    settings.application.playback_fps = 27
+    settings.application.playback_fps = 24
     settings.application.playback_mode = LoopMode.ONCE
 
     dims = Dims(ndim=3)
     view = QtDims(dims)
     qtbot.addWidget(view)
-    slider: QtDimSliderWidget = view.slider_widgets[0]
+    first, second = view.slider_widgets[0], view.slider_widgets[1]
+    assert first.fps == 24
+    assert first.loop_mode == LoopMode.ONCE
 
-    assert slider.fps == 27
-    assert slider.loop_mode == LoopMode.ONCE
-
-
-def test_preference_change_keeps_per_axis_override(qtbot):
-    """Changing the preference must not stomp an axis's own playback speed.
-
-    Each slider owns its fps, set per axis from the play button's popup, so a
-    later preference change is a new default rather than an edict: it applies
-    to sliders created afterwards and leaves existing overrides alone.
-    """
-    settings = get_settings()
-    settings.application.playback_fps = 10
-
-    dims = Dims(ndim=3)
-    view = QtDims(dims)
-    qtbot.addWidget(view)
-    slider: QtDimSliderWidget = view.slider_widgets[0]
-
-    slider.fps = 30  # as the popup does
+    first.fps = 30  # as the popup does
     settings.application.playback_fps = 15
+    assert first.fps == 30
+    assert second.fps == 24
 
-    assert slider.fps == 30
+    settings.reset()
+    assert first.fps == 30
+    assert second.fps == 24
 
 
-def test_popup_restore_defaults_resets_playback_settings(qtbot):
-    """The popup's "restore defaults" re-reads the preference for that axis."""
+def test_popup_restore_defaults_re_reads_the_preference(qtbot):
     settings = get_settings()
-    settings.application.playback_fps = 10
+    settings.application.playback_fps = -12
     settings.application.playback_mode = LoopMode.LOOP
 
     dims = Dims(ndim=3)
     view = QtDims(dims)
     qtbot.addWidget(view)
-    slider: QtDimSliderWidget = view.slider_widgets[0]
-
-    slider.fps = 30
-    slider.loop_mode = LoopMode.ONCE
-
-    slider.play_button.reset_button.click()
-
-    assert slider.fps == 10
-    assert slider.loop_mode == LoopMode.LOOP
-
-
-def test_popup_restore_defaults_resets_only_its_own_axis(qtbot):
-    """Restoring one axis's playback settings leaves the other axes alone."""
-    settings = get_settings()
-    settings.application.playback_fps = 10
-
-    dims = Dims(ndim=3)
-    view = QtDims(dims)
-    qtbot.addWidget(view)
-    first: QtDimSliderWidget = view.slider_widgets[0]
-    second: QtDimSliderWidget = view.slider_widgets[1]
-
+    first, second = view.slider_widgets[0], view.slider_widgets[1]
     first.fps = 30
+    first.loop_mode = LoopMode.ONCE
     second.fps = 45
 
+    announced = []
+    first.fps_changed.connect(announced.append)
     first.play_button.reset_button.click()
 
-    assert first.fps == 10
+    assert first.fps == -12
+    assert first.play_button.reverse_check.isChecked()
+    assert first.loop_mode == LoopMode.LOOP
+    assert announced == [-12]  # never the intermediate -30 or 12
     assert second.fps == 45
 
-
-def test_popup_restore_defaults_restores_reverse_playback(qtbot):
-    """A negative preference fps restores as reverse playback."""
-    settings = get_settings()
-    settings.application.playback_fps = -12
-
-    dims = Dims(ndim=3)
-    view = QtDims(dims)
-    qtbot.addWidget(view)
-    slider: QtDimSliderWidget = view.slider_widgets[0]
-
-    slider.fps = 30
-
-    slider.play_button.reset_button.click()
-
-    assert slider.fps == -12
-    assert slider.play_button.reverse_check.isChecked()
-
-
-def test_popup_restore_defaults_announces_fps_once(qtbot):
-    """Reset publishes the default speed only, never an intermediate one.
-
-    Reversing direction and changing magnitude are one edit. Announcing the
-    new direction against the old magnitude would hand a running animation
-    (which follows ``fps_changed``) a speed the user never chose.
-    """
-    settings = get_settings()
-    settings.application.playback_fps = -12
-
-    dims = Dims(ndim=3)
-    view = QtDims(dims)
-    qtbot.addWidget(view)
-    slider: QtDimSliderWidget = view.slider_widgets[0]
-
-    slider.fps = 30
-
-    announced = []
-    slider.fps_changed.connect(announced.append)
-    slider.play_button.reset_button.click()
-
-    assert announced == [-12]
-
-
-def test_preferences_reset_then_popup_restore_defaults(qtbot):
-    """The full workflow this change is about.
-
-    "Restore Defaults" in preferences restores the preference and leaves the
-    per-axis overrides alone; the popup's own button is what re-reads it.
-    """
-    settings = get_settings()
-    settings.application.playback_fps = 24
-    settings.application.playback_mode = LoopMode.ONCE
-    default_fps = settings.application._defaults['playback_fps']
-    default_mode = settings.application._defaults['playback_mode']
-
-    dims = Dims(ndim=3)
-    view = QtDims(dims)
-    qtbot.addWidget(view)
-    first: QtDimSliderWidget = view.slider_widgets[0]
-    second: QtDimSliderWidget = view.slider_widgets[1]
-    assert first.fps == 24  # seeded from the preference
-
-    first.fps = 30  # as the popup does
-    settings.reset()
-
-    # the preference went back to its default; the axes did not move
-    assert settings.application.playback_fps == default_fps
-    assert first.fps == 30
-    assert second.fps == 24
-
+    settings.application.playback_fps = 20
     first.play_button.reset_button.click()
-
-    assert first.fps == default_fps
-    assert first.loop_mode == default_mode
-    assert second.fps == 24  # still untouched
+    assert first.fps == 20
+    assert not first.play_button.reverse_check.isChecked()

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -29,7 +29,6 @@ from napari._qt.widgets.qt_scrollbar import ModifiedScrollBar
 from napari.components import Dims
 from napari.settings import get_settings
 from napari.settings._constants import LoopMode
-from napari.utils.events.event_utils import connect_setattr_value
 
 if TYPE_CHECKING:
     from qtpy.QtGui import QResizeEvent
@@ -98,18 +97,17 @@ class QtDimSliderWidget(QWidget):
         sep.setFixedSize(1, 14)
         sep.setObjectName('slice_label_sep')
 
+        # The preference seeds this axis's playback settings; it does not stay
+        # bound to them. Each slider owns its own fps and loop mode, which the
+        # play button's popup edits per axis, so pushing a later preference
+        # change into every open slider would silently discard those overrides.
+        # "restore defaults" in the popup re-reads the preference on demand.
         settings = get_settings()
         self._fps = settings.application.playback_fps
-        connect_setattr_value(
-            settings.application.events.playback_fps, self, 'fps'
-        )
 
         self._minframe = 0
         self._maxframe = 0
         self._loop_mode = settings.application.playback_mode
-        connect_setattr_value(
-            settings.application.events.playback_mode, self, 'loop_mode'
-        )
 
         layout = QHBoxLayout()
         self.axis_label = self._create_axis_label_widget()
@@ -218,9 +216,29 @@ class QtDimSliderWidget(QWidget):
 
         play_button.fpsspin.editingFinished.connect(self._fps_listener)
         play_button.reverse_check.stateChanged.connect(self._fps_listener)
+        play_button.reset_button.clicked.connect(self._reset_playback_settings)
         self.play_stopped.connect(play_button._handle_stop)
         self.play_started.connect(play_button._handle_start)
         return play_button
+
+    def _reset_playback_settings(self) -> None:
+        """Re-read this axis's playback settings from the preferences."""
+        settings = get_settings()
+        fps = settings.application.playback_fps
+        # Both controls are updated before anything is announced: letting
+        # setChecked emit would run _fps_listener against the old spinbox
+        # value, publishing a speed that is neither the override nor the
+        # default. A running animation follows fps_changed, so it would act
+        # on that intermediate value. Afterwards _fps_listener runs once, as
+        # it does when the value is typed in, so the button's `reverse`
+        # styling stays in sync.
+        with qt_signals_blocked(self.play_button.reverse_check):
+            self.play_button.reverse_check.setChecked(fps < 0)
+            self.play_button.fpsspin.setValue(abs(fps))
+        self._fps_listener()
+        self.play_button.mode_combo.setCurrentText(
+            str(settings.application.playback_mode).replace('_', ' ')
+        )
 
     def _fps_listener(self, *_) -> None:
         fps = self.play_button.fpsspin.value()
@@ -548,6 +566,17 @@ class QtPlayButton(QPushButton):
         )
         mode_combo.setCurrentText(str(self.mode).replace('_', ' '))
         self.mode_combo = mode_combo
+
+        # The popup is where the per-axis override is made, so it is also where
+        # it is revoked - the preferences dialog resets preferences, not the
+        # per-axis state seeded from them.
+        reset_button = QPushButton('restore defaults', parent=self.popup)
+        reset_button.setObjectName('playbackResetButton')
+        reset_button.setToolTip(
+            'Reset this axis to the playback speed and mode set in preferences.'
+        )
+        form_layout.insertRow(3, reset_button)
+        self.reset_button = reset_button
 
     def mouseReleaseEvent(self, event):
         """Show popup for right-click, toggle animation for right click.

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -29,7 +29,6 @@ from napari._qt.widgets.qt_scrollbar import ModifiedScrollBar
 from napari.components import Dims
 from napari.settings import get_settings
 from napari.settings._constants import LoopMode
-from napari.utils.events.event_utils import connect_setattr_value
 
 if TYPE_CHECKING:
     from qtpy.QtGui import QResizeEvent
@@ -98,18 +97,17 @@ class QtDimSliderWidget(QWidget):
         sep.setFixedSize(1, 14)
         sep.setObjectName('slice_label_sep')
 
+        # The preference seeds this axis's playback settings; it does not stay
+        # bound to them. Each slider owns its own fps and loop mode, which the
+        # play button's popup edits per axis, so pushing a later preference
+        # change into every open slider would silently discard those overrides.
+        # "restore defaults" in the popup re-reads the preference on demand.
         settings = get_settings()
         self._fps = settings.application.playback_fps
-        connect_setattr_value(
-            settings.application.events.playback_fps, self, 'fps'
-        )
 
         self._minframe = 0
         self._maxframe = 0
         self._loop_mode = settings.application.playback_mode
-        connect_setattr_value(
-            settings.application.events.playback_mode, self, 'loop_mode'
-        )
 
         layout = QHBoxLayout()
         self.axis_label = self._create_axis_label_widget()
@@ -218,9 +216,29 @@ class QtDimSliderWidget(QWidget):
 
         play_button.fpsspin.editingFinished.connect(self._fps_listener)
         play_button.reverse_check.stateChanged.connect(self._fps_listener)
+        play_button.reset_button.clicked.connect(self._reset_playback_settings)
         self.play_stopped.connect(play_button._handle_stop)
         self.play_started.connect(play_button._handle_start)
         return play_button
+
+    def _reset_playback_settings(self) -> None:
+        """Re-read this axis's playback settings from the preferences."""
+        settings = get_settings()
+        fps = settings.application.playback_fps
+        # Both controls are updated before anything is announced: letting
+        # setChecked emit would run _fps_listener against the old spinbox
+        # value, publishing a speed that is neither the override nor the
+        # default. A running animation follows fps_changed, so it would act
+        # on that intermediate value. Afterwards _fps_listener runs once, as
+        # it does when the value is typed in, so the button's `reverse`
+        # styling stays in sync.
+        with qt_signals_blocked(self.play_button.reverse_check):
+            self.play_button.reverse_check.setChecked(fps < 0)
+            self.play_button.fpsspin.setValue(abs(fps))
+        self._fps_listener()
+        self.play_button.mode_combo.setCurrentText(
+            str(settings.application.playback_mode).replace('_', ' ')
+        )
 
     def _fps_listener(self, *_) -> None:
         fps = self.play_button.fpsspin.value()
@@ -529,6 +547,17 @@ class QtPlayButton(QPushButton):
         )
         mode_combo.setCurrentText(str(self.mode).replace('_', ' '))
         self.mode_combo = mode_combo
+
+        # The popup is where the per-axis override is made, so it is also where
+        # it is revoked - the preferences dialog resets preferences, not the
+        # per-axis state seeded from them.
+        reset_button = QPushButton('restore defaults', parent=self.popup)
+        reset_button.setObjectName('playbackResetButton')
+        reset_button.setToolTip(
+            'Reset this axis to the playback speed and mode set in preferences.'
+        )
+        form_layout.insertRow(3, reset_button)
+        self.reset_button = reset_button
 
     def mouseReleaseEvent(self, event):
         """Show popup for right-click, toggle animation for right click.

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -97,11 +97,6 @@ class QtDimSliderWidget(QWidget):
         sep.setFixedSize(1, 14)
         sep.setObjectName('slice_label_sep')
 
-        # The preference seeds this axis's playback settings; it does not stay
-        # bound to them. Each slider owns its own fps and loop mode, which the
-        # play button's popup edits per axis, so pushing a later preference
-        # change into every open slider would silently discard those overrides.
-        # "restore defaults" in the popup re-reads the preference on demand.
         settings = get_settings()
         self._fps = settings.application.playback_fps
 
@@ -225,13 +220,8 @@ class QtDimSliderWidget(QWidget):
         """Re-read this axis's playback settings from the preferences."""
         settings = get_settings()
         fps = settings.application.playback_fps
-        # Both controls are updated before anything is announced: letting
-        # setChecked emit would run _fps_listener against the old spinbox
-        # value, publishing a speed that is neither the override nor the
-        # default. A running animation follows fps_changed, so it would act
-        # on that intermediate value. Afterwards _fps_listener runs once, as
-        # it does when the value is typed in, so the button's `reverse`
-        # styling stays in sync.
+        # Set both controls before announcing: a mid-edit emit would hand a
+        # running animation a speed the user never chose.
         with qt_signals_blocked(self.play_button.reverse_check):
             self.play_button.reverse_check.setChecked(fps < 0)
             self.play_button.fpsspin.setValue(abs(fps))
@@ -548,9 +538,6 @@ class QtPlayButton(QPushButton):
         mode_combo.setCurrentText(str(self.mode).replace('_', ' '))
         self.mode_combo = mode_combo
 
-        # The popup is where the per-axis override is made, so it is also where
-        # it is revoked - the preferences dialog resets preferences, not the
-        # per-axis state seeded from them.
         reset_button = QPushButton('restore defaults', parent=self.popup)
         reset_button.setObjectName('playbackResetButton')
         reset_button.setToolTip(


### PR DESCRIPTION
## References and relevant issues

Noticed while using "Restore Defaults" in the preferences dialog. Related: #9329.

## Description

Each dims slider owns its playback fps and loop mode. The play button's popup edits them per axis and never writes the preference, but the slider also *followed* `playback_fps` and `playback_mode`, so the value flowed down and never back up. Two bugs come out of that: changing playback speed in Preferences silently discards every per-axis override, and "Restore Defaults" leaves the overrides in place, since the preference is usually already at its default so resetting it emits nothing.

The preference is the seed, not the value. This drops the live binding and puts the revoke where the override is made: a "restore defaults" button in the popup that re-reads the preference for that axis alone.

Behavior change worth flagging: changing playback speed in Preferences no longer moves sliders that are already open, only ones created afterwards.
