### PR TITLE
Fix handling exception when go to fallback source of data in map example

### DIFF
--- a/examples/latlon-data-with-map.py
+++ b/examples/latlon-data-with-map.py
@@ -13,6 +13,7 @@ import contextily as ctx
 import geopandas as gpd
 import pandas as pd
 import zarr
+from requests.exceptions import HTTPError
 
 import napari
 
@@ -52,7 +53,7 @@ bounds = gpd.GeoSeries(corners.to_crs(3857).geometry).total_bounds
 # fails, perhaps because CI is spamming the API, fall back on napari test data.
 try:
     bg_map, bg_extent = ctx.bounds2img(*bounds, zoom=13)
-except ConnectionError:
+except (ConnectionError, HTTPError):
     bg_map = zarr.open('https://data.napari.dev/prague-map.zarr')
     bg_extent = (
             1599674.1279521685, 1609458.067572671,


### PR DESCRIPTION
# References and relevant issues


# Description

During the checking of reasons why napari docs fail to build, I found such atraceback: 

```python
    Traceback (most recent call last):
      File "/home/runner/work/docs/docs/napari/examples/latlon-data-with-map.py", line 33, in <module>
        bg_map, bg_extent = ctx.bounds2img(bounds[0], bounds[1], bounds[2], bounds[3], zoom=13)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/contextily/tile.py", line 309, in bounds2img
        arrays = Parallel(n_jobs=n_connections, prefer=preferred_backend)(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/joblib/parallel.py", line 1986, in __call__
        return output if self.return_generator else list(output)
                                                    ^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/joblib/parallel.py", line 1914, in _get_sequential_output
        res = func(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/joblib/memory.py", line 607, in __call__
        return self._cached_call(args, kwargs, shelving=False)[0]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/joblib/memory.py", line 562, in _cached_call
        return self._call(call_id, args, kwargs, shelving)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/joblib/memory.py", line 832, in _call
        output = self.func(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/contextily/tile.py", line 339, in _fetch_tile
        array = _retryer(tile_url, wait, max_retries, headers, timeout=timeout)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/contextily/tile.py", line 506, in _retryer
        return _retryer(tile_url, wait, max_retries, headers, timeout=timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/contextily/tile.py", line 506, in _retryer
        return _retryer(tile_url, wait, max_retries, headers, timeout=timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/docs/docs/.venv/lib/python3.12/site-packages/contextily/tile.py", line 508, in _retryer
        raise requests.HTTPError("Connection reset by peer too many times. "
    requests.exceptions.HTTPError: Connection reset by peer too many times. Last message was: 502 Error: Bad Gateway for url: https://a.tile.openstreetmap.fr/hot/13/4424/2776.png
```

This PR fixes it by adding a second exception that causes the use of a fallback data address. 