### PR TITLE
Use LF for all files in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
-napari_gui/_version.py export-subst
+# All text files are stored with LF line endings in the repository (see ruff config)
+# On all OSes (including Windows), we want to ensure LF checkout so that there is not pre-commit churn
+# In addition, things like shell scripts should always use LF line endings, otherwise bash commands will fail on Windows with CRLF
+* text=auto eol=lf
 
-# Shell scripts should always use LF line endings, otherwise bash commands will fail on Windows with CRLF
-*.sh text eol=lf
+napari_gui/_version.py export-subst


### PR DESCRIPTION
## References and Relevant Issues

As many PRs can attest, I've long fought line endings on Windows. This is because, depending on configuration, git will check out text files with CRLF endings. However, I finally put the pieces together and realized that our ruff config enforces LF line endings for all files.
In practicality, this shows up as 895 changed files every time that something like `prek run -a` or `uv run ruff-format` is run on my Windows because ruff will reformat all files to LF endings. However, this is an "invisible" diff so it's confusing. 
Until @czaki said in https://github.com/napari/docs/pull/1096#discussion_r3711890402 that it doesn't work this way on Linux, I didn't connect the dots on the source of this issue.

# Description

tl;dr: sets all files to check out with LF line endings on all OSes to prevent invisible diffs (on Windows) when running our ruff formatter.

I have taken this logic from numpy's .gitattributes file which made this change in January https://github.com/numpy/numpy/pull/31610
In addition, this should prevent weird agentic shenangins that we've seen in some PRs before with line endings.

As a follow-up, I will modify the `.gitattributes` of other repos as necessary, and look closely at the plugin-template. 