### PR TITLE
Fix logger from console 2

### DIFF
--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -25,7 +25,7 @@ from napari._wayland_fix import _nvidia_driver_loaded
 from napari.resources._icons import _theme_path
 from napari.settings import get_settings
 from napari.utils import config, perf
-from napari.utils._logging import register_logger_to_napari_handler
+from napari.utils.logging import using_napari_log_handler
 from napari.utils.logo import get_logo_path
 from napari.utils.notifications import (
     notification_manager,
@@ -440,6 +440,6 @@ def run(
     with (
         notification_manager,
         _maybe_allow_interrupt(app),
-        register_logger_to_napari_handler(''),
+        using_napari_log_handler(''),
     ):
         app.exec_()

--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -81,6 +81,7 @@ from napari.utils import perf
 from napari.utils._proxies import MappingProxy, PublicOnlyProxy
 from napari.utils.events import Event
 from napari.utils.io import imsave
+from napari.utils.logging import register_logger_to_napari_handler
 from napari.utils.misc import (
     in_ipython,
     in_jupyter,
@@ -138,6 +139,8 @@ class _QtMainWindow(QMainWindow):
         show_welcome_screen=True,
     ) -> None:
         super().__init__(parent)
+        register_logger_to_napari_handler('')
+
         self._ev = None
         self._window = window
         self._plugin_manager_dialog = None

--- a/src/napari/_qt/widgets/_tests/test_qt_logger.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_logger.py
@@ -1,8 +1,17 @@
+import logging
+
 from napari._qt.widgets.qt_logger import LogWidget
+from napari.utils import logging as napari_logging
 
 
 def test_qt_logger(qtbot):
     widget = LogWidget()
     qtbot.addWidget(widget)
     widget.show()
+    logger = logging.getLogger('napari')
+
+    with napari_logging.using_napari_log_handler('napari'):
+        logger.warning('TEST WARNING')
+        assert 'TEST WARNING' in widget.log_text_box.toPlainText()
+
     widget.hide()

--- a/src/napari/_qt/widgets/qt_logger.py
+++ b/src/napari/_qt/widgets/qt_logger.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import (
 )
 
 from napari._qt.dialogs.qt_about import QtCopyToClipboardButton
-from napari.utils.logging import _LOG_STREAM, _get_log_level_value
+from napari.utils import logging as napari_logging
 
 
 class LogWidget(QWidget):
@@ -87,7 +87,7 @@ class LogWidget(QWidget):
         self.text_filter.textChanged.connect(self._on_change)
 
         # TODO: super laggy when open :/
-        _LOG_STREAM.changed.connect(self._on_new_message)
+        napari_logging._LOG_STREAM.changed.connect(self._on_new_message)
         self._prev_pos = None
         self.log_text_box.verticalScrollBar().rangeChanged.connect(
             self._jump_to_pos
@@ -98,13 +98,13 @@ class LogWidget(QWidget):
         self._jump_to_pos()
 
     def _on_loglevel_change(self, event=None):
-        level = _get_log_level_value(event)
+        level = napari_logging._get_log_level_value(event)
         logging.getLogger().setLevel(level)
 
     def _on_new_message(self, event=None):
         self._prev_pos = self._scroll_pos()
 
-        logs = _LOG_STREAM.get_filtered_logs_html(
+        logs = napari_logging._LOG_STREAM.get_filtered_logs_html(
             self.level_filter.currentText(),
             self.text_filter.text(),
             last_only=True,
@@ -115,7 +115,7 @@ class LogWidget(QWidget):
     def _on_change(self, event=None):
         self._prev_pos = self._scroll_pos()
 
-        logs = _LOG_STREAM.get_filtered_logs_html(
+        logs = napari_logging._LOG_STREAM.get_filtered_logs_html(
             self.level_filter.currentText(), self.text_filter.text()
         )
         self.log_text_box.clear()

--- a/src/napari/_qt/widgets/qt_logger.py
+++ b/src/napari/_qt/widgets/qt_logger.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import (
 )
 
 from napari._qt.dialogs.qt_about import QtCopyToClipboardButton
-from napari.utils._logging import LOG_STREAM, get_log_level_value
+from napari.utils.logging import _LOG_STREAM, _get_log_level_value
 
 
 class LogWidget(QWidget):
@@ -87,7 +87,7 @@ class LogWidget(QWidget):
         self.text_filter.textChanged.connect(self._on_change)
 
         # TODO: super laggy when open :/
-        LOG_STREAM.changed.connect(self._on_new_message)
+        _LOG_STREAM.changed.connect(self._on_new_message)
         self._prev_pos = None
         self.log_text_box.verticalScrollBar().rangeChanged.connect(
             self._jump_to_pos
@@ -98,23 +98,24 @@ class LogWidget(QWidget):
         self._jump_to_pos()
 
     def _on_loglevel_change(self, event=None):
-        level = get_log_level_value(event)
+        level = _get_log_level_value(event)
         logging.getLogger().setLevel(level)
 
     def _on_new_message(self, event=None):
         self._prev_pos = self._scroll_pos()
 
-        log = LOG_STREAM.get_filtered_logs_html(
+        logs = _LOG_STREAM.get_filtered_logs_html(
             self.level_filter.currentText(),
             self.text_filter.text(),
             last_only=True,
-        )[0]
-        self.log_text_box.append(log)
+        )
+        if logs:
+            self.log_text_box.append(logs[0])
 
     def _on_change(self, event=None):
         self._prev_pos = self._scroll_pos()
 
-        logs = LOG_STREAM.get_filtered_logs_html(
+        logs = _LOG_STREAM.get_filtered_logs_html(
             self.level_filter.currentText(), self.text_filter.text()
         )
         self.log_text_box.clear()

--- a/src/napari/conftest.py
+++ b/src/napari/conftest.py
@@ -1144,7 +1144,7 @@ with contextlib.suppress(ImportError):
         import logging
 
         monkeypatch.setattr(
-            'napari._qt.widgets.qt_logger.get_log_level_value',
+            'napari._qt.widgets.qt_logger._get_log_level_value',
             lambda x: logging.WARNING,
         )
 

--- a/src/napari/conftest.py
+++ b/src/napari/conftest.py
@@ -1144,7 +1144,7 @@ with contextlib.suppress(ImportError):
         import logging
 
         monkeypatch.setattr(
-            'napari._qt.widgets.qt_logger._get_log_level_value',
+            'napari.utils.logging._get_log_level_value',
             lambda x: logging.WARNING,
         )
 

--- a/src/napari/utils/_tests/test_logging.py
+++ b/src/napari/utils/_tests/test_logging.py
@@ -1,13 +1,13 @@
 import logging
 
-from napari.utils._logging import LOG_STREAM, register_logger_to_napari_handler
+from napari.utils.logging import _LOG_STREAM, using_napari_log_handler
 
 
 def test_log_stream():
-    with register_logger_to_napari_handler(''):
+    with using_napari_log_handler(''):
         logger = logging.getLogger('test_logger')
         logger.setLevel('DEBUG')
         log_msg = 'NAPARI TEST LOG MESSAGE'
         logger.debug(log_msg)
 
-    assert log_msg in ''.join(LOG_STREAM.get_filtered_logs_html())
+    assert log_msg in ''.join(_LOG_STREAM.get_filtered_logs_html())

--- a/src/napari/utils/_tests/test_logging.py
+++ b/src/napari/utils/_tests/test_logging.py
@@ -1,13 +1,15 @@
 import logging
 
-from napari.utils.logging import _LOG_STREAM, using_napari_log_handler
+from napari.utils import logging as napari_logging
 
 
 def test_log_stream():
-    with using_napari_log_handler(''):
+    with napari_logging.using_napari_log_handler(''):
         logger = logging.getLogger('test_logger')
         logger.setLevel('DEBUG')
         log_msg = 'NAPARI TEST LOG MESSAGE'
         logger.debug(log_msg)
 
-    assert log_msg in ''.join(_LOG_STREAM.get_filtered_logs_html())
+    assert log_msg in ''.join(
+        napari_logging._LOG_STREAM.get_filtered_logs_html()
+    )

--- a/src/napari/utils/logging.py
+++ b/src/napari/utils/logging.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-def get_log_level_value(log_level_name: str | None) -> int:
+def _get_log_level_value(log_level_name: str | None) -> int:
     if log_level_name is None:
         return logging.NOTSET
     return logging.getLevelNamesMapping().get(log_level_name, logging.NOTSET)
@@ -35,7 +35,7 @@ class _LogStream:
 
     def write(self, log_msg: str) -> None:
         logger, level_name, time, thread, msg = log_msg.split(_LOG_SEPARATOR)
-        level_value = get_log_level_value(level_name)
+        level_value = _get_log_level_value(level_name)
         self.logs.append((logger, level_value, level_name, time, thread, msg))
         # TODO: actually save log to a file somewhere so it can be retrieved?
         self.changed()
@@ -50,9 +50,9 @@ class _LogStream:
         last_only: bool = False,
     ) -> list[str]:
         if isinstance(level, str):
-            level = get_log_level_value(level)
+            level = _get_log_level_value(level)
 
-        logs = [LOG_STREAM.logs[-1]] if last_only else LOG_STREAM.logs
+        logs = [_LOG_STREAM.logs[-1]] if last_only else _LOG_STREAM.logs
 
         selected = [
             (logger_name, level_value, *others)
@@ -77,30 +77,14 @@ class _LogStream:
         ]
 
 
-LOG_STREAM = _LogStream()
-LOG_HANDLER = logging.StreamHandler(LOG_STREAM)
-LOG_HANDLER.setFormatter(
+_LOG_STREAM = _LogStream()
+_LOG_HANDLER = logging.StreamHandler(_LOG_STREAM)
+_LOG_HANDLER.setFormatter(
     logging.Formatter(
         f'%(name)s{_LOG_SEPARATOR}%(levelname)s{_LOG_SEPARATOR}%(asctime)s{_LOG_SEPARATOR}%(threadName)s{_LOG_SEPARATOR}%(message)s'
     )
 )
-LOG_HANDLER.setLevel(logging.DEBUG)
-
-
-@contextmanager
-def register_logger_to_napari_handler(
-    module: str,
-) -> Generator[None, None, None]:
-    """
-    Register a specific module's logger to use our custom log handler.
-    """
-    logger = logging.getLogger(module)
-    # ensure the default "last resort" logging to console remains
-    if not logger.handlers and logging.lastResort:
-        logger.addHandler(logging.lastResort)
-    logger.addHandler(LOG_HANDLER)
-    yield
-    logger.removeHandler(LOG_HANDLER)
+_LOG_HANDLER.setLevel(logging.DEBUG)
 
 
 def _html_tag_for_level(level_name: str, level_value: int) -> str:
@@ -120,3 +104,35 @@ def _html_tag_for_level(level_name: str, level_value: int) -> str:
     # this is ugly AF but html is weird and I don't get it
     padding = '&nbsp;' * (8 - len(level_name))
     return f'<font style="color:{color}">{level_name}{padding}</font>'
+
+
+def register_logger_to_napari_handler(module: str) -> None:
+    """
+    Register a specific module's logger to use our custom log handler.
+    """
+    logger = logging.getLogger(module)
+    # ensure the default "last resort" logging to console remains
+    if not logger.handlers and logging.lastResort:
+        logger.addHandler(logging.lastResort)
+    logger.addHandler(_LOG_HANDLER)
+
+
+def deregister_logger_from_napari_handler(module: str) -> None:
+    """
+    Deregister a specific module's logger from using our custom log handler.
+    """
+    logger = logging.getLogger(module)
+    # fails silently
+    logger.removeHandler(_LOG_HANDLER)
+
+
+@contextmanager
+def using_napari_log_handler(
+    module: str,
+) -> Generator[None, None, None]:
+    """
+    Context manager to temporarily register a module's logger to our custom handler.
+    """
+    register_logger_to_napari_handler(module)
+    yield
+    deregister_logger_from_napari_handler(module)

--- a/src/napari/utils/logging.py
+++ b/src/napari/utils/logging.py
@@ -109,6 +109,8 @@ def _html_tag_for_level(level_name: str, level_value: int) -> str:
 def register_logger_to_napari_handler(module: str) -> None:
     """
     Register a specific module's logger to use our custom log handler.
+
+    .. version-added:: 0.10.0
     """
     logger = logging.getLogger(module)
     # ensure the default "last resort" logging to console remains
@@ -120,6 +122,8 @@ def register_logger_to_napari_handler(module: str) -> None:
 def deregister_logger_from_napari_handler(module: str) -> None:
     """
     Deregister a specific module's logger from using our custom log handler.
+
+    .. version-added:: 0.10.0
     """
     logger = logging.getLogger(module)
     # fails silently
@@ -132,6 +136,8 @@ def using_napari_log_handler(
 ) -> Generator[None, None, None]:
     """
     Context manager to temporarily register a module's logger to our custom handler.
+
+    .. version-added:: 0.10.0
     """
     register_logger_to_napari_handler(module)
     yield

--- a/src/napari/utils/logging.py
+++ b/src/napari/utils/logging.py
@@ -15,6 +15,13 @@ if TYPE_CHECKING:
     from typing import Any
 
 
+__all__ = [
+    'deregister_logger_from_napari_handler',
+    'register_logger_to_napari_handler',
+    'using_napari_log_handler',
+]
+
+
 def _get_log_level_value(log_level_name: str | None) -> int:
     if log_level_name is None:
         return logging.NOTSET


### PR DESCRIPTION
# References and relevant issues
Alternative to #8778

# Description
The old PR was out of date and needed rewriting anyways, so I made this one from scratch. It's much simpler:

1. expose logging registration publicly, so users can choose to use it "early" if they want (ie.: before starting anything else in napari)
2. add a call on launch of the qt window. This ensures that if the GUI is spawned, the logger widget has somethign to show.

@Czaki do you think this is reasonable, given the previous discussion in #8778?
