### PR TITLE
UI: apply tabular numerals to embedded status bars

### DIFF
--- a/src/napari/_qt/_tests/test_app.py
+++ b/src/napari/_qt/_tests/test_app.py
@@ -5,7 +5,8 @@ from collections import defaultdict
 from unittest.mock import Mock
 
 import pytest
-from qtpy.QtWidgets import QAction, QShortcut
+from qtpy.QtGui import QFont
+from qtpy.QtWidgets import QAction, QLabel, QShortcut
 
 from napari._qt.qt_event_loop import (
     _ipython_has_eventloop,
@@ -91,6 +92,32 @@ def test_no_wayland_warning(
     assert not any(
         'Wayland startup workaround' in str(w.message) for w in records
     )
+
+
+@pytest.mark.skipif(
+    not hasattr(QFont, 'Tag'), reason='QFont.setFeature requires Qt 6.7+'
+)
+def test_status_bar_requests_tabular_numerals_with_preexisting_app(
+    make_napari_viewer, qapp, qtbot
+):
+    """The status bar gets tabular figures without changing an embedding host's font."""
+    tag = QFont.Tag('tnum')
+    app_font = QFont(qapp.font())
+    host_label = QLabel('host')
+    qtbot.addWidget(host_label)
+    host_font = QFont(host_label.font())
+
+    viewer = make_napari_viewer()
+    window = viewer.window._qt_window
+    status = window.statusBar()._status
+
+    assert status.font().isFeatureSet(tag)
+    assert qapp.font() == app_font
+    assert host_label.font() == host_font
+
+    viewer.window._update_theme()
+
+    assert status.font().isFeatureSet(tag)
 
 
 def test_shortcut_collision(qtbot, make_napari_viewer):

--- a/src/napari/_qt/_tests/test_qt_utils.py
+++ b/src/napari/_qt/_tests/test_qt_utils.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import pytest
 from qtpy.QtCore import QByteArray, QObject, Signal
-from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QColorDialog, QMainWindow
+from qtpy.QtGui import QColor, QFont
+from qtpy.QtWidgets import QColorDialog, QLabel, QMainWindow
 
 from napari._qt.utils import (
     QBYTE_FLAG,
@@ -17,6 +17,7 @@ from napari._qt.utils import (
     qt_might_be_rich_text,
     qt_signals_blocked,
     str_to_qbytearray,
+    use_tabular_numerals,
 )
 from napari.utils._proxies import PublicOnlyProxy
 
@@ -208,3 +209,18 @@ def test_get_color_reject(
 
     color_ = get_color(color, mode)
     assert color_ is None, 'Expected color to be None when dialog is rejected'
+
+
+@pytest.mark.skipif(
+    not hasattr(QFont, 'Tag'), reason='QFont.setFeature requires Qt 6.7+'
+)
+def test_use_tabular_numerals(qtbot: QtBot) -> None:
+    """Label gets tabular numerals, but font family is not changed."""
+    label = QLabel('123')
+    qtbot.addWidget(label)
+    family = label.font().family()
+
+    assert use_tabular_numerals(label) is True
+
+    assert label.font().isFeatureSet(QFont.Tag('tnum'))
+    assert label.font().family() == family

--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -20,7 +20,7 @@ from napari._qt.qthreading import (
     register_threadworker_processors,
     wait_for_workers_to_quit,
 )
-from napari._qt.utils import _maybe_allow_interrupt
+from napari._qt.utils import _maybe_allow_interrupt, use_tabular_numerals
 from napari._wayland_fix import _nvidia_driver_loaded
 from napari.resources._icons import _theme_path
 from napari.settings import get_settings
@@ -248,6 +248,12 @@ def get_qapp(
         # Intercept tooltip events in order to convert all text to rich text
         # to allow for text wrapping of tooltips
         app.installEventFilter(QtToolTipEventFilter())
+
+        # Give every widget fixed-width digits, so that live numeric readouts
+        # (cursor coordinates, slider values, ...) do not jitter as the digits
+        # change. Only done when napari created the QApplication, so that an
+        # application napari is embedded in keeps the font it chose.
+        use_tabular_numerals(app)
 
     if app.windowIcon().isNull():
         app.setWindowIcon(_svg_path_to_icon(kwargs['icon']))

--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -249,10 +249,6 @@ def get_qapp(
         # to allow for text wrapping of tooltips
         app.installEventFilter(QtToolTipEventFilter())
 
-        # Give every widget fixed-width digits, so that live numeric readouts
-        # (cursor coordinates, slider values, ...) do not jitter as the digits
-        # change. Only done when napari created the QApplication, so that an
-        # application napari is embedded in keeps the font it chose.
         use_tabular_numerals(app)
 
     if app.windowIcon().isNull():

--- a/src/napari/_qt/utils.py
+++ b/src/napari/_qt/utils.py
@@ -20,7 +20,15 @@ from qtpy.QtCore import (
     Qt,
     QThread,
 )
-from qtpy.QtGui import QColor, QCursor, QDrag, QImage, QPainter, QPixmap
+from qtpy.QtGui import (
+    QColor,
+    QCursor,
+    QDrag,
+    QFont,
+    QImage,
+    QPainter,
+    QPixmap,
+)
 from qtpy.QtWidgets import (
     QColorDialog,
     QGraphicsColorizeEffect,
@@ -42,6 +50,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
     from magicgui.widgets import Widget
+    from qtpy.QtGui import QGuiApplication
 
 
 class ColorMode(StringEnum):
@@ -411,6 +420,38 @@ def in_qt_main_thread() -> bool:
         True if we are in the main thread, False otherwise.
     """
     return QCoreApplication.instance().thread() == QThread.currentThread()
+
+
+def use_tabular_numerals(obj: QWidget | QGuiApplication) -> bool:
+    """Render digits in `obj` using tabular numerals, if the font supports it.
+
+    This enables the OpenType `tnum` ("tabular numerals") feature, which uses
+    fixed-width digit glyphs while leaving every other glyph proportional.
+
+    `obj` may be any object with ``font()``/``setFont()``, so this can be
+    applied to a single widget or to the ``QApplication``. When applied to the
+    application, the feature is inherited by every widget and survives theme
+    and font size changes. However, an application-level stylesheet would
+    discard it.
+
+    Important: if the actual font does not support tabular numerals, this
+    will have no effect, because Qt will silently ignore it.
+
+    Returns
+    -------
+    bool
+        True if the feature was requested. False on Qt < 6.7, where
+        ``QFont.setFeature`` does not exist.
+    """
+    # QFont.setFeature and QFont.Tag are Qt 6.7+; napari still supports PyQt5.
+    tag = getattr(QFont, 'Tag', None)
+    if tag is None or not hasattr(QFont, 'setFeature'):
+        return False
+
+    font = QFont(obj.font())
+    font.setFeature(tag('tnum'), 1)
+    obj.setFont(font)
+    return True
 
 
 def get_color(

--- a/src/napari/_qt/widgets/qt_viewer_status_bar.py
+++ b/src/napari/_qt/widgets/qt_viewer_status_bar.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QLabel, QStatusBar, QWidget
 from superqt import QElidingLabel
 
 from napari._qt.dialogs.qt_activity_dialog import ActivityToggleItem
+from napari._qt.utils import use_tabular_numerals
 
 if TYPE_CHECKING:
     from napari._qt.qt_main_window import _QtMainWindow
@@ -56,6 +57,16 @@ class ViewerStatusBar(QStatusBar):
             self._help,
         )
         self.addWidget(main_widget, 1)
+
+        for label in (
+            self._status,
+            self._layer_base,
+            self._source_type,
+            self._plugin_reader,
+            self._coordinates,
+            self._help,
+        ):
+            use_tabular_numerals(label)
 
         self._activity_item = ActivityToggleItem()
         self._activity_item._activityBtn.clicked.connect(


### PR DESCRIPTION
## Summary

Extends #9331 to cover napari windows embedded in a pre-existing QApplication. The two commits from #9331 are included and rebased onto current `main`.

`get_qapp()` deliberately leaves a host-owned QApplication unchanged, so the app-wide `tnum` setting in #9331 does not reach the status bar in that case. Request tabular numerals directly on its labels instead. This preserves the host font and covers `viewer.status`, including downstream custom cursor readouts.

This still doesn't completely solve the problem : in displaying DICOM world coordinates, the text labels still kern and result in movement : 

https://github.com/user-attachments/assets/059ee71a-f227-4ed7-8f25-4899a4cd94d8

