### PR TITLE
Vectors: make edge_color_mode = 'direct' actually leave the feature mapping

### DIFF
--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -457,6 +457,27 @@ def test_edge_color_cycle():
     np.testing.assert_array_equal(layer.edge_color, edge_color_array)
 
 
+def test_switching_edge_color_mode_back_to_direct():
+    """Setting the mode to direct takes the layer out of a feature mapping.
+
+    The setter used to assign an attribute nothing reads (`_edge_color_mode`), so the
+    layer stayed in colormap/cycle mode and only the event fired — Points and Shapes
+    switch as expected.
+    """
+    data = np.zeros((6, 2, 2))
+    data[:, 1] = [1, 1]
+    layer = Vectors(
+        data,
+        features={'phase': np.linspace(-1, 1, 6)},
+        edge_color='phase',
+    )
+    assert layer.edge_color_mode == 'colormap'
+
+    layer.edge_color_mode = 'direct'
+
+    assert layer.edge_color_mode == 'direct'
+
+
 def test_edge_color_colormap():
     """Test creating Vectors where edge color is set by a colormap"""
     shape = (10, 2)

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -591,7 +591,7 @@ class Vectors(Layer):
         edge_color_mode = ColorMode(edge_color_mode)
 
         if edge_color_mode == ColorMode.DIRECT:
-            self._edge_color_mode = edge_color_mode
+            self._edge.color_mode = edge_color_mode
         elif edge_color_mode in (ColorMode.CYCLE, ColorMode.COLORMAP):
             if self._edge.color_properties is not None:
                 color_property = self._edge.color_properties.name


### PR DESCRIPTION
`Vectors.edge_color_mode = 'direct'` assigns `self._edge_color_mode`, an attribute nothing reads — the getter returns `self._edge.color_mode`, which keeps its previous value. A layer in colormap or cycle mode therefore stays there while the setter reports success and fires its event. `Points` and `Shapes` both switch correctly:

```
vectors before: colormap    points  before: colormap    shapes  before: colormap
vectors after : colormap    points  after : direct      shapes  after : direct
```

From the layer controls the bug is masked twice: the mode dropdown updates its own widgets from the *requested* mode, and picking a color afterwards puts the color manager into direct mode as a side effect. Setting the property programmatically has no such rescue.

The fix is one line — assign `self._edge.color_mode`, as the cycle and colormap branches already do.

**Tests:** `test_switching_edge_color_mode_back_to_direct` asserts the round trip out of colormap mode.

Fixes #9332 
