### PR TITLE
feat(shapes): right click removes the last vertex while drawing

### DIFF
--- a/src/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -296,9 +296,15 @@ def finish_drawing_shape(layer: Shapes, event: MouseEvent) -> None:
     layer : Shapes
         Napari shapes layer
     event : MouseEvent
-        A proxy read only wrapper around a vispy mouse event. Not used here, but passed as argument due to being a
-        double click callback of the shapes layer.
+        A proxy read only wrapper around a vispy mouse event. Used to remove a
+        vertex on a right double click rather than finish the shape.
     """
+    if event.button == 2:
+        # A double click arrives as one mouse press followed by this event, so
+        # the second click of a right double click removes its vertex here.
+        if layer._is_creating:
+            remove_last_vertex_from_path(layer)
+        return
     layer._finish_drawing()
 
 
@@ -398,6 +404,36 @@ def add_vertex_to_path(
     layer._last_cursor_position = np.array(event.pos)
 
 
+def remove_last_vertex_from_path(layer: Shapes) -> None:
+    """Remove the most recently placed vertex of the shape being drawn.
+
+    The final vertex of a shape under construction tracks the cursor, so the
+    most recently placed vertex is the second to last one. When no placed
+    vertex is left to remove, the shape under construction is discarded.
+
+    Parameters
+    ----------
+    layer : Shapes
+        Napari shapes layer
+    """
+    index = layer._moving_value[0]
+    vertices = layer._data_view.shapes[index].data
+    if len(vertices) <= 2:
+        # Only the first vertex and the vertex tracking the cursor are left, so
+        # there is no partial shape to keep. Finishing discards a shape this
+        # small, which is what Enter and Escape already do here.
+        layer._finish_drawing()
+        return
+
+    layer._data_view.edit(index, np.delete(vertices, -2, axis=0))
+    layer._value = (index, len(vertices) - 2)
+    layer._moving_value = copy(layer._value)
+    # The removed vertex was the one the duplicate-click guard compares
+    # against, so forget it: clicking the same spot again must put it back.
+    layer._last_cursor_position = None
+    layer.refresh()
+
+
 def polygon_creating(layer: Shapes, event: MouseEvent) -> None:
     """Let active vertex follow cursor while drawing polygon, adding it to polygon after a certain distance.
 
@@ -435,7 +471,8 @@ def add_path_polygon(layer: Shapes, event: MouseEvent) -> None:
     """Add a path or polygon or add vertex to an existing one.
 
     When shape is not yet being created, initiates the drawing of a polygon on mouse press. Else, on subsequent mouse
-    presses, add vertex to polygon being created.
+    presses, add vertex to polygon being created. A right press removes the
+    most recently placed vertex instead, as in the Labels polygon tool.
 
     Parameters
     ----------
@@ -446,6 +483,10 @@ def add_path_polygon(layer: Shapes, event: MouseEvent) -> None:
     """
     # on press
     coordinates = layer.world_to_data(event.position)
+    if event.button == 2:
+        if layer._is_creating:
+            remove_last_vertex_from_path(layer)
+        return
     if layer._is_creating is False:
         # Set last cursor position to initial position of the mouse when starting to draw the shape
         layer._last_cursor_position = np.array(event.pos)

--- a/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
+++ b/src/napari/layers/shapes/_tests/test_shapes_mouse_bindings.py
@@ -1374,3 +1374,135 @@ def test_drag_start_selection(
         pytest.fail('Unreachable code')
     assert layer._drag_box is None
     assert layer._drag_start is None
+
+
+def _press(layer, position, pos, button=1, double_click=False):
+    event_type = 'mouse_double_click' if double_click else 'mouse_press'
+    event = read_only_mouse_event(
+        type=event_type, position=position, pos=np.array(pos), button=button
+    )
+    if double_click:
+        mouse_double_click_callbacks(layer, event)
+    else:
+        mouse_press_callbacks(layer, event)
+
+
+def _move(layer, position, pos):
+    event = read_only_mouse_event(
+        type='mouse_move', position=position, pos=np.array(pos)
+    )
+    mouse_move_callbacks(layer, event)
+
+
+def _draw_vertices(layer, positions, move=True):
+    """Place one vertex per position with the click-per-vertex tools.
+
+    `move` mirrors a real gesture, where the cursor travels between clicks. The
+    tools also have to cope with two clicks and no move in between, which is
+    what `move=False` exercises.
+    """
+    for i, position in enumerate(positions):
+        pos = (float(i + 1), float(i + 1))
+        _press(layer, position, pos)
+        if move:
+            _move(layer, position, pos)
+
+
+@pytest.mark.parametrize('mode', ['add_polygon', 'add_polyline'])
+@pytest.mark.parametrize('move', [True, False])
+def test_right_click_removes_last_placed_vertex(
+    mode, move, create_known_shapes_layer
+):
+    layer, n_shapes, _ = create_known_shapes_layer
+    layer.mode = mode
+
+    _draw_vertices(layer, [(0, 0), (0, 10), (10, 10)], move=move)
+    before = layer.data[-1].copy()
+
+    # Away from every placed vertex: adding one here would be visible in the
+    # comparison below, where adding one on top of the last would not.
+    _press(layer, (5, 5), (9.0, 9.0), button=2)
+
+    assert layer._is_creating
+    assert len(layer.data) == n_shapes + 1
+    # The final vertex tracks the cursor, so the placed vertex before it is the
+    # one a right click takes back.
+    np.testing.assert_array_equal(
+        layer.data[-1], np.delete(before, -2, axis=0)
+    )
+
+    # The surviving final vertex still follows the cursor.
+    _move(layer, (7, 3), (20.0, 20.0))
+    np.testing.assert_allclose(layer.data[-1][-1], (7, 3))
+
+
+@pytest.mark.parametrize('mode', ['add_polygon', 'add_polyline'])
+def test_right_click_past_first_vertex_discards_shape(
+    mode, create_known_shapes_layer
+):
+    layer, n_shapes, _ = create_known_shapes_layer
+    layer.mode = mode
+
+    _draw_vertices(layer, [(0, 0), (0, 10), (10, 10)])
+
+    for i in range(len(layer.data[-1])):
+        _press(layer, (10, 10), (9.0 - i, 9.0 - i), button=2)
+        if not layer._is_creating:
+            break
+
+    assert not layer._is_creating
+    assert not layer._is_moving
+    assert len(layer.data) == n_shapes
+    assert len(layer.selected_data) == 0
+
+
+@pytest.mark.parametrize('mode', ['add_polygon', 'add_polyline'])
+def test_right_double_click_removes_a_vertex(mode, create_known_shapes_layer):
+    layer, _n_shapes, _ = create_known_shapes_layer
+    layer.mode = mode
+
+    _draw_vertices(layer, [(0, 0), (0, 10), (10, 10), (10, 0)])
+    before = layer.data[-1].copy()
+
+    # A canvas double click arrives as a press followed by a double-click
+    # event, so both clicks have to take a vertex back.
+    _press(layer, (5, 5), (9.0, 9.0), button=2)
+    _press(layer, (5, 5), (9.0, 9.0), button=2, double_click=True)
+
+    assert layer._is_creating
+    np.testing.assert_array_equal(
+        layer.data[-1], np.delete(before, [-3, -2], axis=0)
+    )
+
+
+@pytest.mark.parametrize('mode', ['add_polygon', 'add_polyline'])
+def test_vertex_can_be_placed_again_after_removal(
+    mode, create_known_shapes_layer
+):
+    """A right click must not block the next click where the cursor already is."""
+    layer, _n_shapes, _ = create_known_shapes_layer
+    layer.mode = mode
+
+    _draw_vertices(layer, [(0, 0), (0, 10), (10, 10)])
+    n_vertices = len(layer.data[-1])
+
+    _press(layer, (5, 5), (9.0, 9.0), button=2)
+    assert len(layer.data[-1]) == n_vertices - 1
+
+    # The canvas position of the most recent click is what the duplicate-click
+    # guard holds, and a removal must not leave it holding one.
+    _press(layer, (0, 10), (3.0, 3.0))
+    assert len(layer.data[-1]) == n_vertices
+
+
+@pytest.mark.parametrize('mode', ['add_polygon', 'add_polyline'])
+def test_right_click_before_drawing_does_nothing(
+    mode, create_known_shapes_layer
+):
+    layer, n_shapes, _ = create_known_shapes_layer
+    layer.mode = mode
+
+    _press(layer, (5, 5), (9.0, 9.0), button=2)
+
+    assert not layer._is_creating
+    assert len(layer.data) == n_shapes


### PR DESCRIPTION
The Labels polygon tool takes back the most recently placed point on a right press. The Shapes polygon and polyline tools place another vertex instead, so a misplaced click cannot be undone. This is the first two items of @psobolewskiPhD's outstanding list in #6489.

A right press now removes the last placed vertex, and once only the first vertex is left the shape is finished rather than shrunk further, which discards it — the same thing Enter and Escape already do to a shape that small.

This does not affect existing use. In these two tools a right press currently places a vertex exactly as a left press does, because the callbacks never inspect `event.button`, so no existing gesture changes meaning.

Three things the diff does not show:

- The vertex that tracks the cursor is the last element of the data, so the removal targets the second to last.
- A canvas double click arrives as one `mouse_press` followed by `mouse_double_click`, so the right double-click handler removes a vertex for its own click rather than finishing the shape. Two clicks, two vertices removed, as in `LabelsPolygonOverlay`.
- Removing a vertex clears `_last_cursor_position`, or the duplicate-click guard from #6597 rejects the next click at the position the cursor is already on.

On macOS, Ctrl+click arrives as a right press, so it removes a vertex too. Shapes binds no Ctrl mouse gesture of its own, so nothing collides.

The lasso and path tools are unchanged: they sample vertices by cursor distance rather than by clicks, so there is no discrete last click to take back.

Twelve tests, each verified failing before the change.
