### PR TITLE
fix(containers): stop held Delete from emptying the layer list

### DIFF
--- a/src/napari/_qt/containers/_base_item_view.py
+++ b/src/napari/_qt/containers/_base_item_view.py
@@ -65,7 +65,12 @@ class _BaseEventedItemView(_ViewBase, Generic[ItemType]):
         if e is None:
             return None
         if e.key() in (Qt.Key.Key_Backspace, Qt.Key.Key_Delete):
-            self._root.remove_selected()
+            # One press deletes one selection. Deletion is not undoable and
+            # remove_selected() selects a neighbor afterwards, so honoring
+            # auto-repeat would walk down the list and empty it while the key
+            # is held. Swallow the repeats rather than forwarding them.
+            if not e.isAutoRepeat():
+                self._root.remove_selected()
             return None
         return super().keyPressEvent(e)
 

--- a/src/napari/_qt/containers/_tests/test_qt_list.py
+++ b/src/napari/_qt/containers/_tests/test_qt_list.py
@@ -95,6 +95,23 @@ def test_list_view_keypress(qtbot):
     assert first not in root
 
 
+@pytest.mark.parametrize('key', [Qt.Key_Delete, Qt.Key_Backspace])
+def test_list_view_delete_ignores_autorepeat(qtbot, key):
+    """Holding delete must not empty the list, one press deletes one item."""
+    root: SelectableEventedList[T] = SelectableEventedList(map(T, range(5)))
+    view = QtListView(root)
+    qtbot.addWidget(view)
+
+    root.selection = {root[0]}
+    # first press deletes, the following auto-repeats must not
+    view.keyPressEvent(QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier))
+    for _ in range(4):
+        view.keyPressEvent(
+            QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier, '', True)
+        )
+    assert len(root) == 4
+
+
 @pytest.mark.parametrize(('sources', 'dest', 'expectation'), BASIC_INDICES)
 def test_move_multiple(sources, dest, expectation):
     """Test that models stay in sync with complicated moves.


### PR DESCRIPTION
## References and relevant issues

None filed; found while working on an unrelated Qt controls fix.

## Description

`_BaseEventedItemView.keyPressEvent` deletes the current selection on every bare <kbd>Delete</kbd>/<kbd>Backspace</kbd> press. That handler is a plain Qt override living outside the keymap, so the auto-repeat guard in `KeymapHandler.on_key_press` never applies to it — and `SelectableEventedList.remove_selected()` selects a neighbor after each removal, so every auto-repeat has a fresh victim.

Holding <kbd>Delete</kbd> with the layer list focused therefore walks down the list and removes every layer. There is no undo for layer deletion.

To reproduce on `main`: open a viewer with several layers, click a layer in the layer list, then press and hold <kbd>Delete</kbd> — the whole list empties.

Note that the app-model shortcut `napari:delete_selected_layers` (<kbd>Ctrl</kbd>+<kbd>Delete</kbd>) is dispatched through the keymap and is already guarded; only the bare key handled directly by the item view is affected.

This PR ignores auto-repeated <kbd>Delete</kbd>/<kbd>Backspace</kbd> in that handler, so one press deletes one selection. Repeats are swallowed rather than forwarded to the base class, matching how a non-repeated delete is already consumed — so `QtLayerList.keyPressEvent` still does not re-`ignore()` the event up to the viewer. Other keys are untouched, so auto-repeat still works for arrow-key navigation in the list.

The fix lives in the shared base view, so it covers `QtListView`, `QtNodeTreeView`, and `QtLayerList`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] added a new parametrized regression test (`test_list_view_delete_ignores_autorepeat`, over both Delete and Backspace) that sends one real press plus four auto-repeat `QKeyEvent`s at a five-item list and asserts four items remain; it fails without the source change (list emptied) and passes with it
- [x] all tests in `src/napari/_qt/containers/_tests` pass locally (51 passed, 1 skipped)

Verification so far is via synthetic key events only — I have not yet exercised a held physical key in a running viewer.

## Final checklist:

- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works