### PR TITLE
Allow single widget in layer controls

### DIFF
--- a/src/napari/_qt/layer_controls/_tests/test_qt_surface_layer.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_surface_layer.py
@@ -11,9 +11,9 @@ _SURFACE = (data, faces, values)
 
 def _assert_controls_enabled(controls, enabled):
     for control in controls:
-        for label, widget in control.get_widget_controls():
-            assert label.isEnabled() is enabled
-            assert widget.isEnabled() is enabled
+        for widgets in control.get_widget_controls():
+            for widget in widgets:
+                assert widget.isEnabled() is enabled
 
 
 def _scalar_coloring_controls(qtctrl):

--- a/src/napari/_qt/layer_controls/dynamic/_tests/conftest.py
+++ b/src/napari/_qt/layer_controls/dynamic/_tests/conftest.py
@@ -17,9 +17,9 @@ class QtWrap:
 
     def add_control(self, control: T) -> T:
         self._controls.append(control)
-        for label, widget in control.get_widget_controls():
-            self._qtbot.add_widget(widget)
-            self._qtbot.add_widget(label)
+        for widgets in control.get_widget_controls():
+            for widget in widgets:
+                self._qtbot.add_widget(widget)
         return control
 
     def clear(self):

--- a/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
@@ -283,8 +283,8 @@ class QtDynamicLayerControls(QFrame):
         self._controls.append(wrapper)
         controls = wrapper.get_widget_controls()
 
-        for label_text, control_widget in controls:
-            self.layout().addRow(label_text, control_widget)
+        for widgets in controls:
+            self.layout().addRow(*widgets)
 
     @property
     def ndisplay(self) -> int:

--- a/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
@@ -323,10 +323,8 @@ class QtDynamicLayerControls(QFrame):
             control = self.findChild(cls)
             if control is None:
                 continue
-            for label, widget in control.get_widget_controls():
-                set_widgets_enabled_with_opacity(
-                    self, (label, widget), enabled
-                )
+            for widgets in control.get_widget_controls():
+                set_widgets_enabled_with_opacity(self, widgets, enabled)
 
     def _disconnect_child_widget_controls(self, child) -> None:
         disconnect_method = getattr(child, 'disconnect_widget_controls', None)

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_depiction_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_depiction_control.py
@@ -206,7 +206,7 @@ class QtDepictionControl(QtWidgetControlsBase):
         self.plane_thickness_slider.setVisible(visible)
         self.plane_thickness_label.setVisible(visible)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.depiction_label, self.depiction_combobox),
             (self.plane_normal_label, self.plane_normal_buttons),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_depiction_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_depiction_control.py
@@ -206,7 +206,9 @@ class QtDepictionControl(QtWidgetControlsBase):
         self.plane_thickness_slider.setVisible(visible)
         self.plane_thickness_label.setVisible(visible)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.depiction_label, self.depiction_combobox),
             (self.plane_normal_label, self.plane_normal_buttons),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_interpolation_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_interpolation_combobox.py
@@ -108,7 +108,7 @@ class QtInterpolationComboBoxControl(QtWidgetControlsBase):
             self.interpolation_combobox.addItems(interp_names)
             self.interpolation_combobox.setCurrentText(interp)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.interpolation_combobox_label, self.interpolation_combobox)
         ]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_interpolation_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_interpolation_combobox.py
@@ -108,7 +108,9 @@ class QtInterpolationComboBoxControl(QtWidgetControlsBase):
             self.interpolation_combobox.addItems(interp_names)
             self.interpolation_combobox.setCurrentText(interp)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.interpolation_combobox_label, self.interpolation_combobox)
         ]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_render_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_render_control.py
@@ -170,7 +170,9 @@ class QtImageRenderControl(QtWidgetControlsBase):
         self.attenuation_slider.setVisible(attenuation_visible)
         self.attenuation_label.setVisible(attenuation_visible)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.render_label, self.render_combobox),
             (self.iso_threshold_label, self.iso_threshold_slider),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_render_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_image/qt_render_control.py
@@ -170,7 +170,7 @@ class QtImageRenderControl(QtWidgetControlsBase):
         self.attenuation_slider.setVisible(attenuation_visible)
         self.attenuation_label.setVisible(attenuation_visible)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.render_label, self.render_combobox),
             (self.iso_threshold_label, self.iso_threshold_slider),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_brush_size_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_brush_size_slider.py
@@ -71,5 +71,5 @@ class QtBrushSizeSliderControl(QtWidgetControlsBase):
                 self.brush_size_slider.setMaximum(int(value))
             self.brush_size_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.brush_size_slider_label, self.brush_size_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_brush_size_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_brush_size_slider.py
@@ -71,5 +71,7 @@ class QtBrushSizeSliderControl(QtWidgetControlsBase):
                 self.brush_size_slider.setMaximum(int(value))
             self.brush_size_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.brush_size_slider_label, self.brush_size_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_color_mode_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_color_mode_combobox.py
@@ -83,5 +83,5 @@ class QtColorModeComboBoxControl(QtWidgetControlsBase):
         else:
             self.color_mode_combobox.setCurrentEnum(LabelColorMode.DIRECT)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.color_mode_combobox_label, self.color_mode_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_color_mode_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_color_mode_combobox.py
@@ -83,5 +83,7 @@ class QtColorModeComboBoxControl(QtWidgetControlsBase):
         else:
             self.color_mode_combobox.setCurrentEnum(LabelColorMode.DIRECT)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.color_mode_combobox_label, self.color_mode_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contiguous_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contiguous_checkbox.py
@@ -70,5 +70,5 @@ class QtContiguousCheckBoxControl(QtWidgetControlsBase):
 
         self.contiguous_checkbox_label = QtWrappedLabel('contiguous:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.contiguous_checkbox_label, self.contiguous_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contiguous_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contiguous_checkbox.py
@@ -70,5 +70,7 @@ class QtContiguousCheckBoxControl(QtWidgetControlsBase):
 
         self.contiguous_checkbox_label = QtWrappedLabel('contiguous:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.contiguous_checkbox_label, self.contiguous_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contour_spinbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contour_spinbox.py
@@ -81,5 +81,5 @@ class QtContourSpinBoxControl(QtWidgetControlsBase):
         if self.parent() is not None:
             self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.contour_spinbox_label, self.contour_spinbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contour_spinbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_contour_spinbox.py
@@ -81,5 +81,7 @@ class QtContourSpinBoxControl(QtWidgetControlsBase):
         if self.parent() is not None:
             self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.contour_spinbox_label, self.contour_spinbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_current_label_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_current_label_controls.py
@@ -206,5 +206,7 @@ class QtCurrentLabelControls(QtWidgetControlsBase):
         for layer in self._layers:
             new_label(layer)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.label_color_label, self.label_color)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_current_label_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_current_label_controls.py
@@ -206,5 +206,5 @@ class QtCurrentLabelControls(QtWidgetControlsBase):
         for layer in self._layers:
             new_label(layer)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.label_color_label, self.label_color)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_display_selected_label_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_display_selected_label_checkbox.py
@@ -67,7 +67,9 @@ class QtDisplaySelectedLabelCheckBoxControl(QtWidgetControlsBase):
 
         self.selected_color_checkbox_label = QtWrappedLabel('show\nselected:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.selected_color_checkbox_label, self.selected_color_checkbox)
         ]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_display_selected_label_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_display_selected_label_checkbox.py
@@ -67,7 +67,7 @@ class QtDisplaySelectedLabelCheckBoxControl(QtWidgetControlsBase):
 
         self.selected_color_checkbox_label = QtWrappedLabel('show\nselected:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.selected_color_checkbox_label, self.selected_color_checkbox)
         ]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_ndim_spinbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_ndim_spinbox.py
@@ -88,5 +88,5 @@ class QtNdimSpinBoxControl(QtWidgetControlsBase):
     def _on_data_change(self) -> None:
         self.ndim_spinbox.setMaximum(self._layers[0].ndim)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.ndim_spinbox_label, self.ndim_spinbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_ndim_spinbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_ndim_spinbox.py
@@ -88,5 +88,7 @@ class QtNdimSpinBoxControl(QtWidgetControlsBase):
     def _on_data_change(self) -> None:
         self.ndim_spinbox.setMaximum(self._layers[0].ndim)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.ndim_spinbox_label, self.ndim_spinbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_preserve_labels_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_preserve_labels_checkbox.py
@@ -71,7 +71,7 @@ class QtPreserveLabelsCheckBoxControl(QtWidgetControlsBase):
             'preserve\nlabels:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (
                 self.preserve_labels_checkbox_label,

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_preserve_labels_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_preserve_labels_checkbox.py
@@ -71,7 +71,9 @@ class QtPreserveLabelsCheckBoxControl(QtWidgetControlsBase):
             'preserve\nlabels:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (
                 self.preserve_labels_checkbox_label,

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_rendering_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_rendering_control.py
@@ -119,7 +119,7 @@ class QtLabelRenderingControl(QtWidgetControlsBase):
             self.iso_gradient_combobox.hide()
             self.iso_gradient_combobox_label.hide()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.rendering_combobox_label, self.rendering_combobox),
             (self.iso_gradient_combobox_label, self.iso_gradient_combobox),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_rendering_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_labels/qt_rendering_control.py
@@ -119,7 +119,9 @@ class QtLabelRenderingControl(QtWidgetControlsBase):
             self.iso_gradient_combobox.hide()
             self.iso_gradient_combobox_label.hide()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.rendering_combobox_label, self.rendering_combobox),
             (self.iso_gradient_combobox_label, self.iso_gradient_combobox),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_border_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_border_color.py
@@ -72,5 +72,7 @@ class QtBorderColorControl(QtWidgetControlsBase):
 
         self.border_color_edit_label = QtWrappedLabel('border color:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.border_color_edit_label, self.border_color_edit)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_border_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_border_color.py
@@ -72,5 +72,5 @@ class QtBorderColorControl(QtWidgetControlsBase):
 
         self.border_color_edit_label = QtWrappedLabel('border color:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.border_color_edit_label, self.border_color_edit)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_current_size_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_current_size_slider.py
@@ -93,5 +93,5 @@ class QtCurrentSizeSliderControl(QtWidgetControlsBase):
             with contextlib.suppress(TypeError):
                 self.size_slider.setValue(int(value))
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.size_slider_label, self.size_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_current_size_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_current_size_slider.py
@@ -93,5 +93,7 @@ class QtCurrentSizeSliderControl(QtWidgetControlsBase):
             with contextlib.suppress(TypeError):
                 self.size_slider.setValue(int(value))
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.size_slider_label, self.size_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_symbol_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_symbol_combobox.py
@@ -78,5 +78,7 @@ class QtSymbolComboBoxControl(QtWidgetControlsBase):
                 Symbol(self._layers[0].current_symbol)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.symbol_combobox_label, self.symbol_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_symbol_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_points/qt_symbol_combobox.py
@@ -78,5 +78,5 @@ class QtSymbolComboBoxControl(QtWidgetControlsBase):
                 Symbol(self._layers[0].current_symbol)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.symbol_combobox_label, self.symbol_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_color.py
@@ -70,5 +70,5 @@ class QtEdgeColorControl(QtWidgetControlsBase, metaclass=_QtABCMeta):
         )
         self.edge_color_label = QtWrappedLabel('edge color:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.edge_color_label, self.edge_color_edit)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_color.py
@@ -70,5 +70,7 @@ class QtEdgeColorControl(QtWidgetControlsBase, metaclass=_QtABCMeta):
         )
         self.edge_color_label = QtWrappedLabel('edge color:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.edge_color_label, self.edge_color_edit)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_width_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_width_slider.py
@@ -82,5 +82,7 @@ class QtEdgeWidthSliderControl(QtWidgetControlsBase):
             value = np.clip(int(value), 0, 40)
             self.edge_width_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.edge_width_label, self.edge_width_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_width_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_shapes/qt_edge_width_slider.py
@@ -82,5 +82,5 @@ class QtEdgeWidthSliderControl(QtWidgetControlsBase):
             value = np.clip(int(value), 0, 40)
             self.edge_width_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.edge_width_label, self.edge_width_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_surface/qt_shading_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_surface/qt_shading_combobox.py
@@ -74,5 +74,5 @@ class QtShadingComboBoxControl(QtWidgetControlsBase):
                 Shading(self._layers[0].shading)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.shading_combobox_label, self.shading_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_surface/qt_shading_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_surface/qt_shading_combobox.py
@@ -74,5 +74,7 @@ class QtShadingComboBoxControl(QtWidgetControlsBase):
                 Shading(self._layers[0].shading)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.shading_combobox_label, self.shading_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_color_properties_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_color_properties_combobox.py
@@ -79,5 +79,5 @@ class QtColorPropertiesComboBoxControl(QtWidgetControlsBase):
             )
         self._on_color_by_change()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.color_by_combobox_label, self.color_by_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_color_properties_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_color_properties_combobox.py
@@ -79,5 +79,7 @@ class QtColorPropertiesComboBoxControl(QtWidgetControlsBase):
             )
         self._on_color_by_change()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.color_by_combobox_label, self.color_by_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_colormap_control.py
@@ -67,5 +67,5 @@ class QtColormapComboBoxControl(QtWidgetControlsBase):
                 self.colormap_combobox.findData(self._layers[0].colormap)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.colormap_combobox_label, self.colormap_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_colormap_control.py
@@ -67,5 +67,7 @@ class QtColormapComboBoxControl(QtWidgetControlsBase):
                 self.colormap_combobox.findData(self._layers[0].colormap)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.colormap_combobox_label, self.colormap_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_graph_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_graph_checkbox.py
@@ -60,5 +60,5 @@ class QtGraphCheckBoxControl(QtWidgetControlsBase):
 
         self.graph_checkbox_label = QtWrappedLabel('graph:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.graph_checkbox_label, self.graph_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_graph_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_graph_checkbox.py
@@ -60,5 +60,7 @@ class QtGraphCheckBoxControl(QtWidgetControlsBase):
 
         self.graph_checkbox_label = QtWrappedLabel('graph:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.graph_checkbox_label, self.graph_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_head_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_head_slider.py
@@ -70,5 +70,7 @@ class QtHeadLengthSliderControl(QtWidgetControlsBase):
                 self.head_length_slider.setMaximum(self._layers[0]._max_length)
             self.head_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.head_length_slider_label, self.head_length_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_head_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_head_slider.py
@@ -70,5 +70,5 @@ class QtHeadLengthSliderControl(QtWidgetControlsBase):
                 self.head_length_slider.setMaximum(self._layers[0]._max_length)
             self.head_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.head_length_slider_label, self.head_length_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
@@ -69,7 +69,9 @@ class QtHideCompletedTracksCheckBoxControl(QtWidgetControlsBase):
             'hide completed:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (
                 self.hide_completed_tracks_checkbox_label,

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
@@ -69,7 +69,7 @@ class QtHideCompletedTracksCheckBoxControl(QtWidgetControlsBase):
             'hide completed:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (
                 self.hide_completed_tracks_checkbox_label,

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_id_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_id_checkbox.py
@@ -63,5 +63,7 @@ class QtIdCheckBoxControl(QtWidgetControlsBase):
     def update_display_id(self) -> None:
         self.display_id_checkbox.setChecked(self._layers[0].display_id)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.display_id_checkbox_label, self.display_id_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_id_checkbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_id_checkbox.py
@@ -63,5 +63,5 @@ class QtIdCheckBoxControl(QtWidgetControlsBase):
     def update_display_id(self) -> None:
         self.display_id_checkbox.setChecked(self._layers[0].display_id)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.display_id_checkbox_label, self.display_id_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_tail_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_tail_control.py
@@ -76,7 +76,7 @@ class QtTailLengthSliderControl(QtWidgetControlsBase):
                 )
             self.tail_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.tail_length_slider_label, self.tail_length_slider)]
 
 
@@ -136,7 +136,7 @@ class QtTailWidthSliderControl(QtWidgetControlsBase):
                 )
             self.tail_width_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.tail_width_slider_label, self.tail_width_slider)]
 
 
@@ -187,5 +187,5 @@ class QtTailDisplayCheckBoxControl(QtWidgetControlsBase):
         """Receive layer model track line width change event and update checkbox."""
         self.tail_checkbox.setChecked(self._layers[0].display_tail)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.tail_checkbox_label, self.tail_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_tail_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_tracks/qt_tail_control.py
@@ -76,7 +76,9 @@ class QtTailLengthSliderControl(QtWidgetControlsBase):
                 )
             self.tail_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.tail_length_slider_label, self.tail_length_slider)]
 
 
@@ -136,7 +138,9 @@ class QtTailWidthSliderControl(QtWidgetControlsBase):
                 )
             self.tail_width_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.tail_width_slider_label, self.tail_width_slider)]
 
 
@@ -187,5 +191,7 @@ class QtTailDisplayCheckBoxControl(QtWidgetControlsBase):
         """Receive layer model track line width change event and update checkbox."""
         self.tail_checkbox.setChecked(self._layers[0].display_tail)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.tail_checkbox_label, self.tail_checkbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_edge_color.py
@@ -173,7 +173,9 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self.color_feature_box.setHidden(True)
             self.edge_feature_label.setHidden(True)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.color_mode_label, self.color_mode_combobox),
             (self.edge_color_label, self.edge_color_edit),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_edge_color.py
@@ -173,7 +173,7 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self.color_feature_box.setHidden(True)
             self.edge_feature_label.setHidden(True)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.color_mode_label, self.color_mode_combobox),
             (self.edge_color_label, self.edge_color_edit),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_line_dimension_spinbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_line_dimension_spinbox.py
@@ -77,7 +77,7 @@ class QtWidthSpinBoxControl(QtWidgetControlsBase):
         if self.parent() is not None:
             self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.width_spinbox_label, self.width_spinbox)]
 
 
@@ -143,5 +143,5 @@ class QtLengthSpinBoxControl(QtWidgetControlsBase):
         if self.parent() is not None:
             self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.length_spinbox_label, self.length_spinbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_line_dimension_spinbox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_line_dimension_spinbox.py
@@ -77,7 +77,9 @@ class QtWidthSpinBoxControl(QtWidgetControlsBase):
         if self.parent() is not None:
             self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.width_spinbox_label, self.width_spinbox)]
 
 
@@ -143,5 +145,7 @@ class QtLengthSpinBoxControl(QtWidgetControlsBase):
         if self.parent() is not None:
             self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.length_spinbox_label, self.length_spinbox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_vector_style_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_vector_style_combobox.py
@@ -74,5 +74,5 @@ class QtVectorStyleComboBoxControl(QtWidgetControlsBase):
             )
             self.vector_style_combobox.setCurrentIndex(index)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.vector_style_combobox_label, self.vector_style_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_vector_style_combobox.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/_vectors/qt_vector_style_combobox.py
@@ -74,5 +74,7 @@ class QtVectorStyleComboBoxControl(QtWidgetControlsBase):
             )
             self.vector_style_combobox.setCurrentIndex(index)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.vector_style_combobox_label, self.vector_style_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_colormap_control.py
@@ -223,5 +223,7 @@ class QtColormapControl(QtWidgetControlsBase):
             for layer in self._layers:
                 layer.colormap = colormap
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.colormap_widget_label, self.colormapWidget)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_colormap_control.py
@@ -223,5 +223,5 @@ class QtColormapControl(QtWidgetControlsBase):
             for layer in self._layers:
                 layer.colormap = colormap
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.colormap_widget_label, self.colormapWidget)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
@@ -606,7 +606,9 @@ class QtContrastLimitsControl(QtWidgetControlsBase):
             disconnect_events(layer.histogram.events, self)
         super().disconnect_widget_controls()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.auto_scale_buttons_label, self.auto_scale_buttons),
             (self.contrast_limits_slider_label, self._clim_row),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_contrast_limits.py
@@ -606,7 +606,7 @@ class QtContrastLimitsControl(QtWidgetControlsBase):
             disconnect_events(layer.histogram.events, self)
         super().disconnect_widget_controls()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.auto_scale_buttons_label, self.auto_scale_buttons),
             (self.contrast_limits_slider_label, self._clim_row),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_face_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_face_color.py
@@ -78,5 +78,5 @@ class QtFaceColorControl(QtWidgetControlsBase):
                 )
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.face_color_label, self.face_color_edit)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_face_color.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_face_color.py
@@ -78,5 +78,7 @@ class QtFaceColorControl(QtWidgetControlsBase):
                 )
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.face_color_label, self.face_color_edit)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_gamma_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_gamma_slider.py
@@ -61,5 +61,7 @@ class QtGammaSliderControl(QtWidgetControlsBase):
 
         self.gamma_slider_label = QtWrappedLabel('gamma:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.gamma_slider_label, self.gamma_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_gamma_slider.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_gamma_slider.py
@@ -61,5 +61,5 @@ class QtGammaSliderControl(QtWidgetControlsBase):
 
         self.gamma_slider_label = QtWrappedLabel('gamma:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.gamma_slider_label, self.gamma_slider)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_histogram_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_histogram_control.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
 
 from napari._qt.layer_controls.dynamic.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
+    QtWrappedLabel,
 )
 from napari._qt.widgets.qt_histogram_content import QtHistogramContentWidget
 from napari.utils.events import disconnect_events
@@ -112,7 +113,9 @@ class QtHistogramControl(QtWidgetControlsBase):
         self.histogram_widget = self.histogram_content.histogram_widget
         self.settings_widget = self.histogram_content.settings_widget
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         """Return empty list; histogram is dynamically shown/hidden."""
         return []
 

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_histogram_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_histogram_control.py
@@ -12,7 +12,6 @@ from qtpy.QtWidgets import (
 
 from napari._qt.layer_controls.dynamic.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
-    QtWrappedLabel,
 )
 from napari._qt.widgets.qt_histogram_content import QtHistogramContentWidget
 from napari.utils.events import disconnect_events
@@ -113,7 +112,7 @@ class QtHistogramControl(QtWidgetControlsBase):
         self.histogram_widget = self.histogram_content.histogram_widget
         self.settings_widget = self.histogram_content.settings_widget
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         """Return empty list; histogram is dynamically shown/hidden."""
         return []
 

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_multiscale_level_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_multiscale_level_control.py
@@ -153,12 +153,12 @@ class QtMultiscaleLevelControl(QtWidgetControlsBase):
             else:
                 self.level_combobox.setCurrentIndex(0)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         """Return the label/widget pairs for this control.
 
         Returns
         -------
-        list[tuple[QtWrappedLabel, QWidget]]
+        list[tuple[QWidget, ...]]
             Single-element list containing the resolution label and combobox.
         """
         return [(self.level_label, self.level_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_multiscale_level_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_multiscale_level_control.py
@@ -153,12 +153,14 @@ class QtMultiscaleLevelControl(QtWidgetControlsBase):
             else:
                 self.level_combobox.setCurrentIndex(0)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         """Return the label/widget pairs for this control.
 
         Returns
         -------
-        list[tuple[QWidget, ...]]
+        list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]
             Single-element list containing the resolution label and combobox.
         """
         return [(self.level_label, self.level_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_opacity_blending_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_opacity_blending_controls.py
@@ -140,7 +140,7 @@ class QtOpacityBlendingControls(QtWidgetControlsBase):
                 Blending(self._layers[0].blending)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.opacity_label, self.opacity_slider),
             (self.blend_label, self.blend_combobox),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_opacity_blending_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_opacity_blending_controls.py
@@ -140,7 +140,9 @@ class QtOpacityBlendingControls(QtWidgetControlsBase):
                 Blending(self._layers[0].blending)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.opacity_label, self.opacity_slider),
             (self.blend_label, self.blend_combobox),

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
@@ -78,5 +78,7 @@ class QtProjectionModeControl(QtWidgetControlsBase):
                 str(self._layers[0].projection_mode)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.projection_combobox_label, self.projection_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
@@ -78,5 +78,5 @@ class QtProjectionModeControl(QtWidgetControlsBase):
                 str(self._layers[0].projection_mode)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.projection_combobox_label, self.projection_combobox)]

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_text_visibility.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_text_visibility.py
@@ -65,7 +65,9 @@ class QtTextVisibilityControl(QtWidgetControlsBase):
         with qt_signals_blocked(self.text_disp_checkbox):
             self.text_disp_checkbox.setChecked(self._layers[0].text.visible)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.text_disp_label, self.text_disp_checkbox)]
 
     def disconnect_widget_controls(self) -> None:

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_text_visibility.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_text_visibility.py
@@ -65,7 +65,7 @@ class QtTextVisibilityControl(QtWidgetControlsBase):
         with qt_signals_blocked(self.text_disp_checkbox):
             self.text_disp_checkbox.setChecked(self._layers[0].text.visible)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.text_disp_label, self.text_disp_checkbox)]
 
     def disconnect_widget_controls(self) -> None:

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
@@ -64,13 +64,15 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         self._ndisplay: int = 2
 
     @abstractmethod
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         """
         Enable access to the created labels and control widgets.
 
         Returns
         -------
-        list : list[tuple[QWidget, ...]]
+        list : list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]
             List of tuples of the label and widget controls available.
 
         """

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
@@ -64,13 +64,13 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         self._ndisplay: int = 2
 
     @abstractmethod
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         """
         Enable access to the created labels and control widgets.
 
         Returns
         -------
-        list : list[tuple[QtWrappedLabel, QWidget]]
+        list : list[tuple[QWidget, ...]]
             List of tuples of the label and widget controls available.
 
         """

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
@@ -73,7 +73,7 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         Returns
         -------
         list : list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]
-            List of tuples of the label and widget controls available.
+            List of tuples of the widget controls available.
 
         """
         raise NotImplementedError

--- a/src/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -137,8 +137,8 @@ class QtLayerControls(QFrame):
         """
         controls = wrapper.get_widget_controls()
 
-        for label_text, control_widget in controls:
-            self.layout().addRow(label_text, control_widget)
+        for widgets in controls:
+            self.layout().addRow(*widgets)
 
     def changeProjectionMode(self, text):
         with self.layer.events.blocker(self._on_projection_mode_change):

--- a/src/napari/_qt/layer_controls/qt_surface_controls.py
+++ b/src/napari/_qt/layer_controls/qt_surface_controls.py
@@ -55,7 +55,5 @@ class QtSurfaceControls(QtBaseImageControls):
             self._gamma_slider_control,
             self._colormap_control,
         ):
-            for label, widget in control.get_widget_controls():
-                set_widgets_enabled_with_opacity(
-                    self, (label, widget), enabled
-                )
+            for widgets in control.get_widget_controls():
+                set_widgets_enabled_with_opacity(self, widgets, enabled)

--- a/src/napari/_qt/layer_controls/widgets/_image/qt_depiction_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_image/qt_depiction_control.py
@@ -172,7 +172,7 @@ class QtDepictionControl(QtWidgetControlsBase):
         self.plane_thickness_slider.setVisible(visible)
         self.plane_thickness_label.setVisible(visible)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.depiction_label, self.depiction_combobox),
             (self.plane_normal_label, self.plane_normal_buttons),

--- a/src/napari/_qt/layer_controls/widgets/_image/qt_depiction_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_image/qt_depiction_control.py
@@ -172,7 +172,9 @@ class QtDepictionControl(QtWidgetControlsBase):
         self.plane_thickness_slider.setVisible(visible)
         self.plane_thickness_label.setVisible(visible)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.depiction_label, self.depiction_combobox),
             (self.plane_normal_label, self.plane_normal_buttons),

--- a/src/napari/_qt/layer_controls/widgets/_image/qt_interpolation_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_image/qt_interpolation_combobox.py
@@ -98,7 +98,9 @@ class QtInterpolationComboBoxControl(QtWidgetControlsBase):
             self.interpolation_combobox.addItems(interp_names)
             self.interpolation_combobox.setCurrentText(interp)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.interpolation_combobox_label, self.interpolation_combobox)
         ]

--- a/src/napari/_qt/layer_controls/widgets/_image/qt_interpolation_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_image/qt_interpolation_combobox.py
@@ -98,7 +98,7 @@ class QtInterpolationComboBoxControl(QtWidgetControlsBase):
             self.interpolation_combobox.addItems(interp_names)
             self.interpolation_combobox.setCurrentText(interp)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.interpolation_combobox_label, self.interpolation_combobox)
         ]

--- a/src/napari/_qt/layer_controls/widgets/_image/qt_render_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_image/qt_render_control.py
@@ -156,7 +156,9 @@ class QtImageRenderControl(QtWidgetControlsBase):
         self.attenuation_slider.setVisible(attenuation_visible)
         self.attenuation_label.setVisible(attenuation_visible)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.render_label, self.render_combobox),
             (self.iso_threshold_label, self.iso_threshold_slider),

--- a/src/napari/_qt/layer_controls/widgets/_image/qt_render_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_image/qt_render_control.py
@@ -156,7 +156,7 @@ class QtImageRenderControl(QtWidgetControlsBase):
         self.attenuation_slider.setVisible(attenuation_visible)
         self.attenuation_label.setVisible(attenuation_visible)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.render_label, self.render_combobox),
             (self.iso_threshold_label, self.iso_threshold_slider),

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_brush_size_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_brush_size_slider.py
@@ -62,5 +62,7 @@ class QtBrushSizeSliderControl(QtWidgetControlsBase):
                 self.brush_size_slider.setMaximum(int(value))
             self.brush_size_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.brush_size_slider_label, self.brush_size_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_brush_size_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_brush_size_slider.py
@@ -62,5 +62,5 @@ class QtBrushSizeSliderControl(QtWidgetControlsBase):
                 self.brush_size_slider.setMaximum(int(value))
             self.brush_size_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.brush_size_slider_label, self.brush_size_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
@@ -71,5 +71,7 @@ class QtColorModeComboBoxControl(QtWidgetControlsBase):
         else:
             self.color_mode_combobox.setCurrentEnum(LabelColorMode.DIRECT)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.color_mode_combobox_label, self.color_mode_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_color_mode_combobox.py
@@ -71,5 +71,5 @@ class QtColorModeComboBoxControl(QtWidgetControlsBase):
         else:
             self.color_mode_combobox.setCurrentEnum(LabelColorMode.DIRECT)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.color_mode_combobox_label, self.color_mode_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_contiguous_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_contiguous_checkbox.py
@@ -56,5 +56,7 @@ class QtContiguousCheckBoxControl(QtWidgetControlsBase):
 
         self.contiguous_checkbox_label = QtWrappedLabel('contiguous:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.contiguous_checkbox_label, self.contiguous_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_contiguous_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_contiguous_checkbox.py
@@ -56,5 +56,5 @@ class QtContiguousCheckBoxControl(QtWidgetControlsBase):
 
         self.contiguous_checkbox_label = QtWrappedLabel('contiguous:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.contiguous_checkbox_label, self.contiguous_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_contour_spinbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_contour_spinbox.py
@@ -69,5 +69,7 @@ class QtContourSpinBoxControl(QtWidgetControlsBase):
         self.contour_spinbox.clearFocus()
         self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.contour_spinbox_label, self.contour_spinbox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_contour_spinbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_contour_spinbox.py
@@ -69,5 +69,5 @@ class QtContourSpinBoxControl(QtWidgetControlsBase):
         self.contour_spinbox.clearFocus()
         self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.contour_spinbox_label, self.contour_spinbox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_display_selected_label_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_display_selected_label_checkbox.py
@@ -56,7 +56,7 @@ class QtDisplaySelectedLabelCheckBoxControl(QtWidgetControlsBase):
 
         self.selected_color_checkbox_label = QtWrappedLabel('show\nselected:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.selected_color_checkbox_label, self.selected_color_checkbox)
         ]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_display_selected_label_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_display_selected_label_checkbox.py
@@ -56,7 +56,9 @@ class QtDisplaySelectedLabelCheckBoxControl(QtWidgetControlsBase):
 
         self.selected_color_checkbox_label = QtWrappedLabel('show\nselected:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.selected_color_checkbox_label, self.selected_color_checkbox)
         ]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -195,5 +195,5 @@ class QtLabelControl(QtWidgetControlsBase):
         """Select a new label for the labels layer when the button is clicked."""
         new_label(self._layer)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.label_color_label, self.label_color)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -195,5 +195,7 @@ class QtLabelControl(QtWidgetControlsBase):
         """Select a new label for the labels layer when the button is clicked."""
         new_label(self._layer)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.label_color_label, self.label_color)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_ndim_spinbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_ndim_spinbox.py
@@ -77,5 +77,5 @@ class QtNdimSpinBoxControl(QtWidgetControlsBase):
     def _on_data_change(self) -> None:
         self.ndim_spinbox.setMaximum(self._layer.ndim)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.ndim_spinbox_label, self.ndim_spinbox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_ndim_spinbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_ndim_spinbox.py
@@ -77,5 +77,7 @@ class QtNdimSpinBoxControl(QtWidgetControlsBase):
     def _on_data_change(self) -> None:
         self.ndim_spinbox.setMaximum(self._layer.ndim)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.ndim_spinbox_label, self.ndim_spinbox)]

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_preserve_labels_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_preserve_labels_checkbox.py
@@ -60,7 +60,7 @@ class QtPreserveLabelsCheckBoxControl(QtWidgetControlsBase):
             'preserve\nlabels:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (
                 self.preserve_labels_checkbox_label,

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_preserve_labels_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_preserve_labels_checkbox.py
@@ -60,7 +60,9 @@ class QtPreserveLabelsCheckBoxControl(QtWidgetControlsBase):
             'preserve\nlabels:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (
                 self.preserve_labels_checkbox_label,

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_render_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_render_control.py
@@ -103,7 +103,9 @@ class QtLabelRenderControl(QtWidgetControlsBase):
         self.iso_gradient_combobox.show()
         self.iso_gradient_combobox_label.show()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.render_combobox_label, self.render_combobox),
             (self.iso_gradient_combobox_label, self.iso_gradient_combobox),

--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_render_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_render_control.py
@@ -103,7 +103,7 @@ class QtLabelRenderControl(QtWidgetControlsBase):
         self.iso_gradient_combobox.show()
         self.iso_gradient_combobox_label.show()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.render_combobox_label, self.render_combobox),
             (self.iso_gradient_combobox_label, self.iso_gradient_combobox),

--- a/src/napari/_qt/layer_controls/widgets/_points/qt_border_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_points/qt_border_color.py
@@ -63,5 +63,5 @@ class QtBorderColorControl(QtWidgetControlsBase):
 
         self.border_color_edit_label = QtWrappedLabel('border color:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.border_color_edit_label, self.border_color_edit)]

--- a/src/napari/_qt/layer_controls/widgets/_points/qt_border_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_points/qt_border_color.py
@@ -63,5 +63,7 @@ class QtBorderColorControl(QtWidgetControlsBase):
 
         self.border_color_edit_label = QtWrappedLabel('border color:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.border_color_edit_label, self.border_color_edit)]

--- a/src/napari/_qt/layer_controls/widgets/_points/qt_current_size_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_points/qt_current_size_slider.py
@@ -79,5 +79,5 @@ class QtCurrentSizeSliderControl(QtWidgetControlsBase):
             with contextlib.suppress(TypeError):
                 self.size_slider.setValue(int(value))
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.size_slider_label, self.size_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_points/qt_current_size_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_points/qt_current_size_slider.py
@@ -79,5 +79,7 @@ class QtCurrentSizeSliderControl(QtWidgetControlsBase):
             with contextlib.suppress(TypeError):
                 self.size_slider.setValue(int(value))
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.size_slider_label, self.size_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_points/qt_symbol_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_points/qt_symbol_combobox.py
@@ -69,5 +69,5 @@ class QtSymbolComboBoxControl(QtWidgetControlsBase):
                 Symbol(self._layer.current_symbol)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.symbol_combobox_label, self.symbol_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_points/qt_symbol_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_points/qt_symbol_combobox.py
@@ -69,5 +69,7 @@ class QtSymbolComboBoxControl(QtWidgetControlsBase):
                 Symbol(self._layer.current_symbol)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.symbol_combobox_label, self.symbol_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_color.py
@@ -61,5 +61,7 @@ class QtEdgeColorControl(QtWidgetControlsBase, metaclass=_QtABCMeta):
         )
         self.edge_color_label = QtWrappedLabel('edge color:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.edge_color_label, self.edge_color_edit)]

--- a/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_color.py
@@ -61,5 +61,5 @@ class QtEdgeColorControl(QtWidgetControlsBase, metaclass=_QtABCMeta):
         )
         self.edge_color_label = QtWrappedLabel('edge color:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.edge_color_label, self.edge_color_edit)]

--- a/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_width_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_width_slider.py
@@ -70,5 +70,7 @@ class QtEdgeWidthSliderControl(QtWidgetControlsBase):
             value = np.clip(int(value), 0, 40)
             self.edge_width_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.edge_width_label, self.edge_width_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_width_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_shapes/qt_edge_width_slider.py
@@ -70,5 +70,5 @@ class QtEdgeWidthSliderControl(QtWidgetControlsBase):
             value = np.clip(int(value), 0, 40)
             self.edge_width_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.edge_width_label, self.edge_width_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_surface/qt_shading_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_surface/qt_shading_combobox.py
@@ -61,5 +61,5 @@ class QtShadingComboBoxControl(QtWidgetControlsBase):
         with qt_signals_blocked(self.shading_combobox):
             self.shading_combobox.setCurrentEnum(Shading(self._layer.shading))
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.shading_combobox_label, self.shading_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_surface/qt_shading_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_surface/qt_shading_combobox.py
@@ -61,5 +61,7 @@ class QtShadingComboBoxControl(QtWidgetControlsBase):
         with qt_signals_blocked(self.shading_combobox):
             self.shading_combobox.setCurrentEnum(Shading(self._layer.shading))
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.shading_combobox_label, self.shading_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_color_properties_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_color_properties_combobox.py
@@ -66,5 +66,5 @@ class QtColorPropertiesComboBoxControl(QtWidgetControlsBase):
             self.color_by_combobox.addItems(self._layer.properties_to_color_by)
         self._on_color_by_change()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.color_by_combobox_label, self.color_by_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_color_properties_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_color_properties_combobox.py
@@ -66,5 +66,7 @@ class QtColorPropertiesComboBoxControl(QtWidgetControlsBase):
             self.color_by_combobox.addItems(self._layer.properties_to_color_by)
         self._on_color_by_change()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.color_by_combobox_label, self.color_by_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_colormap_control.py
@@ -55,5 +55,7 @@ class QtColormapComboBoxControl(QtWidgetControlsBase):
                 self.colormap_combobox.findData(self._layer.colormap)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.colormap_combobox_label, self.colormap_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_colormap_control.py
@@ -55,5 +55,5 @@ class QtColormapComboBoxControl(QtWidgetControlsBase):
                 self.colormap_combobox.findData(self._layer.colormap)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.colormap_combobox_label, self.colormap_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_graph_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_graph_checkbox.py
@@ -49,5 +49,7 @@ class QtGraphCheckBoxControl(QtWidgetControlsBase):
 
         self.graph_checkbox_label = QtWrappedLabel('graph:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.graph_checkbox_label, self.graph_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_graph_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_graph_checkbox.py
@@ -49,5 +49,5 @@ class QtGraphCheckBoxControl(QtWidgetControlsBase):
 
         self.graph_checkbox_label = QtWrappedLabel('graph:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.graph_checkbox_label, self.graph_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_head_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_head_slider.py
@@ -59,5 +59,7 @@ class QtHeadLengthSliderControl(QtWidgetControlsBase):
                 self.head_length_slider.setMaximum(self._layer._max_length)
             self.head_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.head_length_slider_label, self.head_length_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_head_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_head_slider.py
@@ -59,5 +59,5 @@ class QtHeadLengthSliderControl(QtWidgetControlsBase):
                 self.head_length_slider.setMaximum(self._layer._max_length)
             self.head_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.head_length_slider_label, self.head_length_slider)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
@@ -57,7 +57,9 @@ class QtHideCompletedTracksCheckBoxControl(QtWidgetControlsBase):
             'hide completed:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (
                 self.hide_completed_tracks_checkbox_label,

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
@@ -57,7 +57,7 @@ class QtHideCompletedTracksCheckBoxControl(QtWidgetControlsBase):
             'hide completed:'
         )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (
                 self.hide_completed_tracks_checkbox_label,

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_id_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_id_checkbox.py
@@ -48,5 +48,5 @@ class QtIdCheckBoxControl(QtWidgetControlsBase):
 
         self.id_checkbox_label = QtWrappedLabel('show ID:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.id_checkbox_label, self.id_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_id_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_id_checkbox.py
@@ -48,5 +48,7 @@ class QtIdCheckBoxControl(QtWidgetControlsBase):
 
         self.id_checkbox_label = QtWrappedLabel('show ID:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.id_checkbox_label, self.id_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_tail_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_tail_control.py
@@ -62,7 +62,9 @@ class QtTailLengthSliderControl(QtWidgetControlsBase):
                 self.tail_length_slider.setMaximum(self._layer._max_length)
             self.tail_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.tail_length_slider_label, self.tail_length_slider)]
 
 
@@ -116,7 +118,9 @@ class QtTailWidthSliderControl(QtWidgetControlsBase):
     def _on_data_change(self) -> None:
         self.tail_width_slider.setMaximum(int(self._layer._max_width))
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.tail_width_slider_label, self.tail_width_slider)]
 
 
@@ -157,5 +161,7 @@ class QtTailDisplayCheckBoxControl(QtWidgetControlsBase):
 
         self.tail_checkbox_label = QtWrappedLabel('tail:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.tail_checkbox_label, self.tail_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_tail_control.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_tail_control.py
@@ -62,7 +62,7 @@ class QtTailLengthSliderControl(QtWidgetControlsBase):
                 self.tail_length_slider.setMaximum(self._layer._max_length)
             self.tail_length_slider.setValue(value)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.tail_length_slider_label, self.tail_length_slider)]
 
 
@@ -116,7 +116,7 @@ class QtTailWidthSliderControl(QtWidgetControlsBase):
     def _on_data_change(self) -> None:
         self.tail_width_slider.setMaximum(int(self._layer._max_width))
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.tail_width_slider_label, self.tail_width_slider)]
 
 
@@ -157,5 +157,5 @@ class QtTailDisplayCheckBoxControl(QtWidgetControlsBase):
 
         self.tail_checkbox_label = QtWrappedLabel('tail:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.tail_checkbox_label, self.tail_checkbox)]

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -175,7 +175,7 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self.color_feature_box.setHidden(True)
             self.edge_feature_label.setHidden(True)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.color_mode_label, self.color_mode_combobox),
             (self.edge_color_label, self.edge_color_edit),

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_edge_color.py
@@ -175,7 +175,9 @@ class QtEdgeColorFeatureControl(QtWidgetControlsBase):
             self.color_feature_box.setHidden(True)
             self.edge_feature_label.setHidden(True)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.color_mode_label, self.color_mode_combobox),
             (self.edge_color_label, self.edge_color_edit),

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_line_dimension_spinbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_line_dimension_spinbox.py
@@ -65,7 +65,9 @@ class QtWidthSpinBoxControl(QtWidgetControlsBase):
         # TODO: Check other way to give focus without calling parent
         self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.width_spinbox_label, self.width_spinbox)]
 
 
@@ -124,5 +126,7 @@ class QtLengthSpinBoxControl(QtWidgetControlsBase):
         # TODO: Check other way to give focus without calling parent
         self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.length_spinbox_label, self.length_spinbox)]

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_line_dimension_spinbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_line_dimension_spinbox.py
@@ -65,7 +65,7 @@ class QtWidthSpinBoxControl(QtWidgetControlsBase):
         # TODO: Check other way to give focus without calling parent
         self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.width_spinbox_label, self.width_spinbox)]
 
 
@@ -124,5 +124,5 @@ class QtLengthSpinBoxControl(QtWidgetControlsBase):
         # TODO: Check other way to give focus without calling parent
         self.parent().setFocus()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.length_spinbox_label, self.length_spinbox)]

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_vector_style_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_vector_style_combobox.py
@@ -65,5 +65,5 @@ class QtVectorStyleComboBoxControl(QtWidgetControlsBase):
             )
             self.vector_style_combobox.setCurrentIndex(index)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.vector_style_combobox_label, self.vector_style_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/_vectors/qt_vector_style_combobox.py
+++ b/src/napari/_qt/layer_controls/widgets/_vectors/qt_vector_style_combobox.py
@@ -65,5 +65,7 @@ class QtVectorStyleComboBoxControl(QtWidgetControlsBase):
             )
             self.vector_style_combobox.setCurrentIndex(index)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.vector_style_combobox_label, self.vector_style_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_colormap_control.py
@@ -205,5 +205,5 @@ class QtColormapControl(QtWidgetControlsBase):
         if color:
             self._layer.colormap = ensure_colormap(color)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.colormap_widget_label, self.colormapWidget)]

--- a/src/napari/_qt/layer_controls/widgets/qt_colormap_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_colormap_control.py
@@ -205,5 +205,7 @@ class QtColormapControl(QtWidgetControlsBase):
         if color:
             self._layer.colormap = ensure_colormap(color)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.colormap_widget_label, self.colormapWidget)]

--- a/src/napari/_qt/layer_controls/widgets/qt_contrast_limits.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_contrast_limits.py
@@ -562,7 +562,9 @@ class QtContrastLimitsControl(QtWidgetControlsBase):
         disconnect_events(self._layer.histogram.events, self)
         super().disconnect_widget_controls()
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.auto_scale_buttons_label, self.auto_scale_buttons),
             (self.contrast_limits_slider_label, self._clim_row),

--- a/src/napari/_qt/layer_controls/widgets/qt_contrast_limits.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_contrast_limits.py
@@ -562,7 +562,7 @@ class QtContrastLimitsControl(QtWidgetControlsBase):
         disconnect_events(self._layer.histogram.events, self)
         super().disconnect_widget_controls()
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.auto_scale_buttons_label, self.auto_scale_buttons),
             (self.contrast_limits_slider_label, self._clim_row),

--- a/src/napari/_qt/layer_controls/widgets/qt_face_color.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_face_color.py
@@ -73,5 +73,5 @@ class QtFaceColorControl(QtWidgetControlsBase):
                 )
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.face_color_label, self.face_color_edit)]

--- a/src/napari/_qt/layer_controls/widgets/qt_face_color.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_face_color.py
@@ -73,5 +73,7 @@ class QtFaceColorControl(QtWidgetControlsBase):
                 )
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.face_color_label, self.face_color_edit)]

--- a/src/napari/_qt/layer_controls/widgets/qt_gamma_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_gamma_slider.py
@@ -49,5 +49,5 @@ class QtGammaSliderControl(QtWidgetControlsBase):
 
         self.gamma_slider_label = QtWrappedLabel('gamma:')
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.gamma_slider_label, self.gamma_slider)]

--- a/src/napari/_qt/layer_controls/widgets/qt_gamma_slider.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_gamma_slider.py
@@ -49,5 +49,7 @@ class QtGammaSliderControl(QtWidgetControlsBase):
 
         self.gamma_slider_label = QtWrappedLabel('gamma:')
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.gamma_slider_label, self.gamma_slider)]

--- a/src/napari/_qt/layer_controls/widgets/qt_histogram_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_histogram_control.py
@@ -12,7 +12,6 @@ from qtpy.QtWidgets import (
 
 from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
-    QtWrappedLabel,
 )
 from napari._qt.widgets.qt_histogram_content import QtHistogramContentWidget
 from napari.layers import Image
@@ -108,7 +107,7 @@ class QtHistogramControl(QtWidgetControlsBase):
         self.histogram_widget = self.histogram_content.histogram_widget
         self.settings_widget = self.histogram_content.settings_widget
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         """Return empty list; histogram is dynamically shown/hidden."""
         return []
 

--- a/src/napari/_qt/layer_controls/widgets/qt_histogram_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_histogram_control.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
 
 from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
+    QtWrappedLabel,
 )
 from napari._qt.widgets.qt_histogram_content import QtHistogramContentWidget
 from napari.layers import Image
@@ -107,7 +108,9 @@ class QtHistogramControl(QtWidgetControlsBase):
         self.histogram_widget = self.histogram_content.histogram_widget
         self.settings_widget = self.histogram_content.settings_widget
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         """Return empty list; histogram is dynamically shown/hidden."""
         return []
 

--- a/src/napari/_qt/layer_controls/widgets/qt_multiscale_level_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_multiscale_level_control.py
@@ -134,12 +134,14 @@ class QtMultiscaleLevelControl(QtWidgetControlsBase):
             else:
                 self.level_combobox.setCurrentIndex(0)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         """Return the label/widget pairs for this control.
 
         Returns
         -------
-        list[tuple[QWidget, ...]]
+        list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]
             Single-element list containing the resolution label and combobox.
         """
         return [(self.level_label, self.level_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/qt_multiscale_level_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_multiscale_level_control.py
@@ -134,12 +134,12 @@ class QtMultiscaleLevelControl(QtWidgetControlsBase):
             else:
                 self.level_combobox.setCurrentIndex(0)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         """Return the label/widget pairs for this control.
 
         Returns
         -------
-        list[tuple[QtWrappedLabel, QWidget]]
+        list[tuple[QWidget, ...]]
             Single-element list containing the resolution label and combobox.
         """
         return [(self.level_label, self.level_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/qt_opacity_blending_controls.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_opacity_blending_controls.py
@@ -111,7 +111,7 @@ class QtOpacityBlendingControls(QtWidgetControlsBase):
         with self._layer.events.blending.blocker():
             self.blend_combobox.setCurrentEnum(Blending(self._layer.blending))
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [
             (self.opacity_label, self.opacity_slider),
             (self.blend_label, self.blend_combobox),

--- a/src/napari/_qt/layer_controls/widgets/qt_opacity_blending_controls.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_opacity_blending_controls.py
@@ -111,7 +111,9 @@ class QtOpacityBlendingControls(QtWidgetControlsBase):
         with self._layer.events.blending.blocker():
             self.blend_combobox.setCurrentEnum(Blending(self._layer.blending))
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [
             (self.opacity_label, self.opacity_slider),
             (self.blend_label, self.blend_combobox),

--- a/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
@@ -58,5 +58,5 @@ class QtProjectionModeControl(QtWidgetControlsBase):
                 str(self._layer.projection_mode)
             )
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.projection_combobox_label, self.projection_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
@@ -58,5 +58,7 @@ class QtProjectionModeControl(QtWidgetControlsBase):
                 str(self._layer.projection_mode)
             )
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.projection_combobox_label, self.projection_combobox)]

--- a/src/napari/_qt/layer_controls/widgets/qt_text_visibility.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_text_visibility.py
@@ -55,7 +55,9 @@ class QtTextVisibilityControl(QtWidgetControlsBase):
         with qt_signals_blocked(self.text_disp_checkbox):
             self.text_disp_checkbox.setChecked(self._layer.text.visible)
 
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         return [(self.text_disp_label, self.text_disp_checkbox)]
 
     def disconnect_widget_controls(self) -> None:

--- a/src/napari/_qt/layer_controls/widgets/qt_text_visibility.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_text_visibility.py
@@ -55,7 +55,7 @@ class QtTextVisibilityControl(QtWidgetControlsBase):
         with qt_signals_blocked(self.text_disp_checkbox):
             self.text_disp_checkbox.setChecked(self._layer.text.visible)
 
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         return [(self.text_disp_label, self.text_disp_checkbox)]
 
     def disconnect_widget_controls(self) -> None:

--- a/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
@@ -60,13 +60,13 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         self._callbacks: list[Callable[[Any], None]] = []
 
     @abstractmethod
-    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
         """
         Enable access to the created labels and control widgets.
 
         Returns
         -------
-        list : list[tuple[QtWrappedLabel, QWidget]]
+        list : list[tuple[QWidget, ...]]
             List of tuples of the label and widget controls available.
 
         """

--- a/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
@@ -60,13 +60,15 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         self._callbacks: list[Callable[[Any], None]] = []
 
     @abstractmethod
-    def get_widget_controls(self) -> list[tuple[QWidget, ...]]:
+    def get_widget_controls(
+        self,
+    ) -> list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]:
         """
         Enable access to the created labels and control widgets.
 
         Returns
         -------
-        list : list[tuple[QWidget, ...]]
+        list : list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]
             List of tuples of the label and widget controls available.
 
         """

--- a/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_widget_controls_base.py
@@ -69,7 +69,7 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         Returns
         -------
         list : list[tuple[QtWrappedLabel, QWidget] | tuple[QWidget]]
-            List of tuples of the label and widget controls available.
+            List of tuples of the widget controls available.
 
         """
         raise NotImplementedError


### PR DESCRIPTION
# References and relevant issues
- part of https://github.com/napari/napari/pull/9438

# Description
This is a ton of lines just for type annotation; the real changes are just a couple files (search for `label, widget` in the changes and you'll find them all) where we no longer assume that widgets are always `label, widget`, but they might also be a tuple of a single `widget`. This allows us to return to having the histogram take up all the horizontal space, and to do the same with other widgets in the future if needed.
