### PR TITLE
Fix Points.symbol type annotation

### DIFF
--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -26,6 +26,7 @@ from napari.layers.points._points_constants import (
     Mode,
     PointsProjectionMode,
     Shading,
+    Symbol,
 )
 from napari.layers.points._points_mouse_bindings import add, highlight, select
 from napari.layers.points._points_utils import (
@@ -941,12 +942,14 @@ class Points(Layer):
         self.events.highlight()
 
     @property
-    def current_symbol(self) -> int | float:
+    def current_symbol(self) -> Symbol:
         """float: symbol of marker for the next added point."""
         return self._current_symbol
 
     @current_symbol.setter
-    def current_symbol(self, symbol: float | None) -> None:
+    def current_symbol(
+        self, symbol: str | Symbol | Sequence[str | Symbol]
+    ) -> None:
         symbol = coerce_symbols(np.array([symbol]))[0]
         self._current_symbol = symbol
         if self._update_properties and len(self.selected_data) > 0:


### PR DESCRIPTION
# References and relevant issues


# Description

During work on #9318 I found that the Points.symbols type annotation is wrong. 

This PR fixes it. 

It still is a little inconsistent with other properties as we return Enum, not string. But it might be fixed in a folloup PR. 
