### PR TITLE
Performance [Shapes]: keep the shape being drawn out of the aggregate mesh

### DIFF
--- a/src/napari/_vispy/_tests/test_vispy_shapes_layer.py
+++ b/src/napari/_vispy/_tests/test_vispy_shapes_layer.py
@@ -2,7 +2,63 @@ import numpy as np
 
 from napari._vispy.layers.shapes import VispyShapesLayer
 from napari._vispy.utils.qt_font import FontInfo
+from napari.components import ViewerModel
 from napari.layers import Shapes
+from napari.utils._test_utils import read_only_mouse_event
+from napari.utils.interactions import (
+    mouse_move_callbacks,
+    mouse_press_callbacks,
+    mouse_release_callbacks,
+)
+
+
+def test_active_shape_overlay_tracks_staged_geometry():
+    viewer = ViewerModel()
+    layer = viewer.add_shapes([np.array([[0, 0], [0, 2], [2, 2], [2, 0]])])
+    vispy_layer = VispyShapesLayer(layer, font_info=FontInfo())
+    assert vispy_layer.node._subvisuals[0] is vispy_layer.node.shape_faces
+    assert vispy_layer.node._subvisuals[1] is vispy_layer.node.shape_highlights
+    assert vispy_layer.node._subvisuals[2] is vispy_layer.node.highlight_lines
+    layer.mode = 'add_rectangle'
+
+    mouse_press_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_press', position=[5, 5]),
+    )
+    mouse_move_callbacks(
+        layer,
+        read_only_mouse_event(
+            type='mouse_move', is_dragging=True, position=[10, 12]
+        ),
+    )
+
+    vertices = vispy_layer.node.shape_highlights.mesh_data.get_vertices()
+    index = layer._data_view.staged_index
+    assert index is not None
+    shape = layer._data_view.shapes[index]
+    expected_vertices = np.concatenate(
+        [
+            shape._face_vertices,
+            shape._edge_vertices + shape.edge_width * shape._edge_offsets,
+        ]
+    )[:, ::-1]
+    np.testing.assert_allclose(
+        vertices[: len(expected_vertices)], expected_vertices
+    )
+
+    mouse_release_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_release', position=[10, 12]),
+    )
+
+    outline_vertices, outline_faces = layer._outline_shapes()
+    np.testing.assert_allclose(
+        vispy_layer.node.shape_highlights.mesh_data.get_vertices(),
+        outline_vertices,
+    )
+    np.testing.assert_array_equal(
+        vispy_layer.node.shape_highlights.mesh_data.get_faces(), outline_faces
+    )
 
 
 def test_remove_selected_with_derived_text():

--- a/src/napari/_vispy/layers/shapes.py
+++ b/src/napari/_vispy/layers/shapes.py
@@ -25,6 +25,16 @@ class VispyShapesLayer(VispyBaseLayer):
         node = ShapesVisual(font_info=font_info)
         super().__init__(layer, node, font_info=font_info)
 
+        (
+            self._active_shape_vertices,
+            self._active_shape_faces,
+        ) = self._empty_shape_geometry()
+        self._active_shape_colors = np.empty((0, 4))
+        (
+            self._highlight_shape_vertices,
+            self._highlight_shape_faces,
+        ) = self._empty_shape_geometry()
+
         self._on_highlight_change_debounc = qdebounced(
             self._on_highlight_change_impl
         )
@@ -33,6 +43,7 @@ class VispyShapesLayer(VispyBaseLayer):
         self.layer.events.edge_color.connect(self._on_data_change)
         self.layer.events.face_color.connect(self._on_data_change)
         self.layer.events.highlight.connect(self._on_highlight_change)
+        self.layer.events._active_shape.connect(self._on_active_shape_change)
         self.layer.text.events.connect(self._on_text_change)
         self.layer.events.scale_factor.connect(self._update_text)
 
@@ -42,6 +53,109 @@ class VispyShapesLayer(VispyBaseLayer):
 
         self.reset()
         self._on_data_change()
+
+    def _empty_shape_geometry(self) -> tuple[np.ndarray, np.ndarray]:
+        return (
+            np.empty((0, self.layer._slice_input.ndisplay)),
+            np.empty((0, 3), dtype=int),
+        )
+
+    def _on_active_shape_change(self) -> None:
+        index = self.layer._data_view.staged_index
+        if index is None:
+            (
+                self._active_shape_vertices,
+                self._active_shape_faces,
+            ) = self._empty_shape_geometry()
+            self._active_shape_colors = np.empty((0, 4))
+            self._update_shape_highlight_mesh()
+            return
+
+        shape = self.layer._data_view.shapes[index]
+        face_vertices = shape._face_vertices
+        edge_vertices = (
+            shape._edge_vertices + shape.edge_width * shape._edge_offsets
+        )
+        vertices = np.concatenate([face_vertices, edge_vertices], axis=0)
+        faces = np.concatenate(
+            [
+                shape._face_triangles,
+                shape._edge_triangles + len(face_vertices),
+            ],
+            axis=0,
+        )
+        colors = np.concatenate(
+            [
+                np.repeat(
+                    [self.layer._data_view.face_color[index]],
+                    len(shape._face_triangles),
+                    axis=0,
+                ),
+                np.repeat(
+                    [self.layer._data_view.edge_color[index]],
+                    len(shape._edge_triangles),
+                    axis=0,
+                ),
+            ],
+            axis=0,
+        )
+        vertices = vertices[:, ::-1]
+        if self.layer._slice_input.ndisplay == 3 and self.layer.ndim == 2:
+            vertices = np.pad(vertices, ((0, 0), (0, 1)))
+
+        if len(vertices) == 0 or len(faces) == 0:
+            vertices, faces = self._empty_shape_geometry()
+            colors = np.empty((0, 4))
+
+        self._active_shape_vertices = vertices
+        self._active_shape_faces = faces
+        self._active_shape_colors = colors
+        self._update_shape_highlight_mesh()
+
+    def _update_shape_highlight_mesh(self) -> None:
+        if len(self._active_shape_faces) == 0:
+            if len(self._highlight_shape_faces) == 0:
+                vertices = np.zeros((3, self.layer._slice_input.ndisplay))
+                faces = np.array([[0, 1, 2]])
+                self.node.shape_highlights.set_data(
+                    vertices=vertices,
+                    faces=faces,
+                    face_colors=np.zeros((1, 4)),
+                )
+            else:
+                self.node.shape_highlights.set_data(
+                    vertices=self._highlight_shape_vertices,
+                    faces=self._highlight_shape_faces,
+                    color=self.layer._highlight_color,
+                )
+            self.node.update()
+            return
+
+        vertices = np.concatenate(
+            [self._active_shape_vertices, self._highlight_shape_vertices],
+            axis=0,
+        )
+        faces = np.concatenate(
+            [
+                self._active_shape_faces,
+                self._highlight_shape_faces + len(self._active_shape_vertices),
+            ],
+            axis=0,
+        )
+        highlight_colors = np.repeat(
+            [self.layer._highlight_color],
+            len(self._highlight_shape_faces),
+            axis=0,
+        )
+        colors = np.concatenate(
+            [self._active_shape_colors, highlight_colors],
+            axis=0,
+        )
+
+        self.node.shape_highlights.set_data(
+            vertices=vertices, faces=faces, face_colors=colors
+        )
+        self.node.update()
 
     def _on_data_change(self):
         faces = self.layer._data_view._mesh.displayed_triangles
@@ -94,14 +208,14 @@ class VispyShapesLayer(VispyBaseLayer):
         vertices, faces = self.layer._outline_shapes()
 
         if vertices is None or len(vertices) == 0 or len(faces) == 0:
-            vertices = np.zeros((3, self.layer._slice_input.ndisplay))
-            faces = np.array([[0, 1, 2]])
-
-        self.node.shape_highlights.set_data(
-            vertices=vertices,
-            faces=faces,
-            color=self.layer._highlight_color,
-        )
+            (
+                self._highlight_shape_vertices,
+                self._highlight_shape_faces,
+            ) = self._empty_shape_geometry()
+        else:
+            self._highlight_shape_vertices = vertices
+            self._highlight_shape_faces = faces
+        self._update_shape_highlight_mesh()
 
         # Compute the location and properties of the vertices and box that
         # need to get rendered
@@ -174,6 +288,16 @@ class VispyShapesLayer(VispyBaseLayer):
 
     def reset(self):
         super().reset()
+        (
+            self._active_shape_vertices,
+            self._active_shape_faces,
+        ) = self._empty_shape_geometry()
+        self._active_shape_colors = np.empty((0, 4))
+        (
+            self._highlight_shape_vertices,
+            self._highlight_shape_faces,
+        ) = self._empty_shape_geometry()
+        self._on_active_shape_change()
         self._on_highlight_change()
         self._on_blending_change()
 

--- a/src/napari/_vispy/visuals/shapes.py
+++ b/src/napari/_vispy/visuals/shapes.py
@@ -18,7 +18,7 @@ class ShapesVisual(ClippingPlanesMixin, Compound):
 
     Components:
         - Mesh for shape faces (vispy.MeshVisual)
-        - Mesh for highlights (vispy.MeshVisual)
+        - Mesh for the active shape and highlights (vispy.MeshVisual)
         - Lines for highlights (vispy.LineVisual)
         - Vertices for highlights (vispy.MarkersVisual)
         - Text labels (vispy.TextVisual)
@@ -43,7 +43,7 @@ class ShapesVisual(ClippingPlanesMixin, Compound):
 
     @property
     def shape_highlights(self) -> Mesh:
-        """Mesh for shape highlights"""
+        """Mesh for the active shape and shape highlights."""
         return self._subvisuals[1]
 
     @property

--- a/src/napari/layers/shapes/_shape_list.py
+++ b/src/napari/layers/shapes/_shape_list.py
@@ -437,6 +437,7 @@ class ShapeList:
         self._vertices_index: IndexArray = np.zeros(1, dtype=IndexDtype)
         self._z_index: IndexArray = np.empty(0, dtype=IndexDtype)
         self._z_order: IndexArray = np.empty(0, dtype=IndexDtype)
+        self._staged_index: int | None = None
 
         self._mesh = Mesh(ndisplay=self.ndisplay)
 
@@ -452,6 +453,132 @@ class ShapeList:
         if not isinstance(data, Sequence):
             data = list(data)
         self.add(data)
+
+    @property
+    def staged_index(self) -> int | None:
+        """Index of the shape excluded from aggregate geometry, if any."""
+        return self._staged_index
+
+    def _guard_not_staged(self, index: int, operation: str) -> None:
+        if index == self._staged_index:
+            raise RuntimeError(
+                f'{operation} cannot update staged shape {index}; '
+                'use the staged-shape operation instead'
+            )
+
+    def add_staged(
+        self,
+        shape: Shape,
+        *,
+        face_color: ShapeColor,
+        edge_color: ShapeColor,
+    ) -> int:
+        """Append one topmost shape without adding its aggregate geometry."""
+        if self._staged_index is not None:
+            raise RuntimeError('Only one shape can be staged at a time')
+        if not isinstance(shape, Shape):
+            raise TypeError('shape must be subclass of Shape')
+        if len(self._z_index) and shape.z_index < np.max(self._z_index):
+            raise ValueError('A staged shape must be topmost')
+
+        index = len(self.shapes)
+        self.shapes.append(shape)
+        self._z_index = np.append(self._z_index, shape.z_index)
+        self._z_order = np.append(self._z_order, index)
+        self._face_color = np.vstack([self._face_color, face_color])
+        self._edge_color = np.vstack([self._edge_color, edge_color])
+
+        self._vertices_index = np.append(
+            self._vertices_index, self._vertices_index[-1]
+        )
+        self._mesh.vertices_index = np.append(
+            self._mesh.vertices_index, self._mesh.vertices_index[-1]
+        )
+        self._mesh.triangles_index = np.append(
+            self._mesh.triangles_index, self._mesh.triangles_index[-1]
+        )
+
+        slice_key = np.array([self.slice_key, self.slice_key])
+        displayed = np.all(np.abs(shape.slice_key - slice_key) < 0.5)
+        self._displayed = np.append(self._displayed, displayed)
+        self._staged_index = index
+        self._clear_cache()
+        return index
+
+    def edit_staged(self, index: int, data, new_type=None) -> None:
+        """Update the live geometry for the staged shape only."""
+        if index != self._staged_index:
+            raise RuntimeError(f'Shape {index} is not staged')
+
+        if new_type is not None:
+            cur_shape = self.shapes[index]
+            if isinstance(new_type, str):
+                shape_type = ShapeType(new_type)
+                try:
+                    shape_cls = shape_classes[shape_type]
+                except KeyError as e:
+                    raise ValueError(
+                        f'{shape_type} must be one of {set(shape_classes)}'
+                    ) from e
+            else:
+                shape_cls = new_type
+            self.shapes[index] = shape_cls(
+                data,
+                edge_width=cur_shape.edge_width,
+                z_index=cur_shape.z_index,
+                dims_order=cur_shape.dims_order,
+                ndisplay=cur_shape.ndisplay,
+            )
+        else:
+            self.shapes[index].data = data
+        self._clear_cache()
+
+    def shift_staged(self, index: int, shift) -> None:
+        """Shift the staged shape without touching aggregate geometry."""
+        if index != self._staged_index:
+            raise RuntimeError(f'Shape {index} is not staged')
+        self.shapes[index].shift(shift)
+        self._clear_cache()
+
+    def transform_staged(self, index: int, transform) -> None:
+        """Transform the staged shape without touching aggregate geometry."""
+        if index != self._staged_index:
+            raise RuntimeError(f'Shape {index} is not staged')
+        self.shapes[index].transform(transform)
+        self._clear_cache()
+
+    def update_staged_edge_width(self, index: int, edge_width: float) -> None:
+        """Update the staged shape edge width without aggregate mesh writes."""
+        if index != self._staged_index:
+            raise RuntimeError(f'Shape {index} is not staged')
+        self.shapes[index].edge_width = edge_width
+        self._clear_cache()
+
+    def commit_staged(self, index: int) -> None:
+        """Materialize the staged shape into aggregate geometry once."""
+        if index != self._staged_index:
+            raise RuntimeError(f'Shape {index} is not staged')
+        self._staged_index = None
+        self.update(index)
+
+    def remove_staged(self, index: int) -> None:
+        """Remove the trailing staged shape without materializing it."""
+        if index != self._staged_index:
+            raise RuntimeError(f'Shape {index} is not staged')
+        if index != len(self.shapes) - 1:
+            raise RuntimeError('The staged shape must be the final shape')
+
+        self.shapes.pop()
+        self._z_index = self._z_index[:-1]
+        self._z_order = self._z_order[self._z_order != index]
+        self._face_color = self._face_color[:-1]
+        self._edge_color = self._edge_color[:-1]
+        self._vertices_index = self._vertices_index[:-1]
+        self._mesh.vertices_index = self._mesh.vertices_index[:-1]
+        self._mesh.triangles_index = self._mesh.triangles_index[:-1]
+        self._displayed = self._displayed[:-1]
+        self._staged_index = None
+        self._clear_cache()
 
     def _vertices_slice(self, shape_index: int | np.integer) -> slice:
         """Return the slice of vertices for a given shape index."""
@@ -1101,6 +1228,7 @@ class ShapeList:
     @_batch_dec
     def remove_all(self):
         """Removes all shapes"""
+        self._staged_index = None
         self.shapes = []
         self._vertices = np.empty((0, self.ndisplay))  # type: ignore[assignment]
         self._vertices_index = np.zeros(1, dtype=IndexDtype)
@@ -1114,6 +1242,7 @@ class ShapeList:
     @_batch_dec
     def update(self, index: int) -> None:
         """update shape at index `index`"""
+        self._guard_not_staged(index, 'update')
         self._update_vertices(index)
         self._update_mesh_triangles(index)
         self._update_mesh_vertices(index, edge=True, face=True)
@@ -1154,6 +1283,7 @@ class ShapeList:
         index : int
             Location in list of the shape to be changed.
         """
+        self._guard_not_staged(index, '_update_mesh_triangles')
         shape = self.shapes[index]
         if index == 0:
             triangle_shift = 0
@@ -1260,6 +1390,11 @@ class ShapeList:
         """
         if not indices:
             return
+        if self._staged_index in indices:
+            raise RuntimeError(
+                'remove_multiple cannot update a staged shape; '
+                'use remove_staged instead'
+            )
 
         # Remove indices
         vert_slices = [self._vertices_slice_available(i) for i in indices]
@@ -1346,6 +1481,7 @@ class ShapeList:
             Bool to indicate whether to update mesh vertices corresponding to
             faces and to update the underlying shape vertices
         """
+        self._guard_not_staged(index, '_update_mesh_vertices')
         shape = self.shapes[index]
         if edge and face:
             shape_slice = self._mesh_vertices_slice_available(index)
@@ -1446,6 +1582,7 @@ class ShapeList:
             If string , must be one of "{'line', 'rectangle', 'ellipse',
             'path', 'polygon'}".
         """
+        self._guard_not_staged(index, 'edit')
         if new_type is not None:
             cur_shape = self.shapes[index]
             if isinstance(new_type, str):
@@ -1487,6 +1624,7 @@ class ShapeList:
         edge_width : float
             thickness of lines and edges.
         """
+        self._guard_not_staged(index, 'update_edge_width')
         self.shapes[index].edge_width = edge_width
         self._update_mesh_vertices(index, edge=True)
 
@@ -1601,6 +1739,7 @@ class ShapeList:
             Specifier of z order priority. Shapes with higher z order are
             displayed ontop of others.
         """
+        self._guard_not_staged(index, 'update_z_index')
         self.shapes[index].z_index = z_index
         self._z_index[index] = z_index
         self._update_z_order()
@@ -1615,6 +1754,7 @@ class ShapeList:
         shift : np.ndarray
             length 2 array specifying shift of shapes.
         """
+        self._guard_not_staged(index, 'shift')
         self.shapes[index].shift(shift)
         self._update_mesh_vertices(index, edge=True, face=True)
 
@@ -1630,6 +1770,7 @@ class ShapeList:
         center : list
             length 2 list specifying coordinate of center of scaling.
         """
+        self._guard_not_staged(index, 'scale')
         self.shapes[index].scale(scale, center=center)
         self.update(index)
         self._update_z_order()
@@ -1646,6 +1787,7 @@ class ShapeList:
         center : list
             length 2 list specifying coordinate of center of rotation.
         """
+        self._guard_not_staged(index, 'rotate')
         self.shapes[index].rotate(angle, center=center)
         self._update_mesh_vertices(index, edge=True, face=True)
 
@@ -1662,6 +1804,7 @@ class ShapeList:
         center : list
             length 2 list specifying coordinate of center of flip axes.
         """
+        self._guard_not_staged(index, 'flip')
         self.shapes[index].flip(axis, center=center)
         self._update_mesh_vertices(index, edge=True, face=True)
 
@@ -1675,6 +1818,7 @@ class ShapeList:
         transform : np.ndarray
             2x2 array specifying linear transform.
         """
+        self._guard_not_staged(index, 'transform')
         self.shapes[index].transform(transform)
         self.update(index)
         self._update_z_order()

--- a/src/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -394,7 +394,10 @@ def add_vertex_to_path(
         value = layer._moving_value
     layer._value = (value[0], value[1] + 1)
     layer._moving_value = copy(layer._value)
-    layer._data_view.edit(index, vertices, new_type=new_type)
+    if index == layer._data_view.staged_index:
+        layer._data_view.edit_staged(index, vertices, new_type=new_type)
+    else:
+        layer._data_view.edit(index, vertices, new_type=new_type)
     layer._last_cursor_position = np.array(event.pos)
 
 
@@ -895,9 +898,14 @@ def _add_rectangle_ellipse_line(
     scale_mat = np.array([[drag_scale[0], 0], [0, drag_scale[1]]])
     transform = rot @ scale_mat @ inv_rot
     index = next(iter(layer.selected_data))
-    layer._data_view.shift(index, -layer._fixed_vertex)
-    layer._data_view.transform(index, transform)
-    layer._data_view.shift(index, layer._fixed_vertex)
+    if index == layer._data_view.staged_index:
+        layer._data_view.shift_staged(index, -layer._fixed_vertex)
+        layer._data_view.transform_staged(index, transform)
+        layer._data_view.shift_staged(index, layer._fixed_vertex)
+    else:
+        layer._data_view.shift(index, -layer._fixed_vertex)
+        layer._data_view.transform(index, transform)
+        layer._data_view.shift(index, layer._fixed_vertex)
     layer._transform_box(transform, center=layer._fixed_vertex)
     layer.refresh()
 
@@ -961,5 +969,10 @@ def _move_active_element_under_cursor(
                     vertices[0] = coordinates
             vertices[vertex] = coordinates
 
-            layer._data_view.edit(index, vertices, new_type=new_type)
+            if index == layer._data_view.staged_index:
+                layer._data_view.edit_staged(
+                    index, vertices, new_type=new_type
+                )
+            else:
+                layer._data_view.edit(index, vertices, new_type=new_type)
             layer.refresh()

--- a/src/napari/layers/shapes/_tests/test_shape_list.py
+++ b/src/napari/layers/shapes/_tests/test_shape_list.py
@@ -56,6 +56,83 @@ def test_adding_to_shape_list():
     assert shape_list.shapes[0] == shape
 
 
+def test_staged_shape_materializes_aggregate_geometry_once():
+    shape_list = ShapeList([Rectangle([[0, 0], [2, 2]])])
+    staged = Rectangle([[5, 5], [8, 8]], z_index=1)
+    aggregate_sizes = (
+        len(shape_list._vertices),
+        len(shape_list._mesh.vertices),
+        len(shape_list._mesh.triangles),
+    )
+
+    index = shape_list.add_staged(
+        staged,
+        face_color=np.array([1, 0, 0, 1]),
+        edge_color=np.array([0, 1, 0, 1]),
+    )
+
+    assert index == 1
+    assert shape_list.data[index] is staged.data
+    assert shape_list.staged_index == index
+    assert np.diff(shape_list._vertices_index)[index] == 0
+    assert np.diff(shape_list._mesh.vertices_index)[index] == 0
+    assert np.diff(shape_list._mesh.triangles_index)[index] == 0
+    assert aggregate_sizes == (
+        len(shape_list._vertices),
+        len(shape_list._mesh.vertices),
+        len(shape_list._mesh.triangles),
+    )
+
+    with pytest.raises(RuntimeError, match='use the staged-shape operation'):
+        shape_list.shift(index, [1, 1])
+
+    shape_list.shift_staged(index, [1, 1])
+    assert aggregate_sizes == (
+        len(shape_list._vertices),
+        len(shape_list._mesh.vertices),
+        len(shape_list._mesh.triangles),
+    )
+
+    shape_list.commit_staged(index)
+
+    assert shape_list.staged_index is None
+    assert np.diff(shape_list._vertices_index)[index] == len(
+        staged.data_displayed
+    )
+    assert np.diff(shape_list._mesh.vertices_index)[index] == (
+        staged.vertices_count
+    )
+    assert np.diff(shape_list._mesh.triangles_index)[index] == (
+        staged.triangles_count
+    )
+
+
+def test_remove_staged_shape_leaves_aggregate_geometry_unchanged():
+    shape_list = ShapeList([Rectangle([[0, 0], [2, 2]])])
+    aggregate_arrays = (
+        shape_list._vertices.copy(),
+        shape_list._mesh.vertices.copy(),
+        shape_list._mesh.triangles.copy(),
+    )
+    index = shape_list.add_staged(
+        Rectangle([[5, 5], [8, 8]], z_index=1),
+        face_color=np.ones(4),
+        edge_color=np.ones(4),
+    )
+
+    shape_list.remove_staged(index)
+
+    assert shape_list.staged_index is None
+    assert len(shape_list.shapes) == 1
+    np.testing.assert_array_equal(shape_list._vertices, aggregate_arrays[0])
+    np.testing.assert_array_equal(
+        shape_list._mesh.vertices, aggregate_arrays[1]
+    )
+    np.testing.assert_array_equal(
+        shape_list._mesh.triangles, aggregate_arrays[2]
+    )
+
+
 def test_reset_bounding_box_rotation():
     """Test if rotating shape resets bounding box."""
     shape = Rectangle(np.array([[0, 0], [10, 10]]))

--- a/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -46,6 +46,72 @@ def create_known_shapes_layer():
     return layer, n_shapes, known_non_shape
 
 
+def _assert_last_shape_is_committed(layer: Shapes) -> None:
+    index = layer.nshapes - 1
+    shape = layer._data_view.shapes[index]
+    assert layer._data_view.staged_index is None
+    assert shape.z_index == max(layer.z_index)
+
+    vertices_slice = layer._data_view._vertices_slice_available(index)
+    np.testing.assert_allclose(
+        layer._data_view._vertices[vertices_slice], shape.data_displayed
+    )
+
+    mesh_vertices_slice = layer._data_view._mesh_vertices_slice_available(
+        index
+    )
+    expected_vertices = np.concatenate(
+        [
+            shape._face_vertices,
+            shape._edge_vertices + shape.edge_width * shape._edge_offsets,
+        ]
+    )
+    np.testing.assert_allclose(
+        layer._data_view._mesh.vertices[mesh_vertices_slice],
+        expected_vertices,
+    )
+
+    mesh_triangles_slice = layer._data_view._mesh_triangles_slice_available(
+        index
+    )
+    expected_triangles = np.concatenate(
+        [
+            shape._face_triangles + mesh_vertices_slice.start,
+            shape._edge_triangles
+            + mesh_vertices_slice.start
+            + shape.face_vertices_count,
+        ]
+    )
+    np.testing.assert_array_equal(
+        layer._data_view._mesh.triangles[mesh_triangles_slice],
+        expected_triangles,
+    )
+    expected_colors = np.concatenate(
+        [
+            np.repeat(
+                [layer.face_color[index]],
+                shape.face_triangles_count,
+                axis=0,
+            ),
+            np.repeat(
+                [layer.edge_color[index]],
+                shape.edge_triangles_count,
+                axis=0,
+            ),
+        ]
+    )
+    np.testing.assert_allclose(
+        layer._data_view._mesh.triangles_colors[mesh_triangles_slice],
+        expected_colors,
+    )
+    np.testing.assert_allclose(
+        layer._data_view._mesh.displayed_triangles_colors[
+            -shape.triangles_count :
+        ],
+        expected_colors,
+    )
+
+
 def test_not_adding_or_selecting_shape(create_known_shapes_layer):
     """Don't add or select a shape by clicking on one in pan_zoom mode."""
     layer, n_shapes, _ = create_known_shapes_layer
@@ -109,6 +175,188 @@ def test_add_simple_shape(shape_type, create_known_shapes_layer):
     # Ensure it's selected, accounting for zero-indexing
     assert len(layer.selected_data) == 1
     assert layer.selected_data == {n_shapes}
+    _assert_last_shape_is_committed(layer)
+
+
+@pytest.mark.parametrize('shape_type', ['rectangle', 'ellipse', 'line'])
+def test_gui_creation_defers_aggregate_geometry_until_release(
+    shape_type, create_known_shapes_layer
+):
+    layer, n_shapes, start = create_known_shapes_layer
+    layer.mode = f'add_{shape_type}'
+    set_data = Mock()
+    layer.events.set_data.connect(set_data)
+    aggregate_sizes = (
+        len(layer._data_view._vertices),
+        len(layer._data_view._mesh.vertices),
+        len(layer._data_view._mesh.triangles),
+    )
+
+    mouse_press_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_press', position=start),
+    )
+
+    index = n_shapes
+    assert layer._data_view.staged_index == index
+    assert len(layer.data) == n_shapes + 1
+    assert aggregate_sizes == (
+        len(layer._data_view._vertices),
+        len(layer._data_view._mesh.vertices),
+        len(layer._data_view._mesh.triangles),
+    )
+    assert set_data.call_count == 0
+
+    end = [40, 60]
+    mouse_move_callbacks(
+        layer,
+        read_only_mouse_event(
+            type='mouse_move', is_dragging=True, position=end
+        ),
+    )
+
+    assert aggregate_sizes == (
+        len(layer._data_view._vertices),
+        len(layer._data_view._mesh.vertices),
+        len(layer._data_view._mesh.triangles),
+    )
+    assert set_data.call_count == 0
+
+    mouse_release_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_release', position=end),
+    )
+
+    assert layer._data_view.staged_index is None
+    assert set_data.call_count == 1
+    assert len(layer._data_view._vertices) > aggregate_sizes[0]
+    assert len(layer._data_view._mesh.vertices) > aggregate_sizes[1]
+    assert len(layer._data_view._mesh.triangles) > aggregate_sizes[2]
+
+
+def test_invalid_gui_shape_removes_zero_width_staging_ranges(
+    create_known_shapes_layer,
+):
+    layer, n_shapes, start = create_known_shapes_layer
+    layer.mode = 'add_polyline'
+    aggregate_arrays = (
+        layer._data_view._vertices.copy(),
+        layer._data_view._mesh.vertices.copy(),
+        layer._data_view._mesh.triangles.copy(),
+    )
+
+    mouse_press_callbacks(
+        layer,
+        read_only_mouse_event(
+            type='mouse_press', position=start, pos=np.asarray(start)
+        ),
+    )
+    assert layer._data_view.staged_index == n_shapes
+
+    mouse_double_click_callbacks(
+        layer,
+        read_only_mouse_event(
+            type='mouse_double_click', position=start, pos=np.asarray(start)
+        ),
+    )
+
+    assert layer._data_view.staged_index is None
+    assert len(layer.data) == n_shapes
+    np.testing.assert_array_equal(
+        layer._data_view._vertices, aggregate_arrays[0]
+    )
+    np.testing.assert_array_equal(
+        layer._data_view._mesh.vertices, aggregate_arrays[1]
+    )
+    np.testing.assert_array_equal(
+        layer._data_view._mesh.triangles, aggregate_arrays[2]
+    )
+
+
+@pytest.mark.parametrize(
+    'operation',
+    ['move_to_front', 'move_to_back', 'z_index', 'remove_selected'],
+)
+def test_public_mutation_finishes_staged_shape(
+    operation, create_known_shapes_layer
+):
+    layer, n_shapes, start = create_known_shapes_layer
+    layer.mode = 'add_rectangle'
+    mouse_press_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_press', position=start),
+    )
+    assert layer._data_view.staged_index == n_shapes
+
+    if operation == 'z_index':
+        layer.z_index = -1
+    else:
+        getattr(layer, operation)()
+
+    assert layer._data_view.staged_index is None
+    if operation == 'remove_selected':
+        assert layer.nshapes == n_shapes
+    else:
+        assert layer.nshapes == n_shapes + 1
+
+
+def test_visibility_change_finishes_staged_shape(create_known_shapes_layer):
+    layer, n_shapes, start = create_known_shapes_layer
+    layer.mode = 'add_rectangle'
+    mouse_press_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_press', position=start),
+    )
+    assert layer._data_view.staged_index == n_shapes
+
+    layer.visible = False
+
+    assert layer._data_view.staged_index is None
+
+
+def test_not_displayed_axis_uses_aggregate_geometry():
+    """A layer with a non-displayed axis keeps the aggregate creation path.
+
+    The aggregate arrays then hold only the shapes on the current slice, so
+    those on other slices make the displayed index runs discontiguous and a
+    staged shape with no aggregate range of its own cannot be addressed.
+    """
+
+    def rectangle(z, offset):
+        return [
+            [z, offset, offset],
+            [z, offset, offset + 5],
+            [z, offset + 5, offset + 5],
+            [z, offset + 5, offset],
+        ]
+
+    layer = Shapes([rectangle(0, 0), rectangle(1, 10), rectangle(0, 20)])
+    layer.scale_factor = 0.001
+    assert layer._data_view._displayed.tolist() == [True, False, True]
+
+    layer.mode = 'add_rectangle'
+    mouse_press_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_press', position=[0, 40, 40]),
+    )
+    assert layer._data_view.staged_index is None
+
+    mouse_move_callbacks(
+        layer,
+        read_only_mouse_event(
+            type='mouse_move', is_dragging=True, position=[0, 50, 60]
+        ),
+    )
+    mouse_release_callbacks(
+        layer,
+        read_only_mouse_event(type='mouse_release', position=[0, 50, 60]),
+    )
+
+    assert layer.nshapes == 4
+    np.testing.assert_allclose(
+        layer.data[-1],
+        [[0, 40, 40], [0, 40, 60], [0, 50, 60], [0, 50, 40]],
+    )
 
 
 def test_line_fixed_angles(create_known_shapes_layer):
@@ -290,6 +538,7 @@ def test_path_tablet(create_known_shapes_layer):
     )
     mouse_press_callbacks(layer, event)
     assert layer.shape_type[-1] == 'path'
+    assert layer._data_view.staged_index == n_shapes
 
     for coord in desired_shape[1:]:
         event = read_only_mouse_event(
@@ -317,6 +566,7 @@ def test_path_tablet(create_known_shapes_layer):
     # Ensure it's selected, accounting for zero-indexing
     assert len(layer.selected_data) == 1
     assert layer.selected_data == {n_shapes}
+    _assert_last_shape_is_committed(layer)
 
 
 def test_polyline_mouse(create_known_shapes_layer):
@@ -332,6 +582,7 @@ def test_polyline_mouse(create_known_shapes_layer):
     )
     mouse_press_callbacks(layer, event)
     assert layer.shape_type[-1] == 'path'
+    assert layer._data_view.staged_index == n_shapes
 
     for coord in desired_shape[1:]:
         event = read_only_mouse_event(
@@ -356,6 +607,7 @@ def test_polyline_mouse(create_known_shapes_layer):
     # Ensure it's selected, accounting for zero-indexing
     assert len(layer.selected_data) == 1
     assert layer.selected_data == {n_shapes}
+    _assert_last_shape_is_committed(layer)
 
 
 def test_polygon_lasso_tablet(create_known_shapes_layer):
@@ -375,6 +627,7 @@ def test_polygon_lasso_tablet(create_known_shapes_layer):
     mouse_press_callbacks(layer, event)
 
     assert layer.shape_type[-1] != 'polygon'
+    assert layer._data_view.staged_index == n_shapes
 
     for coord in desired_shape[1:]:
         event = read_only_mouse_event(
@@ -401,6 +654,7 @@ def test_polygon_lasso_tablet(create_known_shapes_layer):
     # Ensure it's selected, accounting for zero-indexing
     assert len(layer.selected_data) == 1
     assert layer.selected_data == {n_shapes}
+    _assert_last_shape_is_committed(layer)
 
 
 def test_polygon_lasso_mouse(create_known_shapes_layer):
@@ -478,7 +732,7 @@ def test_add_complex_shape(shape_type, create_known_shapes_layer):
     # Add shape at location where non exists
     layer.mode = f'add_{shape_type}'
 
-    for coord in desired_shape:
+    for i, coord in enumerate(desired_shape):
         # Simulate move, click, and release
         event = read_only_mouse_event(
             type='mouse_move',
@@ -492,6 +746,8 @@ def test_add_complex_shape(shape_type, create_known_shapes_layer):
             pos=np.array(coord, dtype=float),
         )
         mouse_press_callbacks(layer, event)
+        if i == 0:
+            assert layer._data_view.staged_index == n_shapes
         event = read_only_mouse_event(
             type='mouse_release',
             position=coord,
@@ -517,6 +773,7 @@ def test_add_complex_shape(shape_type, create_known_shapes_layer):
     # Ensure it's selected, accounting for zero-indexing
     assert len(layer.selected_data) == 1
     assert layer.selected_data == {n_shapes}
+    _assert_last_shape_is_committed(layer)
 
 
 @pytest.mark.parametrize(

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -517,6 +517,7 @@ class Shapes(Layer):
             highlight=Event,
             features=Event,
             feature_defaults=Event,
+            _active_shape=Event,
         )
 
         # Flag set to false to block thumbnail refresh
@@ -575,6 +576,7 @@ class Shapes(Layer):
         self._drag_box = None
         self._drag_box_stored = None
         self._is_creating = False
+
         self._clipboard: dict[str, Shapes] = {}
         self._outlines_cache: dict[
             int | None, tuple[np.ndarray, np.ndarray, np.ndarray]
@@ -889,7 +891,10 @@ class Shapes(Layer):
             # To avoid performance cost of repeated update calls, we batch the updates
             with self._data_view.batched_updates():
                 for i in self.selected_data:
-                    self._data_view.update_edge_width(i, edge_width)
+                    if i == self._data_view.staged_index:
+                        self._data_view.update_staged_edge_width(i, edge_width)
+                    else:
+                        self._data_view.update_edge_width(i, edge_width)
         self.events.edge_width()
 
     @property
@@ -1210,7 +1215,10 @@ class Shapes(Layer):
             widths = [width for _ in range(self.nshapes)]
         with self._data_view.batched_updates():
             for i, width in enumerate(widths):
-                self._data_view.update_edge_width(i, width)
+                if i == self._data_view.staged_index:
+                    self._data_view.update_staged_edge_width(i, width)
+                else:
+                    self._data_view.update_edge_width(i, width)
 
     @property
     def z_index(self):
@@ -1228,6 +1236,9 @@ class Shapes(Layer):
         z_index : int or list of int
             z-index of shapes
         """
+        if self._data_view.staged_index is not None:
+            self._finish_drawing()
+
         if isinstance(z_index, list):
             if not len(z_index) == self.nshapes:
                 raise ValueError(
@@ -2118,6 +2129,15 @@ class Shapes(Layer):
                 face_color=face_color,
                 z_index=z_index,
                 n_new_shapes=n_new_shapes,
+                stage=(
+                    gui
+                    and self._is_creating
+                    and n_new_shapes == 1
+                    # With non-displayed axes the aggregate arrays hold only
+                    # the shapes on the current slice, so a staged shape with
+                    # no aggregate range breaks their index bookkeeping.
+                    and self.ndim == self._slice_input.ndisplay
+                ),
             )
             # This should only emit when programmatically adding as with drawing this leads to premature emit.
             if not gui:
@@ -2233,6 +2253,7 @@ class Shapes(Layer):
         face_color=None,
         z_index=None,
         n_new_shapes=0,
+        stage=False,
     ):
         """Add shapes to the data view.
 
@@ -2275,6 +2296,8 @@ class Shapes(Layer):
             shapes.
         n_new_shapes : int
             The number of new shapes to be added to the Shapes layer.
+        stage : bool
+            Whether one topmost GUI-created shape may bypass aggregate geometry.
         """
         if n_new_shapes > 0:
             total_shapes = n_new_shapes + self.nshapes
@@ -2338,13 +2361,17 @@ class Shapes(Layer):
                 strict=False,
             )
 
-            self._add_shapes_to_view(shape_inputs, self._data_view)
+            self._add_shapes_to_view(
+                shape_inputs, self._data_view, stage=stage
+            )
 
         self._display_order_stored = copy(self._slice_input.order)
         self._ndisplay_stored = copy(self._slice_input.ndisplay)
         self._update_dims()
 
-    def _add_shapes_to_view(self, shape_inputs, data_view: ShapeList):
+    def _add_shapes_to_view(
+        self, shape_inputs, data_view: ShapeList, *, stage: bool = False
+    ):
         """Build new shapes and add them to the _data_view"""
 
         shape_inputs = tuple(shape_inputs)
@@ -2367,15 +2394,31 @@ class Shapes(Layer):
 
         shapes, edge_colors, face_colors = tuple(zip(*sh_inp, strict=False))
 
-        # Add all shapes at once (faster than adding them one by one)
-        data_view.add(
-            shape=shapes,
-            edge_color=edge_colors,
-            face_color=face_colors,
-            z_refresh=False,
+        can_stage = (
+            stage
+            and data_view is self._data_view
+            and len(shapes) == 1
+            and (
+                len(data_view._z_index) == 0
+                or shapes[0].z_index >= np.max(data_view._z_index)
+            )
         )
-
-        data_view._update_z_order()
+        if can_stage:
+            data_view.add_staged(
+                shapes[0],
+                edge_color=edge_colors[0],
+                face_color=face_colors[0],
+            )
+            self.events._active_shape()
+        else:
+            # Add all shapes at once (faster than adding them one by one)
+            data_view.add(
+                shape=shapes,
+                edge_color=edge_colors,
+                face_color=face_colors,
+                z_refresh=False,
+            )
+            data_view._update_z_order()
 
     @property
     def text(self) -> TextManager:
@@ -2414,6 +2457,16 @@ class Shapes(Layer):
 
     def _set_view_slice(self):
         """Set the view given the slicing indices."""
+        slice_key = np.array(self._data_slice.point)[
+            self._slice_input.not_displayed
+        ]
+        if self._data_view.staged_index is not None and (
+            self._slice_input.ndisplay != self._ndisplay_stored
+            or self._slice_input.order != self._display_order_stored
+            or not np.array_equal(slice_key, self._data_view.slice_key)
+        ):
+            self._finish_drawing()
+
         view_changed = False
         with self._data_view.batched_updates():
             ndisplay = self._slice_input.ndisplay
@@ -2430,9 +2483,6 @@ class Shapes(Layer):
                 self._clipboard = {}
                 view_changed = True
 
-            slice_key = np.array(self._data_slice.point)[
-                self._slice_input.not_displayed
-            ]
             if not np.array_equal(slice_key, self._data_view.slice_key):
                 view_changed = True
             self._data_view.slice_key = slice_key
@@ -2525,6 +2575,21 @@ class Shapes(Layer):
         extent: bool = True,
         force: bool = False,
     ) -> None:
+        if self._is_creating and self._data_view.staged_index is not None:
+            # The committed visual stays untouched while the active-shape
+            # subvisual owns the in-progress geometry.
+            if data_displayed:
+                self._clean_outline_cache()
+                self.events._active_shape()
+            super().refresh(
+                event,
+                thumbnail=False,
+                data_displayed=False,
+                highlight=highlight,
+                extent=extent,
+                force=force,
+            )
+            return
         if data_displayed:
             self._clean_outline_cache()
         super().refresh(
@@ -2565,7 +2630,17 @@ class Shapes(Layer):
             # Only consider the hovered shape if it is in view and not already
             # selected (selected shapes are highlighted via selected_in_view).
             value = self._value[0]
-            if value is not None and value not in self._view_indices:
+            staged_index = self._data_view.staged_index
+            value_is_staged_in_view = (
+                value == staged_index
+                and staged_index is not None
+                and self._data_view._displayed[staged_index]
+            )
+            if (
+                value is not None
+                and not value_is_staged_in_view
+                and value not in self._view_indices
+            ):
                 value = None
             if value in selected_in_view:
                 value = None
@@ -2653,11 +2728,27 @@ class Shapes(Layer):
                 ]
             ):
                 # If in one of these mode show the vertices of the shape itself
-                inds = np.isin(
-                    self._data_view.displayed_vertices_to_shape_num,
-                    list(selected_in_view),
-                )
-                vertices = self._data_view.displayed_vertices[inds][:, ::-1]
+                staged_index = self._data_view.staged_index
+                committed_selection = [
+                    i for i in selected_in_view if i != staged_index
+                ]
+                if committed_selection:
+                    inds = np.isin(
+                        self._data_view.displayed_vertices_to_shape_num,
+                        committed_selection,
+                    )
+                    vertices = self._data_view.displayed_vertices[inds][
+                        :, ::-1
+                    ]
+                else:
+                    vertices = np.empty((0, self._slice_input.ndisplay))
+                if staged_index in selected_in_view:
+                    staged_vertices = self._data_view.shapes[
+                        staged_index
+                    ].data_displayed[:, ::-1]
+                    vertices = np.concatenate(
+                        [vertices, staged_vertices], axis=0
+                    )
                 # If currently adding path don't show box over last vertex
                 if self._mode == Mode.ADD_POLYLINE:
                     vertices = vertices[:-1]
@@ -2723,6 +2814,8 @@ class Shapes(Layer):
     def _finish_drawing(self, event=None) -> None:
         """Reset properties used in shape drawing."""
         index = copy(self._moving_value[0])
+        staged_index = self._data_view.staged_index
+        removed_staged = False
         self._is_moving = False
         self._drag_start = None
         self._drag_box = None
@@ -2735,12 +2828,19 @@ class Shapes(Layer):
             if self._mode in {Mode.ADD_PATH, Mode.ADD_POLYLINE}:
                 vertices = self._data_view.shapes[index].data
                 if len(vertices) <= 2:
-                    self._data_view.remove(index)
+                    if index == staged_index:
+                        self._data_view.remove_staged(index)
+                        removed_staged = True
+                    else:
+                        self._data_view.remove(index)
                     # Clear selected data to prevent issues.
                     # See https://github.com/napari/napari/pull/6912#discussion_r1601169680
                     self.selected_data.clear()
                 else:
-                    self._data_view.edit(index, vertices[:-1])
+                    if index == staged_index:
+                        self._data_view.edit_staged(index, vertices[:-1])
+                    else:
+                        self._data_view.edit(index, vertices[:-1])
             if self._mode in {Mode.ADD_POLYGON, Mode.ADD_POLYGON_LASSO}:
                 vertices = self._data_view.shapes[index].data
                 if self._mode == Mode.ADD_POLYGON_LASSO:
@@ -2761,16 +2861,31 @@ class Shapes(Layer):
                             'Experimental > RDP epsilon. ',
                         )
                 if len(vertices) <= 3:
-                    self._data_view.remove(index)
+                    if index == staged_index:
+                        self._data_view.remove_staged(index)
+                        removed_staged = True
+                    else:
+                        self._data_view.remove(index)
                     # Clear selected data to prevent issues.
                     # See https://github.com/napari/napari/pull/6912#discussion_r1601169680
                     self.selected_data.clear()
                 else:
-                    self._data_view.edit(
-                        index,
-                        vertices[:-1],
-                        new_type=shape_classes[ShapeType.POLYGON],
-                    )
+                    if index == staged_index:
+                        self._data_view.edit_staged(
+                            index,
+                            vertices[:-1],
+                            new_type=shape_classes[ShapeType.POLYGON],
+                        )
+                    else:
+                        self._data_view.edit(
+                            index,
+                            vertices[:-1],
+                            new_type=shape_classes[ShapeType.POLYGON],
+                        )
+            if staged_index is not None and not removed_staged:
+                self._data_view.commit_staged(staged_index)
+        if removed_staged:
+            self.events._active_shape()
         # handles the case that
         if index is not None:
             self.events.data(
@@ -2782,6 +2897,8 @@ class Shapes(Layer):
             self.events.features()
         self._is_creating = False
         self._update_dims()
+        if staged_index is not None and not removed_staged:
+            self.events._active_shape()
 
     @contextmanager
     def block_thumbnail_update(self):
@@ -2837,6 +2954,12 @@ class Shapes(Layer):
         indices : List[int]
             List of indices of shapes to remove from the layer.
         """
+        staged_index = self._data_view.staged_index
+        if staged_index is not None:
+            self._finish_drawing()
+            if staged_index >= self.nshapes:
+                indices = [i for i in indices if i != staged_index]
+
         to_remove = sorted(indices, reverse=True)
 
         if len(indices) > 0:
@@ -3223,6 +3346,8 @@ class Shapes(Layer):
 
     def move_to_front(self) -> None:
         """Moves selected objects to be displayed in front of all others."""
+        if self._data_view.staged_index is not None:
+            self._finish_drawing()
         if len(self.selected_data) == 0:
             return
         new_z_index = max(self._data_view._z_index) + 1
@@ -3232,6 +3357,8 @@ class Shapes(Layer):
 
     def move_to_back(self) -> None:
         """Moves selected objects to be displayed behind all others."""
+        if self._data_view.staged_index is not None:
+            self._finish_drawing()
         if len(self.selected_data) == 0:
             return
         new_z_index = min(self._data_view._z_index) - 1


### PR DESCRIPTION
Relates to #8650 (drawing slows down as a Shapes layer fills up).

Touches `_vispy/layers/shapes.py` in the same place as #9418, which hides empty Shapes subvisuals. If that one lands first the highlight mesh has to stay visible whenever a shape is staged.

Drawing a new shape gets slower as the layer fills up because every pointer frame rebuilds the whole layer:

- each mouse move edits the new shape through `ShapeList.edit`/`shift`/`transform`, which rewrite the layer's aggregate vertex, triangle and color arrays
- `Shapes.refresh` then reslices the aggregate arrays and hands the full mesh to `MeshVisual.set_data`, so the entire layer is re-uploaded
- cost is therefore proportional to all the geometry already in the layer, not to the shape being drawn (#8650)

Currently, while one GUI-created shape is being drawn it occupies zero-width ranges in the aggregate arrays and renders through the existing highlight mesh. The aggregate ranges are filled in once, at completion.

`layer.data`, `nshapes`, `selected_data`, hit testing, vertex handles and the `ADDING`/`ADDED` events keep their current values throughout: the staged shape is a normal entry in `ShapeList.shapes`, only its aggregate ranges are empty. No new scene node or draw call is added.

## Measured

macOS arm64, PyQt6 6.11, VisPy 0.16.2, 640x480 canvas, median of 30 pointer frames, each drawn and waited on with `glFinish`.

| Existing 32-vertex paths | Pointer frame before | after | |
|---:|---:|---:|---:|
| 10,000 | 106.8 ms | 10.0 ms | 10.7x |
| 50,000 | 556.9 ms | 32.9 ms | 16.9x |

The whole 30-frame drag falls from 16.9 s to 1.5 s at 50,000 paths.

The one-time commit at mouse release grows from 216 ms to 463 ms there, because the aggregate rebuild that used to happen on every frame now happens once. Net work over the drag is far lower, and the stall is at release rather than in every frame.

<details>
<summary>Reproducer</summary>

```python
import os, statistics, tempfile, time
from pathlib import Path
import numpy as np
os.environ.setdefault('NAPARI_CONFIG', str(Path(tempfile.mkdtemp()) / 's.yaml'))
import napari
from napari.utils._test_utils import read_only_mouse_event
from napari.utils.interactions import (
    mouse_move_callbacks, mouse_press_callbacks, mouse_release_callbacks,
)

N, MOVES = 10_000, 30
rng = np.random.default_rng(0)
phi = np.linspace(0, 2 * np.pi, 32, endpoint=False)
rays = np.stack([np.sin(phi), np.cos(phi)], axis=1)[None, ...]
paths = rng.uniform(0, 1000, (N, 2))[:, None, :] + (500 / np.sqrt(N)) * rays

viewer = napari.Viewer(show=False)
layer = viewer.add_shapes(paths, shape_type='path', edge_color='coral')
canvas = viewer.window._qt_viewer.canvas

def frame():
    scene = canvas._scene_canvas
    scene.set_current()
    canvas.on_draw(None)
    scene._draw_scene()
    scene.context.finish()

frame()
layer.mode = 'add_rectangle'
mouse_press_callbacks(
    layer, read_only_mouse_event(type='mouse_press', position=[500.0, 500.0])
)
frame()

samples = []
for i in range(MOVES):
    position = [500.0 + 2 * (i + 1), 500.0 + 3 * (i + 1)]
    started = time.perf_counter()
    mouse_move_callbacks(
        layer,
        read_only_mouse_event(
            type='mouse_move', position=position, is_dragging=True
        ),
    )
    frame()
    samples.append(time.perf_counter() - started)

started = time.perf_counter()
mouse_release_callbacks(
    layer, read_only_mouse_event(type='mouse_release', position=position)
)
frame()
print(f'drag  {1000 * statistics.median(samples):.1f} ms/frame')
print(f'release {1000 * (time.perf_counter() - started):.1f} ms')
viewer.close()
```

</details>

## Scope and limits

Rendered pixels are unchanged.

- **Two deliberate behavior changes while a shape is being drawn.** The layer-list thumbnail no longer updates until the shape is finished, since it would have to rasterize a shape the aggregate arrays do not contain. `move_to_front`, `move_to_back` and setting `z_index` finish the drawing first, because a staged shape has to stay topmost.
- **Only layers whose axes are all displayed stage.** With a non-displayed axis the aggregate arrays hold just the shapes on the current slice, so off-slice shapes make the displayed index runs discontiguous and a zero-width range cannot be addressed. Those layers keep the aggregate path; `test_not_displayed_axis_uses_aggregate_geometry` covers it.
- **Editing an existing shape is not covered.** Hiding one committed range needs persistent, partially writable GPU buffers; an overlay alone would leave the old geometry drawn underneath.
- **What remains per frame.** At 50,000 paths the 33 ms left is almost entirely `Shapes._extent_data`, which gathers a bounding box per shape each time the canvas asks for `layer.extent`.

Rendered pixels are unchanged.
