### PR TITLE
Fix viewer button positioning

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -31,6 +31,7 @@ from napari._qt.dialogs.screenshot_dialog import ScreenshotDialog
 from napari._qt.perf.qt_performance import QtPerformance
 from napari._qt.utils import QImg2array
 from napari._qt.widgets.qt_dims import QtDims
+from napari._qt.widgets.qt_list_and_buttons import QtLayerListAndButtons
 from napari._qt.widgets.qt_viewer_buttons import (
     QtLayerButtons,
     QtViewerButtons,
@@ -325,17 +326,12 @@ class QtViewer(QSplitter):
     def dockLayerList(self) -> QtViewerDockWidget:
         """QWidget wrapped in a QDockWidget with forwarded viewer events."""
         if self._dockLayerList is None:
-            layerList = QWidget()
-            layerList.setObjectName('layerList')
-            layerListLayout = QVBoxLayout()
-            layerListLayout.addWidget(self.layerButtons)
-            layerListLayout.addWidget(self.layers)
-            layerListLayout.addWidget(self.viewerButtons)
-            layerListLayout.setContentsMargins(8, 4, 8, 6)
-            layerList.setLayout(layerListLayout)
+            list_and_buttons = QtLayerListAndButtons(
+                self.layerButtons, self.layers, self.viewerButtons
+            )
             self._dockLayerList = QtViewerDockWidget(
                 self,
-                layerList,
+                list_and_buttons,
                 name='layer list',
                 area='left',
                 allowed_areas=['left', 'right'],

--- a/src/napari/_qt/widgets/qt_list_and_buttons.py
+++ b/src/napari/_qt/widgets/qt_list_and_buttons.py
@@ -3,7 +3,12 @@ from qtpy.QtWidgets import QWIDGETSIZE_MAX, QVBoxLayout, QWidget
 
 
 class QtLayerListAndButtons(QWidget):
-    def __init__(self, layer_buttons, layer_list, viewer_buttons):
+    def __init__(
+        self,
+        layer_buttons: QWidget,
+        layer_list: QWidget,
+        viewer_buttons: QWidget,
+    ) -> None:
         super().__init__()
         self.setObjectName('layerList')
         layerListLayout = QVBoxLayout()
@@ -13,7 +18,7 @@ class QtLayerListAndButtons(QWidget):
         layerListLayout.setContentsMargins(8, 4, 8, 6)
         self.setLayout(layerListLayout)
 
-    def sizeHint(self):
+    def sizeHint(self) -> QSize:
         # because we use Maximum as dock widget size policy;
         # without this, this widget would take just enough space
         # instead of all the available space

--- a/src/napari/_qt/widgets/qt_list_and_buttons.py
+++ b/src/napari/_qt/widgets/qt_list_and_buttons.py
@@ -1,0 +1,20 @@
+from qtpy.QtCore import QSize
+from qtpy.QtWidgets import QWIDGETSIZE_MAX, QVBoxLayout, QWidget
+
+
+class QtLayerListAndButtons(QWidget):
+    def __init__(self, layer_buttons, layer_list, viewer_buttons):
+        super().__init__()
+        self.setObjectName('layerList')
+        layerListLayout = QVBoxLayout()
+        layerListLayout.addWidget(layer_buttons)
+        layerListLayout.addWidget(layer_list)
+        layerListLayout.addWidget(viewer_buttons)
+        layerListLayout.setContentsMargins(8, 4, 8, 6)
+        self.setLayout(layerListLayout)
+
+    def sizeHint(self):
+        # because we use Maximum as dock widget size policy;
+        # without this, this widget would take just enough space
+        # instead of all the available space
+        return QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)

--- a/src/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/src/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -130,7 +130,7 @@ class QtViewerDockWidget(QDockWidget):
         widget_ = combine_widgets(widget, vertical=is_vertical)
         widget_.setSizePolicy(
             QSizePolicy.Policy.Preferred,
-            QSizePolicy.Policy.Maximum,
+            QSizePolicy.Policy.Preferred,
         )
         self.setWidget(widget_)
         if is_vertical and add_vertical_stretch:

--- a/src/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/src/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -130,7 +130,7 @@ class QtViewerDockWidget(QDockWidget):
         widget_ = combine_widgets(widget, vertical=is_vertical)
         widget_.setSizePolicy(
             QSizePolicy.Policy.Preferred,
-            QSizePolicy.Policy.Preferred,
+            QSizePolicy.Policy.Maximum,
         )
         self.setWidget(widget_)
         if is_vertical and add_vertical_stretch:


### PR DESCRIPTION
# References and relevant issues
- caused by https://github.com/napari/napari/pull/9393
- https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E9.2E0/near/618946835

# Description
Unfortuinately here we're battling between two things:
1. we want user dock widget to not "spread out" and take all the space
2. we want one of our widgets (combined layer list and viewer buttons) to do just that.

So I made a separate class that overrides its MaximumSize, so that it requests as much space as possible, despite the fact that `Maximum` size policy is enabled (which is confusingly named: it means "take up what the maximum size hint says and no more").