### PR TITLE
Change tox and codecov configuration to simplify local reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -951,6 +951,17 @@ source = [
     "napari_builtins",
 ]
 
+[tool.coverage.paths]
+source = [
+  "src/napari",
+  "**/site-packages/napari",
+]
+builtins = [
+  "src/napari_builtins",
+  "**/site-packages/napari_builtins",
+]
+
+
 [tool.importlinter]
 root_package = "napari"
 include_external_packages = true

--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ indexserver =
     extra = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 commands =
     {env:TOX_TEST_RUNNER:python} \
-        -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir} \
+        -m pytest {env:PYTEST_PATH:} --color=yes --basetemp={envtmpdir}/.pytest_tmp \
         --ignore tools --maxfail=5 --json-report \
     linux: --pystack-threshold=60 --pystack-args="--native-all" \
         --json-report-file={toxinidir}/report-{envname}.json {posargs} \
@@ -124,7 +124,7 @@ extras =
     optional-numba
 commands =
     {env:TOX_TEST_RUNNER:python} \
-        -m pytest --color=yes --basetemp={envtmpdir} --ignore src/napari/_vispy \
+        -m pytest --color=yes --basetemp={envtmpdir}/.pytest_tmp --ignore src/napari/_vispy \
         --ignore src/napari/_qt --ignore src/napari/_tests --ignore tools --ignore src/napari_builtins/_qt \
         --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs} \
         --save-leaked-object-graph --import-mode=importlib


### PR DESCRIPTION
# References and relevant issues

required for https://github.com/napari/docs/pull/1088

# Description

When I was doing #8367, I did not spot that fully removing of `[tool.coverage.paths]` from `pyproject.toml` will make it hard to generate a local coverage report when running tests using Tox. 

This PR restores this option. 

On the other hand, no one reported this problem... 
