### PR TITLE
Performance [Shapes]: don't draw empty sub-visuals

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_shapes_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_shapes_layer.py
@@ -2,7 +2,70 @@ import numpy as np
 
 from napari._vispy.layers.shapes import VispyShapesLayer
 from napari._vispy.utils.qt_font import FontInfo
+from napari.components import Dims
 from napari.layers import Shapes
+
+SQUARE = np.array([[0, 0], [0, 10], [10, 10], [10, 0]])
+
+
+def test_empty_shape_faces_are_hidden_until_data_is_added():
+    layer = Shapes()
+    vispy_layer = VispyShapesLayer(layer, font_info=FontInfo())
+
+    assert not vispy_layer.node.shape_faces.visible
+
+    layer.add(SQUARE)
+    assert vispy_layer.node.shape_faces.visible
+
+    layer.data = []
+    assert not vispy_layer.node.shape_faces.visible
+
+
+def test_shape_faces_are_hidden_only_while_the_slice_is_empty():
+    shape = np.pad(SQUARE, ((0, 0), (1, 0)))
+    layer = Shapes(shape)
+    vispy_layer = VispyShapesLayer(layer, font_info=FontInfo())
+
+    assert vispy_layer.node.shape_faces.visible
+
+    layer._slice_dims(Dims(ndim=3, point=(1, 0, 0)))
+    assert not vispy_layer.node.shape_faces.visible
+
+    layer._slice_dims(Dims(ndim=3, point=(0, 0, 0)))
+    assert vispy_layer.node.shape_faces.visible
+
+
+def test_shape_highlights_are_hidden_until_a_shape_is_selected():
+    layer = Shapes(SQUARE)
+    vispy_layer = VispyShapesLayer(layer, font_info=FontInfo())
+    highlight_nodes = (
+        vispy_layer.node.shape_highlights,
+        vispy_layer.node.highlight_lines,
+        vispy_layer.node.highlight_vertices,
+    )
+
+    assert [node.visible for node in highlight_nodes] == [False, False, False]
+
+    layer.mode = 'select'
+    layer.selected_data = {0}
+    assert [node.visible for node in highlight_nodes] == [True, True, True]
+
+    layer.selected_data = set()
+    assert [node.visible for node in highlight_nodes] == [False, False, False]
+
+
+def test_shape_text_is_hidden_when_no_text_is_visible():
+    layer = Shapes(text={'string': {'constant': 'label'}})
+    vispy_layer = VispyShapesLayer(layer, font_info=FontInfo())
+    text_node = vispy_layer._get_text_node()
+
+    assert not text_node.visible
+
+    layer.add(SQUARE)
+    assert text_node.visible
+
+    layer.text.visible = False
+    assert not text_node.visible
 
 
 def test_remove_selected_with_derived_text():

--- a/src/napari/_vispy/layers/shapes.py
+++ b/src/napari/_vispy/layers/shapes.py
@@ -7,7 +7,7 @@ from superqt.utils import qdebounced
 
 from napari._vispy.layers.base import VispyBaseLayer
 from napari._vispy.utils.gl import BLENDING_MODES
-from napari._vispy.utils.text import update_text
+from napari._vispy.utils.text import _has_visible_text, update_text
 from napari._vispy.visuals.shapes import ShapesVisual
 from napari.settings import get_settings
 from napari.utils.events import disconnect_events
@@ -48,12 +48,16 @@ class VispyShapesLayer(VispyBaseLayer):
         colors = self.layer._data_view._mesh.displayed_triangles_colors
         vertices = self.layer._data_view._mesh.vertices
 
+        has_faces = (
+            vertices is not None and len(vertices) > 0 and len(faces) > 0
+        )
+
         # Note that the indices of the vertices need to be reversed to
         # go from numpy style to xyz
         if vertices is not None:
             vertices = vertices[:, ::-1]
 
-        if len(vertices) == 0 or len(faces) == 0:
+        if not has_faces:
             vertices = np.zeros((3, self.layer._slice_input.ndisplay))
             faces = np.array([[0, 1, 2]])
             colors = np.array([[0, 0, 0, 0]])
@@ -68,6 +72,7 @@ class VispyShapesLayer(VispyBaseLayer):
         self.node.shape_faces.set_data(
             vertices=vertices, faces=faces, face_colors=colors
         )
+        self.node.shape_faces.visible = has_faces
 
         # Call to update order of translation values with new dims:
         self._on_matrix_change()
@@ -93,7 +98,11 @@ class VispyShapesLayer(VispyBaseLayer):
         # Compute the vertices and faces of any shape outlines
         vertices, faces = self.layer._outline_shapes()
 
-        if vertices is None or len(vertices) == 0 or len(faces) == 0:
+        has_outline = (
+            vertices is not None and len(vertices) > 0 and len(faces) > 0
+        )
+
+        if not has_outline:
             vertices = np.zeros((3, self.layer._slice_input.ndisplay))
             faces = np.array([[0, 1, 2]])
 
@@ -102,6 +111,7 @@ class VispyShapesLayer(VispyBaseLayer):
             faces=faces,
             color=self.layer._highlight_color,
         )
+        self.node.shape_highlights.visible = has_outline
 
         # Compute the location and properties of the vertices and box that
         # need to get rendered
@@ -115,7 +125,9 @@ class VispyShapesLayer(VispyBaseLayer):
 
         width = settings.appearance.highlight.highlight_thickness
 
-        if vertices is None or len(vertices) == 0:
+        has_vertices = vertices is not None and len(vertices) > 0
+
+        if not has_vertices:
             vertices = np.zeros((1, self.layer._slice_input.ndisplay))
             size = 0
         else:
@@ -128,14 +140,18 @@ class VispyShapesLayer(VispyBaseLayer):
             edge_color=edge_color,
             edge_width=width,
         )
+        self.node.highlight_vertices.visible = has_vertices
 
-        if pos is None or len(pos) == 0:
+        has_box = pos is not None and len(pos) > 0
+
+        if not has_box:
             pos = np.zeros((1, self.layer._slice_input.ndisplay))
             width = 0
 
         self.node.highlight_lines.set_data(
             pos=pos, color=edge_color, width=width
         )
+        self.node.highlight_lines.visible = has_box
 
     def _update_text(self, *, update_node=True):
         """Function to update the text node properties
@@ -145,7 +161,9 @@ class VispyShapesLayer(VispyBaseLayer):
         update_node : bool
             If true, update the node after setting the properties
         """
-        update_text(node=self._get_text_node(), layer=self.layer)
+        text_node = self._get_text_node()
+        update_text(node=text_node, layer=self.layer)
+        text_node.visible = _has_visible_text(self.layer)
         if update_node:
             self.node.update()
 


### PR DESCRIPTION
Touches `_vispy/layers/shapes.py` in the same place as #9419, which keeps a shape being drawn out of the aggregate mesh. If that one lands first, the highlight mesh has to stay visible whenever a shape is staged.

# Description

Shapes layers that are sliced to nothing still cost most of a full draw, which is the symptom reported in #6658.

- `VispyShapesLayer._on_data_change` feeds an empty layer one dummy transparent triangle so VisPy does not error on empty geometry, and leaves the node visible.
- The highlight mesh, highlight box, vertex markers and text node are visible from construction and stay visible whether or not they carry anything.
- All five subvisuals of every Shapes layer are therefore traversed, prepared and submitted on every slice and every camera frame.

Each subvisual now becomes invisible while its payload is empty. The dummy geometry stays in place, and the existing update paths (`_on_data_change`, `_on_highlight_change_impl`, `_update_text`) turn each node back on as soon as it has something to draw, so nothing has to be reactivated from elsewhere.

## Measured

macOS arm64, PyQt6 6.11, VisPy 0.16.2, 640x480 canvas, median of 20 frames, each drawn and waited on with `glFinish`.

| Workload | Before | After | |
|---|---:|---:|---:|
| Slicing a stack with 32 Shapes layers whose shapes are on other slices | 272.2 ms | 20.6 ms | 13.2x |
| Camera zoom with 2,048 shapes spread over 16 layers | 11.7 ms | 4.1 ms | 2.9x |

The second row is the inactive-subvisual half: nothing is selected or hovered, so the highlight nodes carry nothing on either side.

<details>
<summary>Reproducer</summary>

```python
import os, statistics, tempfile, time
from pathlib import Path
import numpy as np
os.environ.setdefault('NAPARI_CONFIG', str(Path(tempfile.mkdtemp()) / 's.yaml'))
import napari

N_LAYERS, FRAMES = 32, 20

def rect(z, y, x, size=6):
    return np.array(
        [[z, y, x], [z, y, x + size], [z, y + size, x + size], [z, y + size, x]]
    )

viewer = napari.Viewer(show=False)
viewer.add_image(np.zeros((40, 64, 64)))
for i in range(N_LAYERS):
    viewer.add_shapes(
        [rect(50 + i, 10 + 3 * i, 10 + 3 * i) for _ in range(4)],
        shape_type='rectangle',
    )
canvas = viewer.window._qt_viewer.canvas
viewer.reset_view()

def frame():
    scene = canvas._scene_canvas
    scene.set_current()
    canvas.on_draw(None)
    scene._draw_scene()
    scene.context.finish()

samples = []
for i in range(FRAMES + 3):
    started = time.perf_counter()
    viewer.dims.set_point(0, i % 40)
    frame()
    if i >= 3:
        samples.append(time.perf_counter() - started)
print(f'{1000 * statistics.median(samples):.1f} ms/frame')
viewer.close()
```

Replace `add_shapes` with `add_points`/`add_vectors` for the sibling PR's workloads.

</details>

## Notes

- The dummy geometry is still uploaded, only not drawn. 
- The parent compound node keeps its own visibility, so `layer.visible` and the layer's overlays are unaffected.
- Rendered pixels are unchanged.
