### PR TITLE
Fix broken shapes due to incomplete merge

### DIFF
--- a/src/napari/layers/shapes/_tests/test_shapes_selection.py
+++ b/src/napari/layers/shapes/_tests/test_shapes_selection.py
@@ -21,13 +21,13 @@ def test_selected_data_in_view():
     # View at z=0: only shape 0 is in view.
     dims.set_point(0, 0)
     layer._slice_dims(dims)
-    assert list(layer._indices_view) == [0]
+    assert list(layer._view_indices) == [0]
     assert layer._selected_data_in_view == [0]
 
     # View at z=1: only shape 1 is in view (selection is unchanged).
     dims.set_point(0, 1)
     layer._slice_dims(dims)
-    assert list(layer._indices_view) == [1]
+    assert list(layer._view_indices) == [1]
     assert layer._selected_data_in_view == [1]
 
     # View at z=0.5: no shapes in view.
@@ -128,7 +128,7 @@ def test_interaction_box_tracks_current_slice_multiselect():
     slices, the interaction box (``_selected_box``) used for handle
     hit-testing must follow the shape that is in view on the current slice.
     Previously it lagged one slice behind because ``_set_view_slice`` rebuilt
-    it inside a batched update, before ``_indices_view`` reflected the new
+    it inside a batched update, before ``_view_indices`` reflected the new
     slice, leaving the previous slice's box hoverable as a phantom highlight.
     """
     viewer = ViewerModel()

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -1256,7 +1256,7 @@ class Shapes(Layer):
         # Drop a stale hover value if the hovered shape is no longer in view.
         if (
             self._value[0] is not None
-            and self._value[0] not in self._indices_view
+            and self._value[0] not in self._view_indices
         ):
             self._value = (None, None)
 
@@ -1641,8 +1641,8 @@ class Shapes(Layer):
         highlights (interaction box, vertices, and outlines) are only drawn for
         the shapes visible in the current slice.
         """
-        indices_view = set(self._indices_view.tolist())
-        return [i for i in self.selected_data if i in indices_view]
+        view_indices = set(self._view_indices.tolist())
+        return [i for i in self.selected_data if i in view_indices]
 
     @property
     def _view_text(self) -> np.ndarray:
@@ -2441,7 +2441,7 @@ class Shapes(Layer):
         # the set of shapes *in view* changes, so the highlight state must be
         # refreshed. This is done after the batched update exits: inside the
         # batch ``_data_view._displayed`` is not yet updated, so
-        # ``_indices_view`` would still report the previous view and the
+        # ``_view_indices`` would still report the previous view and the
         # interaction box would lag one step behind. The redraw itself is
         # triggered by the refresh that wraps slicing (``_refresh_sync``).
         if view_changed:
@@ -2565,7 +2565,7 @@ class Shapes(Layer):
             # Only consider the hovered shape if it is in view and not already
             # selected (selected shapes are highlighted via selected_in_view).
             value = self._value[0]
-            if value is not None and value not in self._indices_view:
+            if value is not None and value not in self._view_indices:
                 value = None
             if value in selected_in_view:
                 value = None


### PR DESCRIPTION
# References and relevant issues
- caused by hasty merge of https://github.com/napari/napari/pull/9059

# Description
Everything was green and I merged it without updating to main. Turns out some stuff was renamed in the meantime and it broke it :/ Small fix!
