### PR TITLE
Clean up status for grid/multiple selection

### DIFF
--- a/src/napari/_qt/_tests/test_threads.py
+++ b/src/napari/_qt/_tests/test_threads.py
@@ -36,7 +36,7 @@ def test_terminate_no_ref(monkeypatch):
 
 def test_waiting_on_no_request(monkeypatch, qtbot):
     def _check_status(value):
-        return value == ('Ready', '')
+        return value == (' » [empty]', '')
 
     model = ViewerModel()
     model.mouse_over_canvas = True

--- a/src/napari/components/_tests/test_viewer_model.py
+++ b/src/napari/components/_tests/test_viewer_model.py
@@ -1031,7 +1031,7 @@ def test_get_status_text():
     viewer.mouse_over_canvas = False
     assert viewer._calc_status_from_cursor() is None
     viewer.mouse_over_canvas = True
-    assert viewer._calc_status_from_cursor() == ('Ready', '')
+    assert viewer._calc_status_from_cursor() == (' » [empty]', '')
     viewer.cursor.position = (1, 2)
     viewer.add_labels(
         np.zeros((10, 10), dtype='uint8'), features={'a': [1, 2]}

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -904,7 +904,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
                 dims_displayed=list(self.dims.displayed),
                 world=True,
             )
-            if status['value'] != '':
+            if status['value'] == '':
                 # 'coordinates' is the one used by the status bar itself
                 status['coordinates'] = f'{status["coords"]}: [empty]'
             return status, tooltip_text

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -866,14 +866,20 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
                 dims_displayed=list(self.dims.displayed),
                 world=True,
             )
+            if not status['value']:
+                # 'coordinates' is the one used by the status bar itself
+                status['coordinates'] = f'{status["coords"]}: [empty]'
             return status, tooltip_text
 
         # Otherwise, return the layer status of multiple selected layers
-        # or gridded layers if no selection. If no selection and no grid, return nothing.
+        # or gridded layers if no selection. If no selection and no grid, all layers are used.
         if selection:
-            layers = list(selection)[::-1]
+            layers = [
+                layer for layer in self.layers[::-1] if layer in selection
+            ]
         elif self.canvas.grid.enabled:
             if self.cursor.viewbox is None:
+                # should never happen, but better safe than sorry
                 return None
             layers = [
                 self.layers[idx]
@@ -881,14 +887,14 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
                     self.canvas.grid.contents_at(
                         self.cursor.viewbox, self.layers
                     ),
-                    reverse=True,
+                    reverse=self.canvas.grid.stride > 0,
                 )
             ]
         else:
-            return None
+            layers = self.layers[::-1]
 
-        coord2val: dict[str, list[str]] = {}
-        coord_str = ''
+        statuses: list[str] = []
+        coords = ''
         for layer in layers:
             if not layer.visible or not layer._slicing_state._loaded:
                 continue
@@ -899,33 +905,16 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
                 dims_displayed=list(self.dims.displayed),
                 world=True,
             )
-            separator = '    '
-            emphasis = separator if layer is active else ''
-            coord_str = f'{status["coords"]} » '
-            if status['value'] != '':
-                if coord_str not in coord2val:
-                    coord2val[coord_str] = []
-                coord2val[coord_str].append(
-                    f'{layer.name}: {status["value"]}{emphasis}'
-                )
-        if coord2val:
-            if not self.canvas.grid.enabled:
-                # use a single coordinate system
-                values = list(itertools.chain(*coord2val.values()))
-                key = next(iter(coord2val))  # choose arbitrary coordinate
-                coord2val = {key: values}
-            status_strs = [
-                key + separator.join(values)
-                for key, values in coord2val.items()
-            ]
-            status_str = separator.join(status_strs)
-        elif coord_str and not self.canvas.grid.enabled:
-            status_str = coord_str + '[empty]'
-        elif self.canvas.grid.enabled:
-            status_str = '[empty]'
-        else:
-            status_str = 'Ready'
+            if not coords or not layer._use_integer_coords_in_status():
+                # we prioritize float coords if any layer wants them
+                coords = status['coords']
+            if status['value']:
+                statuses.append(f'{layer.name}: {status["value"]}')
 
+        separator = '    '
+        values = '[empty]' if not statuses else separator.join(statuses)
+
+        status_str = f'{coords} » {values}'
         return status_str, ''
 
     def update_status_from_cursor(self):

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -844,34 +844,22 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
     ) -> tuple[str | Dict, str] | None:
         if not self.mouse_over_canvas:
             return None
-        coord2val: dict[str, list[str]] = {}
-        coord_str = ''
-        status_str = ''
-        tooltip_text = ''
+
         selection = self.layers.selection
         active = selection.active
-        # TODO: this doesn't work well yet with grid mode (and is broken by wide borders too)
 
-        # Compute the tooltip first since it is always needed.
-        if (
-            self.tooltip.visible
-            and active is not None
-            and active._slicing_state._loaded
-        ):
-            tooltip_text = active._get_tooltip_text(
-                np.asarray(self.cursor.position),
-                view_direction=self.cursor._view_direction,
-                dims_displayed=list(self.dims.displayed),
-                world=True,
-            )
+        # If there is a single selected layer, calculate status using "the classic way".
+        if active is not None and active._slicing_state._loaded:
+            if self.tooltip.visible:
+                tooltip_text = active._get_tooltip_text(
+                    np.asarray(self.cursor.position),
+                    view_direction=self.cursor._view_direction,
+                    dims_displayed=list(self.dims.displayed),
+                    world=True,
+                )
+            else:
+                tooltip_text = ''
 
-        # If there is an active layer and a single selection, calculate status using "the classic way".
-        # Then return the status and the tooltip.
-        if (
-            active is not None
-            and active._slicing_state._loaded
-            and len(selection) < 2
-        ):
             status = active.get_status(
                 self.cursor.position,
                 view_direction=self.cursor._view_direction,
@@ -881,15 +869,30 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
             return status, tooltip_text
 
         # Otherwise, return the layer status of multiple selected layers
-        # or gridded layers as well as the tooltip.
-        for layer in self.layers[::-1]:
-            if (
-                not layer.visible
-                or layer.opacity == 0
-                or not layer._slicing_state._loaded
-                or (layer not in selection and not self.canvas.grid.enabled)
-            ):
+        # or gridded layers if no selection. If no selection and no grid, return nothing.
+        if selection:
+            layers = list(selection)[::-1]
+        elif self.canvas.grid.enabled:
+            if self.cursor.viewbox is None:
+                return None
+            layers = [
+                self.layers[idx]
+                for idx in sorted(
+                    self.canvas.grid.contents_at(
+                        self.cursor.viewbox, self.layers
+                    ),
+                    reverse=True,
+                )
+            ]
+        else:
+            return None
+
+        coord2val: dict[str, list[str]] = {}
+        coord_str = ''
+        for layer in layers:
+            if not layer.visible or not layer._slicing_state._loaded:
                 continue
+
             status = layer.get_status(
                 self.cursor.position,
                 view_direction=self.cursor._view_direction,
@@ -923,7 +926,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         else:
             status_str = 'Ready'
 
-        return status_str, tooltip_text
+        return status_str, ''
 
     def update_status_from_cursor(self):
         """Update the status and tooltip from the cursor position."""

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -904,7 +904,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
                 dims_displayed=list(self.dims.displayed),
                 world=True,
             )
-            if not status['value']:
+            if status['value'] != '':
                 # 'coordinates' is the one used by the status bar itself
                 status['coordinates'] = f'{status["coords"]}: [empty]'
             return status, tooltip_text

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -909,6 +909,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
                 status['coordinates'] = f'{status["coords"]}: [empty]'
             return status, tooltip_text
 
+        layers: Sequence[Layer]
         # Otherwise, return the layer status of multiple selected layers
         # or gridded layers if no selection. If no selection and no grid, all layers are used.
         if selection:


### PR DESCRIPTION
# References and relevant issues
- related to #9313

# Description
This old code from the status bar is currently kinda broken if multiple layers are selected, and if grid mode is enabled. This PR cleans up a bit (avoiding huge refactors for now), in order to have a more consistent experience.

To summarize, this PR will show status in this order of priority:
- for a single layer if only one is selected (no matter where the mouse is)
- for selected layers, in a more condensed manner (same as main, and no matter where the mouse is)
- for layers in the current viewbox if grid is enabled (as if those were selected)
- for all layers if none are selected and no grid (as if all were selected)

To test I suggest you open the `lily` sample on main vs here, and try out all combinations of:
- number of selected layers (0, 1, or multiple)
- grid disabled or enabled
- grid stride

Hopefully this feels better than main :P
