### PR TITLE
Allow individual dimension axes to be locked against navigation, with a padlock in the slider row

### DIFF
--- a/src/napari/_qt/qt_resources/styles/02_custom.qss
+++ b/src/napari/_qt/qt_resources/styles/02_custom.qss
@@ -219,6 +219,21 @@ QtDimSliderWidget > QScrollBar::handle[last_used=true]:horizontal {
     background: {{ current }};
 }
 
+QtDimSliderWidget > QScrollBar::handle:disabled {
+    background: {{ primary }};
+}
+
+/* A locked active axis is still the one the arrow keys will drive once it is
+   released, so it greys out like every other locked handle but keeps a
+   `current` rim. A rim rather than a muted `current` fill: the fill has to stay
+   clear of the enabled `current`, and `darken()` shifts a colour towards the
+   theme background, so in the light theme `darken(current, 25)` lands a few
+   units from the enabled colour and a locked handle reads as live. */
+QtDimSliderWidget > QScrollBar::handle[last_used=true]:disabled {
+    background: {{ primary }};
+    border: 1px solid {{ current }};
+}
+
 QtDimSliderWidget > QScrollBar:left-arrow:horizontal {
     image: url("theme_{{ id }}:/step_left.svg");
 }
@@ -229,6 +244,24 @@ QtDimSliderWidget > QScrollBar::right-arrow:horizontal {
 
 QtDimSliderWidget > QLineEdit {
   background-color: {{ background }};
+}
+
+#axis_lock_button {
+  border-radius: 2px;
+  height: 13px;
+  width: 13px;
+  margin: 0px 2px;
+  padding: 1px;
+  border: 0px;
+  image: url("theme_{{ id }}:/lock_open.svg");
+}
+
+#axis_lock_button:checked {
+  image: url("theme_{{ id }}:/lock.svg");
+}
+
+#axis_lock_button[flash=true] {
+  background: {{ warning }};
 }
 
 /* ------------- QtModal (Grid, Play, nDisplay, Roll) --------- */

--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -445,16 +445,6 @@ def test_pressing_a_frozen_slider_claims_the_axis(qt_dims):
     assert qt_dims.dims.last_used == 0
 
 
-def test_pressing_the_padlock_never_flashes_it(qt_dims):
-    qt_dims.dims.ndim = 3
-    slider_widget = qt_dims.slider_widgets[0]
-    qt_dims.dims.lock_axis(0)
-
-    _press(slider_widget.lock_button)
-
-    assert not slider_widget.lock_button.property('flash')
-
-
 def test_locking_a_playing_axis_stops_it(qt_dims, qtbot):
     """A blocked write emits nothing, so the frame pump would wait forever."""
     qt_dims.dims.ndim = 3

--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-from qtpy.QtCore import Qt
+from qtpy.QtCore import QEvent, Qt
+from qtpy.QtGui import QMouseEvent
+from qtpy.QtWidgets import QApplication
 
 from napari._qt.widgets.qt_dims import QtDims
 from napari.components import Dims
@@ -359,6 +361,108 @@ def test_last_used_style_property_set_at_creation(qtbot):
     assert [
         widg.slider.property('last_used') for widg in view.slider_widgets
     ] == [False, True, False, False]
+
+
+def test_lock_button_toggles_the_axis_lock(qt_dims, qtbot):
+    qt_dims.dims.ndim = 3
+    slider = qt_dims.slider_widgets[0]
+
+    qtbot.mouseClick(slider.lock_button, Qt.MouseButton.LeftButton)
+    assert qt_dims.dims.is_axis_locked(0)
+
+    qtbot.mouseClick(slider.lock_button, Qt.MouseButton.LeftButton)
+    assert not qt_dims.dims.is_axis_locked(0)
+
+
+def test_locked_axis_disables_its_navigation_controls(qt_dims):
+    qt_dims.dims.ndim = 3
+    slider = qt_dims.slider_widgets[0]
+
+    qt_dims.dims.lock_axis(0)
+
+    assert not slider.slider.isEnabled()
+    assert not slider.play_button.isEnabled()
+    assert not slider.curslice_label.isEnabled()
+    # the padlock has to stay clickable or the lock cannot be released
+    assert slider.lock_button.isEnabled()
+
+    qt_dims.dims.unlock_axis(0)
+    assert slider.slider.isEnabled()
+
+
+def test_refused_navigation_flashes_the_padlock(qt_dims):
+    qt_dims.dims.ndim = 3
+    qt_dims.dims.set_range(0, (0, 5, 1))
+    slider = qt_dims.slider_widgets[0]
+    qt_dims.dims.lock_axis(0)
+    assert not slider.lock_button.property('flash')
+
+    qt_dims.dims.set_point(0, 3)
+
+    assert slider.lock_button.property('flash')
+
+
+def _press(widget):
+    """Send a press straight to ``widget``, as a real click on it would."""
+    centre = widget.rect().center()
+    position = centre.toPointF() if hasattr(centre, 'toPointF') else centre
+    QApplication.sendEvent(
+        widget,
+        QMouseEvent(
+            QEvent.Type.MouseButtonPress,
+            position,
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    'control', ['slider', 'play_button', 'curslice_label']
+)
+def test_pressing_a_frozen_control_flashes_the_padlock(qt_dims, control):
+    qt_dims.dims.ndim = 3
+    qt_dims.dims.set_range(0, (0, 5, 1))
+    slider_widget = qt_dims.slider_widgets[0]
+    qt_dims.dims.lock_axis(0)
+    assert not slider_widget.lock_button.property('flash')
+
+    _press(getattr(slider_widget, control))
+
+    assert slider_widget.lock_button.property('flash')
+
+
+def test_pressing_a_frozen_slider_claims_the_axis(qt_dims):
+    qt_dims.dims.ndim = 3
+    qt_dims.dims.set_range(0, (0, 5, 1))
+    qt_dims.dims.last_used = 1
+    slider_widget = qt_dims.slider_widgets[0]
+    qt_dims.dims.lock_axis(0)
+
+    _press(slider_widget.slider)
+
+    assert qt_dims.dims.last_used == 0
+
+
+def test_pressing_the_padlock_never_flashes_it(qt_dims):
+    qt_dims.dims.ndim = 3
+    slider_widget = qt_dims.slider_widgets[0]
+    qt_dims.dims.lock_axis(0)
+
+    _press(slider_widget.lock_button)
+
+    assert not slider_widget.lock_button.property('flash')
+
+
+def test_locked_axis_does_not_start_playing(qt_dims):
+    qt_dims.dims.ndim = 3
+    qt_dims.dims.set_range(0, (0, 5, 1))
+    qt_dims.dims.lock_axis(0)
+
+    qt_dims.play(0)
+
+    assert not qt_dims.is_playing
 
 
 @pytest.mark.skipif(

--- a/src/napari/_qt/widgets/_tests/test_qt_dims.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dims.py
@@ -455,6 +455,21 @@ def test_pressing_the_padlock_never_flashes_it(qt_dims):
     assert not slider_widget.lock_button.property('flash')
 
 
+def test_locking_a_playing_axis_stops_it(qt_dims, qtbot):
+    """A blocked write emits nothing, so the frame pump would wait forever."""
+    qt_dims.dims.ndim = 3
+    qt_dims.dims.set_range(0, (0, 5, 1))
+
+    with qtbot.waitSignal(qt_dims._animation_thread.started):
+        qt_dims.play(0, fps=20)
+    qtbot.waitUntil(lambda: qt_dims.is_playing)
+
+    with qtbot.waitSignal(qt_dims._animation_thread.finished):
+        qt_dims.dims.lock_axis(0)
+
+    assert not qt_dims.is_playing
+
+
 def test_locked_axis_does_not_start_playing(qt_dims):
     qt_dims.dims.ndim = 3
     qt_dims.dims.set_range(0, (0, 5, 1))

--- a/src/napari/_qt/widgets/qt_dims.py
+++ b/src/napari/_qt/widgets/qt_dims.py
@@ -63,6 +63,26 @@ class QtDims(QWidget):
         self.dims.events.ndisplay.connect(self._update_display)
         self.dims.events.order.connect(self._update_display)
         self.dims.events.last_used.connect(self._on_last_used_changed)
+        self.dims.events.axis_locked.connect(self._on_axis_lock_changed)
+        self.dims.events.navigation_refused.connect(
+            self._on_navigation_refused
+        )
+
+    def _on_axis_lock_changed(self, event=None) -> None:
+        for widget in self.slider_widgets:
+            widget._update_lock_state()
+        if self.is_playing:
+            axis = self._animation_thread.axis
+            if (
+                axis is None
+                or axis >= self.dims.ndim
+                or self.dims.axis_locked[axis]
+            ):
+                self.stop()
+
+    def _on_navigation_refused(self, event) -> None:
+        for axis in event.axes:
+            self.slider_widgets[axis]._flash_lock()
 
     @property
     def nsliders(self):
@@ -297,6 +317,8 @@ class QtDims(QWidget):
 
         if axis >= self.dims.ndim:
             raise IndexError('axis argument out of range')
+        if self.dims.axis_locked[axis]:
+            return
 
         if self.is_playing and self._animation_thread.axis == axis:
             self.slider_widgets[axis]._update_play_settings(
@@ -352,6 +374,9 @@ class QtDims(QWidget):
         the canvas can draw, this will drop the intermediate frames, keeping
         the effective frame rate constant even if the canvas cannot keep up.
         """
+        if axis >= self.dims.ndim or self.dims.axis_locked[axis]:
+            self.stop()
+            return
         if self.dims._play_ready:
             # disable additional point advance requests until this one draws
             self.dims._play_ready = False

--- a/src/napari/_qt/widgets/qt_dims.py
+++ b/src/napari/_qt/widgets/qt_dims.py
@@ -64,9 +64,7 @@ class QtDims(QWidget):
         self.dims.events.order.connect(self._update_display)
         self.dims.events.last_used.connect(self._on_last_used_changed)
         self.dims.events.axis_locked.connect(self._on_axis_lock_changed)
-        self.dims.events.navigation_refused.connect(
-            self._on_navigation_refused
-        )
+        self.dims.events._point_refused.connect(self._on_point_refused)
 
     def _on_axis_lock_changed(self, event=None) -> None:
         for widget in self.slider_widgets:
@@ -80,7 +78,7 @@ class QtDims(QWidget):
             ):
                 self.stop()
 
-    def _on_navigation_refused(self, event) -> None:
+    def _on_point_refused(self, event) -> None:
         for axis in event.axes:
             self.slider_widgets[axis]._flash_lock()
 

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -139,6 +139,9 @@ class QtDimSliderWidget(QWidget):
         self.setLayout(layout)
         self.dims.events.axis_labels.connect(self._pull_label)
 
+        # Unparented, and stopped on destruction: a timer parented to the row
+        # is deleted with it while still running, and firing into the deleted
+        # C++ object raises at teardown.
         self._lock_flash_timer = QTimer()
         self._lock_flash_timer.setSingleShot(True)
         self._lock_flash_timer.setInterval(LOCK_FLASH_MS)

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -152,8 +152,8 @@ class QtDimSliderWidget(QWidget):
         """Flash the padlock when a press lands on a control the lock froze.
 
         The slider, play button and slice editor are disabled while the axis is
-        locked, so they issue no navigation request and nothing reaches
-        ``navigation_refused``. A disabled widget also receives no mouse events and
+        locked, so they ask for no move and nothing reaches
+        ``_point_refused``. A disabled widget also receives no mouse events and
         does not hand them to its parent, so the row cannot see the attempt
         either; a filter installed on the child is what still does.
 
@@ -267,7 +267,7 @@ class QtDimSliderWidget(QWidget):
         return play_button
 
     def _create_lock_button_widget(self) -> QPushButton:
-        """Create the padlock that toggles navigation for this axis."""
+        """Create the padlock that locks and unlocks this axis."""
         button = QPushButton(self)
         button.setObjectName('axis_lock_button')
         button.setCheckable(True)
@@ -282,7 +282,7 @@ class QtDimSliderWidget(QWidget):
             self.dims.unlock_axis(self.axis)
 
     def _update_lock_state(self) -> None:
-        """Sync navigation controls and padlock to the Dims model."""
+        """Sync the row's controls and padlock to the Dims model."""
         if self.axis >= self.dims.ndim:
             return
         locked = self.dims.axis_locked[self.axis]
@@ -298,7 +298,7 @@ class QtDimSliderWidget(QWidget):
             self._set_lock_flash(False)
 
     def _flash_lock(self) -> None:
-        """Briefly highlight the padlock after refused navigation."""
+        """Briefly highlight the padlock after a refused move."""
         if self.axis >= self.dims.ndim or not self.dims.axis_locked[self.axis]:
             return
         self._set_lock_flash(True)

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -5,7 +5,15 @@ from typing import TYPE_CHECKING
 from weakref import ref
 
 import numpy as np
-from qtpy.QtCore import QObject, Qt, QThread, Signal, Slot
+from qtpy.QtCore import (
+    QEvent,
+    QObject,
+    Qt,
+    QThread,
+    QTimer,
+    Signal,
+    Slot,
+)
 from qtpy.QtGui import QIntValidator
 from qtpy.QtWidgets import (
     QApplication,
@@ -40,6 +48,7 @@ if TYPE_CHECKING:
 # Width companion to QtDims.SLIDERHEIGHT: keeps a narrow window from collapsing
 # the groove until the handle covers it and dragging becomes impossible.
 SLIDER_MINIMUM_WIDTH = 150
+LOCK_FLASH_MS = 300
 
 
 class _ModifiedScrollBar(ModifiedScrollBar):
@@ -115,8 +124,10 @@ class QtDimSliderWidget(QWidget):
         self.axis_label = self._create_axis_label_widget()
         self.slider = self._create_range_slider_widget()
         self.play_button = self._create_play_button_widget()
+        self.lock_button = self._create_lock_button_widget()
 
         layout.addWidget(self.axis_label)
+        layout.addWidget(self.lock_button)
         layout.addWidget(self.play_button)
         layout.addWidget(self.slider, stretch=2)
         layout.addWidget(self.curslice_label)
@@ -127,6 +138,39 @@ class QtDimSliderWidget(QWidget):
         layout.setAlignment(Qt.AlignmentFlag.AlignVCenter)
         self.setLayout(layout)
         self.dims.events.axis_labels.connect(self._pull_label)
+
+        self._lock_flash_timer = QTimer()
+        self._lock_flash_timer.setSingleShot(True)
+        self._lock_flash_timer.setInterval(LOCK_FLASH_MS)
+        self._lock_flash_timer.timeout.connect(self._end_lock_flash)
+        self.destroyed.connect(self._lock_flash_timer.stop)
+        for frozen in (self.slider, self.play_button, self.curslice_label):
+            frozen.installEventFilter(self)
+        self._update_lock_state()
+
+    def eventFilter(self, qobject: QObject, event: QEvent) -> bool:
+        """Flash the padlock when a press lands on a control the lock froze.
+
+        The slider, play button and slice editor are disabled while the axis is
+        locked, so they issue no navigation request and nothing reaches
+        ``navigation_refused``. A disabled widget also receives no mouse events and
+        does not hand them to its parent, so the row cannot see the attempt
+        either; a filter installed on the child is what still does.
+
+        A press on the frozen slider also claims the axis, standing in for the
+        ``sliderPressed`` a disabled scrollbar never emits. Without it a locked
+        axis could not be made the active one, and the arrow keys would have no
+        way back to it once released.
+        """
+        if (
+            event.type() == QEvent.Type.MouseButtonPress
+            and self.axis < self.dims.ndim
+            and self.dims.axis_locked[self.axis]
+        ):
+            if qobject is self.slider:
+                self.dims.last_used = self.axis
+            self._flash_lock()
+        return super().eventFilter(qobject, event)
 
     def _set_slice_from_label(self) -> None:
         """Update the dims point based on the curslice_label."""
@@ -221,6 +265,54 @@ class QtDimSliderWidget(QWidget):
         self.play_stopped.connect(play_button._handle_stop)
         self.play_started.connect(play_button._handle_start)
         return play_button
+
+    def _create_lock_button_widget(self) -> QPushButton:
+        """Create the padlock that toggles navigation for this axis."""
+        button = QPushButton(self)
+        button.setObjectName('axis_lock_button')
+        button.setCheckable(True)
+        button.setProperty('flash', False)
+        button.clicked.connect(self._on_lock_button_clicked)
+        return button
+
+    def _on_lock_button_clicked(self, checked: bool) -> None:
+        if checked:
+            self.dims.lock_axis(self.axis)
+        else:
+            self.dims.unlock_axis(self.axis)
+
+    def _update_lock_state(self) -> None:
+        """Sync navigation controls and padlock to the Dims model."""
+        if self.axis >= self.dims.ndim:
+            return
+        locked = self.dims.axis_locked[self.axis]
+        for widget in (self.slider, self.play_button, self.curslice_label):
+            widget.setEnabled(not locked)
+        self.lock_button.setChecked(locked)
+        action = 'Unlock' if locked else 'Lock'
+        description = f'{action} axis {self.axis}'
+        self.lock_button.setToolTip(description)
+        self.lock_button.setAccessibleName(description)
+        if not locked:
+            self._lock_flash_timer.stop()
+            self._set_lock_flash(False)
+
+    def _flash_lock(self) -> None:
+        """Briefly highlight the padlock after refused navigation."""
+        if self.axis >= self.dims.ndim or not self.dims.axis_locked[self.axis]:
+            return
+        self._set_lock_flash(True)
+        self._lock_flash_timer.start()
+
+    def _end_lock_flash(self) -> None:
+        self._set_lock_flash(False)
+
+    def _set_lock_flash(self, enabled: bool) -> None:
+        if bool(self.lock_button.property('flash')) is enabled:
+            return
+        self.lock_button.setProperty('flash', enabled)
+        self.lock_button.style().unpolish(self.lock_button)
+        self.lock_button.style().polish(self.lock_button)
 
     def _fps_listener(self, *_) -> None:
         fps = self.play_button.fpsspin.value()

--- a/src/napari/components/_tests/test_dims.py
+++ b/src/napari/components/_tests/test_dims.py
@@ -179,7 +179,7 @@ def test_axis_lock_guards_model_update():
     dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
     dims.lock_axis(0)
     events = []
-    dims.events.navigation_refused.connect(events.append)
+    dims.events._point_refused.connect(events.append)
 
     dims.update({'point': (0, 0, 0)})
 
@@ -227,7 +227,7 @@ def test_axis_lock_refusal_reports_the_refused_axes():
     dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
     dims.lock_axis(0)
     events = []
-    dims.events.navigation_refused.connect(events.append)
+    dims.events._point_refused.connect(events.append)
 
     dims.set_point(0, 1)
 
@@ -238,7 +238,7 @@ def test_axis_lock_is_silent_when_nothing_is_refused():
     dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
     dims.lock_axis(0)
     events = []
-    dims.events.navigation_refused.connect(events.append)
+    dims.events._point_refused.connect(events.append)
 
     # already where the lock holds it, and a move on a free axis
     dims.set_point(0, 4)
@@ -253,7 +253,7 @@ def test_range_change_may_still_clip_a_locked_point():
     dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
     dims.lock_axis(0)
     events = []
-    dims.events.navigation_refused.connect(events.append)
+    dims.events._point_refused.connect(events.append)
 
     dims.range = ((0, 2, 1),) * 3
 
@@ -265,12 +265,52 @@ def test_axis_lock_rejects_an_invalid_component_without_moving():
     dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
     dims.lock_axis(0)
     events = []
-    dims.events.navigation_refused.connect(events.append)
+    dims.events._point_refused.connect(events.append)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         dims.point = (np.array([1, 2]), 5, 5)
 
     assert dims.point == (4, 2, 1)
+    assert events == []
+
+
+def test_axis_lock_holds_a_point_of_the_wrong_length():
+    """A short or long point is padded and cropped before the lock reads it."""
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+    events = []
+    dims.events._point_refused.connect(events.append)
+
+    dims.point = (0, 0)
+    assert dims.point == (4, 0, 0)
+
+    dims.point = (0, 5, 5, 5)
+    assert dims.point == (4, 5, 5)
+
+    dims.update({'point': (0, 0), 'last_used': 1})
+    assert dims.point == (4, 0, 0)
+
+    assert [event.axes for event in events] == [(0,), (0,), (0,)]
+
+
+def test_clipping_that_also_moves_last_used_refuses_nothing():
+    """``last_used`` is assigned outside the validating context, re-entering
+    the validator; the lock must not read that as a refused request."""
+    dims = Dims(
+        ndim=4,
+        ndisplay=2,
+        range=((0, 5, 1),) * 4,
+        point=(4, 2, 1, 1),
+        last_used=0,
+    )
+    dims.lock_axis(0)
+    events = []
+    dims.events._point_refused.connect(events.append)
+
+    dims.range = ((0, 0, 1), (0, 5, 1), (0, 5, 1), (0, 5, 1))
+
+    assert dims.point == (0, 2, 1, 1)
+    assert dims.last_used == 1
     assert events == []
 
 

--- a/src/napari/components/_tests/test_dims.py
+++ b/src/napari/components/_tests/test_dims.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pydantic import ValidationError
 
@@ -145,6 +146,161 @@ def test_point_variable_step_size():
 
     with pytest.raises(ValueError, match='must have equal length'):
         dims.set_current_step((0, 1), (0, 0, 0))
+
+
+def test_axis_lock_holds_the_point_against_navigation():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+
+    dims.set_point(0, 1)
+    assert dims.point == (4, 2, 1)
+
+    # a request spanning both still moves the axis that is free
+    dims.set_point((0, 1), (1, 5))
+    assert dims.point == (4, 5, 1)
+
+    dims.unlock_axis(0)
+    dims.set_point(0, 1)
+    assert dims.point == (1, 5, 1)
+
+
+def test_axis_lock_guards_direct_assignment():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+
+    dims.point = (0, 0, 0)
+    assert dims.point == (4, 0, 0)
+
+    dims.current_step = (5, 5, 5)
+    assert dims.point == (4, 5, 5)
+
+
+def test_axis_lock_guards_model_update():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+    events = []
+    dims.events.navigation_refused.connect(events.append)
+
+    dims.update({'point': (0, 0, 0)})
+
+    assert dims.point == (4, 0, 0)
+    assert [event.axes for event in events] == [(0,)]
+
+
+def test_axis_lock_query_and_bulk_setters():
+    dims = Dims(ndim=3)
+
+    assert dims.axis_locked == (False,) * 3
+    assert not dims.is_axis_locked(0)
+
+    dims.lock_all_axes()
+    assert dims.axis_locked == (True,) * 3
+    assert dims.is_axis_locked(-1)
+
+    dims.unlock_all_axes()
+    assert dims.axis_locked == (False,) * 3
+
+
+def test_axis_lock_grows_with_ndim():
+    dims = Dims(ndim=2)
+    dims.lock_axis(0)
+
+    dims.ndim = 4
+
+    # new axes are prepended, so the locked one keeps its position from the end
+    assert dims.axis_locked == (False, False, True, False)
+
+
+def test_axis_lock_shrinks_with_ndim():
+    dims = Dims(ndim=4, range=((0, 5, 1),) * 4, point=(1, 2, 3, 4))
+    dims.lock_axis(2)
+
+    dims.ndim = 3
+
+    # leading axes are dropped, so the lock keeps its position from the end
+    assert dims.axis_locked == (False, True, False)
+    dims.point = (0, 0, 0)
+    assert dims.point == (0, 3, 0)
+
+
+def test_axis_lock_refusal_reports_the_refused_axes():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+    events = []
+    dims.events.navigation_refused.connect(events.append)
+
+    dims.set_point(0, 1)
+
+    assert [event.axes for event in events] == [(0,)]
+
+
+def test_axis_lock_is_silent_when_nothing_is_refused():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+    events = []
+    dims.events.navigation_refused.connect(events.append)
+
+    # already where the lock holds it, and a move on a free axis
+    dims.set_point(0, 4)
+    dims.set_point(1, 5)
+
+    assert events == []
+    assert dims.point == (4, 5, 1)
+
+
+def test_range_change_may_still_clip_a_locked_point():
+    """Removing a layer rewrites ``range``; that must keep clipping the point."""
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+    events = []
+    dims.events.navigation_refused.connect(events.append)
+
+    dims.range = ((0, 2, 1),) * 3
+
+    assert dims.point == (2, 2, 1)
+    assert events == []
+
+
+def test_axis_lock_rejects_an_invalid_component_without_moving():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+    events = []
+    dims.events.navigation_refused.connect(events.append)
+
+    with pytest.raises(TypeError):
+        dims.point = (np.array([1, 2]), 5, 5)
+
+    assert dims.point == (4, 2, 1)
+    assert events == []
+
+
+def test_non_sequence_point_assignment_is_refused_without_moving():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+
+    with pytest.raises(TypeError):
+        dims.point = 5
+
+    assert dims.point == (4, 2, 1)
+
+
+def test_axis_lock_preserves_field_event_payloads_and_order():
+    dims = Dims(ndim=3, range=((0, 5, 1),) * 3, point=(4, 2, 1))
+    dims.lock_axis(0)
+    events = []
+    dims.events.point.connect(
+        lambda event: events.append(('point', event.value))
+    )
+    dims.events.current_step.connect(
+        lambda event: events.append(('current_step', event.value))
+    )
+
+    dims.current_step = (0, 5, 1)
+
+    assert events == [
+        ('current_step', (4, 5, 1)),
+        ('point', (4.0, 5.0, 1.0)),
+    ]
 
 
 def test_range():

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -93,21 +93,20 @@ class Dims(EventedModel):
     rollable :  tuple of bool
         Tuple of axis roll state. If True the axis is rollable.
     axis_locked : tuple of bool
-        Tuple of per-axis navigation lock state. If True, navigation cannot
-        move the point on that axis.
+        Tuple of per-axis lock state. If True, the point cannot be moved on
+        that axis by anything that asks for it: the sliders, the arrow keys,
+        Ctrl+scroll, or an assignment to ``point``. A ``range`` or ``ndim``
+        change still moves it, so a layer leaving the viewer can still clip a
+        locked axis back into the remaining extent.
 
         .. versionadded:: 0.10.0
 
-    Events
-    ------
-    navigation_refused : Event
-        Emitted when an assignment to ``point`` (directly, or through
-        ``current_step``, ``set_point``, ``set_current_step`` or ``update``)
-        asked to move a locked axis. Carries ``axes``, the tuple of refused
-        axis indices. Point changes caused by a ``range`` or ``ndim`` change do
-        not emit it.
-
-        .. versionadded:: 0.10.0
+    Notes
+    -----
+    ``events._point_refused`` is emitted, with ``axes``, when such a request is
+    refused. It is private: the padlock in the slider row listens to it so a
+    refusal from the keyboard or from plugin code is visible, and there is no
+    other consumer.
     """
 
     # fields
@@ -131,6 +130,7 @@ class Dims(EventedModel):
     _play_ready: bool = True  # False if currently awaiting a draw event
     _scroll_progress: int = 0
     _validating: bool = False
+    _point_before_check: tuple[float, ...] = ()
 
     # validators
     # check fields is false to allow private fields to work
@@ -177,6 +177,7 @@ class Dims(EventedModel):
         """
         if self._validating:
             return self
+        refused = self._hold_locked_axes()
         with self.events.blocker_all(), self._validating_ctx():
             ndim = self.ndim
 
@@ -245,46 +246,46 @@ class Dims(EventedModel):
         if len(not_displayed) > 0 and last_used not in not_displayed:
             self.last_used = not_displayed[0]
 
+        if refused:
+            self.events._point_refused(axes=refused)
+
         return self
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        self.events.add(navigation_refused=Event)
+    def _hold_locked_axes(self) -> tuple[int, ...]:
+        """Put locked components back to where they were before this write.
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Hold locked axes at their coordinate on an external point write.
-
-        Every navigation path ends in an assignment to ``point``:
-        ``current_step`` converts and assigns it, ``set_point`` and
-        ``set_current_step`` go through those, and ``update`` assigns each
-        field in turn. Intercepting ``point`` alone therefore covers them all.
-        A ``range`` or ``ndim`` change moves the point without one, which is
-        why layer-driven clipping of a locked axis stays permitted.
+        The snapshot is as long as the old ``ndim``, so a snapshot of a
+        different length means dimensionality changed rather than the point
+        being written; padding and cropping the point for a new ``ndim`` is
+        this validator's own work, not a request to move it.
         """
-        if name != 'point' or self._validating or not any(self.axis_locked):
-            super().__setattr__(name, value)
-            return
-
-        # Coerce before substituting: a component the field would reject must
-        # raise here, with the point untouched, rather than after a partial write.
-        requested = ensure_len(tuple(float(v) for v in value), self.ndim, 0.0)
-        previous = self.point
+        previous = self._point_before_check
+        if not any(self.axis_locked) or len(previous) != self.ndim:
+            return ()
+        # A short or long point is padded and cropped the same way the
+        # validator would, so the comparison is per axis rather than by offset.
+        requested = ensure_len(self.point, self.ndim, 0.0)
         held = tuple(
-            prev if locked else req
-            for req, prev, locked in zip(
+            prev if locked else new
+            for new, prev, locked in zip(
                 requested, previous, self.axis_locked, strict=False
             )
         )
         refused = tuple(
             axis
-            for axis, (req, kept) in enumerate(
+            for axis, (new, kept) in enumerate(
                 zip(requested, held, strict=False)
             )
-            if req != kept
+            if new != kept
         )
-        super().__setattr__(name, held)
         if refused:
-            self.events.navigation_refused(axes=refused)
+            with self._validating_ctx():
+                self.point = held
+        return refused
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.events.add(_point_refused=Event)
 
     @staticmethod
     def _nsteps_from_range(dims_range) -> tuple[float, ...]:
@@ -452,23 +453,23 @@ class Dims(EventedModel):
         self.set_point(axis, value_world)
 
     def lock_axis(self, axis: int) -> None:
-        """Stop navigation from moving the point on ``axis``."""
+        """Hold the point on ``axis`` where it is."""
         self._set_axis_locked(axis, True)
 
     def unlock_axis(self, axis: int) -> None:
-        """Allow navigation to move the point on ``axis`` again."""
+        """Let the point move on ``axis`` again."""
         self._set_axis_locked(axis, False)
 
     def is_axis_locked(self, axis: int) -> bool:
-        """Whether navigation is locked on ``axis``."""
+        """Whether the point is held on ``axis``."""
         return self.axis_locked[ensure_axis_in_bounds(axis, self.ndim)]
 
     def lock_all_axes(self) -> None:
-        """Lock navigation on every axis."""
+        """Hold the point on every axis."""
         self.axis_locked = (True,) * self.ndim
 
     def unlock_all_axes(self) -> None:
-        """Unlock navigation on every axis."""
+        """Let the point move on every axis again."""
         self.axis_locked = (False,) * self.ndim
 
     def _set_axis_locked(self, axis: int, locked: bool) -> None:
@@ -612,6 +613,11 @@ class Dims(EventedModel):
             yield
         finally:
             self._validating = prev
+            if not prev:
+                # The lock compares an incoming point against this snapshot, so
+                # every write that is allowed to move the point without asking
+                # must leave it as the new reference.
+                self._point_before_check = self.point
 
 
 def ensure_len(value: tuple, length: int, pad_width: Any):

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -11,7 +11,7 @@ import numpy as np
 import pint
 from pydantic import field_validator, model_validator
 
-from napari.utils.events import EventedModel
+from napari.utils.events import Event, EventedModel
 from napari.utils.misc import argsort, reorder_after_dim_reduction
 
 
@@ -92,6 +92,22 @@ class Dims(EventedModel):
         ``displayed`` dimensions.
     rollable :  tuple of bool
         Tuple of axis roll state. If True the axis is rollable.
+    axis_locked : tuple of bool
+        Tuple of per-axis navigation lock state. If True, navigation cannot
+        move the point on that axis.
+
+        .. versionadded:: 0.10.0
+
+    Events
+    ------
+    navigation_refused : Event
+        Emitted when an assignment to ``point`` (directly, or through
+        ``current_step``, ``set_point``, ``set_current_step`` or ``update``)
+        asked to move a locked axis. Carries ``axes``, the tuple of refused
+        axis indices. Point changes caused by a ``range`` or ``ndim`` change do
+        not emit it.
+
+        .. versionadded:: 0.10.0
     """
 
     # fields
@@ -101,6 +117,7 @@ class Dims(EventedModel):
     order: tuple[int, ...] = ()
     axis_labels: tuple[str, ...] = ()
     rollable: tuple[bool, ...] = ()
+    axis_locked: tuple[bool, ...] = ()
 
     range: tuple[RangeTuple, ...] = ()
     margin_left: tuple[float, ...] = ()
@@ -121,6 +138,7 @@ class Dims(EventedModel):
         'order',
         'axis_labels',
         'rollable',
+        'axis_locked',
         'point',
         'margin_left',
         'margin_right',
@@ -214,6 +232,7 @@ class Dims(EventedModel):
         with self._validating_ctx():
             # Check the rollable axes tuple has same number of elements as ndim
             self.rollable = ensure_len(self.rollable, ndim, True)
+            self.axis_locked = ensure_len(self.axis_locked, ndim, False)
 
         # If the last used slider is no longer visible, use the first.
         last_used = self.last_used
@@ -227,6 +246,45 @@ class Dims(EventedModel):
             self.last_used = not_displayed[0]
 
         return self
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.events.add(navigation_refused=Event)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Hold locked axes at their coordinate on an external point write.
+
+        Every navigation path ends in an assignment to ``point``:
+        ``current_step`` converts and assigns it, ``set_point`` and
+        ``set_current_step`` go through those, and ``update`` assigns each
+        field in turn. Intercepting ``point`` alone therefore covers them all.
+        A ``range`` or ``ndim`` change moves the point without one, which is
+        why layer-driven clipping of a locked axis stays permitted.
+        """
+        if name != 'point' or self._validating or not any(self.axis_locked):
+            super().__setattr__(name, value)
+            return
+
+        # Coerce before substituting: a component the field would reject must
+        # raise here, with the point untouched, rather than after a partial write.
+        requested = ensure_len(tuple(float(v) for v in value), self.ndim, 0.0)
+        previous = self.point
+        held = tuple(
+            prev if locked else req
+            for req, prev, locked in zip(
+                requested, previous, self.axis_locked, strict=False
+            )
+        )
+        refused = tuple(
+            axis
+            for axis, (req, kept) in enumerate(
+                zip(requested, held, strict=False)
+            )
+            if req != kept
+        )
+        super().__setattr__(name, held)
+        if refused:
+            self.events.navigation_refused(axes=refused)
 
     @staticmethod
     def _nsteps_from_range(dims_range) -> tuple[float, ...]:
@@ -393,6 +451,31 @@ class Dims(EventedModel):
             value_world.append(rng.start + val * rng.step)
         self.set_point(axis, value_world)
 
+    def lock_axis(self, axis: int) -> None:
+        """Stop navigation from moving the point on ``axis``."""
+        self._set_axis_locked(axis, True)
+
+    def unlock_axis(self, axis: int) -> None:
+        """Allow navigation to move the point on ``axis`` again."""
+        self._set_axis_locked(axis, False)
+
+    def is_axis_locked(self, axis: int) -> bool:
+        """Whether navigation is locked on ``axis``."""
+        return self.axis_locked[ensure_axis_in_bounds(axis, self.ndim)]
+
+    def lock_all_axes(self) -> None:
+        """Lock navigation on every axis."""
+        self.axis_locked = (True,) * self.ndim
+
+    def unlock_all_axes(self) -> None:
+        """Unlock navigation on every axis."""
+        self.axis_locked = (False,) * self.ndim
+
+    def _set_axis_locked(self, axis: int, locked: bool) -> None:
+        axis_locked = list(self.axis_locked)
+        axis_locked[ensure_axis_in_bounds(axis, self.ndim)] = locked
+        self.axis_locked = tuple(axis_locked)
+
     def set_axis_label(
         self,
         axis: int | Sequence[int],
@@ -417,7 +500,7 @@ class Dims(EventedModel):
 
     def reset(self):
         """Reset dims values to initial states."""
-        # Don't reset axis labels
+        # Don't reset axis labels or axis locks
         # TODO: could be optimized with self.update, but need to fix
         #       event firing in EventedModel first
         self.range = ((0, 2, 1),) * self.ndim


### PR DESCRIPTION
# References and relevant issues

Closes #9278
Closes #9279
Replaces #9439

# Description

Adds `Dims.axis_locked`, a per-axis bool tuple, so an axis can be held in place while the rest stay free. A padlock in each slider row toggles it; a locked row's slider, play button and slice editor are disabled and the padlock flashes when the user tries them anyway.

Enforcement lives in the existing `_check_dims` model validator. `_hold_locked_axes()` runs at the top of it and puts locked components back to where they were, comparing against a snapshot of the point that `_validating_ctx` refreshes on its way out. The snapshot's length is the old `ndim`, which is what separates a request to move the point from the validator's own padding and cropping: a `range` or `ndim` change still moves a locked axis, so a layer leaving the viewer clips it back into the remaining extent.

A refused request emits `Dims.events._point_refused` carrying the refused axis indices. It is private, following `Canvas.events._overlay_positions_changed`, and the padlock is its only consumer. It exists because two of the paths that move the point never reach `QtDims`: the arrow keys (`components/_viewer_key_bindings.py:98,105`) and Ctrl+scroll (`components/_viewer_mouse_bindings.py:31,34`) both call `dims._increment_dims_left/right()` from the components layer. Without a model-side signal those two would refuse silently, with no padlock flash, which reads as a dead keypress rather than as a lock. Presses on the row's own controls need no event: those widgets are disabled, and an event filter on them flashes the padlock directly.

Two details that are not obvious from the diff:

- The press on a frozen control is caught with an event filter on each child rather than the row's `mousePressEvent`. A disabled `QScrollBar` propagates the press to its parent, but a disabled `QPushButton` swallows it, so a row-level handler silently misses the play button.
- Locking the axis that is playing stops playback. `QtDims._set_frame` clears `Dims._play_ready` before requesting a frame and only a canvas draw restores it, so a blocked write would wedge the animation with its play button now disabled.

Note that this guards a direct assignment to `point` as well, which #9278 said would stay unguarded. Guarding it is what makes the lock hold for plugin code and keybindings, not just the widgets, but it is a deliberate departure from the issue and I would like a maintainer's call on whether to keep it.

# Type of change

- [x] New feature (non-breaking change which adds functionality)
