### PR TITLE
Fix missing `f` for strings modified in #8935

### DIFF
--- a/src/napari/_qt/dialogs/confirm_close_dialog.py
+++ b/src/napari/_qt/dialogs/confirm_close_dialog.py
@@ -37,7 +37,7 @@ class ConfirmCloseDialog(QDialog):
             text = (
                 'Do you want to close the application? '
                 f"('{QKeySequence('Ctrl+Q').toString(QKeySequence.NativeText)}' to confirm). "
-                'This will close all Qt Windows in this process{extra_info}'
+                f'This will close all Qt Windows in this process{extra_info}'
             )
             close_btn.setObjectName('error_icon_btn')
             close_btn.setShortcut(QKeySequence('Ctrl+Q'))

--- a/src/napari/_qt/widgets/qt_keyboard_settings.py
+++ b/src/napari/_qt/widgets/qt_keyboard_settings.py
@@ -361,8 +361,8 @@ class ShortcutEditor(QWidget):
         # show warning message
         message = (
             f'The keybinding <b>{new_shortcut}</b> is already assigned to:'
-            '{conflicting_actions_string}'
-            'Change or clear conflicting shortcuts before assigning <b>{new_shortcut}</b> to this one.'
+            f'{conflicting_actions_string}'
+            f'Change or clear conflicting shortcuts before assigning <b>{new_shortcut}</b> to this one.'
         )
         self._show_warning(conflicting_rows[0], message)
 

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -1434,7 +1434,7 @@ class VispyCanvas:
         if raw_spacing > safe_spacing:
             warnings.warn(
                 f'Grid spacing of {raw_spacing:.1f} pixels is too large and has been '
-                'reduced to {safe_spacing:.1f} pixels to prevent viewboxes from '
+                f'reduced to {safe_spacing:.1f} pixels to prevent viewboxes from '
                 'becoming too small. Consider using a smaller spacing value or '
                 'increasing the canvas size.',
                 UserWarning,

--- a/src/napari/_vispy/layers/scalar_field.py
+++ b/src/napari/_vispy/layers/scalar_field.py
@@ -210,13 +210,13 @@ class VispyScalarFieldBaseLayer(VispyBaseLayer[ScalarFieldBase]):
             if self.layer.multiscale:
                 raise ValueError(
                     f'Shape of individual tiles in multiscale {data.shape} cannot '
-                    'exceed GL_MAX_TEXTURE_SIZE {MAX_TEXTURE_SIZE}. Rendering is '
-                    'currently in {self.layer._slice_input.ndisplay}D mode.'
+                    f'exceed GL_MAX_TEXTURE_SIZE {MAX_TEXTURE_SIZE}. Rendering is '
+                    f'currently in {self.layer._slice_input.ndisplay}D mode.'
                 )
             warnings.warn(
                 f'data shape {data.shape} exceeds GL_MAX_TEXTURE_SIZE {MAX_TEXTURE_SIZE}'
                 ' in at least one axis and will be downsampled.'
-                ' Rendering is currently in {self.layer._slice_input.ndisplay}D mode.'
+                f' Rendering is currently in {self.layer._slice_input.ndisplay}D mode.'
             )
             downsample = np.ceil(
                 np.divide(data.shape, MAX_TEXTURE_SIZE)

--- a/src/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/src/napari/utils/colormaps/_tests/test_colormaps.py
@@ -51,6 +51,7 @@ def test_increment_unnamed_colormap():
         '[unnamed colormap 1]',
     ]
     assert _increment_unnamed_colormap(names)[0] == '[unnamed colormap 2]'
+    assert _increment_unnamed_colormap(names)[1] == '[unnamed colormap 2]'
 
     # test that named colormaps are not incremented
     named_colormap = 'perfect_colormap'

--- a/src/napari/utils/colormaps/colormap.py
+++ b/src/napari/utils/colormaps/colormap.py
@@ -118,7 +118,7 @@ class Colormap(EventedModel):
         if v[0] != 0 or (len(v) > 1 and v[-1] != 1):
             raise ValueError(
                 'Control points must start with 0.0 and end with 1.0. '
-                'Got {v[0]} and {v[-1]}'
+                f'Got {v[0]} and {v[-1]}'
             )
 
         # Check control points are sorted correctly

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -737,7 +737,7 @@ def _increment_unnamed_colormap(
     if name == '[unnamed colormap]':
         past_names = [n for n in existing if n.startswith('[unnamed colormap')]
         name = f'[unnamed colormap {len(past_names)}]'
-        display_name = '[unnamed colormap {number}]'
+        display_name = f'[unnamed colormap {len(past_names)}]'
 
     return name, display_name
 


### PR DESCRIPTION
# References and relevant issues
I noticed that when I try to quit napari I get:
<img width="883" height="264" alt="image" src="https://github.com/user-attachments/assets/17eca55f-9e6f-4ccf-9863-5e495f84eae4" />

Note the `{extra_info}`

Bisect pointed to: https://github.com/napari/napari/pull/8935

# Description
It looks like when the translation machinery was removed, this code ended up with a missing `f` to make an f-string, so I just add it. Resolves the issue for me locally.

Edit: On a lark, I asked Deepseek to check https://github.com/napari/napari/pull/8935 for any more string regressions. It found a couple more, so I had Deepseek fix those also. For one it even caught a missing test that should have caught the regression, so it fixed that too.
