### PR TITLE
Add a Dims point_requested event reporting the requested point alongside the resulting one

### DIFF
--- a/src/napari/components/_tests/test_dims.py
+++ b/src/napari/components/_tests/test_dims.py
@@ -224,6 +224,18 @@ def test_point_requested_converts_step_assignment_to_world_coordinates():
     assert events[0].value == (6.0,)
 
 
+def test_non_sequence_point_assignment_requests_nothing():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    events = []
+    dims.events.point_requested.connect(events.append)
+
+    with pytest.raises(TypeError):
+        dims.point = 5
+
+    assert events == []
+    assert dims.point == (4, 2, 1)
+
+
 def test_range_normalization_does_not_request_a_point():
     dims = Dims(
         ndim=3,

--- a/src/napari/components/_tests/test_dims.py
+++ b/src/napari/components/_tests/test_dims.py
@@ -211,6 +211,19 @@ def test_point_transition_preserves_field_event_order():
     assert events == ['point_transition', 'current_step', 'point']
 
 
+def test_point_transition_converts_step_assignment_to_world_coordinates():
+    dims = Dims(ndim=1, range=((0, 10, 2),), point=(4,))
+    events = []
+    dims.events.point_transition.connect(events.append)
+
+    dims.current_step = (3,)
+
+    assert len(events) == 1
+    assert events[0].old_value == (4.0,)
+    assert events[0].requested_value == (6.0,)
+    assert events[0].value == (6.0,)
+
+
 def test_range_normalization_is_not_a_point_transition():
     dims = Dims(
         ndim=3,

--- a/src/napari/components/_tests/test_dims.py
+++ b/src/napari/components/_tests/test_dims.py
@@ -147,6 +147,85 @@ def test_point_variable_step_size():
         dims.set_current_step((0, 1), (0, 0, 0))
 
 
+@pytest.mark.parametrize(
+    ('change', 'requested', 'value'),
+    [
+        (lambda dims: dims.set_point(0, 5), (5.0, 2.0, 1.0), (5, 2, 1)),
+        (
+            lambda dims: setattr(dims, 'point', (99, 2, 1)),
+            (99.0, 2.0, 1.0),
+            (5, 2, 1),
+        ),
+        (lambda dims: dims.set_point(0, 4), (4.0, 2.0, 1.0), (4, 2, 1)),
+        (
+            lambda dims: setattr(dims, 'current_step', (3, 2, 1)),
+            (3.0, 2.0, 1.0),
+            (3, 2, 1),
+        ),
+        (
+            lambda dims: dims.update({'point': (3, 2, 1)}),
+            (3.0, 2.0, 1.0),
+            (3, 2, 1),
+        ),
+    ],
+    ids=(
+        'set-point',
+        'direct-point-clipped',
+        'set-point-noop',
+        'direct-step',
+        'model-update',
+    ),
+)
+def test_point_transition(change, requested, value):
+    dims = Dims(
+        ndim=3,
+        range=((0, 5, 1),) * 3,
+        point=(4, 2, 1),
+    )
+    events = []
+    dims.events.point_transition.connect(events.append)
+
+    change(dims)
+
+    assert len(events) == 1
+    assert events[0].old_value == (4.0, 2.0, 1.0)
+    assert events[0].requested_value == requested
+    assert events[0].value == value
+
+
+def test_point_transition_preserves_field_event_order():
+    dims = Dims(
+        ndim=3,
+        range=((0, 5, 1),) * 3,
+        point=(4, 2, 1),
+    )
+    events = []
+    dims.events.point_transition.connect(
+        lambda event: events.append(event.type)
+    )
+    dims.events.point.connect(lambda event: events.append(event.type))
+    dims.events.current_step.connect(lambda event: events.append(event.type))
+
+    dims.current_step = (3, 2, 1)
+
+    assert events == ['point_transition', 'current_step', 'point']
+
+
+def test_range_normalization_is_not_a_point_transition():
+    dims = Dims(
+        ndim=3,
+        range=((0, 5, 1),) * 3,
+        point=(4, 2, 1),
+    )
+    events = []
+    dims.events.point_transition.connect(events.append)
+
+    dims.range = ((0, 2, 1),) * 3
+
+    assert dims.point == (2, 2, 1)
+    assert events == []
+
+
 def test_range():
     """
     Tests range setting.

--- a/src/napari/components/_tests/test_dims.py
+++ b/src/napari/components/_tests/test_dims.py
@@ -176,14 +176,14 @@ def test_point_variable_step_size():
         'model-update',
     ),
 )
-def test_point_transition(change, requested, value):
+def test_point_requested(change, requested, value):
     dims = Dims(
         ndim=3,
         range=((0, 5, 1),) * 3,
         point=(4, 2, 1),
     )
     events = []
-    dims.events.point_transition.connect(events.append)
+    dims.events.point_requested.connect(events.append)
 
     change(dims)
 
@@ -193,14 +193,14 @@ def test_point_transition(change, requested, value):
     assert events[0].value == value
 
 
-def test_point_transition_preserves_field_event_order():
+def test_point_requested_preserves_field_event_order():
     dims = Dims(
         ndim=3,
         range=((0, 5, 1),) * 3,
         point=(4, 2, 1),
     )
     events = []
-    dims.events.point_transition.connect(
+    dims.events.point_requested.connect(
         lambda event: events.append(event.type)
     )
     dims.events.point.connect(lambda event: events.append(event.type))
@@ -208,13 +208,13 @@ def test_point_transition_preserves_field_event_order():
 
     dims.current_step = (3, 2, 1)
 
-    assert events == ['point_transition', 'current_step', 'point']
+    assert events == ['point_requested', 'current_step', 'point']
 
 
-def test_point_transition_converts_step_assignment_to_world_coordinates():
+def test_point_requested_converts_step_assignment_to_world_coordinates():
     dims = Dims(ndim=1, range=((0, 10, 2),), point=(4,))
     events = []
-    dims.events.point_transition.connect(events.append)
+    dims.events.point_requested.connect(events.append)
 
     dims.current_step = (3,)
 
@@ -224,14 +224,14 @@ def test_point_transition_converts_step_assignment_to_world_coordinates():
     assert events[0].value == (6.0,)
 
 
-def test_range_normalization_is_not_a_point_transition():
+def test_range_normalization_does_not_request_a_point():
     dims = Dims(
         ndim=3,
         range=((0, 5, 1),) * 3,
         point=(4, 2, 1),
     )
     events = []
-    dims.events.point_transition.connect(events.append)
+    dims.events.point_requested.connect(events.append)
 
     dims.range = ((0, 2, 1),) * 3
 

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -273,12 +273,7 @@ class Dims(EventedModel):
             self._point_transition_depth -= 1
 
         if name == 'current_step':
-            assignment_value = tuple(
-                rng.start + step * (rng.step or 1)
-                for step, rng in zip(
-                    assignment_value, self.range, strict=False
-                )
-            )
+            assignment_value = self._steps_to_point(assignment_value)
         requested_value = ensure_len(assignment_value, self.ndim, 0.0)
         self.events.point_transition(
             old_value=previous_value,
@@ -316,9 +311,13 @@ class Dims(EventedModel):
 
     @current_step.setter
     def current_step(self, value):
-        self.point = tuple(
-            rng.start + point * (rng.step or 1)
-            for point, rng in zip(value, self.range, strict=False)
+        self.point = self._steps_to_point(value)
+
+    def _steps_to_point(self, steps) -> tuple[float, ...]:
+        """Convert per-axis step indices to world coordinates."""
+        return tuple(
+            rng.start + step * (rng.step or 1)
+            for step, rng in zip(steps, self.range, strict=False)
         )
 
     @property

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -97,11 +97,11 @@ class Dims(EventedModel):
     Events
     ------
     point_transition : Event
-        Emitted after a ``point`` or ``current_step`` assignment is
-        validated, including unchanged assignments. Provides ``old_value``,
-        ``requested_value``, and ``value`` in world coordinates, before the
-        existing field-change events. Structural normalization caused by other
-        fields does not emit this event.
+        Emitted for every ``point`` or ``current_step`` assignment, including
+        ones that leave the point unchanged, and before the corresponding
+        field-change events. Carries ``old_value``, ``requested_value`` and
+        ``value`` as world-coordinate points. Point changes caused by a
+        ``range`` or ``ndim`` change do not emit it.
 
         .. versionadded:: 0.10.0
     """

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -247,19 +247,18 @@ class Dims(EventedModel):
         super().__init__(**kwargs)
         self.events.add(point_transition=Event)
 
-    @contextlib.contextmanager
-    def _setattr_context(self, name: str, value: Any):
-        if (
-            name not in {'point', 'current_step'}
-            or self._point_transition_depth
-            or self._validating
-            or not (
+    def _should_use_setattr_context(self, name: str) -> bool:
+        return (
+            name in {'point', 'current_step'}
+            and not self._point_transition_depth
+            and not self._validating
+            and bool(
                 self.events.point_transition.callbacks or self.events.callbacks
             )
-        ):
-            yield value
-            return
+        )
 
+    @contextlib.contextmanager
+    def _setattr_context(self, name: str, value: Any):
         try:
             assignment_value = tuple(value)
         except TypeError:

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from numbers import Integral
 from typing import (
     Any,
+    ClassVar,
     Literal,
     NamedTuple,
 )
@@ -11,7 +12,7 @@ import numpy as np
 import pint
 from pydantic import field_validator, model_validator
 
-from napari.utils.events import EventedModel
+from napari.utils.events import Event, EventedModel
 from napari.utils.misc import argsort, reorder_after_dim_reduction
 
 
@@ -92,7 +93,20 @@ class Dims(EventedModel):
         ``displayed`` dimensions.
     rollable :  tuple of bool
         Tuple of axis roll state. If True the axis is rollable.
+
+    Events
+    ------
+    point_transition : Event
+        Emitted after a ``point`` or ``current_step`` assignment is
+        validated, including unchanged assignments. Provides ``old_value``,
+        ``requested_value``, and ``value`` in world coordinates, before the
+        existing field-change events. Structural normalization caused by other
+        fields does not emit this event.
+
+        .. versionadded:: 0.10.0
     """
+
+    _use_setattr_context: ClassVar[bool] = True
 
     # fields
     ndim: int = 2
@@ -112,6 +126,7 @@ class Dims(EventedModel):
 
     # private vars
     _play_ready: bool = True  # False if currently awaiting a draw event
+    _point_transition_depth: int = 0
     _scroll_progress: int = 0
     _validating: bool = False
 
@@ -227,6 +242,50 @@ class Dims(EventedModel):
             self.last_used = not_displayed[0]
 
         return self
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.events.add(point_transition=Event)
+
+    @contextlib.contextmanager
+    def _setattr_context(self, name: str, value: Any):
+        if (
+            name not in {'point', 'current_step'}
+            or self._point_transition_depth
+            or self._validating
+            or not (
+                self.events.point_transition.callbacks or self.events.callbacks
+            )
+        ):
+            yield value
+            return
+
+        try:
+            assignment_value = tuple(value)
+        except TypeError:
+            yield value
+            return
+
+        previous_value = self.point
+        self._point_transition_depth += 1
+        try:
+            yield assignment_value
+        finally:
+            self._point_transition_depth -= 1
+
+        if name == 'current_step':
+            assignment_value = tuple(
+                rng.start + step * (rng.step or 1)
+                for step, rng in zip(
+                    assignment_value, self.range, strict=False
+                )
+            )
+        requested_value = ensure_len(assignment_value, self.ndim, 0.0)
+        self.events.point_transition(
+            old_value=previous_value,
+            requested_value=tuple(float(x) for x in requested_value),
+            value=self.point,
+        )
 
     @staticmethod
     def _nsteps_from_range(dims_range) -> tuple[float, ...]:

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -96,7 +96,7 @@ class Dims(EventedModel):
 
     Events
     ------
-    point_transition : Event
+    point_requested : Event
         Emitted for every ``point`` or ``current_step`` assignment, including
         ones that leave the point unchanged, and before the corresponding
         field-change events. Carries ``old_value``, ``requested_value`` and
@@ -126,7 +126,7 @@ class Dims(EventedModel):
 
     # private vars
     _play_ready: bool = True  # False if currently awaiting a draw event
-    _point_transition_depth: int = 0
+    _point_request_depth: int = 0
     _scroll_progress: int = 0
     _validating: bool = False
 
@@ -245,15 +245,15 @@ class Dims(EventedModel):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.events.add(point_transition=Event)
+        self.events.add(point_requested=Event)
 
     def _should_use_setattr_context(self, name: str) -> bool:
         return (
             name in {'point', 'current_step'}
-            and not self._point_transition_depth
+            and not self._point_request_depth
             and not self._validating
             and bool(
-                self.events.point_transition.callbacks or self.events.callbacks
+                self.events.point_requested.callbacks or self.events.callbacks
             )
         )
 
@@ -266,16 +266,16 @@ class Dims(EventedModel):
             return
 
         previous_value = self.point
-        self._point_transition_depth += 1
+        self._point_request_depth += 1
         try:
             yield assignment_value
         finally:
-            self._point_transition_depth -= 1
+            self._point_request_depth -= 1
 
         if name == 'current_step':
             assignment_value = self._steps_to_point(assignment_value)
         requested_value = ensure_len(assignment_value, self.ndim, 0.0)
-        self.events.point_transition(
+        self.events.point_requested(
             old_value=previous_value,
             requested_value=tuple(float(x) for x in requested_value),
             value=self.point,

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -259,12 +259,7 @@ class Dims(EventedModel):
 
     @contextlib.contextmanager
     def _setattr_context(self, name: str, value: Any):
-        try:
-            assignment_value = tuple(value)
-        except TypeError:
-            yield value
-            return
-
+        assignment_value = tuple(value)
         previous_value = self.point
         self._point_request_depth += 1
         try:

--- a/src/napari/utils/events/_tests/test_evented_model.py
+++ b/src/napari/utils/events/_tests/test_evented_model.py
@@ -809,3 +809,19 @@ def test_events_called():
     s.a = 2
 
     e_m.assert_called_once()
+
+
+def test_setattr_context_defaults_are_transparent():
+    class Model(EventedModel):
+        _use_setattr_context: ClassVar[bool] = True
+        a: int = 0
+
+    m = Model()
+    mock = Mock()
+    m.events.a.connect(mock)
+
+    m.a = 1
+
+    assert m.a == 1
+    mock.assert_called_once()
+    assert mock.call_args[0][0].value == 1

--- a/src/napari/utils/events/evented_model.py
+++ b/src/napari/utils/events/evented_model.py
@@ -259,7 +259,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             # `_config_path` before calling the superclass constructor
             super().__setattr__(name, value)
             return
-        if self._use_setattr_context:
+        if self._use_setattr_context and self._should_use_setattr_context(
+            name
+        ):
             with (
                 ComparisonDelayer(self),
                 self._setattr_context(name, value) as value,
@@ -276,6 +278,9 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     def _setattr_context(self, name: str, value: Any):
         """Allow subclasses to wrap assignment without replacing event handling."""
         yield value
+
+    def _should_use_setattr_context(self, name: str) -> bool:
+        return True
 
     def _check_if_values_changed_and_emit_if_needed(self):
         """

--- a/src/napari/utils/events/evented_model.py
+++ b/src/napari/utils/events/evented_model.py
@@ -187,6 +187,8 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
     _changes_queue: dict[str, Any] = PrivateAttr(default_factory=dict)
     _primary_changes: dict[str, None] = PrivateAttr(default_factory=dict)
     _delay_check_semaphore: int = PrivateAttr(0)
+    # Avoid context manager overhead for models that do not override the hook.
+    _use_setattr_context: ClassVar[bool] = False
     __slots__: ClassVar[set[str]] = {'__weakref__'}  # type: ignore
 
     # pydantic BaseModel configuration.  see:
@@ -257,10 +259,23 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
             # `_config_path` before calling the superclass constructor
             super().__setattr__(name, value)
             return
+        if self._use_setattr_context:
+            with (
+                ComparisonDelayer(self),
+                self._setattr_context(name, value) as value,
+            ):
+                self._primary_changes[name] = None
+                self._setattr_impl(name, value)
+            return
         with ComparisonDelayer(self):
             # NOTE: this is a dict and not just a set, because we need ORDERED!
             self._primary_changes[name] = None
             self._setattr_impl(name, value)
+
+    @contextmanager
+    def _setattr_context(self, name: str, value: Any):
+        """Allow subclasses to wrap assignment without replacing event handling."""
+        yield value
 
     def _check_if_values_changed_and_emit_if_needed(self):
         """


### PR DESCRIPTION
# References and relevant issues

Related: #9278 (the intended first consumer)
Related: #9207

# Description

`Dims.point` and `Dims.current_step` are evented fields, so a listener only ever learns where the point ended up, never what was asked for:

```python
dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
dims.events.point.connect(print)

dims.set_point(0, 99)   # out of range, clipped: point event carries (5.0, 2.0, 1.0)
dims.set_point(0, 5)    # in range, satisfied:   point event carries (5.0, 2.0, 1.0)
dims.set_point(0, 5)    # already there:         no event at all
```

A shape being drawn (#9207) or a pinned axis (#9278) needs to know about an attempt to leave the slice, including attempts that move nothing.

This adds a `point_requested` event on `Dims`, emitted once per point request with three world-coordinate tuples: `old_value`, `requested_value`, and `value`. It covers `set_point`, `set_current_step`, direct assignment to `point` or `current_step`, and `update()`, and fires before the existing `point` and `current_step` events, whose payload and order are unchanged.

The event allows the UI paths that funnel into `set_current_step` (slider, wheel, slice editor, playback) to be observed from one place. Existing setter signatures and their behavior are unchanged.

The EventedModel change is a no-op hook - the wrapper is skipped unless a subclass opts in with `_use_setattr_context`, so no other model changes behavior or pays for it.
