### PR TITLE
Keep dock widgets resizable when their widget asks for vertical space

### DIFF
--- a/src/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -2,8 +2,10 @@ import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QDockWidget,
+    QGroupBox,
     QHBoxLayout,
     QPushButton,
+    QSizePolicy,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -154,6 +156,40 @@ def test_adding_stretch(make_napari_viewer):
         widg, area='bottom', add_vertical_stretch=True
     )
     assert widg.layout().count() == 1
+    dw.close()
+
+
+def test_dock_widget_can_grow_vertically(make_napari_viewer):
+    """A dock is capped at its widget's size hint unless the widget's vertical size policy can grow."""
+    viewer = make_napari_viewer()
+
+    # a compact widget is held at its size hint rather than stretched
+    widg = QWidget()
+    widg.setLayout(QVBoxLayout())
+    widg.layout().addWidget(QPushButton())
+    dw = viewer.window.add_dock_widget(widg, area='right')
+    assert dw.layout().maximumSize().height() < widg.maximumHeight()
+    dw.close()
+
+    # ... unless something in its layout wants vertical space, at any depth
+    widg = QWidget()
+    widg.setLayout(QVBoxLayout())
+    box = QGroupBox()
+    box.setLayout(QVBoxLayout())
+    box.layout().addWidget(QTextEdit())
+    widg.layout().addWidget(box)
+    dw = viewer.window.add_dock_widget(widg, area='right')
+    assert dw.layout().maximumSize().height() == widg.maximumHeight()
+    dw.close()
+
+    # ... or the widget asks for it itself, with the horizontal policy still normalized
+    widg = QWidget()
+    widg.setSizePolicy(
+        QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+    )
+    dw = viewer.window.add_dock_widget(widg, area='right')
+    assert dw.layout().maximumSize().height() == widg.maximumHeight()
+    assert widg.sizePolicy().horizontalPolicy() == QSizePolicy.Policy.Preferred
     dw.close()
 
 

--- a/src/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/src/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QLayout,
     QPushButton,
     QSizePolicy,
     QVBoxLayout,
@@ -37,6 +38,42 @@ dock_area_to_str = {
     Qt.DockWidgetArea.TopDockWidgetArea: 'top',
     Qt.DockWidgetArea.BottomDockWidgetArea: 'bottom',
 }
+
+
+_GROWING_POLICIES = frozenset(
+    {
+        QSizePolicy.Policy.Expanding,
+        QSizePolicy.Policy.MinimumExpanding,
+        QSizePolicy.Policy.Ignored,
+    }
+)
+
+
+def _wants_vertical_space(widget: QWidget) -> bool:
+    """Whether a widget, or anything in its layout, asks to grow vertically."""
+    if widget.sizePolicy().verticalPolicy() in _GROWING_POLICIES:
+        return True
+
+    # not uncommon to see people shadow the builtin layout() method
+    try:
+        wlayout = widget.layout()
+    except TypeError:
+        return False
+    return wlayout is not None and _layout_wants_vertical_space(wlayout)
+
+
+def _layout_wants_vertical_space(layout: QLayout) -> bool:
+    for i in range(layout.count()):
+        item = layout.itemAt(i)
+        wdg = item.widget()
+        if wdg is not None:
+            if _wants_vertical_space(wdg):
+                return True
+        elif item.layout() is not None and _layout_wants_vertical_space(
+            item.layout()
+        ):
+            return True
+    return False
 
 
 class QtViewerDockWidget(QDockWidget):
@@ -128,10 +165,12 @@ class QtViewerDockWidget(QDockWidget):
 
         is_vertical = area in {'left', 'right'}
         widget_ = combine_widgets(widget, vertical=is_vertical)
-        widget_.setSizePolicy(
-            QSizePolicy.Policy.Preferred,
-            QSizePolicy.Policy.Maximum,
+        vertical_policy = (
+            widget_.sizePolicy().verticalPolicy()
+            if _wants_vertical_space(widget_)
+            else QSizePolicy.Policy.Maximum
         )
+        widget_.setSizePolicy(QSizePolicy.Policy.Preferred, vertical_policy)
         self.setWidget(widget_)
         if is_vertical and add_vertical_stretch:
             self._maybe_add_vertical_stretch(widget_)
@@ -202,12 +241,7 @@ class QtViewerDockWidget(QDockWidget):
         ...if there is not already a widget that wants vertical space
         (like a textedit or listwidget or something).
         """
-        exempt_policies = {
-            QSizePolicy.Expanding,
-            QSizePolicy.MinimumExpanding,
-            QSizePolicy.Ignored,
-        }
-        if widget.sizePolicy().verticalPolicy() in exempt_policies:
+        if _wants_vertical_space(widget):
             return
 
         # not uncommon to see people shadow the builtin layout() method
@@ -218,14 +252,6 @@ class QtViewerDockWidget(QDockWidget):
                 return
         except TypeError:
             return
-
-        for i in range(wlayout.count()):
-            wdg = wlayout.itemAt(i).widget()
-            if (
-                wdg is not None
-                and wdg.sizePolicy().verticalPolicy() in exempt_policies
-            ):
-                return
 
         # not all widgets have addStretch...
         if hasattr(wlayout, 'addStretch'):


### PR DESCRIPTION
# References and relevant issues

Follow-up to #9393. Related: #9447.

Closes #9483 

# Description

#9393 gives the docked widget a vertical size policy of `Maximum`, which turns its size hint into a hard ceiling. A dock holding a list or a plot can no longer be dragged taller, docked or floating. #9447 restored the policy for the layer list at the call site; any other dock widget that wants to grow needs the same workaround.

The stretch that #9393 replaced skipped widgets asking for vertical space through their own size policy or a child's. This restores that exemption for the vertical policy and keeps normalizing the horizontal one. It walks the layout tree rather than only direct children, so a growable widget inside a group box counts too.

Compact widgets still get `Maximum`, so the `magicgui` case from #9393 is unchanged. The layer list is exempt, which makes #9447's restore a no-op that could be dropped.
