### PR TITLE
Update build docs on circleci to PyQt6 and update python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: git clone --depth=1 git@github.com:napari/docs.git docs
       - run:
           name: Install qt libs + xvfb
-          command: sudo apt-get update && sudo apt-get install -y xvfb libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils
+          command: sudo apt-get update && sudo apt-get install -y xvfb libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0
       - run:
           name: Setup virtual environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ version: 2.1
 # Orbs are reusable packages of CircleCI configuration that you may share across projects.
 # See: https://circleci.com/docs/2.1/orb-intro/
 orbs:
-  python: circleci/python@3.1.0
+  python: circleci/python@4.0.0
 jobs:
   build-docs:
     docker:
       # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
-      - image: cimg/python:3.12.10
+      - image: cimg/python:3.12.13
     environment:
       XDG_CACHE_HOME: /home/circleci/.cache
     steps:
@@ -37,7 +37,7 @@ jobs:
           name: Install napari-dev
           command: |
             . .venv/bin/activate
-            uv pip install -e "napari/[pyqt5]" --group napari/pyproject.toml:docs
+            uv pip install -e "napari/[pyqt6]" --group napari/pyproject.toml:docs
           environment:
             UV_CONSTRAINT: napari/resources/constraints/constraints_py3.12_docs.txt
       - run:


### PR DESCRIPTION
# References and relevant issues

foloup of https://github.com/napari/docs/pull/1102
Build on GHA should be handled by https://github.com/napari/napari/pull/9077

# Description

Update circle ci configuration us use Qt6 for building docs and avoid having Qt5 warnings in docs output. 
