### PR TITLE
Use magnitude of `Layer.scale` for points/shape handles

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_points_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_points_layer.py
@@ -124,6 +124,31 @@ def test_change_antialiasing():
     assert vispy_layer.node.antialias == layer.antialiasing
 
 
+@pytest.mark.parametrize('scale', [(-1, -1), (1, -1), (-1, 1)])
+def test_negative_scale_highlight(scale):
+    """Negative layer scale must not produce negative sizes/widths.
+
+    A negative scale is sometimes used to flip axes (and can be inherited
+    from an image layer); vispy rejects negative ``edge_width``, so adding
+    or selecting a point used to raise ValueError.
+    """
+    layer = Points(np.zeros((0, 2)), size=10, scale=scale)
+    layer.border_width_is_relative = False
+    layer.border_width = 1.0
+
+    vispy_layer = VispyPointsLayer(layer, font_info=FontInfo())
+
+    # previously raised ValueError: edge_width cannot be negative
+    layer.add([10, 10])
+
+    for markers in (
+        vispy_layer.node.points_markers,
+        vispy_layer.node.selection_markers,
+    ):
+        assert np.all(markers._data['a_size'] > 0)
+        assert np.all(markers._data['a_edgewidth'] >= 0)
+
+
 def test_highlight_with_out_of_slice_display():
     """Highlight should work when out_of_slice_display is enabled.
 

--- a/src/napari/_vispy/layers/points.py
+++ b/src/napari/_vispy/layers/points.py
@@ -72,7 +72,7 @@ class VispyPointsLayer(VispyBaseLayer):
         set_data = self.node.points_markers.set_data
 
         # use only last dimension to scale point sizes, see #5582
-        scale = self.layer.scale[-1]
+        scale = abs(self.layer.scale[-1])
         scaled_size = size * scale
 
         if self.layer.border_width_is_relative:
@@ -90,7 +90,7 @@ class VispyPointsLayer(VispyBaseLayer):
 
         set_data(
             data[:, ::-1],
-            size=size * scale,
+            size=scaled_size,
             symbol=symbol,
             # edge_color is the name of the vispy marker visual kwarg
             edge_color=border_color,
@@ -135,7 +135,7 @@ class VispyPointsLayer(VispyBaseLayer):
             symbol = ['o']
             border_width = np.empty(0)
 
-        scale = self.layer.scale[-1]
+        scale = abs(self.layer.scale[-1])
         highlight_thickness = settings.appearance.highlight.highlight_thickness
         scaled_size = (size + border_width) * scale
         # cap scaled_highlight to the marker size, cause otherwise we get strange effects

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -1670,7 +1670,7 @@ class Points(Layer):
             ]
             # positions are scaled anisotropically by scale, but sizes are not,
             # so we need to calculate the ratio to correctly map to screen coordinates
-            scale_ratio = (
+            scale_ratio = np.abs(
                 self.scale[self._slice_input.displayed] / self.scale[-1]
             )
             # Get the point sizes
@@ -1736,7 +1736,9 @@ class Points(Layer):
 
         # positions are scaled anisotropically by scale, but sizes are not,
         # so we need to calculate the ratio to correctly map to screen coordinates
-        scale_ratio = self.scale[self._slice_input.displayed] / self.scale[-1]
+        scale_ratio = np.abs(
+            self.scale[self._slice_input.displayed] / self.scale[-1]
+        )
         # find the points the click intersects
         sizes = np.expand_dims(self._view_size, axis=1) / scale_ratio / 2
         distances = abs(rotated_points - rotated_click_point)

--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2329,6 +2329,31 @@ def test_value():
     assert value == (None, None)
 
 
+@pytest.mark.parametrize('scale', [(-1, -1), (1, -1), (-2, 3)])
+def test_value_vertex_with_negative_scale(scale):
+    """Vertices must stay grabbable when the layer scale is negative.
+
+    A negative scale flips the layer, but the vertex radius in screen space
+    must remain positive, otherwise no vertex ever matches.
+    """
+    data = [[[0, 0], [0, 10], [10, 10], [10, 0]]]
+
+    def selected_layer(layer_scale):
+        layer = Shapes(data, scale=layer_scale)
+        layer.mode = 'select'
+        layer.selected_data = {0}
+        return layer
+
+    layer = selected_layer(scale)
+    # flipping the layer must not change which vertex is under the cursor
+    # in data coordinates, only the sign of the scale differs
+    reference = selected_layer(np.abs(scale))
+
+    assert layer._normalized_vertex_radius > 0
+    assert layer.get_value((0, 0)) == reference.get_value((0, 0))
+    assert layer.get_value((0, 0))[1] is not None
+
+
 def test_value_non_convex():
     """Test getting the value of the data at the current coordinates."""
     data = [

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2383,8 +2383,10 @@ class Shapes(Layer):
 
         This is often needed when calculating screen-space sizes and distances
         of vertices for interactivity (rescaling, adding vertices, etc).
+        We use only the magnitude of the layer scale, because sizes and
+        distances must remain positive.
         """
-        return self.scale_factor / self.scale[-1]
+        return self.scale_factor / abs(self.scale[-1])
 
     @property
     def _normalized_vertex_radius(self):


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/9338

# Description
Uses `abs()` to ensure that the magnitude of the Layer.scale is used for scaling points size and in shapes layer normalized scale. Added minimal tests that fail on main, pass with this branch, with use of Claude.
