### PR TITLE
Change `Dims` slider connection from `textChanged` to `textEdited` to stop wrong updates

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -281,7 +281,9 @@ def test_update_dims_labels(qtbot):
 
     # check that the label text corresponds with the dims model
     # while being elided on the GUI
-    first_label.setText('napari')
+    first_label.setFocus()
+    first_label.selectAll()
+    qtbot.keyClicks(first_label, 'napari')
     assert first_label.text() == view.dims.axis_labels[0]
     assert '…' in first_label._elidedText()
     assert observed_axis_labels_event

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -158,7 +158,7 @@ class QtDimSliderWidget(QWidget):
         label.setEnabled(True)
         label.setAlignment(Qt.AlignmentFlag.AlignRight)
         label.setContentsMargins(0, 0, 2, 0)
-        label.textChanged.connect(self._update_label)
+        label.textEdited.connect(self._update_label)
         label.editingFinished.connect(self._clear_label_focus)
         return label
 


### PR DESCRIPTION
# References and relevant issues
closes #9349

# Description
This changes the connection from `textChanged` to `textEdited` so that when a file is open and the layer dimensions change, the `Dims` scroll widget is not overriding the `Dims.axis_labels` upong a rescale/layout change. This happens whenever you're opening a file and selecting the default plugin, for example, from CLI:
```bash
napari URL-TO-REMOTE-ZARR
```