### PR TITLE
Fix connection of callbacks of settings changes

### DIFF
--- a/src/napari/settings/__init__.py
+++ b/src/napari/settings/__init__.py
@@ -75,6 +75,8 @@ def get_settings(path=_NOT_SET) -> NapariSettings:
         if path is not _NOT_SET:
             path = Path(path).resolve() if path is not None else None
         _SETTINGS = NapariSettings(config_path=path)
+        _SETTINGS._connect_events()
+
     elif path is not _NOT_SET:
         _raise_path_set_twice()
 

--- a/src/napari/settings/_application.py
+++ b/src/napari/settings/_application.py
@@ -49,8 +49,8 @@ class DaskSettings(EventedModel):
 
 
 class ApplicationSettings(EventedModel):
-    def __init__(self, **kwargs: Any):
-        super().__init__(**kwargs)
+    def _connect_events(self):
+        """Connects the events for the application settings to their respective update functions."""
         # register callback to update brush size on mouse move modifiers
         self.events.brush_size_on_mouse_move_modifiers.connect(
             brush_size_on_mouse_move_modifiers_callback

--- a/src/napari/settings/_application.py
+++ b/src/napari/settings/_application.py
@@ -49,7 +49,7 @@ class DaskSettings(EventedModel):
 
 
 class ApplicationSettings(EventedModel):
-    def _connect_events(self):
+    def _connect_events(self) -> None:
         """Connects the events for the application settings to their respective update functions."""
         # register callback to update brush size on mouse move modifiers
         self.events.brush_size_on_mouse_move_modifiers.connect(

--- a/src/napari/settings/_experimental.py
+++ b/src/napari/settings/_experimental.py
@@ -27,7 +27,7 @@ class PaletteFuzzySearch(StrEnum):
 # this class inherits from EventedSettings instead of EventedModel because
 # it uses Field(validation_alias=...) for some of its attributes
 class ExperimentalSettings(EventedSettings):
-    def _connect_events(self):
+    def _connect_events(self) -> None:
         """Connects the events for the triangulation and colormap backends to their respective update functions."""
         self.events.triangulation_backend.connect(
             _update_triangulation_backend

--- a/src/napari/settings/_experimental.py
+++ b/src/napari/settings/_experimental.py
@@ -1,5 +1,4 @@
 from enum import StrEnum
-from typing import Any
 
 from pydantic import AliasChoices, Field
 
@@ -28,9 +27,8 @@ class PaletteFuzzySearch(StrEnum):
 # this class inherits from EventedSettings instead of EventedModel because
 # it uses Field(validation_alias=...) for some of its attributes
 class ExperimentalSettings(EventedSettings):
-    def __init__(self, **data: dict[str, Any]):
-        super().__init__(**data)
-
+    def _connect_events(self):
+        """Connects the events for the triangulation and colormap backends to their respective update functions."""
         self.events.triangulation_backend.connect(
             _update_triangulation_backend
         )

--- a/src/napari/settings/_napari_settings.py
+++ b/src/napari/settings/_napari_settings.py
@@ -83,6 +83,11 @@ class NapariSettings(EventedConfigFileSettings):
         populate_by_name=True,
     )
 
+    def _connect_events(self):
+        """Connects the events for the settings to their respective update functions."""
+        self.application._connect_events()
+        self.experimental._connect_events()
+
     def __init__(
         self, config_path: Path | _NotSetType | None = _NOT_SET, **values: Any
     ) -> None:

--- a/src/napari/settings/_napari_settings.py
+++ b/src/napari/settings/_napari_settings.py
@@ -83,7 +83,7 @@ class NapariSettings(EventedConfigFileSettings):
         populate_by_name=True,
     )
 
-    def _connect_events(self):
+    def _connect_events(self) -> None:
         """Connects the events for the settings to their respective update functions."""
         self.application._connect_events()
         self.experimental._connect_events()


### PR DESCRIPTION
# References and relevant issues

# Description

During debugging Bermuda, I found that the machinery to update the triangulation backend is not working, always setting the proper variable to the fastest available. 

I found that it was caused by Pydantic is creating next object during dump phase to find non default values. 

So I move the callback connection from the constructor to the method called from `get_settings`.

Our test doesn't catch this, as we disable dumping settings during the testing procedure. 