### PR TITLE
Vectors: choose the colormap and its contrast limits for feature-mapped edge color

### DIFF
--- a/src/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_layer_controls.py
@@ -19,7 +19,7 @@ from qtpy.QtWidgets import (
     QPushButton,
     QRadioButton,
 )
-from superqt.sliders import QRangeSlider
+from superqt.sliders import QLabeledRangeSlider, QRangeSlider
 
 from napari._qt.layer_controls.qt_image_controls import QtImageControls
 from napari._qt.layer_controls.qt_image_controls_base import (
@@ -55,6 +55,10 @@ from napari.utils._test_utils import (
 )
 from napari.utils.colormaps import DirectLabelColormap
 from napari.utils.events.event import Event
+
+# A labeled range slider is not a QRangeSlider subclass, but takes the same
+# (low, high) values -- both spellings must go down the ranged branches below.
+_RANGE_SLIDERS = (QRangeSlider, QLabeledRangeSlider)
 
 
 def strip_ansi_codes(text: str) -> str:
@@ -367,7 +371,7 @@ def test_create_layer_controls_qslider(
     # check QAbstractSlider by changing value with `setValue` from minimum value to maximum
     for qslider in ctrl.findChildren(QAbstractSlider):
         if isinstance(qslider.minimum(), float):
-            if isinstance(qslider, QRangeSlider):
+            if isinstance(qslider, _RANGE_SLIDERS):
                 # create a list of tuples in the case the slider is ranged
                 # from (minimum, minimum) to (maximum, maximum) +
                 # from (minimum, maximum) to (minimum, minimum)
@@ -389,7 +393,7 @@ def test_create_layer_controls_qslider(
             else:
                 value_range = np.linspace(qslider.minimum(), qslider.maximum())
         else:
-            if isinstance(qslider, QRangeSlider):
+            if isinstance(qslider, _RANGE_SLIDERS):
                 # create a list of tuples in the case the slider is ranged
                 # from (minimum, minimum) to (maximum, maximum) +
                 # from (minimum, maximum) to (minimum, minimum)
@@ -420,7 +424,7 @@ def test_create_layer_controls_qslider(
             captured = capsys.readouterr()
             assert not captured.out
             assert not captured.err
-        if isinstance(qslider, QRangeSlider):
+        if isinstance(qslider, _RANGE_SLIDERS):
             assert qslider.value()[0] == qslider.minimum()
         else:
             assert qslider.value() == qslider.maximum()

--- a/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
@@ -14,3 +14,35 @@ def test_out_of_slice_display_checkbox(qtbot):
     assert layer.out_of_slice_display
     qtctrl._out_slice_checkbox_control.out_of_slice_checkbox.setChecked(False)
     assert not layer.out_of_slice_display
+
+
+def test_colormap_controls_follow_the_mode(qtbot):
+    """The colormap and its limits are shown, and editable, in colormap mode only."""
+    layer = Vectors(_VECTORS)
+    qtctrl = QtVectorsControls(layer)
+    qtbot.addWidget(qtctrl)
+    control = qtctrl._edge_color_feature_control
+
+    assert control.colormap_combobox.isHidden()
+    assert control.contrast_limits_slider.isHidden()
+
+    layer.features = {'phase': np.array([-np.pi, np.pi])}
+    layer.edge_color = 'phase'
+    layer.edge_color_mode = 'colormap'
+    assert not control.colormap_combobox.isHidden()
+    assert not control.contrast_limits_slider.isHidden()
+
+    # widget -> layer
+    index = control.colormap_combobox.findData('twilight')
+    control.colormap_combobox.setCurrentIndex(index)
+    control.contrast_limits_slider.setValue((-1.0, 1.0))
+    assert layer.edge_colormap.name == 'twilight'
+    np.testing.assert_allclose(layer.edge_contrast_limits, (-1.0, 1.0))
+
+    # layer -> widget
+    layer.edge_colormap = 'hsv'
+    layer.edge_contrast_limits = (-2.0, 2.0)
+    assert control.colormap_combobox.currentData() == 'hsv'
+    np.testing.assert_allclose(
+        control.contrast_limits_slider.value(), (-2.0, 2.0)
+    )

--- a/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
@@ -36,3 +36,35 @@ def test_mode_change_from_controls_reaches_other_listeners(qtbot):
 
     assert layer.edge_color_mode == 'direct'
     assert len(heard) == 1
+
+
+def test_colormap_controls_follow_the_mode(qtbot):
+    """The colormap and its limits are shown, and editable, in colormap mode only."""
+    layer = Vectors(_VECTORS)
+    qtctrl = QtVectorsControls(layer)
+    qtbot.addWidget(qtctrl)
+    control = qtctrl._edge_color_feature_control
+
+    assert control.colormap_combobox.isHidden()
+    assert control.contrast_limits_slider.isHidden()
+
+    layer.features = {'phase': np.array([-np.pi, np.pi])}
+    layer.edge_color = 'phase'
+    layer.edge_color_mode = 'colormap'
+    assert not control.colormap_combobox.isHidden()
+    assert not control.contrast_limits_slider.isHidden()
+
+    # widget -> layer
+    index = control.colormap_combobox.findData('twilight')
+    control.colormap_combobox.setCurrentIndex(index)
+    control.contrast_limits_slider.setValue((-1.0, 1.0))
+    assert layer.edge_colormap.name == 'twilight'
+    np.testing.assert_allclose(layer.edge_contrast_limits, (-1.0, 1.0))
+
+    # layer -> widget
+    layer.edge_colormap = 'hsv'
+    layer.edge_contrast_limits = (-2.0, 2.0)
+    assert control.colormap_combobox.currentData() == 'hsv'
+    np.testing.assert_allclose(
+        control.contrast_limits_slider.value(), (-2.0, 2.0)
+    )

--- a/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
@@ -46,3 +46,35 @@ def test_mode_change_from_controls_reaches_other_listeners(qtbot):
 
     assert layer.edge_color_mode == 'direct'
     assert len(heard) == 1
+
+
+def test_colormap_controls_follow_the_mode(qtbot):
+    """The colormap and its limits are shown, and editable, in colormap mode only."""
+    layer = Vectors(_VECTORS)
+    qtctrl = QtVectorsControls(layer)
+    qtbot.addWidget(qtctrl)
+    control = qtctrl._edge_color_feature_control
+
+    assert control.colormap_combobox.isHidden()
+    assert control.contrast_limits_slider.isHidden()
+
+    layer.features = {'phase': np.array([-np.pi, np.pi])}
+    layer.edge_color = 'phase'
+    layer.edge_color_mode = 'colormap'
+    assert not control.colormap_combobox.isHidden()
+    assert not control.contrast_limits_slider.isHidden()
+
+    # widget -> layer
+    index = control.colormap_combobox.findData('twilight')
+    control.colormap_combobox.setCurrentIndex(index)
+    control.contrast_limits_slider.setValue((-1.0, 1.0))
+    assert layer.edge_colormap.name == 'twilight'
+    np.testing.assert_allclose(layer.edge_contrast_limits, (-1.0, 1.0))
+
+    # layer -> widget
+    layer.edge_colormap = 'hsv'
+    layer.edge_contrast_limits = (-2.0, 2.0)
+    assert control.colormap_combobox.currentData() == 'hsv'
+    np.testing.assert_allclose(
+        control.contrast_limits_slider.value(), (-2.0, 2.0)
+    )

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -1,6 +1,11 @@
+import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox, QWidget
+from superqt import QLabeledDoubleRangeSlider
 
+from napari._qt.layer_controls.widgets.qt_colormap_control import (
+    QtColormapComboBox,
+)
 from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
     QtWrappedLabel,
@@ -9,6 +14,7 @@ from napari._qt.utils import qt_signals_blocked
 from napari._qt.widgets.qt_color_swatch import QColorSwatchEdit
 from napari.layers import Vectors
 from napari.layers.utils._color_manager_constants import ColorMode
+from napari.utils.colormaps import AVAILABLE_COLORMAPS
 from napari.utils.events.event_utils import connect_setattr
 
 
@@ -39,6 +45,14 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
         Dropdown to select the feature for mapping edge_color.
     edge_feature_label : napari._qt.layer_controls.widgets.qt_widget_controls_base.QtWrappedLabel
         Label for the color_feature_box chooser widget.
+    colormap_combobox : qtpy.QtWidgets.QComboBox
+        Dropdown to select the colormap used in colormap mode.
+    colormap_label : napari._qt.layer_controls.widgets.qt_widget_controls_base.QtWrappedLabel
+        Label for the colormap_combobox chooser widget.
+    contrast_limits_slider : superqt.QLabeledDoubleRangeSlider
+        Slider controlling the feature values mapped to the ends of the colormap.
+    contrast_limits_label : napari._qt.layer_controls.widgets.qt_widget_controls_base.QtWrappedLabel
+        Label for the contrast_limits_slider widget.
     """
 
     def __init__(self, parent: QWidget, layer: Vectors) -> None:
@@ -48,6 +62,10 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self._on_edge_color_mode_change
         )
         self._layer.events.edge_color.connect(self._on_edge_color_change)
+        self._layer.events.edge_colormap.connect(self._on_colormap_change)
+        self._layer.events.edge_contrast_limits.connect(
+            self._on_contrast_limits_change
+        )
 
         # Setup widgets
         # dropdown to select the feature for mapping edge_color
@@ -57,6 +75,26 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self.change_edge_color_feature
         )
         self.edge_feature_label = QtWrappedLabel('edge feature:')
+
+        # The mapping half of colormap mode: which colormap, over which values.
+        self.colormap_combobox = QtColormapComboBox(parent)
+        self.colormap_combobox.setObjectName('colormapComboBox')
+        for name, colormap in AVAILABLE_COLORMAPS.items():
+            self.colormap_combobox.addItem(colormap._display_name, name)
+        self.colormap_combobox.currentTextChanged.connect(self.change_colormap)
+        self.colormap_label = QtWrappedLabel('edge colormap:')
+
+        self.contrast_limits_slider = QLabeledDoubleRangeSlider(
+            Qt.Orientation.Horizontal, parent
+        )
+        self.contrast_limits_slider.setMinimum(0)
+        self.contrast_limits_slider.setMaximum(1)
+        self.contrast_limits_slider.valueChanged.connect(
+            self.change_contrast_limits
+        )
+        self.contrast_limits_label = QtWrappedLabel('edge contrast limits:')
+        self._on_colormap_change()
+        self._on_contrast_limits_change()
 
         # vector direct color mode adjustment and widget
         self.edge_color_edit = QColorSwatchEdit(
@@ -119,6 +157,67 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
                 self.color_mode_combobox.setCurrentText(old_mode)
                 raise
 
+    def change_colormap(self, colormap: str):
+        """Change the colormap the mapped feature is rendered through.
+
+        Parameters
+        ----------
+        colormap : str
+            Display name of the colormap, as shown in the dropdown.
+        """
+        self._layer.edge_colormap = self.colormap_combobox.currentData()
+
+    def change_contrast_limits(self, contrast_limits: tuple[float, float]):
+        """Change the feature values mapped to the ends of the colormap.
+
+        Parameters
+        ----------
+        contrast_limits : tuple of float
+            The low and high feature value.
+        """
+        self._layer.edge_contrast_limits = tuple(contrast_limits)
+
+    def _on_colormap_change(self):
+        """Receive layer model colormap change event and update the dropdown."""
+        if not hasattr(self, 'colormap_combobox'):
+            # Ignore early events i.e when widgets haven't been created yet.
+            return
+        name = self._layer.edge_colormap.name
+        index = self.colormap_combobox.findData(name)
+        if index != -1 and index != self.colormap_combobox.currentIndex():
+            with qt_signals_blocked(self.colormap_combobox):
+                self.colormap_combobox.setCurrentIndex(index)
+
+    def _on_contrast_limits_change(self):
+        """Receive layer model contrast limits change event and update the slider.
+
+        The slider spans the mapped feature's values, widened to reach limits set
+        outside them.
+        """
+        if not hasattr(self, 'contrast_limits_slider'):
+            # Ignore early events i.e when widgets haven't been created yet.
+            return
+        limits = self._layer.edge_contrast_limits
+        if limits is None:
+            return
+        low, high = float(limits[0]), float(limits[1])
+        values = self._feature_values()
+        if values is not None and len(values):
+            low = min(low, float(np.min(values)))
+            high = max(high, float(np.max(values)))
+        if high <= low:
+            high = low + 1.0
+        with qt_signals_blocked(self.contrast_limits_slider):
+            self.contrast_limits_slider.setRange(low, high)
+            self.contrast_limits_slider.setValue(tuple(limits))
+
+    def _feature_values(self):
+        """Values of the feature currently mapped to color, or None."""
+        color_properties = self._layer._edge.color_properties
+        if color_properties is None:
+            return None
+        return np.asarray(color_properties.values, dtype=float)
+
     def _on_edge_color_mode_change(self):
         """Receive layer model edge color mode change event & update dropdown."""
         if not hasattr(self, 'color_mode_combobox'):
@@ -175,9 +274,21 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self.color_feature_box.setHidden(True)
             self.edge_feature_label.setHidden(True)
 
+        # Only colormap mode has a colormap to choose and limits to map through.
+        colormapped = mode == 'colormap'
+        self.colormap_combobox.setHidden(not colormapped)
+        self.colormap_label.setHidden(not colormapped)
+        self.contrast_limits_slider.setHidden(not colormapped)
+        self.contrast_limits_label.setHidden(not colormapped)
+        if colormapped:
+            self._on_colormap_change()
+            self._on_contrast_limits_change()
+
     def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
         return [
             (self.color_mode_label, self.color_mode_combobox),
             (self.edge_color_label, self.edge_color_edit),
             (self.edge_feature_label, self.color_feature_box),
+            (self.colormap_label, self.colormap_combobox),
+            (self.contrast_limits_label, self.contrast_limits_slider),
         ]

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -1,6 +1,11 @@
+import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QComboBox, QWidget
+from superqt import QLabeledDoubleRangeSlider
 
+from napari._qt.layer_controls.widgets.qt_colormap_control import (
+    QtColormapComboBox,
+)
 from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
     QtWrappedLabel,
@@ -9,6 +14,7 @@ from napari._qt.utils import qt_signals_blocked
 from napari._qt.widgets.qt_color_swatch import QColorSwatchEdit
 from napari.layers import Vectors
 from napari.layers.utils._color_manager_constants import ColorMode
+from napari.utils.colormaps import AVAILABLE_COLORMAPS
 from napari.utils.events.event_utils import connect_setattr
 
 
@@ -39,6 +45,14 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
         Dropdown to select the feature for mapping edge_color.
     edge_feature_label : napari._qt.layer_controls.widgets.qt_widget_controls_base.QtWrappedLabel
         Label for the color_feature_box chooser widget.
+    colormap_combobox : qtpy.QtWidgets.QComboBox
+        Dropdown to select the colormap used in colormap mode.
+    colormap_label : napari._qt.layer_controls.widgets.qt_widget_controls_base.QtWrappedLabel
+        Label for the colormap_combobox chooser widget.
+    contrast_limits_slider : superqt.QLabeledDoubleRangeSlider
+        Slider controlling the feature values mapped to the ends of the colormap.
+    contrast_limits_label : napari._qt.layer_controls.widgets.qt_widget_controls_base.QtWrappedLabel
+        Label for the contrast_limits_slider widget.
     """
 
     def __init__(self, parent: QWidget, layer: Vectors) -> None:
@@ -48,6 +62,10 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self._on_edge_color_mode_change
         )
         self._layer.events.edge_color.connect(self._on_edge_color_change)
+        self._layer.events.edge_colormap.connect(self._on_colormap_change)
+        self._layer.events.edge_contrast_limits.connect(
+            self._on_contrast_limits_change
+        )
 
         # Setup widgets
         # dropdown to select the feature for mapping edge_color
@@ -57,6 +75,26 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
         )
         self.color_feature_box.addItems(self._layer.features.columns)
         self.edge_feature_label = QtWrappedLabel('edge feature:')
+
+        # The mapping half of colormap mode: which colormap, over which values.
+        self.colormap_combobox = QtColormapComboBox(parent)
+        self.colormap_combobox.setObjectName('colormapComboBox')
+        for name, colormap in AVAILABLE_COLORMAPS.items():
+            self.colormap_combobox.addItem(colormap._display_name, name)
+        self.colormap_combobox.currentTextChanged.connect(self.change_colormap)
+        self.colormap_label = QtWrappedLabel('edge colormap:')
+
+        self.contrast_limits_slider = QLabeledDoubleRangeSlider(
+            Qt.Orientation.Horizontal, parent
+        )
+        self.contrast_limits_slider.setMinimum(0)
+        self.contrast_limits_slider.setMaximum(1)
+        self.contrast_limits_slider.valueChanged.connect(
+            self.change_contrast_limits
+        )
+        self.contrast_limits_label = QtWrappedLabel('edge contrast limits:')
+        self._on_colormap_change()
+        self._on_contrast_limits_change()
 
         # vector direct color mode adjustment and widget
         self.edge_color_edit = QColorSwatchEdit(
@@ -117,6 +155,67 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
                 self.color_mode_combobox.setCurrentText(old_mode)
                 raise
 
+    def change_colormap(self, colormap: str):
+        """Change the colormap the mapped feature is rendered through.
+
+        Parameters
+        ----------
+        colormap : str
+            Display name of the colormap, as shown in the dropdown.
+        """
+        self._layer.edge_colormap = self.colormap_combobox.currentData()
+
+    def change_contrast_limits(self, contrast_limits: tuple[float, float]):
+        """Change the feature values mapped to the ends of the colormap.
+
+        Parameters
+        ----------
+        contrast_limits : tuple of float
+            The low and high feature value.
+        """
+        self._layer.edge_contrast_limits = tuple(contrast_limits)
+
+    def _on_colormap_change(self):
+        """Receive layer model colormap change event and update the dropdown."""
+        if not hasattr(self, 'colormap_combobox'):
+            # Ignore early events i.e when widgets haven't been created yet.
+            return
+        name = self._layer.edge_colormap.name
+        index = self.colormap_combobox.findData(name)
+        if index != -1 and index != self.colormap_combobox.currentIndex():
+            with qt_signals_blocked(self.colormap_combobox):
+                self.colormap_combobox.setCurrentIndex(index)
+
+    def _on_contrast_limits_change(self):
+        """Receive layer model contrast limits change event and update the slider.
+
+        The slider spans the mapped feature's values, widened to reach limits set
+        outside them.
+        """
+        if not hasattr(self, 'contrast_limits_slider'):
+            # Ignore early events i.e when widgets haven't been created yet.
+            return
+        limits = self._layer.edge_contrast_limits
+        if limits is None:
+            return
+        low, high = float(limits[0]), float(limits[1])
+        values = self._feature_values()
+        if values is not None and len(values):
+            low = min(low, float(np.min(values)))
+            high = max(high, float(np.max(values)))
+        if high <= low:
+            high = low + 1.0
+        with qt_signals_blocked(self.contrast_limits_slider):
+            self.contrast_limits_slider.setRange(low, high)
+            self.contrast_limits_slider.setValue(tuple(limits))
+
+    def _feature_values(self):
+        """Values of the feature currently mapped to color, or None."""
+        color_properties = self._layer._edge.color_properties
+        if color_properties is None:
+            return None
+        return np.asarray(color_properties.values, dtype=float)
+
     def _on_edge_color_mode_change(self):
         """Receive layer model edge color mode change event & update dropdown."""
         if not hasattr(self, 'color_mode_combobox'):
@@ -173,9 +272,21 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self.color_feature_box.setHidden(True)
             self.edge_feature_label.setHidden(True)
 
+        # Only colormap mode has a colormap to choose and limits to map through.
+        colormapped = mode == 'colormap'
+        self.colormap_combobox.setHidden(not colormapped)
+        self.colormap_label.setHidden(not colormapped)
+        self.contrast_limits_slider.setHidden(not colormapped)
+        self.contrast_limits_label.setHidden(not colormapped)
+        if colormapped:
+            self._on_colormap_change()
+            self._on_contrast_limits_change()
+
     def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
         return [
             (self.color_mode_label, self.color_mode_combobox),
             (self.edge_color_label, self.edge_color_edit),
             (self.edge_feature_label, self.color_feature_box),
+            (self.colormap_label, self.colormap_combobox),
+            (self.contrast_limits_label, self.contrast_limits_slider),
         ]

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -497,6 +497,19 @@ def test_switching_edge_color_mode_back_to_direct():
     assert layer.edge_color_mode == 'direct'
 
 
+def test_setting_a_feature_as_edge_color_emits_the_mode_change():
+    data = np.zeros((6, 2, 2))
+    data[:, 1] = [1, 1]
+    layer = Vectors(data, features={'phase': np.linspace(-1, 1, 6)})
+    heard = []
+    layer.events.edge_color_mode.connect(lambda event: heard.append(event))
+
+    layer.edge_color = 'phase'
+
+    assert layer.edge_color_mode == 'colormap'
+    assert len(heard) == 1
+
+
 def test_setting_the_current_edge_color_mode_does_not_emit():
     data = np.zeros((6, 2, 2))
     data[:, 1] = [1, 1]

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -508,6 +508,19 @@ def test_switching_edge_color_mode_fires_edge_color_event():
     assert len(np.unique(layer.edge_color, axis=0)) == 6
 
 
+def test_setting_a_feature_as_edge_color_emits_the_mode_change():
+    data = np.zeros((6, 2, 2))
+    data[:, 1] = [1, 1]
+    layer = Vectors(data, features={'phase': np.linspace(-1, 1, 6)})
+    heard = []
+    layer.events.edge_color_mode.connect(lambda event: heard.append(event))
+
+    layer.edge_color = 'phase'
+
+    assert layer.edge_color_mode == 'colormap'
+    assert len(heard) == 1
+
+
 def test_setting_the_current_edge_color_mode_does_not_emit():
     data = np.zeros((6, 2, 2))
     data[:, 1] = [1, 1]

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -265,6 +265,8 @@ class Vectors(Layer):
             edge_color=Event,
             vector_style=Event,
             edge_color_mode=Event,
+            edge_colormap=Event,
+            edge_contrast_limits=Event,
             properties=Event,
             out_of_slice_display=Event,
             features=Event,
@@ -299,6 +301,12 @@ class Vectors(Layer):
                 if self._data.size > 0
                 else self._feature_table.currents()
             ),
+        )
+        self._edge.events.continuous_colormap.connect(
+            lambda _event: self.events.edge_colormap()
+        )
+        self._edge.events.contrast_limits.connect(
+            lambda _event: self.events.edge_contrast_limits()
         )
 
         # now that everything is set up, make the layer visible (if set to visible)

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -305,6 +305,9 @@ class Vectors(Layer):
                 else self._feature_table.currents()
             ),
         )
+        self._edge.events.color_mode.connect(
+            lambda _event: self.events.edge_color_mode()
+        )
 
         # now that everything is set up, make the layer visible (if set to visible)
         self.refresh()
@@ -610,7 +613,6 @@ class Vectors(Layer):
     @edge_color_mode.setter
     def edge_color_mode(self, edge_color_mode: str | ColorMode):
         edge_color_mode = ColorMode(edge_color_mode)
-        old_mode = self._edge.color_mode
 
         if edge_color_mode == ColorMode.DIRECT:
             self._edge.color_mode = edge_color_mode
@@ -649,9 +651,6 @@ class Vectors(Layer):
 
             self._edge.color_mode = edge_color_mode
             self.events.edge_color()
-
-        if self._edge.color_mode != old_mode:
-            self.events.edge_color_mode()
 
     @property
     def edge_color_cycle(self) -> np.ndarray:

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -265,6 +265,8 @@ class Vectors(Layer):
             edge_color=Event,
             vector_style=Event,
             edge_color_mode=Event,
+            edge_colormap=Event,
+            edge_contrast_limits=Event,
             properties=Event,
             out_of_slice_display=Event,
             features=Event,
@@ -302,6 +304,12 @@ class Vectors(Layer):
         )
         self._edge.events.color_mode.connect(
             lambda _event: self.events.edge_color_mode()
+        )
+        self._edge.events.continuous_colormap.connect(
+            lambda _event: self.events.edge_colormap()
+        )
+        self._edge.events.contrast_limits.connect(
+            lambda _event: self.events.edge_contrast_limits()
         )
 
         # now that everything is set up, make the layer visible (if set to visible)

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -300,6 +300,9 @@ class Vectors(Layer):
                 else self._feature_table.currents()
             ),
         )
+        self._edge.events.color_mode.connect(
+            lambda _event: self.events.edge_color_mode()
+        )
 
         # now that everything is set up, make the layer visible (if set to visible)
         self.refresh()
@@ -589,7 +592,6 @@ class Vectors(Layer):
     @edge_color_mode.setter
     def edge_color_mode(self, edge_color_mode: str | ColorMode):
         edge_color_mode = ColorMode(edge_color_mode)
-        old_mode = self._edge.color_mode
 
         if edge_color_mode == ColorMode.DIRECT:
             self._edge.color_mode = edge_color_mode
@@ -627,8 +629,6 @@ class Vectors(Layer):
                 )
 
             self._edge.color_mode = edge_color_mode
-        if self._edge.color_mode != old_mode:
-            self.events.edge_color_mode()
 
     @property
     def edge_color_cycle(self) -> np.ndarray:

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -267,6 +267,8 @@ class Vectors(Layer):
             edge_color=Event,
             vector_style=Event,
             edge_color_mode=Event,
+            edge_colormap=Event,
+            edge_contrast_limits=Event,
             properties=Event,
             out_of_slice_display=WarningEmitter(
                 _OUT_SLICE_DISP_WARNING_MSG,
@@ -307,6 +309,12 @@ class Vectors(Layer):
         )
         self._edge.events.color_mode.connect(
             lambda _event: self.events.edge_color_mode()
+        )
+        self._edge.events.continuous_colormap.connect(
+            lambda _event: self.events.edge_colormap()
+        )
+        self._edge.events.contrast_limits.connect(
+            lambda _event: self.events.edge_contrast_limits()
         )
 
         # now that everything is set up, make the layer visible (if set to visible)


### PR DESCRIPTION
Depends on #9396, which is the first commit here. Review that one first; only the second commit is this PR's.

(Related to #9330). In colormap mode the Vectors layer controls let a user pick *which* feature colors the glyphs, but not how it is mapped: there is no colormap chooser and no contrast limits, though `edge_colormap` and `edge_contrast_limits` exist on the layer and work. Image and Surface controls have both. For a cyclic quantity such as phase that leaves viridis over whatever range happened to be in view, with no in-GUI remedy.

This adds, shown in colormap mode only:

- a colormap dropdown — the same colorbar-painting `QtColormapComboBox` the Image controls use;
- a contrast-limits range slider, spanning the mapped feature's values and widening to reach limits set outside them.

`Vectors` gains `edge_colormap` and `edge_contrast_limits` events, re-emitted from the color manager so a change made through the layer property, through the color manager, or by remapping a feature all reach the widgets.

One shared test changed: `test_create_layer_controls_qslider` drives every `QAbstractSlider` in a controls panel, and branched on `isinstance(qslider, QRangeSlider)` to decide between scalar and (low, high) values. A labeled range slider is not a `QRangeSlider` subclass, so it took the scalar branch and raised; the check now covers `QLabeledRangeSlider` too. Image's contrast-limits slider never hit this because it lives in a popup rather than in the panel.

