### PR TITLE
fix(vectors): emit edge_color_mode when the color setter changes the mode

### DIFF
--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -497,6 +497,19 @@ def test_switching_edge_color_mode_back_to_direct():
     assert layer.edge_color_mode == 'direct'
 
 
+def test_setting_a_feature_as_edge_color_emits_the_mode_change():
+    data = np.zeros((6, 2, 2))
+    data[:, 1] = [1, 1]
+    layer = Vectors(data, features={'phase': np.linspace(-1, 1, 6)})
+    heard = []
+    layer.events.edge_color_mode.connect(lambda event: heard.append(event))
+
+    layer.edge_color = 'phase'
+
+    assert layer.edge_color_mode == 'colormap'
+    assert len(heard) == 1
+
+
 def test_setting_the_current_edge_color_mode_does_not_emit():
     data = np.zeros((6, 2, 2))
     data[:, 1] = [1, 1]

--- a/src/napari/layers/vectors/_tests/test_vectors.py
+++ b/src/napari/layers/vectors/_tests/test_vectors.py
@@ -508,6 +508,19 @@ def test_switching_edge_color_mode_fires_edge_color_event():
     assert len(np.unique(layer.edge_color, axis=0)) == 6
 
 
+def test_setting_a_feature_as_edge_color_emits_the_mode_change():
+    data = np.zeros((6, 2, 2))
+    data[:, 1] = [1, 1]
+    layer = Vectors(data, features={'phase': np.linspace(-1, 1, 6)})
+    heard = []
+    layer.events.edge_color_mode.connect(lambda event: heard.append(event))
+
+    layer.edge_color = 'phase'
+
+    assert layer.edge_color_mode == 'colormap'
+    assert len(heard) == 1
+
+
 def test_setting_the_current_edge_color_mode_does_not_emit():
     data = np.zeros((6, 2, 2))
     data[:, 1] = [1, 1]

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -305,6 +305,9 @@ class Vectors(Layer):
                 else self._feature_table.currents()
             ),
         )
+        self._edge.events.color_mode.connect(
+            lambda _event: self.events.edge_color_mode()
+        )
 
         # now that everything is set up, make the layer visible (if set to visible)
         self.refresh()
@@ -610,7 +613,6 @@ class Vectors(Layer):
     @edge_color_mode.setter
     def edge_color_mode(self, edge_color_mode: str | ColorMode):
         edge_color_mode = ColorMode(edge_color_mode)
-        old_mode = self._edge.color_mode
 
         if edge_color_mode == ColorMode.DIRECT:
             self._edge.color_mode = edge_color_mode
@@ -649,9 +651,6 @@ class Vectors(Layer):
 
             self._edge.color_mode = edge_color_mode
             self.events.edge_color()
-
-        if self._edge.color_mode != old_mode:
-            self.events.edge_color_mode()
 
     @property
     def edge_color_cycle(self) -> np.ndarray:

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -300,6 +300,9 @@ class Vectors(Layer):
                 else self._feature_table.currents()
             ),
         )
+        self._edge.events.color_mode.connect(
+            lambda _event: self.events.edge_color_mode()
+        )
 
         # now that everything is set up, make the layer visible (if set to visible)
         self.refresh()
@@ -589,7 +592,6 @@ class Vectors(Layer):
     @edge_color_mode.setter
     def edge_color_mode(self, edge_color_mode: str | ColorMode):
         edge_color_mode = ColorMode(edge_color_mode)
-        old_mode = self._edge.color_mode
 
         if edge_color_mode == ColorMode.DIRECT:
             self._edge.color_mode = edge_color_mode
@@ -627,8 +629,6 @@ class Vectors(Layer):
                 )
 
             self._edge.color_mode = edge_color_mode
-        if self._edge.color_mode != old_mode:
-            self.events.edge_color_mode()
 
     @property
     def edge_color_cycle(self) -> np.ndarray:


### PR DESCRIPTION
## Description

Assigning a feature name to `edge_color` puts the layer in colormap or cycle mode, but that transition happens inside `ColorManager` and the layer emits nothing for it. Listeners hear that the colors changed, never that the mode did.

```python
layer = Vectors(data, features={'phase': np.linspace(-1, 1, 6)})
layer.events.edge_color_mode.connect(print)

layer.edge_color = 'phase'      # nothing printed
layer.edge_color_mode           # 'colormap'
```

An explicit `edge_color_mode = 'colormap'` used to cover for this, since it emitted unconditionally. #9364 correctly stopped emitting when the assignment changes nothing, so it no longer does.

Forward the manager's own `color_mode` event rather than emitting from the setter. `ColorManager` is an `EventedModel`, so it emits exactly when the field changes, whoever changed it. That subsumes the guard #9364 added, which was reproducing the same change detection one level up.

Redundant assignments still emit nothing, and a real change still emits once, both covered by the tests from #9364.

One behavior note: on the implicit path `edge_color_mode` now arrives before `edge_color`.

`Points` and `Shapes` are unaffected. Neither exposes a color-mode event at all, so there is nothing to keep truthful there.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] all tests pass with my change
- [x] I added tests that fail without my change

`python -m pytest src/napari/layers/vectors src/napari/layers/points src/napari/_qt/layer_controls/_tests/test_qt_vectors_layer.py` passes (271).

## Final checklist

- [x] My PR is the minimum possible work for the desired functionality
