### PR TITLE
Fix background of contrast limit popup

### DIFF
--- a/src/napari/_qt/layer_controls/dynamic/_tests/test_general_widgets.py
+++ b/src/napari/_qt/layer_controls/dynamic/_tests/test_general_widgets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from qtpy.QtWidgets import QLabel
+from qtpy.QtWidgets import QLabel, QWidget
 
 from napari._qt.layer_controls.dynamic.widgets import (
     QtColormapControl,
@@ -130,12 +130,13 @@ class TestQtContrastLimitsControl:
                 np.array([0, 1, 2]),
             )
         )
-        control = QtContrastLimitsControl([surface])
-        qt_wrap.add_control(control)
+        widget = QWidget()
+        control = QtContrastLimitsControl([surface], parent=widget)
+        qt_wrap.add_widget(widget)
 
         control.show_clim_popup()
         control.clim_popup.hide()  # so it doesn't show when testing
-        qt_wrap._qtbot.add_widget(control.clim_popup)
+        qt_wrap.add_widget(control.clim_popup)
 
     def test_histogram_button(self, qt_wrap: QtWrap) -> None:
         image = Image(np.zeros((10, 10), dtype=np.uint8))

--- a/src/napari/_qt/layer_controls/dynamic/_tests/test_general_widgets.py
+++ b/src/napari/_qt/layer_controls/dynamic/_tests/test_general_widgets.py
@@ -135,6 +135,7 @@ class TestQtContrastLimitsControl:
 
         control.show_clim_popup()
         control.clim_popup.hide()  # so it doesn't show when testing
+        qt_wrap._qtbot.add_widget(control.clim_popup)
 
     def test_histogram_button(self, qt_wrap: QtWrap) -> None:
         image = Image(np.zeros((10, 10), dtype=np.uint8))

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
@@ -498,7 +498,7 @@ class QtContrastLimitsControl(QtWidgetControlsBase):
     def show_clim_popup(self):
         self.clim_popup = QContrastLimitsPopup(
             layers=self._layers,
-            parent=self.contrast_limits_slider.parent(),
+            parent=self.parent(),
         )
         self.clim_popup.move_to('top', min_length=650)
         self.clim_popup.show()

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
@@ -500,7 +500,8 @@ class QtContrastLimitsControl(QtWidgetControlsBase):
             layers=self._layers,
             parent=self.parent(),
         )
-        self.clim_popup.move_to('top', min_length=650)
+        if self.parent():
+            self.clim_popup.move_to('top', min_length=650)
         self.clim_popup.show()
 
     def _on_contrast_limits_change(self):


### PR DESCRIPTION
# References and relevant issues
- bug from #9318

# Description
The parent was set wrong, resulting in bad stylesheet (with multiple layers selected):

main:

<img width="1091" height="653" alt="image" src="https://github.com/user-attachments/assets/b6e50f3c-583e-47d4-aae8-f023a348c219" />


this pr:


<img width="1091" height="653" alt="image" src="https://github.com/user-attachments/assets/c95ca320-bf9f-4186-b396-cf594d268613" />
