### PR TITLE
Add docstrings for relocated models on ViewerModel

### DIFF
--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -313,7 +313,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     def camera(self) -> Camera:
         """The camera model controlling the view of the scene.
 
-        Deprecated since 0.9.0; use ``viewer.scene.camera`` instead.
+        .. deprecated:: 0.9.0
+            camera property is deprecated use ``viewer.scene.camera`` instead.
         """
         return self.scene.camera
 
@@ -328,7 +329,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     def axes(self) -> SceneAxesOverlay:
         """The overlay controlling the display of the scene axes.
 
-        Deprecated since 0.9.0; use ``viewer.scene.overlays.axes`` instead.
+        .. deprecated:: 0.9.0
+            axes property is deprecated use ``viewer.scene.overlays.axes`` instead.
         """
         return self.scene.overlays.axes  # type: ignore[return-value]
 
@@ -343,7 +345,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     def floating_axes(self) -> CanvasAxesOverlay:
         """The overlay controlling the display of the canvas axes.
 
-        Deprecated since 0.9.0; use ``viewer.canvas.overlays.axes`` instead.
+        .. deprecated:: 0.9.0
+            floating_axes property is deprecated use ``viewer.canvas.overlays.axes`` instead.
         """
         return self.canvas.overlays.axes  # type: ignore[return-value]
 
@@ -358,7 +361,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     def scale_bar(self) -> ScaleBarOverlay:
         """The overlay controlling the display of the scale bar.
 
-        Deprecated since 0.9.0; use ``viewer.canvas.overlays.scale_bar`` instead.
+        .. deprecated:: 0.9.0
+            scale_bar property is deprecated use ``viewer.canvas.overlays.scale_bar`` instead.
         """
         return self.canvas.overlays.scale_bar  # type: ignore[return-value]
 
@@ -373,7 +377,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     def text_overlay(self) -> TextOverlay:
         """The overlay controlling the display of text on the canvas.
 
-        Deprecated since 0.9.0; use ``viewer.canvas.overlays.text`` instead.
+        .. deprecated:: 0.9.0
+            text_overlay property is deprecated use ``viewer.canvas.overlays.text`` instead.
         """
         return self.canvas.overlays.text  # type: ignore[return-value]
 
@@ -388,7 +393,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     def grid(self) -> GridCanvas:
         """The model controlling the display of the grid mode.
 
-        Deprecated since 0.9.0; use ``viewer.canvas.grid`` instead.
+        .. deprecated:: 0.9.0
+            grid property is deprecated use ``viewer.canvas.grid`` instead.
         """
         return self.canvas.grid
 

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -161,6 +161,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     ----------
     canvas : napari.components.canvas.Canvas
         The canvas model, controlling grid mode and canvas overlays.
+
+        .. versionadded:: 0.9.0
     cursor: napari.components.cursor.Cursor
         The cursor object containing the position and properties of the cursor.
     dims : napari.components.dims.Dimensions
@@ -173,6 +175,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         Indicating whether the mouse cursor is on the viewer canvas.
     scene : napari.components.scene.Scene
         The scene model, controlling the camera and scene overlays.
+
+        .. versionadded:: 0.9.0
     theme: str
         Name of the Napari theme of the viewer
     title: str

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -314,7 +314,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         """The camera model controlling the view of the scene.
 
         .. deprecated:: 0.9.0
-            camera property is deprecated use ``viewer.scene.camera`` instead.
+            The camera property is deprecated. Use `viewer.scene.camera` instead.
         """
         return self.scene.camera
 
@@ -330,7 +330,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         """The overlay controlling the display of the scene axes.
 
         .. deprecated:: 0.9.0
-            axes property is deprecated use ``viewer.scene.overlays.axes`` instead.
+            The axes property is deprecated. Use `viewer.scene.overlays.axes` instead.
         """
         return self.scene.overlays.axes  # type: ignore[return-value]
 
@@ -346,7 +346,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         """The overlay controlling the display of the canvas axes.
 
         .. deprecated:: 0.9.0
-            floating_axes property is deprecated use ``viewer.canvas.overlays.axes`` instead.
+            The floating_axes property is deprecated. Use `viewer.canvas.overlays.axes` instead.
         """
         return self.canvas.overlays.axes  # type: ignore[return-value]
 
@@ -362,7 +362,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         """The overlay controlling the display of the scale bar.
 
         .. deprecated:: 0.9.0
-            scale_bar property is deprecated use ``viewer.canvas.overlays.scale_bar`` instead.
+            The scale_bar property is deprecated. Use `viewer.canvas.overlays.scale_bar` instead.
         """
         return self.canvas.overlays.scale_bar  # type: ignore[return-value]
 
@@ -378,7 +378,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         """The overlay controlling the display of text on the canvas.
 
         .. deprecated:: 0.9.0
-            text_overlay property is deprecated use ``viewer.canvas.overlays.text`` instead.
+            The text_overlay property is deprecated. Use `viewer.canvas.overlays.text` instead.
         """
         return self.canvas.overlays.text  # type: ignore[return-value]
 
@@ -394,7 +394,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         """The model controlling the display of the grid mode.
 
         .. deprecated:: 0.9.0
-            grid property is deprecated use ``viewer.canvas.grid`` instead.
+            The grid property is deprecated. Use `viewer.canvas.grid` instead.
         """
         return self.canvas.grid
 

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -159,6 +159,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
 
     Attributes
     ----------
+    canvas : napari.components.canvas.Canvas
+        The canvas model, controlling grid mode and canvas overlays.
     cursor: napari.components.cursor.Cursor
         The cursor object containing the position and properties of the cursor.
     dims : napari.components.dims.Dimensions
@@ -169,6 +171,8 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         List of contained layers.
     mouse_over_canvas: bool
         Indicating whether the mouse cursor is on the viewer canvas.
+    scene : napari.components.scene.Scene
+        The scene model, controlling the camera and scene overlays.
     theme: str
         Name of the Napari theme of the viewer
     title: str
@@ -307,6 +311,10 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         stacklevel=2,
     )
     def camera(self) -> Camera:
+        """The camera model controlling the view of the scene.
+
+        Deprecated since 0.9.0; use ``viewer.scene.camera`` instead.
+        """
         return self.scene.camera
 
     @property
@@ -318,6 +326,10 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         stacklevel=2,
     )
     def axes(self) -> SceneAxesOverlay:
+        """The overlay controlling the display of the scene axes.
+
+        Deprecated since 0.9.0; use ``viewer.scene.overlays.axes`` instead.
+        """
         return self.scene.overlays.axes  # type: ignore[return-value]
 
     @property
@@ -329,6 +341,10 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         stacklevel=2,
     )
     def floating_axes(self) -> CanvasAxesOverlay:
+        """The overlay controlling the display of the canvas axes.
+
+        Deprecated since 0.9.0; use ``viewer.canvas.overlays.axes`` instead.
+        """
         return self.canvas.overlays.axes  # type: ignore[return-value]
 
     @property
@@ -340,6 +356,10 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         stacklevel=2,
     )
     def scale_bar(self) -> ScaleBarOverlay:
+        """The overlay controlling the display of the scale bar.
+
+        Deprecated since 0.9.0; use ``viewer.canvas.overlays.scale_bar`` instead.
+        """
         return self.canvas.overlays.scale_bar  # type: ignore[return-value]
 
     @property
@@ -351,6 +371,10 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         stacklevel=2,
     )
     def text_overlay(self) -> TextOverlay:
+        """The overlay controlling the display of text on the canvas.
+
+        Deprecated since 0.9.0; use ``viewer.canvas.overlays.text`` instead.
+        """
         return self.canvas.overlays.text  # type: ignore[return-value]
 
     @property
@@ -362,6 +386,10 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         stacklevel=2,
     )
     def grid(self) -> GridCanvas:
+        """The model controlling the display of the grid mode.
+
+        Deprecated since 0.9.0; use ``viewer.canvas.grid`` instead.
+        """
         return self.canvas.grid
 
     def _tooltip_visible_update(self, event):


### PR DESCRIPTION
# References and relevant issues

Follow-ups to #8633 and #9323

# Description

After rearranging models for `Canvas` and `Scene` changes, we didn't add docstrings.
I noticed today when investigating the API doc rendering and observed lack of autolinking.
In addition, there is a lack of hover support for all of these.
So, I added docstrings (Pydantic `Fields.description` doesn't work in pure Sphinx autodoc) so that things get cross linked well.
