### PR TITLE
[perf] Remove extra _update_theme call from Window init

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -747,7 +747,6 @@ class Window:
         # menu update, so we add them to the layerlist context for now.
         add_dummy_actions(self._qt_viewer.viewer.layers._ctx)
         self._update_theme()
-        self._update_theme_font_size()
         get_settings().appearance.events.theme.connect(self._update_theme)
         get_settings().appearance.events.font_size.connect(
             self._update_theme_font_size


### PR DESCRIPTION
# References and relevant issues
Related to: https://github.com/napari/napari/issues/8689
Identified by DeepSeek

# Description
`_update_theme` already adds font_size when it's missing from `extra_variables` arguement (aka the case of the Window init), so calling `_update_theme_font_size` is extraneous.
See below -- current main:
https://github.com/napari/napari/blob/319d090c7c8b8a1a016961af4135ed4ed7590c0e/src/napari/_qt/qt_main_window.py#L1568-L1598

This yields a minor startup cost savings, ~50 ms on my mac and there is no change in any font/theme related behavior.

