### PR TITLE
Delay deprecation of qt_viewer and private access to 0.10.0

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -879,7 +879,7 @@ class Window:
     def qt_viewer(self):
         warnings.warn(
             'Public access to Window.qt_viewer is deprecated and will be removed in\n'
-            'no earlier than v0.9.0. It is considered an "implementation detail" '
+            'no earlier than v0.10.0. It is considered an "implementation detail" '
             'of the napari\napplication, not part of the napari viewer model. If your use case\n'
             'requires access to qt_viewer, please open an issue to discuss.',
             category=FutureWarning,

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -57,7 +57,7 @@ class ScaleBarOverlay(CanvasOverlay):
     def unit(self) -> None:
         warnings.warn(
             'ScaleBar.unit is deprecated and now always returns None. '
-            'This attribute will be removed in 0.9.0.\n'
+            'This attribute will be removed in 0.10.0.\n'
             'Units are instead computed from the layers in the layerlist. '
             'Use `Layer.units` to set units for each layer.',
             category=FutureWarning,
@@ -69,7 +69,7 @@ class ScaleBarOverlay(CanvasOverlay):
     def unit(self, value: str | None) -> None:
         warnings.warn(
             'Setting unit on the ScaleBar model is deprecated and no longer has any effect. '
-            'This attribute will be removed in 0.9.0.\n'
+            'This attribute will be removed in 0.10.0.\n'
             'Units are instead computed from the layers in the layerlist. '
             'Use `Layer.units` to set units for each layer.',
             category=FutureWarning,

--- a/src/napari/utils/_proxies.py
+++ b/src/napari/utils/_proxies.py
@@ -57,7 +57,7 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
         warnings.warn(
             f"Private attribute access ('{typ}.{name}') in this context "
             '(e.g. inside a plugin widget or dock widget) is deprecated '
-            'and will be unavailable in version 0.9.0',
+            'and will be unavailable no earlier than 0.10.0',
             category=FutureWarning,
             stacklevel=3,
         )


### PR DESCRIPTION
# References and relevant issues


# Description

As we decided not to remove anything during summer, let's do our ritual bump on `qt_viewer` plus delay scale bar cleanup.  