### PR TITLE
fix(layer_utils): handle non-native byte order in convert_to_uint8

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -615,5 +615,9 @@ authors:
   alias: ArozHada
   affiliation: University Hospital Heidelberg
   orcid: https://orcid.org/0000-0002-0691-1214
+- given-names: Venkateswarlu
+  family-names: Nagineni
+  alias: VenkateswarluNagineni
+  affiliation: Texas A&M University
 repository-code: https://github.com/napari/napari
 license: BSD-3-Clause

--- a/src/napari/layers/utils/_tests/test_layer_utils.py
+++ b/src/napari/layers/utils/_tests/test_layer_utils.py
@@ -10,6 +10,7 @@ from napari.layers.utils.layer_utils import (
     calc_data_range,
     coerce_current_properties,
     compute_multiscale_level,
+    convert_to_uint8,
     dataframe_to_properties,
     dims_displayed_world_to_layer,
     get_current_properties,
@@ -561,3 +562,22 @@ def test_register_label_attr_action(monkeypatch):
     monkeypatch.setattr(time, 'time', lambda: 2)
     assert handler.release_key('K')
     assert foo.value == 0
+
+
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        '>f4',  # big-endian float32 (non-native on little-endian machines)
+        '>i2',  # big-endian int16  (non-native on little-endian machines)
+    ],
+)
+def test_convert_to_uint8_non_native_byte_order(dtype):
+    """convert_to_uint8 must not raise TypeError for non-native-endian arrays.
+
+    np.multiply and np.maximum reject byte-order-qualified dtype arguments.
+    Passing dtype=data.dtype to either ufunc when data has a non-native byte
+    order raises TypeError. See https://github.com/napari/napari/issues/9144.
+    """
+    data = np.arange(6, dtype=dtype).reshape(2, 3)
+    result = convert_to_uint8(data)
+    assert result.dtype == np.uint8

--- a/src/napari/layers/utils/layer_utils.py
+++ b/src/napari/layers/utils/layer_utils.py
@@ -391,7 +391,7 @@ def convert_to_uint8(data: np.ndarray) -> np.ndarray:
     if in_kind == 'b':
         return data.astype(out_dtype) * 255
     if in_kind == 'f':
-        image_out = np.multiply(data, out_max, dtype=data.dtype)
+        image_out = np.multiply(data, out_max)
         np.rint(image_out, out=image_out)
         np.clip(image_out, 0, out_max, out=image_out)
         image_out = np.nan_to_num(image_out, copy=False)
@@ -405,7 +405,7 @@ def convert_to_uint8(data: np.ndarray) -> np.ndarray:
                 out_dtype
             )
 
-        np.maximum(data, 0, out=data, dtype=data.dtype)
+        np.maximum(data, 0, out=data)
         if data.dtype == np.int8:
             return (data * 2).astype(np.uint8)
         if data.max() < out_max:


### PR DESCRIPTION
## Description

Fixes #9144.

`convert_to_uint8` raises `TypeError` on arrays with non-native byte order
(e.g. `dtype='>f4'` or `dtype='>i2'` on a little-endian machine) because
`np.multiply` and `np.maximum` do not accept a `dtype=` argument that carries
a byte-order qualifier:

```
TypeError: The dtype and signature arguments to ufuncs only select the general
DType and not details such as the byte order or time unit.
```

The `dtype=data.dtype` argument was redundant in both places: the `out=`
parameter already constrains the output buffer type, and the downstream
`.astype(np.uint8)` handles the final conversion. Removing the two `dtype=`
keyword arguments is the minimal fix.

## Changes

- `src/napari/layers/utils/layer_utils.py`: remove `dtype=data.dtype` from
  `np.multiply(data, out_max, ...)` (float branch) and
  `np.maximum(data, 0, out=data, ...)` (signed-int branch).
- `src/napari/layers/utils/_tests/test_layer_utils.py`: add
  `test_convert_to_uint8_non_native_byte_order` parametrized over `>f4` and
  `>i2` dtypes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)