### PR TITLE
Fix out-of-sync extent in async mode

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -633,7 +633,7 @@ class QtViewer(QSplitter):
                     data_displayed=False,
                     thumbnail=True,
                     highlight=True,
-                    extent=True,
+                    extent=False,  # already updated
                 )
 
     def _on_active_change(self) -> None:

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -633,7 +633,7 @@ class QtViewer(QSplitter):
                     data_displayed=False,
                     thumbnail=True,
                     highlight=True,
-                    extent=False,  # already updated
+                    extent=False,  # already updated via Layer.refresh()
                 )
 
     def _on_active_change(self) -> None:

--- a/src/napari/layers/base/base.py
+++ b/src/napari/layers/base/base.py
@@ -1697,6 +1697,9 @@ class Layer(KeymapProvider, MousemapProvider, ABC, metaclass=PostInit):
         logger.debug('Layer.refresh: %s', self)
         # If async is enabled then emit an event that the viewer should handle.
         if get_settings().experimental.async_ and data_displayed:
+            # eagerly refresh the extent, even if the layer is invisible, because
+            # the viewer needs to know if the extent changed to update the gui
+            self._refresh_sync(extent=extent, force=True)
             # full async slice reload, it will also update everything when done slicing
             # via the callback of layer.loaded which calls _refresh_sync
             self.events.reload(layer=self)


### PR DESCRIPTION
# References and relevant issues
- https://github.com/napari/napari/pull/9440#issuecomment-5423003103
- https://napari.zulipchat.com/#narrow/channel/212875-general/topic/3.2E14.20silently.20breaking.20stuff/with/619230777

# Description
Layer extent should be eagerly updated regardless of sync/async slicing, because the viewer gui depends on it being "up to date" when it updates itself. I *think* this is the right way to fix it, because extent is not slicing-dependent, and is *relatively* cheaper to compute than the slicing. We also don't want the dims slider to be jumping around halfway through moving them because a layer slice comes in from the async thread..
