### PR TITLE
fix(vectors): stop edge-color controls mutating the layer and hiding mode changes

### DIFF
--- a/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from napari._qt.layer_controls.qt_vectors_controls import QtVectorsControls
 from napari.layers import Vectors
@@ -14,3 +15,76 @@ def test_out_of_slice_display_checkbox(qtbot):
     assert layer.out_of_slice_display
     qtctrl._out_slice_checkbox_control.out_of_slice_checkbox.setChecked(False)
     assert not layer.out_of_slice_display
+
+
+def test_building_controls_leaves_the_layer_unchanged(qtbot):
+    """Constructing the controls must not assign a feature as edge_color.
+
+    Populating the feature dropdown emits currentTextChanged for the first
+    item; if the handler is already connected, building the controls assigns
+    that feature as the layer's edge color, replacing an explicitly requested
+    direct color with feature-mapped colors (the color assertion below is the
+    regression detector; the mode is restored by change_edge_color_feature).
+    """
+    layer = Vectors(
+        _VECTORS,
+        features={'phase': np.array([0.5, 1.5])},
+        edge_color='yellow',
+    )
+    assert layer.edge_color_mode == 'direct'
+
+    qtctrl = QtVectorsControls(layer)
+    qtbot.addWidget(qtctrl)
+
+    assert layer.edge_color_mode == 'direct'
+    np.testing.assert_allclose(layer.edge_color, [[1, 1, 0, 1], [1, 1, 0, 1]])
+
+
+def test_mode_changes_from_the_controls_reach_other_listeners(qtbot):
+    """A mode switch made in the combobox must emit edge_color_mode.
+
+    change_edge_color_mode blocks its own resync callback while assigning the
+    mode; blocking the whole emitter instead hides every combobox-driven mode
+    switch from external listeners synchronizing state to the layer.
+    """
+    layer = Vectors(
+        _VECTORS,
+        features={'phase': np.array([0.5, 1.5])},
+        edge_color='phase',
+    )
+    assert layer.edge_color_mode == 'colormap'
+    qtctrl = QtVectorsControls(layer)
+    qtbot.addWidget(qtctrl)
+    heard = []
+    layer.events.edge_color_mode.connect(
+        lambda event: heard.append(str(layer.edge_color_mode))
+    )
+
+    combobox = qtctrl._edge_color_feature_control.color_mode_combobox
+    combobox.setCurrentText('direct')
+
+    assert layer.edge_color_mode == 'direct'
+    assert heard == ['direct']
+    assert combobox.currentText() == 'direct'
+
+
+def test_rejected_mode_change_rolls_back_without_notifying(qtbot):
+    """A mode the layer refuses must not emit edge_color_mode to listeners.
+
+    Selecting a mapped mode on a featureless layer raises; the layer never
+    changed, so listeners must hear nothing, and the combobox must return to
+    the mode the layer is actually in.
+    """
+    layer = Vectors(_VECTORS)
+    qtctrl = QtVectorsControls(layer)
+    qtbot.addWidget(qtctrl)
+    control = qtctrl._edge_color_feature_control
+    heard = []
+    layer.events.edge_color_mode.connect(lambda event: heard.append(True))
+
+    with pytest.raises(ValueError, match='valid Points'):
+        control.change_edge_color_mode('colormap')
+
+    assert layer.edge_color_mode == 'direct'
+    assert control.color_mode_combobox.currentText() == 'direct'
+    assert heard == []

--- a/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from napari._qt.layer_controls.qt_vectors_controls import QtVectorsControls
 from napari.layers import Vectors
@@ -18,20 +17,11 @@ def test_out_of_slice_display_checkbox(qtbot):
 
 
 def test_building_controls_leaves_the_layer_unchanged(qtbot):
-    """Constructing the controls must not assign a feature as edge_color.
-
-    Populating the feature dropdown emits currentTextChanged for the first
-    item; if the handler is already connected, building the controls assigns
-    that feature as the layer's edge color, replacing an explicitly requested
-    direct color with feature-mapped colors (the color assertion below is the
-    regression detector; the mode is restored by change_edge_color_feature).
-    """
     layer = Vectors(
         _VECTORS,
         features={'phase': np.array([0.5, 1.5])},
         edge_color='yellow',
     )
-    assert layer.edge_color_mode == 'direct'
 
     qtctrl = QtVectorsControls(layer)
     qtbot.addWidget(qtctrl)
@@ -40,51 +30,19 @@ def test_building_controls_leaves_the_layer_unchanged(qtbot):
     np.testing.assert_allclose(layer.edge_color, [[1, 1, 0, 1], [1, 1, 0, 1]])
 
 
-def test_mode_changes_from_the_controls_reach_other_listeners(qtbot):
-    """A mode switch made in the combobox must emit edge_color_mode.
-
-    change_edge_color_mode blocks its own resync callback while assigning the
-    mode; blocking the whole emitter instead hides every combobox-driven mode
-    switch from external listeners synchronizing state to the layer.
-    """
+def test_mode_change_from_controls_reaches_other_listeners(qtbot):
     layer = Vectors(
         _VECTORS,
         features={'phase': np.array([0.5, 1.5])},
         edge_color='phase',
     )
-    assert layer.edge_color_mode == 'colormap'
     qtctrl = QtVectorsControls(layer)
     qtbot.addWidget(qtctrl)
     heard = []
-    layer.events.edge_color_mode.connect(
-        lambda event: heard.append(str(layer.edge_color_mode))
-    )
+    layer.events.edge_color_mode.connect(lambda event: heard.append(event))
 
-    combobox = qtctrl._edge_color_feature_control.color_mode_combobox
-    combobox.setCurrentText('direct')
-
-    assert layer.edge_color_mode == 'direct'
-    assert heard == ['direct']
-    assert combobox.currentText() == 'direct'
-
-
-def test_rejected_mode_change_rolls_back_without_notifying(qtbot):
-    """A mode the layer refuses must not emit edge_color_mode to listeners.
-
-    Selecting a mapped mode on a featureless layer raises; the layer never
-    changed, so listeners must hear nothing, and the combobox must return to
-    the mode the layer is actually in.
-    """
-    layer = Vectors(_VECTORS)
-    qtctrl = QtVectorsControls(layer)
-    qtbot.addWidget(qtctrl)
     control = qtctrl._edge_color_feature_control
-    heard = []
-    layer.events.edge_color_mode.connect(lambda event: heard.append(True))
-
-    with pytest.raises(ValueError, match='valid Points'):
-        control.change_edge_color_mode('colormap')
+    control.color_mode_combobox.setCurrentText('direct')
 
     assert layer.edge_color_mode == 'direct'
-    assert control.color_mode_combobox.currentText() == 'direct'
-    assert heard == []
+    assert len(heard) == 1

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -52,10 +52,15 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
         # Setup widgets
         # dropdown to select the feature for mapping edge_color
         self.color_feature_box = QComboBox(parent)
+        # Populate before connecting: inserting the first item emits
+        # currentTextChanged, and connecting first would assign that feature
+        # as the layer's edge_color while the controls are being built —
+        # replacing an explicitly requested direct color with feature-mapped
+        # colors the layer then keeps when its mode is restored.
+        self.color_feature_box.addItems(self._layer.features.columns)
         self.color_feature_box.currentTextChanged.connect(
             self.change_edge_color_feature
         )
-        self.color_feature_box.addItems(self._layer.features.columns)
         self.edge_feature_label = QtWrappedLabel('edge feature:')
 
         # vector direct color mode adjustment and widget
@@ -106,15 +111,24 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             Edge color for vectors. Must be: 'direct', 'cycle', or 'colormap'
         """
         old_mode = self._layer.edge_color_mode
-        with self._layer.events.edge_color_mode.blocker():
+        # Block only this widget's own resync callback; a bare blocker() would
+        # silence every listener of the event, leaving other observers of
+        # edge_color_mode unaware of mode changes made through these controls.
+        with self._layer.events.edge_color_mode.blocker(
+            self._on_edge_color_mode_change
+        ):
             try:
                 self._layer.edge_color_mode = mode
                 self._update_edge_color_gui(mode)
 
             except ValueError:
-                # if the color mode was invalid, revert to the old mode (layer and GUI)
-                self._layer.edge_color_mode = old_mode
-                self.color_mode_combobox.setCurrentText(old_mode)
+                # The rejected mode never took effect: roll back silently —
+                # listeners must not be notified of a change that did not
+                # happen — and restore the GUI through the resync handler,
+                # whose blocked combobox signal avoids re-entering this method.
+                with self._layer.events.edge_color_mode.blocker():
+                    self._layer.edge_color_mode = old_mode
+                self._on_edge_color_mode_change()
                 raise
 
     def _on_edge_color_mode_change(self):

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -52,11 +52,6 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
         # Setup widgets
         # dropdown to select the feature for mapping edge_color
         self.color_feature_box = QComboBox(parent)
-        # Populate before connecting: inserting the first item emits
-        # currentTextChanged, and connecting first would assign that feature
-        # as the layer's edge_color while the controls are being built —
-        # replacing an explicitly requested direct color with feature-mapped
-        # colors the layer then keeps when its mode is restored.
         self.color_feature_box.addItems(self._layer.features.columns)
         self.color_feature_box.currentTextChanged.connect(
             self.change_edge_color_feature
@@ -111,9 +106,6 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             Edge color for vectors. Must be: 'direct', 'cycle', or 'colormap'
         """
         old_mode = self._layer.edge_color_mode
-        # Block only this widget's own resync callback; a bare blocker() would
-        # silence every listener of the event, leaving other observers of
-        # edge_color_mode unaware of mode changes made through these controls.
         with self._layer.events.edge_color_mode.blocker(
             self._on_edge_color_mode_change
         ):
@@ -122,13 +114,9 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
                 self._update_edge_color_gui(mode)
 
             except ValueError:
-                # The rejected mode never took effect: roll back silently —
-                # listeners must not be notified of a change that did not
-                # happen — and restore the GUI through the resync handler,
-                # whose blocked combobox signal avoids re-entering this method.
-                with self._layer.events.edge_color_mode.blocker():
-                    self._layer.edge_color_mode = old_mode
-                self._on_edge_color_mode_change()
+                # if the color mode was invalid, revert to the old mode (layer and GUI)
+                self._layer.edge_color_mode = old_mode
+                self.color_mode_combobox.setCurrentText(old_mode)
                 raise
 
     def _on_edge_color_mode_change(self):

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -478,6 +478,18 @@ def test_switching_edge_color_mode_back_to_direct():
     assert layer.edge_color_mode == 'direct'
 
 
+def test_setting_the_current_edge_color_mode_does_not_emit():
+    data = np.zeros((6, 2, 2))
+    data[:, 1] = [1, 1]
+    layer = Vectors(data)
+    heard = []
+    layer.events.edge_color_mode.connect(lambda event: heard.append(event))
+
+    layer.edge_color_mode = 'direct'
+
+    assert heard == []
+
+
 def test_edge_color_colormap():
     """Test creating Vectors where edge color is set by a colormap"""
     shape = (10, 2)

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -589,6 +589,7 @@ class Vectors(Layer):
     @edge_color_mode.setter
     def edge_color_mode(self, edge_color_mode: str | ColorMode):
         edge_color_mode = ColorMode(edge_color_mode)
+        old_mode = self._edge.color_mode
 
         if edge_color_mode == ColorMode.DIRECT:
             self._edge.color_mode = edge_color_mode
@@ -626,7 +627,8 @@ class Vectors(Layer):
                 )
 
             self._edge.color_mode = edge_color_mode
-        self.events.edge_color_mode()
+        if self._edge.color_mode != old_mode:
+            self.events.edge_color_mode()
 
     @property
     def edge_color_cycle(self) -> np.ndarray:


### PR DESCRIPTION
Closes #9365. Related: #9330 (this is its item 3).

Three one-liners in the Vectors edge-color path:

The feature dropdown is populated after currentTextChanged is connected, so adding the first feature sets `layer.edge_color`— opening the controls overwrites the user's color. Populate first. `change_edge_color_mode` blocks the whole edge_color_mode emitter, so GUI mode changes reach no other listener. Block only our own callback.

Per @brisvag's review: `Vectors.edge_color_mode` emitted when nothing changed. Fixed there, so the rollback path here goes back to main's version.

Regression tests in `test_qt_vectors_layer.py` and `test_vectors.py`.
