### PR TITLE
Fix warning on new label button

### DIFF
--- a/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
+++ b/src/napari/_qt/layer_controls/widgets/_labels/qt_label_color.py
@@ -17,7 +17,6 @@ from napari.layers import Labels
 from napari.layers.labels._labels_key_bindings import new_label
 from napari.layers.labels._labels_utils import get_dtype
 from napari.utils._dtype import get_dtype_limits
-from napari.utils.action_manager import action_manager
 from napari.utils.events import disconnect_events
 
 
@@ -154,7 +153,6 @@ class QtLabelControl(QtWidgetControlsBase):
         self.new_label_button = QPushButton()
         self.new_label_button.setText('new')
         self.new_label_button.setObjectName('newLabelButton')
-        action_manager.bind_button('napari:new_label', self.new_label_button)
         self.new_label_button.clicked.connect(self._on_button_click)
 
         self.label_color_label = QtWrappedLabel('label:')


### PR DESCRIPTION
# References and relevant issues
- closes https://github.com/napari/napari/issues/9454


# Description
We actually fixed this already in the dynamic controls; this was double-firing because of the connection to the action managed AND also the action being called manually. 
