### PR TITLE
Cancel draw cleanly when remove_selected runs mid-construction

### DIFF
--- a/src/napari/layers/shapes/_tests/test_shapes.py
+++ b/src/napari/layers/shapes/_tests/test_shapes.py
@@ -1508,6 +1508,21 @@ def test_removing_shapes():
     layer.remove([])
 
 
+def test_removing_selected_shapes_mid_draw_cancels_the_draw():
+    from napari.layers.shapes._shapes_mouse_bindings import (
+        initiate_polygon_draw,
+    )
+
+    layer = Shapes()
+    layer.mode = 'add_polygon'
+    initiate_polygon_draw(layer, np.array([1.0, 1.0]))
+
+    layer.remove_selected()
+
+    assert layer._is_creating is False
+    assert layer.nshapes == 0
+
+
 def test_removing_selected_shapes():
     """Test removing selected shapes."""
     np.random.seed(0)

--- a/src/napari/layers/shapes/shapes.py
+++ b/src/napari/layers/shapes/shapes.py
@@ -2731,7 +2731,11 @@ class Shapes(Layer):
         self._value = (None, None)
         self._moving_value = (None, None)
         self._last_cursor_position = None
-        if self._is_creating is True:
+        # remove() deletes the shape under construction before calling here, so
+        # the index taken from _moving_value can no longer resolve.
+        if index is not None and index >= len(self._data_view.shapes):
+            index = None
+        if self._is_creating is True and index is not None:
             if self._mode in {Mode.ADD_PATH, Mode.ADD_POLYLINE}:
                 vertices = self._data_view.shapes[index].data
                 if len(vertices) <= 2:


### PR DESCRIPTION
# References and relevant issues

Closes #9277
Improves #9275 

# Description

`remove()` deletes the selected shapes and then calls `_finish_drawing()`, which still holds the index of the shape under construction in `_moving_value`. When that shape is one of the deleted ones, the multi-vertex cleanup leaves the layer stranded mid-draw. `_finish_drawing` already treats a null index as nothing to finish. This PR treats a dangling one the same way, so the fix reuses the existing path rather than adding a second one.

This also fixes a case where #9275's new `drawing_finished` event is silently wrong.



