### PR TITLE
Use a fixed-pitch font for the status bar's numeric readouts

### DIFF
--- a/src/napari/_qt/_tests/test_app.py
+++ b/src/napari/_qt/_tests/test_app.py
@@ -5,7 +5,8 @@ from collections import defaultdict
 from unittest.mock import Mock
 
 import pytest
-from qtpy.QtWidgets import QAction, QShortcut
+from qtpy.QtGui import QFont
+from qtpy.QtWidgets import QAction, QLabel, QShortcut
 
 from napari._qt.qt_event_loop import (
     _ipython_has_eventloop,
@@ -91,6 +92,32 @@ def test_no_wayland_warning(
     assert not any(
         'Wayland startup workaround' in str(w.message) for w in records
     )
+
+
+@pytest.mark.skipif(
+    not hasattr(QFont, 'Tag'), reason='QFont.setFeature requires Qt 6.7+'
+)
+def test_status_bar_requests_tabular_numerals_with_preexisting_app(
+    make_napari_viewer, qapp, qtbot
+):
+    """The status bar gets tabular figures without changing an embedding host's font."""
+    tag = QFont.Tag('tnum')
+    app_font = QFont(qapp.font())
+    host_label = QLabel('host')
+    qtbot.addWidget(host_label)
+    host_font = QFont(host_label.font())
+
+    viewer = make_napari_viewer()
+    window = viewer.window._qt_window
+    status = window.statusBar()._status
+
+    assert status.font().isFeatureSet(tag)
+    assert qapp.font() == app_font
+    assert host_label.font() == host_font
+
+    viewer.window._update_theme()
+
+    assert status.font().isFeatureSet(tag)
 
 
 def test_shortcut_collision(qtbot, make_napari_viewer):

--- a/src/napari/_qt/_tests/test_app.py
+++ b/src/napari/_qt/_tests/test_app.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from unittest.mock import Mock
 
 import pytest
-from qtpy.QtGui import QFont
+from qtpy.QtGui import QFont, QFontMetricsF
 from qtpy.QtWidgets import QAction, QLabel, QShortcut
 
 from napari._qt.qt_event_loop import (
@@ -118,6 +118,15 @@ def test_status_bar_requests_tabular_numerals_with_preexisting_app(
     viewer.window._update_theme()
 
     assert status.font().isFeatureSet(tag)
+
+
+def test_status_readouts_use_fixed_pitch_font(make_napari_viewer):
+    viewer = make_napari_viewer()
+    status_bar = viewer.window._qt_window.statusBar()
+
+    for label in (status_bar._status, status_bar._coordinates):
+        fm = QFontMetricsF(label.font())
+        assert len({fm.horizontalAdvance(c) for c in '0189 .-'}) == 1
 
 
 def test_shortcut_collision(qtbot, make_napari_viewer):

--- a/src/napari/_qt/_tests/test_qt_utils.py
+++ b/src/napari/_qt/_tests/test_qt_utils.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 import pytest
 from qtpy.QtCore import QByteArray, QObject, Signal
-from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QColorDialog, QMainWindow
+from qtpy.QtGui import QColor, QFont
+from qtpy.QtWidgets import QColorDialog, QLabel, QMainWindow
 
 from napari._qt.utils import (
     QBYTE_FLAG,
@@ -17,6 +17,7 @@ from napari._qt.utils import (
     qt_might_be_rich_text,
     qt_signals_blocked,
     str_to_qbytearray,
+    use_tabular_numerals,
 )
 from napari.utils._proxies import PublicOnlyProxy
 
@@ -208,3 +209,18 @@ def test_get_color_reject(
 
     color_ = get_color(color, mode)
     assert color_ is None, 'Expected color to be None when dialog is rejected'
+
+
+@pytest.mark.skipif(
+    not hasattr(QFont, 'Tag'), reason='QFont.setFeature requires Qt 6.7+'
+)
+def test_use_tabular_numerals(qtbot: QtBot) -> None:
+    """Label gets tabular numerals, but font family is not changed."""
+    label = QLabel('123')
+    qtbot.addWidget(label)
+    family = label.font().family()
+
+    assert use_tabular_numerals(label) is True
+
+    assert label.font().isFeatureSet(QFont.Tag('tnum'))
+    assert label.font().family() == family

--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -20,7 +20,7 @@ from napari._qt.qthreading import (
     register_threadworker_processors,
     wait_for_workers_to_quit,
 )
-from napari._qt.utils import _maybe_allow_interrupt
+from napari._qt.utils import _maybe_allow_interrupt, use_tabular_numerals
 from napari._wayland_fix import _nvidia_driver_loaded
 from napari.resources._icons import _theme_path
 from napari.settings import get_settings
@@ -248,6 +248,12 @@ def get_qapp(
         # Intercept tooltip events in order to convert all text to rich text
         # to allow for text wrapping of tooltips
         app.installEventFilter(QtToolTipEventFilter())
+
+        # Give every widget fixed-width digits, so that live numeric readouts
+        # (cursor coordinates, slider values, ...) do not jitter as the digits
+        # change. Only done when napari created the QApplication, so that an
+        # application napari is embedded in keeps the font it chose.
+        use_tabular_numerals(app)
 
     if app.windowIcon().isNull():
         app.setWindowIcon(_svg_path_to_icon(kwargs['icon']))

--- a/src/napari/_qt/qt_event_loop.py
+++ b/src/napari/_qt/qt_event_loop.py
@@ -249,10 +249,6 @@ def get_qapp(
         # to allow for text wrapping of tooltips
         app.installEventFilter(QtToolTipEventFilter())
 
-        # Give every widget fixed-width digits, so that live numeric readouts
-        # (cursor coordinates, slider values, ...) do not jitter as the digits
-        # change. Only done when napari created the QApplication, so that an
-        # application napari is embedded in keeps the font it chose.
         use_tabular_numerals(app)
 
     if app.windowIcon().isNull():

--- a/src/napari/_qt/utils.py
+++ b/src/napari/_qt/utils.py
@@ -20,7 +20,15 @@ from qtpy.QtCore import (
     Qt,
     QThread,
 )
-from qtpy.QtGui import QColor, QCursor, QDrag, QImage, QPainter, QPixmap
+from qtpy.QtGui import (
+    QColor,
+    QCursor,
+    QDrag,
+    QFont,
+    QImage,
+    QPainter,
+    QPixmap,
+)
 from qtpy.QtWidgets import (
     QColorDialog,
     QGraphicsColorizeEffect,
@@ -42,6 +50,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
     from magicgui.widgets import Widget
+    from qtpy.QtGui import QGuiApplication
 
 
 class ColorMode(StringEnum):
@@ -411,6 +420,38 @@ def in_qt_main_thread() -> bool:
         True if we are in the main thread, False otherwise.
     """
     return QCoreApplication.instance().thread() == QThread.currentThread()
+
+
+def use_tabular_numerals(obj: QWidget | QGuiApplication) -> bool:
+    """Render digits in `obj` using tabular numerals, if the font supports it.
+
+    This enables the OpenType `tnum` ("tabular numerals") feature, which uses
+    fixed-width digit glyphs while leaving every other glyph proportional.
+
+    `obj` may be any object with ``font()``/``setFont()``, so this can be
+    applied to a single widget or to the ``QApplication``. When applied to the
+    application, the feature is inherited by every widget and survives theme
+    and font size changes. However, an application-level stylesheet would
+    discard it.
+
+    Important: if the actual font does not support tabular numerals, this
+    will have no effect, because Qt will silently ignore it.
+
+    Returns
+    -------
+    bool
+        True if the feature was requested. False on Qt < 6.7, where
+        ``QFont.setFeature`` does not exist.
+    """
+    # QFont.setFeature and QFont.Tag are Qt 6.7+; napari still supports PyQt5.
+    tag = getattr(QFont, 'Tag', None)
+    if tag is None or not hasattr(QFont, 'setFeature'):
+        return False
+
+    font = QFont(obj.font())
+    font.setFeature(tag('tnum'), 1)
+    obj.setFont(font)
+    return True
 
 
 def get_color(

--- a/src/napari/_qt/utils.py
+++ b/src/napari/_qt/utils.py
@@ -25,6 +25,7 @@ from qtpy.QtGui import (
     QCursor,
     QDrag,
     QFont,
+    QFontDatabase,
     QImage,
     QPainter,
     QPixmap,
@@ -452,6 +453,18 @@ def use_tabular_numerals(obj: QWidget | QGuiApplication) -> bool:
     font.setFeature(tag('tnum'), 1)
     obj.setFont(font)
     return True
+
+
+def use_fixed_pitch_font(obj: QWidget | QGuiApplication) -> None:
+    """Render `obj` in the platform's default fixed-pitch font.
+
+    Only the family is set, so the size still follows the application font.
+    """
+    font = QFont(obj.font())
+    font.setFamilies(
+        [QFontDatabase.systemFont(QFontDatabase.FixedFont).family()]
+    )
+    obj.setFont(font)
 
 
 def get_color(

--- a/src/napari/_qt/widgets/qt_viewer_status_bar.py
+++ b/src/napari/_qt/widgets/qt_viewer_status_bar.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QLabel, QStatusBar, QWidget
 from superqt import QElidingLabel
 
 from napari._qt.dialogs.qt_activity_dialog import ActivityToggleItem
+from napari._qt.utils import use_tabular_numerals
 
 if TYPE_CHECKING:
     from napari._qt.qt_main_window import _QtMainWindow
@@ -56,6 +57,16 @@ class ViewerStatusBar(QStatusBar):
             self._help,
         )
         self.addWidget(main_widget, 1)
+
+        for label in (
+            self._status,
+            self._layer_base,
+            self._source_type,
+            self._plugin_reader,
+            self._coordinates,
+            self._help,
+        ):
+            use_tabular_numerals(label)
 
         self._activity_item = ActivityToggleItem()
         self._activity_item._activityBtn.clicked.connect(

--- a/src/napari/_qt/widgets/qt_viewer_status_bar.py
+++ b/src/napari/_qt/widgets/qt_viewer_status_bar.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import QLabel, QStatusBar, QWidget
 from superqt import QElidingLabel
 
 from napari._qt.dialogs.qt_activity_dialog import ActivityToggleItem
-from napari._qt.utils import use_tabular_numerals
+from napari._qt.utils import use_fixed_pitch_font, use_tabular_numerals
 
 if TYPE_CHECKING:
     from napari._qt.qt_main_window import _QtMainWindow
@@ -67,6 +67,9 @@ class ViewerStatusBar(QStatusBar):
             self._help,
         ):
             use_tabular_numerals(label)
+
+        for label in (self._status, self._coordinates):
+            use_fixed_pitch_font(label)
 
         self._activity_item = ActivityToggleItem()
         self._activity_item._activityBtn.clicked.connect(
@@ -156,11 +159,12 @@ class StatusBarWidget(QWidget):
         return super().event(event)
 
     @staticmethod
-    def _calc_width(fm: QFontMetrics, label: QLabel) -> int:
+    def _calc_width(label: QLabel) -> int:
         # magical nuber +2 is from superqt code
         # magical number +12 is from experiments
         # Adding this values is required to avoid the text to be elided
         # if there is enough space to show it.
+        fm = QFontMetrics(label.font())
         return (
             (
                 fm.boundingRect(label.text()).width()
@@ -176,13 +180,11 @@ class StatusBarWidget(QWidget):
         width = self.width()
         height = self.height()
 
-        fm = QFontMetrics(self._status_label.font())
-
-        status_width = self._calc_width(fm, self._status_label)
-        layer_width = self._calc_width(fm, self._layer_label)
-        source_width = self._calc_width(fm, self._source_label)
-        plugin_width = self._calc_width(fm, self._plugin_label)
-        coordinates_width = self._calc_width(fm, self._coordinates_label)
+        status_width = self._calc_width(self._status_label)
+        layer_width = self._calc_width(self._layer_label)
+        source_width = self._calc_width(self._source_label)
+        plugin_width = self._calc_width(self._plugin_label)
+        coordinates_width = self._calc_width(self._coordinates_label)
 
         base_width = (
             status_width


### PR DESCRIPTION
# References and relevant issues

Depends on #9407. Only the top commit is new here.

# Description

Tabular numerals give every digit the same advance, but a space, a minus and a period keep their own: on macOS at 13pt a digit is 8.03px against 3.50px for a space. A readout therefore still shifts when a value gains a digit, drops a sign, or is padded, which is the movement left over in the capture on #9407.

`_status` and `_coordinates` now use the platform's default fixed-pitch font, where every glyph has one advance. Only the family is set, so size and the `tnum` request still apply. The other four labels show layer names and help text and stay proportional, so `_calc_width` measures each label with its own font rather than sharing one.

Fixed-pitch text is wider, so a long status message elides sooner than before.
