### PR TITLE
fix(shapes): pick shapes on a fractional slice key

### DIFF
--- a/src/napari/layers/shapes/_shape_list.py
+++ b/src/napari/layers/shapes/_shape_list.py
@@ -1858,17 +1858,22 @@ class ShapeList:
 
     @cached_property
     def _visible_shapes(self) -> list[tuple[int, Shape]]:
-        slice_key = self.slice_key
-        if len(slice_key):
-            return [
-                (i, s)
-                for i, s in enumerate(self.shapes)
-                if (
-                    np.all(s.slice_key[0] <= slice_key)
-                    and np.all(slice_key <= s.slice_key[1])
-                )
-            ]
-        return list(enumerate(self.shapes))
+        slice_key = np.asarray(self.slice_key)
+        if not len(slice_key) or not self.shapes:
+            return list(enumerate(self.shapes))
+        # This key is a real-valued data coordinate while a shape's is whole
+        # slices, so match `_update_displayed`'s half-slice tolerance where the
+        # shape does not span, and keep exact containment where it does.
+        lower, upper = self.slice_keys[:, 0], self.slice_keys[:, 1]
+        visible = np.all(
+            np.where(
+                lower == upper,
+                np.abs(slice_key - lower) < 0.5,
+                (lower <= slice_key) & (slice_key <= upper),
+            ),
+            axis=1,
+        )
+        return [(i, s) for i, s in enumerate(self.shapes) if visible[i]]
 
     @cached_property
     def _bounding_boxes(

--- a/src/napari/layers/shapes/_tests/test_shape_list.py
+++ b/src/napari/layers/shapes/_tests/test_shape_list.py
@@ -207,6 +207,46 @@ def test_inside():
     assert shape_list.inside((0.5, 0.5)) == 1
 
 
+@pytest.mark.parametrize(
+    ('slice_key', 'expected'),
+    [
+        ((0.9,), 1),  # within half a slice of shape2: drawn, so pickable
+        ((0.5,), None),  # half way between shape1 and shape2: neither is drawn
+        ((1.5,), None),
+    ],
+)
+def test_inside_with_fractional_slice_key(slice_key, expected):
+    """A planar shape is pickable exactly when `_update_displayed` draws it."""
+    shape_list = ShapeList()
+    shape_list.add(
+        [
+            Polygon(np.array([[0, 0, 0], [0, 1, 0], [0, 1, 1], [0, 0, 1]])),
+            Polygon(np.array([[1, 0, 0], [1, 1, 0], [1, 1, 1], [1, 0, 1]])),
+        ]
+    )
+    shape_list.slice_key = slice_key
+
+    npt.assert_array_equal(
+        shape_list._visible_shapes_indices,
+        np.flatnonzero(shape_list._displayed),
+    )
+    assert shape_list.inside((0.5, 0.5)) == expected
+
+
+def test_visible_shapes_spanning_slices_are_not_widened():
+    """A spanning shape covers its own slices, not half of the next one."""
+    shape_list = ShapeList()
+    shape_list.add(
+        Polygon(np.array([[0, 0, 0], [0, 1, 0], [1, 1, 1], [1, 0, 1]]))
+    )
+
+    shape_list.slice_key = (-0.4,)
+    assert shape_list._visible_shapes == []
+
+    shape_list.slice_key = (1,)
+    assert len(shape_list._visible_shapes) == 1
+
+
 def test_visible_shapes_4d():
     """Test _visible_shapes with 4D data like those from OME-Zarr/OMERO."""
     shape1 = Polygon(

--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -2329,6 +2329,25 @@ def test_value():
     assert value == (None, None)
 
 
+def test_value_with_fractional_slice_key():
+    """A non-integer translate puts the displayed slice between whole slices."""
+    layer = Shapes(ndim=3, translate=(5.1, 0, 0))
+    layer.add(
+        [np.array([[19, 10, 10], [19, 10, 20], [19, 20, 20], [19, 20, 10]])],
+        shape_type='rectangle',
+    )
+    layer._slice_dims(
+        Dims(
+            ndim=3,
+            ndisplay=2,
+            range=((0, 30, 1),) * 3,
+            point=(24, 0, 0),
+        )
+    )
+
+    assert layer.get_value((24, 15, 15), world=True) == (0, None)
+
+
 @pytest.mark.parametrize('scale', [(-1, -1), (1, -1), (-2, 3)])
 def test_value_vertex_with_negative_scale(scale):
     """Vertices must stay grabbable when the layer scale is negative.


### PR DESCRIPTION
# References and relevant issues

Closes #8901

# Description 

A shape's slice keys off integer slices, but `ShapeList.slice_key` is the real-valued data coordinate of the displayed slice. The two disagree when the layer has a non-integer translate (as in #8901) or a scale whose round trip through the layer transform is not exact. `_visible_shapes` will then exclude a shape that `_update_displayed` draws leaving the shape on screen but not responsive to click or rubber band selection.

The translate case is the one filed, but scale is enough - easy to hit with DICOM slice spacing:

```python
import napari
import numpy as np

scale = (2.000000185149993, 1.0, 1.0)
viewer = napari.Viewer()
viewer.add_image(np.zeros((84, 32, 32)), scale=scale)
shapes = viewer.add_shapes(ndim=3, scale=scale)
shapes.mode = "select"

for z in (40, 41, 42):
    viewer.dims.set_current_step(0, z)
    shapes.data = [np.array([[z, 5, 5], [z, 15, 5], [z, 15, 15], [z, 5, 15]], dtype=float)]
    print(z, shapes._data_view.slice_key, shapes._get_value((float(z), 10.0, 10.0)))
```

```
40 [40.0]              (0, None)
41 [40.99999999999999] (None, None)
42 [42.0]              (0, None)
```

The shape is drawn on all three slices. Which slices break depend on the FP values, so it reads as intermittent.

The new `ShapeList` test asserts that picking and rendering agree for planar shapes only. `test_visible_shapes_4d` pins that a spanning shape is deliberately pickable where `_update_displayed` does not draw it, and this leaves that alone.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] all tests pass with my change
- [x] I added tests that fail without my change

`python -m pytest src/napari/layers/shapes/_tests src/napari/components/_tests` passes (1184). Without the fix, `test_value_with_fractional_slice_key` and the `0.9` case of `test_inside_with_fractional_slice_key` fail.

- [x] My PR is the minimum possible work for the desired functionality
