### PR TITLE
New custom icon for the surface layer

### DIFF
--- a/src/napari/resources/icons/new_surface.svg
+++ b/src/napari/resources/icons/new_surface.svg
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
 <path
-	 d="M 46.7 55.7 L 46.7 85.3 L 21.1 70.5 Z
-M 43.4 50 L 17.8 64.8 L 17.8 35.2 Z
-M 46.7 44.3 L 21.1 29.5 L 46.7 14.7 Z
-M 53.3 44.3 L 53.3 14.7 L 78.9 29.5 Z
-M 56.6 50 L 82.2 35.2 L 82.2 64.8 Z
-M 53.3 55.7 L 78.9 70.5 L 53.3 85.3 Z"
-/>
+   d="M 40.1,55.7 36.562259,85.3 21.1,70.5 Z M 36.8,50 17.8,64.8 V 32.88595 Z m 3.3,-5.7 -19,-17.11405 41.633058,-10.392286 z m 6.6,0 L 69.333058,16.793664 78.9,38.535813 Z M 50,50 82.2,44.235813 V 64.8 Z m -3.3,5.7 32.2,14.8 -35.737741,14.8 z"
+   id="path1" />
 </svg>

--- a/src/napari/resources/icons/new_surface.svg
+++ b/src/napari/resources/icons/new_surface.svg
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 100 100" style="enable-background:new 0 0 100 100;" xml:space="preserve">
-<polygon points="67.3,73.6 50.6,64.7 33.7,73.4 37,54.8 23.5,41.5 42.3,38.8 50.8,21.9 59.1,38.9 77.8,41.7 64.2,54.9 "/>
+<path
+	 d="M 46.7 55.7 L 46.7 85.3 L 21.1 70.5 Z
+M 43.4 50 L 17.8 64.8 L 17.8 35.2 Z
+M 46.7 44.3 L 21.1 29.5 L 46.7 14.7 Z
+M 53.3 44.3 L 53.3 14.7 L 78.9 29.5 Z
+M 56.6 50 L 82.2 35.2 L 82.2 64.8 Z
+M 53.3 55.7 L 78.9 70.5 L 53.3 85.3 Z"
+/>
 </svg>


### PR DESCRIPTION
# References and relevant issues

Inspired by seeing the Star icon again while making: [#general > 0.9.0 (pre)release @ 💬](https://napari.zulipchat.com/#narrow/channel/212875-general/topic/0.2E9.2E0.20.28pre.29release/near/617759060)

# Description

The Star icon has been seen as folks (myself included) as either A) just a placeholder B) meaning to represent something "special" or C) just not really fitting this layer.

Here I propose using a series of triangles with the implication attempt to being a "mesh". The first commit is fully asymmetric (also making it easy to play with modifying the SVG yourself. But I've landed here (on the right) during lunch break:

<img width="1001" height="183" alt="image" src="https://github.com/user-attachments/assets/380b7380-f096-41dd-b37b-483d60eda7d0" />


