### PR TITLE
[bug fix] Keep playback in sync when dimension ranges change

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -361,6 +361,17 @@ def test_last_used_style_property_set_at_creation(qtbot):
     ] == [False, True, False, False]
 
 
+def test_frame_request_that_moves_nothing_keeps_playback_armed(qtbot):
+    dims = Dims(ndim=3, range=((0, 10, 1),) * 3)
+    view = QtDims(dims)
+    qtbot.addWidget(view)
+
+    dims._play_ready = True
+    view._set_frame(0, dims.current_step[0])
+
+    assert dims._play_ready
+
+
 @pytest.mark.skipif(
     os.environ.get('CI') and platform == 'win32',
     reason='not working in windows VM',

--- a/src/napari/_qt/widgets/_tests/test_qt_play.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_play.py
@@ -152,6 +152,71 @@ def test_play_raises_value_errors(qtbot, ref_view):
         view.dims.play(0, 20, loop_mode=5)
 
 
+def test_playback_survives_axis_shrinking(ref_view, qtbot):
+    view = ref_view()
+    layer = view.viewer.layers[0]
+    layer.data = np.zeros((500, 10, 10, 15))
+    view.viewer.dims.set_current_step(0, 480)
+    # Offscreen canvases never paint, so supply the draw that re-arms playback.
+    view.viewer.dims.events.current_step.connect(view.canvas.enable_dims_play)
+
+    with qtbot.waitSignal(view.dims._animation_thread.started):
+        view.dims.play(0, 20)
+
+    thread = view.dims._animation_thread
+    thread.current = 480
+    # advance() holds this block around its emit, and delivery to the main
+    # thread is queued, so the clamp Dims applies can land while it is held.
+    with view.viewer.dims.events.current_step.blocker(thread._on_axis_changed):
+        layer.data = np.zeros((3, 10, 10, 15))
+
+    assert view.dims.is_playing
+    step = view.viewer.dims.current_step[0]
+    qtbot.wait_until(lambda: view.viewer.dims.current_step[0] != step)
+    assert view.viewer.dims.current_step[0] < 3
+
+
+def test_playback_survives_axis_growing(ref_view, qtbot):
+    view = ref_view()
+    layer = view.viewer.layers[0]
+    layer.data = np.zeros((3, 10, 10, 15))
+    view.viewer.dims.events.current_step.connect(view.canvas.enable_dims_play)
+
+    with qtbot.waitSignal(view.dims._animation_thread.started):
+        view.dims.play(0, 20)
+
+    layer.data = np.zeros((6, 10, 10, 15))
+
+    assert view.dims.is_playing
+    qtbot.wait_until(lambda: view.viewer.dims.current_step[0] >= 3)
+
+
+def test_playback_stops_when_axis_loses_its_slider(ref_view, qtbot):
+    view = ref_view()
+    layer = view.viewer.layers[0]
+    layer.data = np.zeros((10, 10, 10, 15))
+
+    with qtbot.waitSignal(view.dims._animation_thread.started):
+        view.dims.play(0, 20)
+
+    layer.data = np.zeros((1, 10, 10, 15))
+
+    assert not view.dims.is_playing
+
+
+def test_playback_stops_when_frame_range_becomes_invalid(ref_view, qtbot):
+    view = ref_view()
+    layer = view.viewer.layers[0]
+    layer.data = np.zeros((10, 10, 10, 15))
+
+    with qtbot.waitSignal(view.dims._animation_thread.started):
+        view.dims.play(0, 20, frame_range=(2, 6))
+
+    layer.data = np.zeros((3, 10, 10, 15))
+
+    assert not view.dims.is_playing
+
+
 def test_playing_hidden_slider_does_nothing(ref_view):
     """Make sure playing a dimension without a slider does nothing"""
 

--- a/src/napari/_qt/widgets/qt_dims.py
+++ b/src/napari/_qt/widgets/qt_dims.py
@@ -93,6 +93,16 @@ class QtDims(QWidget):
         for widget in self.slider_widgets:
             widget._update_range()
 
+        if self._animation_thread.isRunning():
+            axis = self._animation_thread.axis
+            if (
+                axis is None
+                or axis >= len(self._displayed_sliders)
+                or not self._displayed_sliders[axis]
+                or not self._animation_thread.refresh_dims_range()
+            ):
+                self.stop()
+
         nsliders = np.sum(self._displayed_sliders)
         self.setMinimumHeight(nsliders * self.SLIDERHEIGHT)
         self._resize_slice_labels()
@@ -355,7 +365,11 @@ class QtDims(QWidget):
         if self.dims._play_ready:
             # disable additional point advance requests until this one draws
             self.dims._play_ready = False
+            before = self.dims.point
             self.dims.set_current_step(axis, frame)
+            if self.dims.point == before:
+                # nothing moved, so no draw is coming to re-enable playback
+                self.dims._play_ready = True
 
     def closeEvent(self, event):
         [w.deleteLater() for w in self.slider_widgets]

--- a/src/napari/_qt/widgets/qt_dims.py
+++ b/src/napari/_qt/widgets/qt_dims.py
@@ -93,15 +93,28 @@ class QtDims(QWidget):
         for widget in self.slider_widgets:
             widget._update_range()
 
-        if self._animation_thread.isRunning():
-            axis = self._animation_thread.axis
+        animation_thread = self._animation_thread
+        if animation_thread.isRunning():
+            axis = animation_thread.axis
+            frame_range = animation_thread.frame_range
             if (
                 axis is None
                 or axis >= len(self._displayed_sliders)
                 or not self._displayed_sliders[axis]
-                or not self._animation_thread.refresh_dims_range()
+            ) or (
+                frame_range != (0, 0)
+                and frame_range[1] >= self.dims.nsteps[axis]
             ):
                 self.stop()
+            else:
+                animation_thread.set_frame_range(frame_range)
+                animation_thread.current = min(
+                    max(
+                        animation_thread.current,
+                        animation_thread.min_point,
+                    ),
+                    animation_thread.max_point - 1,
+                )
 
         nsliders = np.sum(self._displayed_sliders)
         self.setMinimumHeight(nsliders * self.SLIDERHEIGHT)

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -699,6 +699,20 @@ class AnimationThread(QThread):
             )
         self.max_point += 1  # range is inclusive
 
+    def refresh_dims_range(self) -> bool:
+        """Re-read the axis extent, then resync the bounds and position.
+
+        Returns False when an explicit frame range no longer fits the axis.
+        """
+        try:
+            self.set_frame_range(self.frame_range)
+        except IndexError:
+            return False
+        self.current = min(
+            max(self.current, self.min_point), self.max_point - 1
+        )
+        return True
+
     @Slot()
     def advance(self):
         """Advance the current frame in the animation.

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -699,20 +699,6 @@ class AnimationThread(QThread):
             )
         self.max_point += 1  # range is inclusive
 
-    def refresh_dims_range(self) -> bool:
-        """Re-read the axis extent, then resync the bounds and position.
-
-        Returns False when an explicit frame range no longer fits the axis.
-        """
-        try:
-            self.set_frame_range(self.frame_range)
-        except IndexError:
-            return False
-        self.current = min(
-            max(self.current, self.min_point), self.max_point - 1
-        )
-        return True
-
     @Slot()
     def advance(self):
         """Advance the current frame in the animation.


### PR DESCRIPTION
# References and relevant issues

Related: #9278
Related: #9459

# Description

Playback caches its frame bounds when it starts, so resizing data or removing a longer layer can leave it requesting frames outside the new range. This refreshes the active bounds when `Dims.range` changes and stops playback when the axis or an explicit subrange is no longer playable. The no-op guard remains for frame requests already queued when the range changes.

The thread's position is resynced too, not just the bounds. `advance` blocks `_on_axis_changed` around its emit and delivery to the main thread is queued, so the clamp `Dims` applies to `current_step` can land while that block is still held, leaving the thread's position past the new end.
