### PR TITLE
Deliver key auto-repeat by default, suppressing only hold-semantics bindings

### DIFF
--- a/src/napari/components/_viewer_key_bindings.py
+++ b/src/napari/components/_viewer_key_bindings.py
@@ -91,16 +91,12 @@ def delete_selected_layers(viewer: ViewerModel) -> None:
     viewer.layers.remove_selected()
 
 
-@register_viewer_action(
-    'Increment dimensions slider to the left', repeatable=True
-)
+@register_viewer_action('Increment dimensions slider to the left')
 def increment_dims_left(viewer: ViewerModel) -> None:
     viewer.dims._increment_dims_left()
 
 
-@register_viewer_action(
-    'Increment dimensions slider to the right', repeatable=True
-)
+@register_viewer_action('Increment dimensions slider to the right')
 def increment_dims_right(viewer: ViewerModel) -> None:
     viewer.dims._increment_dims_right()
 

--- a/src/napari/layers/labels/_labels_key_bindings.py
+++ b/src/napari/layers/labels/_labels_key_bindings.py
@@ -129,10 +129,7 @@ def increase_label_id(layer: Labels) -> None:
         show_warning(f'{e.text}\n{CONVERT_TEXT}')
 
 
-@register_label_action(
-    'Decrease the paint brush size by one',
-    repeatable=True,
-)
+@register_label_action('Decrease the paint brush size by one')
 def decrease_brush_size(layer: Labels) -> None:
     """Decrease the brush size"""
     if (
@@ -142,10 +139,7 @@ def decrease_brush_size(layer: Labels) -> None:
         layer.brush_size -= 1
 
 
-@register_label_action(
-    'Increase the paint brush size by one',
-    repeatable=True,
-)
+@register_label_action('Increase the paint brush size by one')
 def increase_brush_size(layer: Labels) -> None:
     """Increase the brush size"""
     layer.brush_size += 1

--- a/src/napari/layers/utils/layer_utils.py
+++ b/src/napari/layers/utils/layer_utils.py
@@ -116,7 +116,8 @@ def register_layer_action(
         The description of the action, this will typically be translated and
         will be what will be used in tooltips.
     repeatable : bool
-        A flag indicating whether the action autorepeats when key is held
+        Deprecated and ignored. Key auto-repeat is delivered to every binding
+        by default; hold-semantics bindings suppress it automatically.
     shortcuts : str | List[str]
         Shortcut to bind by default to the action we are registering.
 
@@ -204,9 +205,10 @@ def register_layer_attr_action(
 
             return _callback
 
-        repeatable = False  # attribute actions are always non-repeatable
+        # _wrapper returns a release callback, so held-key auto-repeat is
+        # suppressed automatically while the hold is pending
         register_layer_action(
-            keymapprovider, description, repeatable, shortcuts
+            keymapprovider, description, shortcuts=shortcuts
         )(_wrapper)
         return func
 

--- a/src/napari/layers/utils/layer_utils.py
+++ b/src/napari/layers/utils/layer_utils.py
@@ -115,7 +115,8 @@ def register_layer_action(
         The description of the action, this will typically be translated and
         will be what will be used in tooltips.
     repeatable : bool
-        A flag indicating whether the action autorepeats when key is held
+        Deprecated and ignored. Key auto-repeat is delivered to every binding
+        by default; hold-semantics bindings suppress it automatically.
     shortcuts : str | List[str]
         Shortcut to bind by default to the action we are registering.
 
@@ -203,10 +204,11 @@ def register_layer_attr_action(
 
             return _callback
 
-        repeatable = False  # attribute actions are always non-repeatable
-        register_layer_action(
-            keymapprovider, description, repeatable, shortcuts
-        )(_wrapper)
+        # _wrapper returns a release callback, so held-key auto-repeat is
+        # suppressed automatically while the hold is pending
+        register_layer_action(keymapprovider, description, False, shortcuts)(
+            _wrapper
+        )
         return func
 
     return _handle

--- a/src/napari/utils/_tests/test_key_bindings.py
+++ b/src/napari/utils/_tests/test_key_bindings.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from app_model.types import KeyBinding, KeyCode, KeyMod
+from vispy.util import keys
 
 from napari.utils import key_bindings
 from napari.utils.key_bindings import (
@@ -417,3 +418,170 @@ def test_key_release_callback(monkeypatch):
     monkeypatch.setattr(time, 'time', lambda: 2)
     handler.release_key('K')
     assert called2
+
+
+def _key_event(name, *, auto_repeat, modifiers=()):
+    """Minimal stand-in for the vispy key event `on_key_press` consumes."""
+    return types.SimpleNamespace(
+        key=types.SimpleNamespace(name=name),
+        modifiers=list(modifiers),
+        native=types.SimpleNamespace(isAutoRepeat=lambda: auto_repeat),
+        handled=False,
+    )
+
+
+def _press(handler, name, *, held_for=0, modifiers=()):
+    """Send one real press followed by `held_for` auto-repeats."""
+    handler.on_key_press(
+        _key_event(name, auto_repeat=False, modifiers=modifiers)
+    )
+    for _ in range(held_for):
+        handler.on_key_press(
+            _key_event(name, auto_repeat=True, modifiers=modifiers)
+        )
+
+
+def _handler_with_provider():
+    """A fresh handler and its own provider class, isolated per test."""
+
+    class Foo(KeymapProvider): ...
+
+    handler = KeymapHandler()
+    handler.keymap_providers = [Foo()]
+    return handler, Foo
+
+
+@pytest.mark.parametrize('key', ['Up', 'K', 'PageDown'])
+def test_autorepeat_delivered_by_default(key):
+    """A held key repeats at the OS rate, however and to whatever it is bound.
+
+    Auto-repeat used to be dropped unless the binding was on an opt-in
+    whitelist; now the OS policy applies uniformly, as in any desktop app.
+    """
+    handler, Foo = _handler_with_provider()
+    presses = []
+
+    @Foo.bind_key(key)
+    def _count(x):
+        presses.append(1)
+
+    _press(handler, key, held_for=4)
+    assert len(presses) == 5  # initial press plus every auto-repeat
+
+
+def test_modified_keys_autorepeat():
+    """Modified combos repeat too, exactly like their bare counterparts.
+
+    Uses Alt, not Control: vispy's CONTROL maps to KeyMod.CtrlCmd, spelled
+    `Meta+` on macOS but `Ctrl+` by `bind_key`, so a Control test would miss
+    the binding for reasons unrelated to auto-repeat.
+    """
+    handler, Foo = _handler_with_provider()
+    presses = []
+
+    @Foo.bind_key('Alt+Up')
+    def _count(x):
+        presses.append(1)
+
+    _press(handler, 'Up', held_for=4, modifiers=[keys.ALT])
+    assert len(presses) == 5
+
+
+def test_autorepeat_suppressed_while_hold_generator_pending():
+    """A generator (press/release) binding must not re-enter under repeat.
+
+    Its press body runs once; auto-repeats while the release side is pending
+    are dropped, and the release body still runs exactly once on real release.
+    """
+    handler, Foo = _handler_with_provider()
+    pressed = []
+    released = []
+
+    @Foo.bind_key('A')
+    def _hold(x):
+        pressed.append(1)
+        yield
+        released.append(1)
+
+    _press(handler, 'A', held_for=4)
+    assert len(pressed) == 1
+    assert len(released) == 0
+
+    handler.on_key_release(_key_event('A', auto_repeat=False))
+    assert len(released) == 1
+
+
+def test_autorepeat_release_events_ignored():
+    """Auto-repeat *release* events never resume a pending hold.
+
+    On Linux a held key arrives as press/release trains; resuming the
+    generator on those would end the hold while the key is still down.
+    """
+    handler, Foo = _handler_with_provider()
+    released = []
+
+    @Foo.bind_key('A')
+    def _hold(x):
+        yield
+        released.append(1)
+
+    _press(handler, 'A', held_for=2)
+    handler.on_key_release(_key_event('A', auto_repeat=True))
+    assert len(released) == 0
+
+    handler.on_key_release(_key_event('A', auto_repeat=False))
+    assert len(released) == 1
+
+
+def test_autorepeat_preserves_tap_vs_hold(monkeypatch):
+    """Repeats neither re-enter a release-callback binding nor reset its clock.
+
+    Attribute actions (layer mode switches) return a restore callback and time
+    the hold; re-entering under repeat would re-stash with a fresh timestamp,
+    turning every hold into a tap.
+    """
+    monkeypatch.setattr(time, 'time', lambda: 1)
+    handler, Foo = _handler_with_provider()
+    presses = []
+    restored = []
+
+    @Foo.bind_key('K')
+    def _mode_switch(x):
+        presses.append(1)
+        return lambda: restored.append(1)
+
+    _press(handler, 'K', held_for=4)
+    assert len(presses) == 1
+    assert len(restored) == 0
+
+    monkeypatch.setattr(time, 'time', lambda: 2)  # > hold_button_delay
+    handler.on_key_release(_key_event('K', auto_repeat=False))
+    assert len(restored) == 1
+
+
+def test_release_clears_pending_hold_state():
+    """Release pops the stashed hold, so presence means exactly 'pending'.
+
+    The auto-repeat suppression in `on_key_press` keys off that stash; a
+    stale entry would wrongly swallow repeats of later bindings on the key.
+    """
+    handler, Foo = _handler_with_provider()
+
+    @Foo.bind_key('A')
+    def _hold(x):
+        yield
+
+    assert handler.press_key('A')
+    assert handler.release_key('A')
+    # popped: a second release finds nothing to resume
+    assert not handler.release_key('A')
+
+    # and a subsequent auto-repeat of the same key is delivered again
+    presses = []
+
+    @Foo.bind_key('A', overwrite=True)
+    def _count(x):
+        presses.append(1)
+
+    _press(handler, 'A', held_for=2)
+    assert len(presses) == 3

--- a/src/napari/utils/_tests/test_key_bindings.py
+++ b/src/napari/utils/_tests/test_key_bindings.py
@@ -451,13 +451,12 @@ def _handler_with_provider():
     return handler, Foo
 
 
-@pytest.mark.parametrize('key', ['Up', 'Down', 'Left', 'Right'])
-def test_navigation_keys_autorepeat_however_they_are_bound(key):
-    """Held navigation keys repeat even when bound through `bind_key` (#9203).
+@pytest.mark.parametrize('key', ['Up', 'K', 'PageDown'])
+def test_autorepeat_delivered_by_default(key):
+    """A held key repeats at the OS rate, however and to whatever it is bound.
 
-    The old `repeatables` set held the nav keys as `str` literals, which never
-    `==`-match the `KeyBinding` tested against them, so a nav key bound via
-    `bind_key` fired once no matter how long it was held.
+    Auto-repeat used to be dropped unless the binding was on an opt-in
+    whitelist; now the OS policy applies uniformly, as in any desktop app.
     """
     handler, Foo = _handler_with_provider()
     presses = []
@@ -470,26 +469,12 @@ def test_navigation_keys_autorepeat_however_they_are_bound(key):
     assert len(presses) == 5  # initial press plus every auto-repeat
 
 
-def test_non_navigation_keys_still_do_not_autorepeat():
-    """The exemption is scoped: an ordinary bound key still fires once."""
-    handler, Foo = _handler_with_provider()
-    presses = []
-
-    @Foo.bind_key('K')
-    def _count(x):
-        presses.append(1)
-
-    _press(handler, 'K', held_for=4)
-    assert len(presses) == 1  # auto-repeats filtered out
-
-
-def test_modified_navigation_keys_still_do_not_autorepeat():
-    """A modified arrow is a different KeyBinding than the bare one, so it stays
-    filtered -- pinning the exemption to exactly the four bare nav keys.
+def test_modified_keys_autorepeat():
+    """Modified combos repeat too, exactly like their bare counterparts.
 
     Uses Alt, not Control: vispy's CONTROL maps to KeyMod.CtrlCmd, spelled
-    `Meta+` on macOS but `Ctrl+` by `bind_key`, so a Control test would miss the
-    binding for reasons unrelated to auto-repeat.
+    `Meta+` on macOS but `Ctrl+` by `bind_key`, so a Control test would miss
+    the binding for reasons unrelated to auto-repeat.
     """
     handler, Foo = _handler_with_provider()
     presses = []
@@ -499,4 +484,104 @@ def test_modified_navigation_keys_still_do_not_autorepeat():
         presses.append(1)
 
     _press(handler, 'Up', held_for=4, modifiers=[keys.ALT])
-    assert len(presses) == 1  # bound and fired, but auto-repeats filtered out
+    assert len(presses) == 5
+
+
+def test_autorepeat_suppressed_while_hold_generator_pending():
+    """A generator (press/release) binding must not re-enter under repeat.
+
+    Its press body runs once; auto-repeats while the release side is pending
+    are dropped, and the release body still runs exactly once on real release.
+    """
+    handler, Foo = _handler_with_provider()
+    pressed = []
+    released = []
+
+    @Foo.bind_key('A')
+    def _hold(x):
+        pressed.append(1)
+        yield
+        released.append(1)
+
+    _press(handler, 'A', held_for=4)
+    assert len(pressed) == 1
+    assert len(released) == 0
+
+    handler.on_key_release(_key_event('A', auto_repeat=False))
+    assert len(released) == 1
+
+
+def test_autorepeat_release_events_ignored():
+    """Auto-repeat *release* events never resume a pending hold.
+
+    On Linux a held key arrives as press/release trains; resuming the
+    generator on those would end the hold while the key is still down.
+    """
+    handler, Foo = _handler_with_provider()
+    released = []
+
+    @Foo.bind_key('A')
+    def _hold(x):
+        yield
+        released.append(1)
+
+    _press(handler, 'A', held_for=2)
+    handler.on_key_release(_key_event('A', auto_repeat=True))
+    assert len(released) == 0
+
+    handler.on_key_release(_key_event('A', auto_repeat=False))
+    assert len(released) == 1
+
+
+def test_autorepeat_preserves_tap_vs_hold(monkeypatch):
+    """Repeats neither re-enter a release-callback binding nor reset its clock.
+
+    Attribute actions (layer mode switches) return a restore callback and time
+    the hold; re-entering under repeat would re-stash with a fresh timestamp,
+    turning every hold into a tap.
+    """
+    monkeypatch.setattr(time, 'time', lambda: 1)
+    handler, Foo = _handler_with_provider()
+    presses = []
+    restored = []
+
+    @Foo.bind_key('K')
+    def _mode_switch(x):
+        presses.append(1)
+        return lambda: restored.append(1)
+
+    _press(handler, 'K', held_for=4)
+    assert len(presses) == 1
+    assert len(restored) == 0
+
+    monkeypatch.setattr(time, 'time', lambda: 2)  # > hold_button_delay
+    handler.on_key_release(_key_event('K', auto_repeat=False))
+    assert len(restored) == 1
+
+
+def test_release_clears_pending_hold_state():
+    """Release pops the stashed hold, so presence means exactly 'pending'.
+
+    The auto-repeat suppression in `on_key_press` keys off that stash; a
+    stale entry would wrongly swallow repeats of later bindings on the key.
+    """
+    handler, Foo = _handler_with_provider()
+
+    @Foo.bind_key('A')
+    def _hold(x):
+        yield
+
+    assert handler.press_key('A')
+    assert handler.release_key('A')
+    # popped: a second release finds nothing to resume
+    assert not handler.release_key('A')
+
+    # and a subsequent auto-repeat of the same key is delivered again
+    presses = []
+
+    @Foo.bind_key('A', overwrite=True)
+    def _count(x):
+        presses.append(1)
+
+    _press(handler, 'A', held_for=2)
+    assert len(presses) == 3

--- a/src/napari/utils/action_manager.py
+++ b/src/napari/utils/action_manager.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from napari.utils.events import EmitterGroup
 from napari.utils.interactions import Shortcut
+from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -36,7 +37,7 @@ class Action:
     command: Callable
     description: str
     keymapprovider: KeymapProvider  # subclassclass or instance of a subclass
-    repeatable: bool = False
+    repeatable: bool = False  # deprecated, ignored: auto-repeat is the default
 
     @cached_property
     def injected(self) -> Callable[..., Future]:
@@ -110,8 +111,6 @@ class ActionManager:
          - a name (unique), usually `packagename:name`
          - a description
          - A keymap provider (easier for focus and backward compatibility).
-         - a boolean repeatability flag indicating whether it can be auto-
-           repeated (i.e. when a key is held down); defaults to False
 
         Actions can then be later bound/unbound from button elements, and
         shortcuts; and the action manager will take care of modifying the keymap
@@ -134,8 +133,10 @@ class ActionManager:
             registered. This make sure the shortcut is active only when an
             instance of this is in focus.
         repeatable : bool
-            a boolean flag indicating whether the action can be autorepeated.
-            Defaults to False.
+            Deprecated and ignored. Key auto-repeat is now delivered to every
+            binding by default; only hold-semantics bindings (generators and
+            bindings returning a release callback) suppress it, which is
+            derived from the bound callable rather than declared here.
 
 
         Notes
@@ -153,6 +154,18 @@ class ActionManager:
 
         """
 
+        if repeatable:
+            warnings.warn(
+                trans._(
+                    'The `repeatable` flag is deprecated since napari 0.8.1 '
+                    'and is ignored: key auto-repeat is now delivered to '
+                    'every binding by default, and hold-semantics bindings '
+                    'suppress it automatically. Stop passing `repeatable`.',
+                    deferred=True,
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._validate_action_name(name)
         self._actions[name] = Action(
             command, description, keymapprovider, repeatable
@@ -388,33 +401,6 @@ class ActionManager:
                     active_shortcuts[str(shortcut)] = action.description
 
         return active_shortcuts
-
-    def _get_repeatable_shortcuts(self, active_keymap) -> list:
-        """
-        Get active, repeatable shortcuts for the given active keymap.
-
-        Parameters
-        ----------
-        active_keymap : KeymapProvider
-            The active keymap provider.
-
-        Returns
-        -------
-        list
-            List of shortcuts that are repeatable.
-        """
-        active_func_names = {i[1].__name__ for i in active_keymap.items()}
-        active_repeatable_shortcuts = []
-        for name, shortcuts in self._shortcuts.items():
-            action = self._actions.get(name, None)
-            if (
-                action
-                and action.command.__name__ in active_func_names
-                and action.repeatable
-            ):
-                active_repeatable_shortcuts.extend(shortcuts)
-
-        return active_repeatable_shortcuts
 
     def trigger(self, name: str) -> Any:
         """Trigger the action `name`."""

--- a/src/napari/utils/action_manager.py
+++ b/src/napari/utils/action_manager.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from napari.utils.events import EmitterGroup
 from napari.utils.interactions import Shortcut
+from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -36,7 +37,7 @@ class Action:
     command: Callable
     description: str
     keymapprovider: KeymapProvider  # subclassclass or instance of a subclass
-    repeatable: bool = False
+    repeatable: bool = False  # deprecated, ignored: auto-repeat is the default
 
     @cached_property
     def injected(self) -> Callable[..., Future]:
@@ -110,8 +111,6 @@ class ActionManager:
          - a name (unique), usually `packagename:name`
          - a description
          - A keymap provider (easier for focus and backward compatibility).
-         - a boolean repeatability flag indicating whether it can be auto-
-           repeated (i.e. when a key is held down); defaults to False
 
         Actions can then be later bound/unbound from button elements, and
         shortcuts; and the action manager will take care of modifying the keymap
@@ -134,8 +133,10 @@ class ActionManager:
             registered. This make sure the shortcut is active only when an
             instance of this is in focus.
         repeatable : bool
-            a boolean flag indicating whether the action can be autorepeated.
-            Defaults to False.
+            Deprecated and ignored. Key auto-repeat is now delivered to every
+            binding by default; only hold-semantics bindings (generators and
+            bindings returning a release callback) suppress it, which is
+            derived from the bound callable rather than declared here.
 
 
         Notes
@@ -153,6 +154,18 @@ class ActionManager:
 
         """
 
+        if repeatable:
+            warnings.warn(
+                trans._(
+                    'The `repeatable` flag is deprecated and ignored: key '
+                    'auto-repeat is now delivered to '
+                    'every binding by default, and hold-semantics bindings '
+                    'suppress it automatically. Stop passing `repeatable`.',
+                    deferred=True,
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._validate_action_name(name)
         self._actions[name] = Action(
             command, description, keymapprovider, repeatable
@@ -388,33 +401,6 @@ class ActionManager:
                     active_shortcuts[str(shortcut)] = action.description
 
         return active_shortcuts
-
-    def _get_repeatable_shortcuts(self, active_keymap) -> list:
-        """
-        Get active, repeatable shortcuts for the given active keymap.
-
-        Parameters
-        ----------
-        active_keymap : KeymapProvider
-            The active keymap provider.
-
-        Returns
-        -------
-        list
-            List of shortcuts that are repeatable.
-        """
-        active_func_names = {i[1].__name__ for i in active_keymap.items()}
-        active_repeatable_shortcuts = []
-        for name, shortcuts in self._shortcuts.items():
-            action = self._actions.get(name, None)
-            if (
-                action
-                and action.command.__name__ in active_func_names
-                and action.repeatable
-            ):
-                active_repeatable_shortcuts.extend(shortcuts)
-
-        return active_repeatable_shortcuts
 
     def trigger(self, name: str) -> Any:
         """Trigger the action `name`."""

--- a/src/napari/utils/key_bindings.py
+++ b/src/napari/utils/key_bindings.py
@@ -439,7 +439,9 @@ class KeymapHandler:
         key_bind = coerce_keybinding(key_bind)
         key = str(key_bind.parts[-1].key)
         try:
-            val = self._key_release_generators[key]
+            # pop so the pending-hold check in on_key_press sees exactly the
+            # holds whose release side has not yet run
+            val = self._key_release_generators.pop(key)
             # val could be callback function with time to check
             # if it should be called or generator that need to make
             # additional step on key release
@@ -461,39 +463,32 @@ class KeymapHandler:
     def on_key_press(self, event):
         """Called whenever key pressed in canvas.
 
+        OS auto-repeat is delivered like any other press, so a held key
+        repeats at the user's configured rate — matching how every desktop
+        platform treats held keys. The one case a repeat is mechanically
+        wrong is a hold-semantics binding (a generator, or a binding that
+        returned a release callback) whose release side is still pending:
+        re-entering the press body would clobber the stashed release state
+        and reset the tap-vs-hold timing. Only those repeats are dropped.
+
         Parameters
         ----------
         event : vispy.util.event.Event
             The vispy key press event that triggered this method.
         """
-        from napari.utils.action_manager import action_manager
-
         if event.key is None:
             # TODO determine when None key could be sent.
             return
 
         kb = _vispy2appmodel(event)
 
-        repeatables = {
-            *action_manager._get_repeatable_shortcuts(self.keymap_chain),
-            # Nav keys are exempt however they were bound. They must be
-            # KeyBinding, not str: the set is tested against a KeyBinding, which
-            # never compares equal to a str, so str literals here silently never
-            # matched and no key bound via bind_key() auto-repeated. See #9203.
-            *(
-                KeyBinding.from_str(key)
-                for key in ('Up', 'Down', 'Left', 'Right')
-            ),
-        }
-
         if (
             event.native is not None
             and event.native.isAutoRepeat()
-            and kb not in repeatables
-        ) or event.key is None:
-            # pass if no key is present or if the shortcut combo is held down,
-            # unless the combo being held down is one of the autorepeatables or
-            # one of the navigation keys (helps with scrolling).
+            and str(kb.parts[-1].key) in self._key_release_generators
+        ):
+            # a hold-semantics binding is in flight for this key; its press
+            # body already ran and must not re-enter until release
             return
 
         event.handled = self.press_key(kb)

--- a/src/napari/utils/key_bindings.py
+++ b/src/napari/utils/key_bindings.py
@@ -439,7 +439,9 @@ class KeymapHandler:
         key_bind = coerce_keybinding(key_bind)
         key = str(key_bind.parts[-1].key)
         try:
-            val = self._key_release_generators[key]
+            # pop so the pending-hold check in on_key_press sees exactly the
+            # holds whose release side has not yet run
+            val = self._key_release_generators.pop(key)
             # val could be callback function with time to check
             # if it should be called or generator that need to make
             # additional step on key release
@@ -461,35 +463,32 @@ class KeymapHandler:
     def on_key_press(self, event):
         """Called whenever key pressed in canvas.
 
+        OS auto-repeat is delivered like any other press, so a held key
+        repeats at the user's configured rate — matching how every desktop
+        platform treats held keys. The one case a repeat is mechanically
+        wrong is a hold-semantics binding (a generator, or a binding that
+        returned a release callback) whose release side is still pending:
+        re-entering the press body would clobber the stashed release state
+        and reset the tap-vs-hold timing. Only those repeats are dropped.
+
         Parameters
         ----------
         event : vispy.util.event.Event
             The vispy key press event that triggered this method.
         """
-        from napari.utils.action_manager import action_manager
-
         if event.key is None:
             # TODO determine when None key could be sent.
             return
 
         kb = _vispy2appmodel(event)
 
-        repeatables = {
-            *action_manager._get_repeatable_shortcuts(self.keymap_chain),
-            'Up',
-            'Down',
-            'Left',
-            'Right',
-        }
-
         if (
             event.native is not None
             and event.native.isAutoRepeat()
-            and kb not in repeatables
-        ) or event.key is None:
-            # pass if no key is present or if the shortcut combo is held down,
-            # unless the combo being held down is one of the autorepeatables or
-            # one of the navigation keys (helps with scrolling).
+            and str(kb.parts[-1].key) in self._key_release_generators
+        ):
+            # a hold-semantics binding is in flight for this key; its press
+            # body already ran and must not re-enter until release
             return
 
         event.handled = self.press_key(kb)


### PR DESCRIPTION
# References and relevant issues

Closes #9203. Closes #9276 — the `repeatables` set no longer exists, taking its str-vs-`KeyBinding` gap with it.

Overlaps #9257 (same author): that PR is the minimal fix within the existing opt-in model; this is the policy change discussed in its review thread. It supersedes #9257 if this direction is preferred, otherwise it rebases trivially on top. Related: #5999 (str/`KeyBinding` mixing in action_manager); #6204 keeps a per-action `repeatable` flag while NAP-7 specifies no repeat policy, so this policy would transfer there as a default flip.

# Description

napari drops OS key auto-repeat unless the binding is on an opt-in whitelist: four `repeatable=True` actions plus the four bare arrows (dead code until #9203). No desktop platform behaves this way — macOS, Windows, and Linux deliver auto-repeat uniformly at the user's configured rate (Alt/Option+arrow word-skip, PageDown, Shift+arrow selection all repeat when held), and applications suppress it only where a repeated press is mechanically wrong.

This PR adopts that policy. `KeymapHandler.on_key_press` delivers auto-repeat presses **unless a hold-semantics binding is pending on that key**: a generator action (Space pan-zoom, Shift aspect-lock) or a tap-vs-hold attribute action (all layer mode switches), where re-entering the press body would clobber the stashed release state or reset the hold timer. Auto-repeat *release* events are still dropped (Linux delivers held keys as press/release trains).

User-visible changes:

- Modified navigation keys repeat when held (`Alt+Up`/`Down` focus-axes, `Ctrl/Cmd+Up`/`Down` layer selection), matching the bare arrows.
- One-shot commands repeat as in any native app — holding `-`/`=` steps the label id continuously, exactly as `[`/`]` brush-size already did. Holds and mode switches remain single-fire.
- The `repeatable` flag is deprecated (accepted, warns, ignored); internal callers stop passing it, and the private `_get_repeatable_shortcuts` is removed.

# Approach

Suppression keys off `_key_release_generators` — the stash of pending release sides the hold machinery already maintains — rather than a registration-time flag. A binding that stashed a generator or release callback has exactly the shape that must not re-enter; everything else repeats. There is no second source of truth to drift, and plain `bind_key()` bindings (which never touch action_manager) behave correctly with no registration step. For the stash to mean "release pending", `release_key` now pops entries (previously they were never removed, only overwritten). Extending the whitelist instead was rejected: any curated list reproduces today's failure mode (#9276, #5999).

Pre-existing and unchanged: the stash is keyed by the base key with modifiers stripped, so `Shift+X`-press/`X`-release collide; the suppression check uses the same keying, so behavior stays consistent.

# Tests

New coverage in `src/napari/utils/_tests/test_key_bindings.py` (this path had none): repeat delivered however bound, bare and modified; generator press body fires once under repeat, release body once on real release; auto-repeat releases never resume a hold; tap-vs-hold timing survives repeat; release pops the pending-hold state.

Ran locally: `utils/_tests` (251 passed), `test_viewer_keybindings.py` (25), labels key bindings, `test_layer_utils.py` (44); ruff check/format clean. `src/napari/_tests/test_key_bindings.py` segfaults on this machine on unmodified `main` as well (offscreen Qt + real Viewer) — deferring to CI for that module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
