### PR TITLE
Follow-up: Rename PluginPreferences to PluginSettings

### DIFF
--- a/src/napari/_qt/dialogs/preferences_dialog.py
+++ b/src/napari/_qt/dialogs/preferences_dialog.py
@@ -148,7 +148,7 @@ class PreferencesDialog(QDialog):
         ----------
         plugin_name : str
             the name of the plugin
-        plugin : PluginPreferences
+        plugin : PluginSettings
             the schemas containing multiple widgets for each plugin.
         """
 
@@ -188,7 +188,7 @@ class PreferencesDialog(QDialog):
         Parameters
         ----------
         field_name : str
-            the name of the plugin
+            the name of the setting (page) to add
         field_info : FieldInfo
             the schema to create the widget.
         """

--- a/src/napari/conftest.py
+++ b/src/napari/conftest.py
@@ -340,7 +340,7 @@ def plugin_settings_(plugin_settings):
 
     Without this, whichever test happens to call `get_plugin_settings`
     first (e.g. by constructing a `PreferencesDialog`) would populate and
-    freeze `_PLUGIN_PREFERENCES` for the rest of the session, against the
+    freeze `_PLUGIN_SETTINGS` for the rest of the session, against the
     real user config directory.
     """
     return plugin_settings

--- a/src/napari/settings/__init__.py
+++ b/src/napari/settings/__init__.py
@@ -11,13 +11,14 @@ from napari.settings._napari_settings import (
     NapariSettings,
 )
 from napari.settings._plugin_config_generator import (
-    PluginPreferences,
+    PluginSettings,
     plugin_configuration_generator,
 )
 
 __all__ = [
     'CURRENT_SCHEMA_VERSION',
     'NapariSettings',
+    'PluginSettings',
     'get_plugin_settings',
     'get_settings',
 ]
@@ -81,47 +82,49 @@ def get_settings(path=_NOT_SET) -> NapariSettings:
     return _SETTINGS
 
 
-_PLUGIN_PREFERENCES: dict[str, PluginPreferences] = {}
+_PLUGIN_SETTINGS: dict[str, PluginSettings] = {}
 
 
 def _clear_plugin_settings_cache(*_args, **_kwargs) -> None:
     """Invalidate the plugin-settings cache.
 
-    `get_plugin_settings` caches _PLUGIN_PREFERENCES i.e. only
-    builds it on first call.
+    `get_plugin_settings` caches `_PLUGIN_SETTINGS`, i.e. it only builds
+    the plugin-settings models on first call.
 
     This utility clears the dict so that the next call forces a
     rebuild of the plugin-settings cache.
 
     Used when plugins are enabled/disabled or in tests.
     """
-    _PLUGIN_PREFERENCES.clear()
+    _PLUGIN_SETTINGS.clear()
 
 
 @overload
 def get_plugin_settings(
     plugin: None = None,
     path_dir: Path | str | _NotSetType | None = _NOT_SET,
-) -> dict[str, PluginPreferences]: ...
+) -> dict[str, PluginSettings]: ...
 
 
 @overload
 def get_plugin_settings(
     plugin: str,
     path_dir: Path | str | _NotSetType | None = _NOT_SET,
-) -> PluginPreferences: ...
+) -> PluginSettings: ...
 
 
 def get_plugin_settings(
     plugin: str | None = None,
     path_dir: Path | str | _NotSetType | None = _NOT_SET,
-) -> dict[str, PluginPreferences] | PluginPreferences:
+) -> dict[str, PluginSettings] | PluginSettings:
     """Get settings for all plugins, or for a single plugin.
+
     Plugin settings are declared by plugins in their manifest under
     ``contributions.configurations``. Each plugin's settings are persisted
     to their own file (e.g. ``<config dir>/<plugin-name>.yaml``), stored in
     the same directory as napari's own settings file, and are auto-saved
     whenever a value changes.
+
     Parameters
     ----------
     plugin : str, optional
@@ -133,11 +136,13 @@ def get_plugin_settings(
         provided, defaults to the directory containing napari's own
         settings file (honoring ``NAPARI_CONFIG``). The path can only be
         set once per session.
+
     Returns
     -------
-    PluginPreferences or dict of PluginPreferences
+    PluginSettings or dict of PluginSettings
         The settings for the requested plugin, or a mapping of all plugin
         settings keyed by plugin name.
+
     Examples
     --------
     >>> from napari.settings import get_plugin_settings
@@ -145,9 +150,9 @@ def get_plugin_settings(
     >>> settings.reader.lazy
     False
     """
-    global _PLUGIN_PREFERENCES
+    global _PLUGIN_SETTINGS
 
-    if not _PLUGIN_PREFERENCES:
+    if not _PLUGIN_SETTINGS:
         if isinstance(path_dir, _NotSetType):
             # same directory as napari's own settings file (``_CFG_PATH``), so
             # plugin settings honor ``NAPARI_CONFIG`` exactly like napari's do
@@ -159,15 +164,15 @@ def get_plugin_settings(
             config_path = (
                 None if path_dir is None else path_dir / f'{key}.yaml'
             )
-            _PLUGIN_PREFERENCES[key] = model(config_path=config_path)
+            _PLUGIN_SETTINGS[key] = model(config_path=config_path)
 
     elif not isinstance(path_dir, _NotSetType):
         _raise_path_set_twice()
 
     if plugin is not None:
         try:
-            return _PLUGIN_PREFERENCES[plugin]
+            return _PLUGIN_SETTINGS[plugin]
         except KeyError as err:
             raise KeyError(f"Plugin named '{plugin}' does not exist.") from err
 
-    return _PLUGIN_PREFERENCES
+    return _PLUGIN_SETTINGS

--- a/src/napari/settings/_plugin_config_generator.py
+++ b/src/napari/settings/_plugin_config_generator.py
@@ -9,7 +9,7 @@ from pydantic import (
     create_model,
 )
 
-from napari.settings._plugin_preferences import PluginPreferences
+from napari.settings._plugin_settings import PluginSettings
 from napari.utils.events import EventedModel
 
 if TYPE_CHECKING:
@@ -143,8 +143,8 @@ def _build_single_config_model(
 
 def plugin_configuration_generator(
     plugin_manager: PluginManager | None = None,
-) -> dict[str, type[PluginPreferences]]:
-    """Build a plugin-preferences model class for each plugin with configurations."""
+) -> dict[str, type[PluginSettings]]:
+    """Build a plugin-settings model class for each plugin with configurations."""
     if plugin_manager is None:
         from npe2 import PluginManager
 
@@ -163,7 +163,7 @@ def plugin_configuration_generator(
         for plug in plugins
         if plug.contributions.configurations
     }
-    plugin_settings: dict[str, type[PluginPreferences]] = {}
+    plugin_settings: dict[str, type[PluginSettings]] = {}
     for plugin_name, configuration in configurations.items():
         fields: dict[str, Any] = {}
         for conf_name, conf in configuration.items():
@@ -174,7 +174,7 @@ def plugin_configuration_generator(
             )
         plugin_settings[plugin_name] = create_model(
             _model_name(plugin_name),
-            __base__=PluginPreferences,
+            __base__=PluginSettings,
             **fields,
         )
         # ``display_name`` is plugin metadata (not a settings field): it is set

--- a/src/napari/settings/_plugin_settings.py
+++ b/src/napari/settings/_plugin_settings.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path  # noqa: TC003
+
+from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
 from napari.settings._base import (
     EventedConfigFileSettings,
+    _NotSetType,
     _remove_empty_dicts,
 )
 
@@ -18,6 +22,7 @@ class PluginSettings(EventedConfigFileSettings):
         extra='ignore',
         populate_by_name=True,
     )
+    config_path: Path | _NotSetType | None = Field(None, exclude=True)
 
     def __str__(self) -> str:
         out = 'PluginSettings (defaults excluded)\n' + 34 * '-' + '\n'

--- a/src/napari/settings/_plugin_settings.py
+++ b/src/napari/settings/_plugin_settings.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path  # noqa: TC003
-
-from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
 from napari.settings._base import (
     EventedConfigFileSettings,
-    _NotSetType,
     _remove_empty_dicts,
 )
 
 
-class PluginPreferences(EventedConfigFileSettings):
+class PluginSettings(EventedConfigFileSettings):
     model_config = SettingsConfigDict(
         env_prefix='napari_',
         nested_model_default_partial_update=True,
@@ -22,7 +18,6 @@ class PluginPreferences(EventedConfigFileSettings):
         extra='ignore',
         populate_by_name=True,
     )
-    config_path: Path | _NotSetType | None = Field(None, exclude=True)
 
     def __str__(self) -> str:
         out = 'PluginSettings (defaults excluded)\n' + 34 * '-' + '\n'

--- a/src/napari/settings/_tests/test_plugin_settings_fixture.py
+++ b/src/napari/settings/_tests/test_plugin_settings_fixture.py
@@ -2,7 +2,7 @@
 
 The ``plugin_settings`` fixture (in ``napari.utils._testsupport``) makes
 ``napari.settings.get_plugin_settings`` hermetic per-test: it clears the
-``_PLUGIN_PREFERENCES`` cache, points the default ``path_dir`` at the test's
+``_PLUGIN_SETTINGS`` cache, points the default ``path_dir`` at the test's
 ``tmp_path``, and connects ``_clear_plugin_settings_cache`` to npe2's
 ``plugins_registered`` / ``enablement_changed`` signals so plugins registered
 mid-test are picked up.

--- a/src/napari/settings/_tests/test_settings.py
+++ b/src/napari/settings/_tests/test_settings.py
@@ -496,10 +496,10 @@ def test_settings_no_import_qt(tmp_path):
 @pytest.fixture
 def test_settings_2():
     """A fixture that mimics plugin_configuration_generator()."""
-    from napari.settings import PluginPreferences
+    from napari.settings import PluginSettings
     from napari.settings._base import SettingsConfigDict
 
-    class TestPluginSettings(PluginPreferences):
+    class TestPluginSettings(PluginSettings):
         model_config = SettingsConfigDict(env_prefix='testnapari_plugin_')
 
         display_name: str = 'demo'
@@ -594,8 +594,8 @@ def test_get_plugin_settings_default_path_dir_disabled(
     assert s['test-plugin'].config_path is None
 
 
-def test_plugin_preferences_str(tmp_path, monkeypatch, test_settings_2):
-    """``str(plugin_preferences)`` shows only non-default values."""
+def test_plugin_settings_str(tmp_path, monkeypatch, test_settings_2):
+    """``str(plugin_settings)`` shows only non-default values."""
     monkeypatch.setattr(
         settings,
         'plugin_configuration_generator',


### PR DESCRIPTION
# References and relevant issues

Follow-up to #9308

# Description

`PluginPreferences` stands out as oddly named compared to the rest of the `NapariSettings` / `get_settings` API.
In addition, we use `get_plugin_settings` et al for most plugin stuff. We only use the word prefences for the GUI side of things (whic is an interesting choice, but ok)
The main point of consideration here is that `PluginsSettings` is a pre-existing API that is used for the napari settings "Plugins" preferences page.

Adding this to the 0.9.0 to force API decision prior to release. I am ok if this is closed, but wanted to open for discussion.