### PR TITLE
Fix changing theme with dynamic controls

### DIFF
--- a/src/napari/_qt/layer_controls/_tests/test_qt_controls_container.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_controls_container.py
@@ -25,9 +25,10 @@ def test_qt_container_creation(dynamic, qtbot, viewer_model):
 
 @pytest.mark.parametrize('dynamic', [True, False])
 def test_qt_container_theme_change(dynamic, qtbot, viewer_model):
+    get_settings().experimental.dynamic_layer_controls = dynamic
     cont = QtLayerControlsContainer(viewer_model)
     qtbot.addWidget(cont)
     viewer_model.add_image(np.arange(25).reshape(5, 5))
-    get_settings().appearance.theme = 'light'
+    viewer_model.theme = 'light'
     # only affects histogram; too nasty to actualy check for, but
     # at least this runs the lines to ensure nothign crashes

--- a/src/napari/_qt/layer_controls/_tests/test_qt_controls_container.py
+++ b/src/napari/_qt/layer_controls/_tests/test_qt_controls_container.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+
+from napari._qt.layer_controls.dynamic.qt_dynamic_layer_controls import (
+    QtDynamicLayerControls,
+)
+from napari._qt.layer_controls.qt_layer_controls_container import (
+    QtLayerControlsContainer,
+)
+from napari._qt.layer_controls.qt_points_controls import QtPointsControls
+from napari.settings import get_settings
+
+
+@pytest.mark.parametrize('dynamic', [True, False])
+def test_qt_container_creation(dynamic, qtbot, viewer_model):
+    get_settings().experimental.dynamic_layer_controls = dynamic
+    cont = QtLayerControlsContainer(viewer_model)
+    qtbot.addWidget(cont)
+    viewer_model.add_points()
+    if dynamic:
+        assert isinstance(cont.currentWidget(), QtDynamicLayerControls)
+    else:
+        assert isinstance(cont.currentWidget(), QtPointsControls)
+
+
+@pytest.mark.parametrize('dynamic', [True, False])
+def test_qt_container_theme_change(dynamic, qtbot, viewer_model):
+    cont = QtLayerControlsContainer(viewer_model)
+    qtbot.addWidget(cont)
+    viewer_model.add_image(np.arange(25).reshape(5, 5))
+    get_settings().appearance.theme = 'light'
+    # only affects histogram; too nasty to actualy check for, but
+    # at least this runs the lines to ensure nothign crashes

--- a/src/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -136,7 +136,7 @@ class QtLayerControlsContainer(QStackedWidget):
                 hist_widget._on_theme_change(event)
 
         if self.panel is not None:
-            for widget in self.panel.values():
+            for widget in self.panel._controls:
                 histogram_control = getattr(widget, '_histogram_control', None)
                 if histogram_control is None:
                     continue


### PR DESCRIPTION
# Description
We messed up a loop in our refactor; currently, if you change viewer theme (ctrl+shift+t) while dynamic controls are open, it will fail.
