### PR TITLE
UX/UI: Bump the splitter (separator) size by 1px

### DIFF
--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -23,8 +23,8 @@ QStatusBar {
 /* ------------- Window separator --------- */
 
 QMainWindow::separator {
-  width: 4px;
-  height: 4px;
+  width: 5px;
+  height: 5px;
   padding: 2px;
   border: none;
   background-color: {{ background }};


### PR DESCRIPTION
# References and relevant issues
Closes: #3103
(adresses last remaining issue)

# Description
This adds 1px to the height/width of the splitter (separator) which makes it a bit easier to see and increases the target area for grabbing.

This PR:
<img width="1216" height="892" alt="image" src="https://github.com/user-attachments/assets/04d4a80f-d2b8-4e23-9ff8-cfa0218b4595" />

main:
<img width="1216" height="892" alt="image" src="https://github.com/user-attachments/assets/e6f4f226-3600-411c-935a-3e90a2775eef" />



