### PR TITLE
Fix the built-in `nan` colormap setting `bad_color` instead of `nan_color`

### DIFF
--- a/src/napari/utils/colormaps/_tests/test_colormaps.py
+++ b/src/napari/utils/colormaps/_tests/test_colormaps.py
@@ -42,6 +42,12 @@ def test_colormap(name):
     np.testing.assert_almost_equal(colors, vispy_colors, decimal=6)
 
 
+def test_nan_colormap_maps_nan_to_red():
+    np.testing.assert_array_equal(
+        AVAILABLE_COLORMAPS['nan'].map(np.nan), [[1.0, 0.0, 0.0, 1.0]]
+    )
+
+
 def test_increment_unnamed_colormap():
     # test that unnamed colormaps are incremented
     names = [

--- a/src/napari/utils/colormaps/colormap_utils.py
+++ b/src/napari/utils/colormaps/colormap_utils.py
@@ -219,7 +219,7 @@ DISCONTINUOUS_COLORMAPS = {
         name='nan',
         display_name='NaN',
         colors=[[0.0, 0.0, 0.0, 1.0], [1.0, 1.0, 1.0, 1.0]],
-        bad_color=[1.0, 0.0, 0.0, 1.0],
+        nan_color=[1.0, 0.0, 0.0, 1.0],
     ),
 }
 


### PR DESCRIPTION
# References and relevant issues

Related: 
#8056 - a separate `nan_color` bug, in the render path rather than the colormap definition.
#9372 - feature request for better/more granular handling of out-of-range values

# Description

The built-in `nan` colormap does nothing. It passes `bad_color`, which is vispy's name for the field; napari's `Colormap` calls it `nan_color` and ignores unknown keywords, so the red was dropped and NaN kept the default transparent.

I left the silent ignore alone - `Colormap` accepting unknown keywords is worth its own look.
