### PR TITLE
Restore size policy for layerList docked widget

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -333,6 +333,7 @@ class QtViewer(QSplitter):
             layerListLayout.addWidget(self.viewerButtons)
             layerListLayout.setContentsMargins(8, 4, 8, 6)
             layerList.setLayout(layerListLayout)
+            prev_policy = layerList.sizePolicy()
             self._dockLayerList = QtViewerDockWidget(
                 self,
                 layerList,
@@ -342,6 +343,8 @@ class QtViewer(QSplitter):
                 object_name='layer list',
                 close_btn=False,
             )
+            # restore policy to avoid empty space below buttons
+            layerList.setSizePolicy(prev_policy)
         return self._dockLayerList
 
     @property

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -344,6 +344,7 @@ class QtViewer(QSplitter):
                 close_btn=False,
             )
             # restore policy to avoid empty space below buttons
+            # See https://github.com/napari/napari/pull/9447
             layerList.setSizePolicy(prev_policy)
         return self._dockLayerList
 


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E9.2E0/near/618946835

# Description

Restore the original size policy for the layer list dock widget to avoid having space below buttons. 

<img width="3248" height="2128" alt="image" src="https://github.com/user-attachments/assets/a8e4f406-3216-460c-befc-70b13e6655af" />
