### PR TITLE
Fix comprehensive test configuration for examples job

### DIFF
--- a/.github/workflows/test_comprehensive.yml
+++ b/.github/workflows/test_comprehensive.yml
@@ -96,7 +96,7 @@ jobs:
     uses: ./.github/workflows/reusable_run_tox_test.yml
     needs: build_wheel
     with:
-        toxenv: py312-linux-pyqt6-examples-cov
+        toxenv: py312-pyqt6-examples
         timeout: 60
         python_version: 3.12
         constraints_suffix: _examples


### PR DESCRIPTION
# References and relevant issues

It should be done in #9309


# Description

After simplification of the environment name, the `py312-linux-pyqt6-examples-cov` should be changed too. 

I changed to `py312-pyqt6-examples` to be identical with the pull request jobs. 