### PR TITLE
fix: merge axis labels per axis to handle `mixed` default cases

### DIFF
--- a/src/napari/components/_tests/test_layers_list.py
+++ b/src/napari/components/_tests/test_layers_list.py
@@ -802,6 +802,14 @@ def test_remove_selected_all_locked():
             ('y1', 'x1'),
             2,
         ),  # topmost equally long annotated wins
+        (
+            [
+                ((100, 100, 100), ('Z', 'y', 'X')),
+                ((100, 100, 100), ('-3', 'c', 'X')),
+            ],
+            ('Z', 'c', 'X'),
+            3,
+        ),  # labels merge per axis across layers
     ],
 )
 def test_layerlist_axis_labels(

--- a/src/napari/components/_tests/test_viewer_model.py
+++ b/src/napari/components/_tests/test_viewer_model.py
@@ -1364,6 +1364,11 @@ def test_dims_axis_labels_reset_to_default_when_layer_resets():
     layer.axis_labels = ['-4', '-3', '-2', '-1']
     assert viewer.dims.axis_labels == ('-4', '-3', '-2', '-1')
 
+    # a partial reset resets only the positions returned to default
+    layer.axis_labels = ['Z', 'c', 'Y', 'x']
+    layer.axis_labels = ['-4', '-3', 'Y', 'x']
+    assert viewer.dims.axis_labels == ('-4', '-3', 'Y', 'x')
+
 
 def test_dims_axis_labels_default_when_all_layers_default():
     """Non-default layer labels win until every layer is back to the default."""
@@ -1377,3 +1382,18 @@ def test_dims_axis_labels_default_when_all_layers_default():
 
     layer0.axis_labels = ['-4', '-3', '-2', '-1']
     assert viewer.dims.axis_labels == ('-4', '-3', '-2', '-1')  # all default
+
+
+def test_dims_axis_labels_reset_mixed_dimensionality():
+    """Mixed-dimensionality layers merge per axis, then reset to default."""
+    viewer = ViewerModel()
+    layer0 = viewer.add_image(np.zeros((4, 4, 4, 4)), axis_labels=list('tzyx'))
+    layer1 = viewer.add_image(np.zeros((4, 4, 4)), axis_labels=list('zyx'))
+    assert viewer.dims.axis_labels == tuple('tzyx')
+
+    # only the last 3 axes stay annotated once the 4d layer is default
+    layer0.axis_labels = ['-4', '-3', '-2', '-1']
+    assert viewer.dims.axis_labels == ('-4', 'z', 'y', 'x')
+
+    layer1.axis_labels = ['-3', '-2', '-1']
+    assert viewer.dims.axis_labels == ('-4', '-3', '-2', '-1')

--- a/src/napari/components/layerlist.py
+++ b/src/napari/components/layerlist.py
@@ -643,31 +643,23 @@ class LayerList(SelectableEventedList[Layer]):
         """
         return max((layer.ndim for layer in self), default=2)
 
-    def _find_longest_annotated(self) -> tuple[str, ...]:
-        """Return the annotated axis labels spanning the most dimensions.
-
-        Returns () when no layer is annotated. When more are equally long,
-        the most recent layer wins.
-        """
-        annotated_list = [
-            layer.axis_labels
-            for layer in self
-            if not layer._has_default_axis_labels()
-        ][::-1]
-        return max(annotated_list, key=len, default=())
-
     @property
     def axis_labels(self) -> tuple[str, ...]:
         """Axis labels for the layer list.
 
-        Uses the labels from the layer with the longest annotated axis labels.
-        Missing axes annotations fall back to default indices.
+        Each axis takes its label from the layer that annotates it, with
+        higher-dimensional layers winning over lower-dimensional ones and the
+        topmost layer winning between layers of the same dimensionality.
+        Axis that no layer annotates fall back to default indices.
         """
-        axis_labels = [str(i) for i in range(-self.ndim, 0)]
-        labels = self._find_longest_annotated()
-        offset = self.ndim - len(labels)
-        for idx, label in enumerate(labels):
-            axis_labels[offset + idx] = label
+        ndim = self.ndim
+        default_labels = [str(i) for i in range(-ndim, 0)]
+        axis_labels = list(default_labels)
+        for layer in sorted(self, key=lambda layer: layer.ndim):
+            offset = ndim - layer.ndim
+            for axis, label in enumerate(layer.axis_labels):
+                if label != default_labels[offset + axis]:
+                    axis_labels[offset + axis] = label
         return tuple(axis_labels)
 
     def _link_layers(

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -206,8 +206,9 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     # is required for default values.
     _layer_slicer: _LayerSlicer = PrivateAttr(default_factory=_LayerSlicer)
     _layer_list_scroll_progress: float = 0
-    # True if any layer had custom axis labels the last time layers changed
-    _layers_had_custom_axis_labels: bool = PrivateAttr(default=False)
+    # The labels the layers gave us last time, so we can tell which dims
+    # labels came from a layer and which the user set directly
+    _layers_axis_labels: tuple[str, ...] = PrivateAttr(default=())
 
     def __init__(
         self, title='napari', ndisplay=2, order=(), axis_labels=()
@@ -774,39 +775,47 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             self.scene.camera.mouse_zoom = active_layer.mouse_zoom
             self.update_status_from_cursor()
 
-    def _merge_dims_and_layers_axis_labels(self) -> tuple[str, ...]:
+    def _merge_dims_and_layers_axis_labels(
+        self, layers_axis_labels: tuple[str, ...]
+    ) -> tuple[str, ...]:
         """Combine layerlist axis labels onto the current dims labels.
 
-        Replaces dims axis label at indices where layers axis labels exist.
+        A layer's label wins on any axis it names. On the other axes we keep
+        whatever label dims already has, unless that label came from a layer
+        that has since gone back to its default - then it is stale and is
+        reset to the default too.
         """
+        ndim = self.dims.ndim
+        default_labels = [str(i) for i in range(-ndim, 0)]
+
+        previous = default_labels.copy()
+        overlap = min(len(self._layers_axis_labels), ndim)
+        previous[ndim - overlap :] = self._layers_axis_labels[-overlap:]
+
         updated_axis_labels = list(self.dims.axis_labels)
-        for pos, label in enumerate(self.layers.axis_labels):
-            if label != str(pos - self.dims.ndim):
+        for pos, label in enumerate(layers_axis_labels):
+            if label != default_labels[pos]:
                 updated_axis_labels[pos] = label
+            elif updated_axis_labels[pos] == previous[pos]:
+                updated_axis_labels[pos] = default_labels[pos]
         return tuple(updated_axis_labels)
 
     def _on_layers_change(self):
         if len(self.layers) == 0:
             self.dims.ndim = 2
             self.dims.reset()
-            self._layers_had_custom_axis_labels = False
+            self._layers_axis_labels = ()
         else:
             ranges = self.layers._ranges
             # TODO: can be optimized with dims.update(), but events need fixing
             self.dims.ndim = len(ranges)
             self.dims.range = ranges
             self.dims.units = self.layers.units
-            layers_are_default = all(
-                layer._has_default_axis_labels() for layer in self.layers
+            layers_axis_labels = self.layers.axis_labels
+            self.dims.axis_labels = self._merge_dims_and_layers_axis_labels(
+                layers_axis_labels
             )
-            if self._layers_had_custom_axis_labels and layers_are_default:
-                # All layers are back to default, so reset the stale dims labels
-                self.dims.axis_labels = self.layers.axis_labels
-            else:
-                self.dims.axis_labels = (
-                    self._merge_dims_and_layers_axis_labels()
-                )
-            self._layers_had_custom_axis_labels = not layers_are_default
+            self._layers_axis_labels = layers_axis_labels
 
         new_dim = self.dims.ndim
         dim_diff = new_dim - len(self.cursor.position)


### PR DESCRIPTION
# References and relevant issues
fixes #9404 

# Description

In previous PR we have fixed the case where all layers go back to default labels. In this we are fixing the mixed cases we left out

So we had mainly two issues:-
- only one layer's labels were used
- dims labels only reset when every axis went back to default

how we approached:-
- for each axis , we ask something like "does any layer give axis a name". and use that name. If two layers both name the same axis, the layer with more dimensions wins, and if they're the same size, the one on top wins, Axes that no layer names get the default label.

- for our second scenario( we now remember what the layers told us last time)  we now store the actual labels the layers gave us. When  an axis has a label,  we can check where it came from, If it matches what a layer gave us last time and that layer is now back to default, the label is stale and we reset it. If it doesn't match the user set is directly on `dims`, so we leave it alone. this fixes our second issue, one axis at a time.

why we deleted  `_find_longest_annotated` so it was answering us which single layer has the most custom labels, we needed that back when we picked one layer and used all of its labels.
Now as we're going axis by axis, we never pick a single winning, layer so nothing call it anymore.

Also cleaned up:
`layers.axis_labels` is now read once in `_on_layers_change` and passed to the merge method, previously we looped over the layers to check for custom labels and then the merged looped over them again.

- labels you set on `dims` yourself are still kept, when we add layers without labels. Custom labels still win until every layer is back to default.

Results i got while testing:

<details><summary>Details</summary>
<p>

```
import numpy as np

layer = viewer.add_image(np.zeros([100, 100, 100, 100]))

viewer.dims.axis_labels
Out[3]: ('-4', '-3', '-2', '-1')

layer.axis_labels = ["Z", "c", "Y", "x"]

viewer.dims.axis_labels
Out[5]: ('Z', 'c', 'Y', 'x')

layer.axis_labels = ["-4", "-3", "-2", "-1"]

viewer.dims.axis_labels
Out[7]: ('-4', '-3', '-2', '-1')

layer.axis_labels = ["Z", "c", "Y", "x"]

layer.axis_labels = ["-4", "-3", "Y", "x"]

viewer.dims.axis_labels
Out[10]: ('-4', '-3', 'Y', 'x')

viewer.layers.clear()

l0 = viewer.add_image(np.zeros([4, 4, 4, 4]), axis_labels=list('tzyx'))

l1 = viewer.add_image(np.zeros([4, 4, 4]), axis_labels=list('zyx'))

viewer.dims.axis_labels
Out[14]: ('t', 'z', 'y', 'x')

l0.axis_labels = ["-4", "-3", "-2", "-1"]

viewer.dims.axis_labels
Out[16]: ('-4', 'z', 'y', 'x')

l1.axis_labels = ["-3", "-2", "-1"]

viewer.dims.axis_labels
Out[18]: ('-4', '-3', '-2', '-1')

viewer.layers.clear()

viewer.add_image(np.zeros([100, 100, 100]), axis_labels=["Z", "y", "X"])
Out[20]: <Image layer 'Image' at 0x7344b006b950>

viewer.add_image(np.zeros([100, 100, 100]), axis_labels=["-3", "c", "X"])
Out[21]: <Image layer 'Image [1]' at 0x7344b0201f40>

viewer.layers.axis_labels
Out[22]: ('Z', 'c', 'X')

viewer.dims.axis_labels
Out[23]: ('Z', 'c', 'X')

viewer.layers.clear()

a = viewer.add_image(np.zeros([4, 4, 4, 4]), axis_labels=list('tzyx'))

b = viewer.add_image(np.zeros([4, 4, 4, 4]), axis_labels=list('tzyx'))

b.axis_labels = ["-4", "-3", "-2", "-1"]

viewer.dims.axis_labels
Out[28]: ('t', 'z', 'y', 'x')

a.axis_labels = ["-4", "-3", "-2", "-1"]

viewer.dims.axis_labels
Out[30]: ('-4', '-3', '-2', '-1')
```

</p>
</details> 


cc @carlosmariorr happy to know your thoughts on this and maybe possible improvement 😊 





