### PR TITLE
Fix keeping properties and equality operators from parent class

### DIFF
--- a/src/napari/utils/events/_tests/test_evented_model.py
+++ b/src/napari/utils/events/_tests/test_evented_model.py
@@ -510,14 +510,14 @@ def test_inheritance_and_calculated_helpers():
         a: int = 1
 
         @property
-        def b(self) -> int:
+        def b(self) -> int:  # pragma: no cover
             return self.a * 2
 
     class Sub(Base):
         c: int = 3
 
         @property
-        def d(self) -> int:
+        def d(self) -> int:  # pragma: no cover
             return self.c + self.b
 
     assert Sub.__properties__ == {'b': Base.b, 'd': Sub.d}

--- a/src/napari/utils/events/_tests/test_evented_model.py
+++ b/src/napari/utils/events/_tests/test_evented_model.py
@@ -505,7 +505,7 @@ def test_evented_model_with_property_setters():
         t.e = 100
 
 
-def test_base_class_property_in_subclass():
+def test_inheritance_and_calculated_helpers():
     class Base(EventedModel):
         a: int = 1
 
@@ -521,6 +521,13 @@ def test_base_class_property_in_subclass():
             return self.c + self.b
 
     assert Sub.__properties__ == {'b': Base.b, 'd': Sub.d}
+    assert Sub.__eq_operators__ == {
+        'a': operator.eq,
+        'b': operator.eq,
+        'c': operator.eq,
+        'd': operator.eq,
+    }
+    assert Sub.__field_dependents__ == {'a': {'b', 'd'}, 'c': {'d'}}
 
 
 @pytest.fixture

--- a/src/napari/utils/events/_tests/test_evented_model.py
+++ b/src/napari/utils/events/_tests/test_evented_model.py
@@ -505,6 +505,24 @@ def test_evented_model_with_property_setters():
         t.e = 100
 
 
+def test_base_class_property_in_subclass():
+    class Base(EventedModel):
+        a: int = 1
+
+        @property
+        def b(self) -> int:
+            return self.a * 2
+
+    class Sub(Base):
+        c: int = 3
+
+        @property
+        def d(self) -> int:
+            return self.c + self.b
+
+    assert Sub.__properties__ == {'b': Base.b, 'd': Sub.d}
+
+
 @pytest.fixture
 def mocked_object():
     t = T()

--- a/src/napari/utils/events/evented_model.py
+++ b/src/napari/utils/events/evented_model.py
@@ -60,7 +60,8 @@ class EventedMetaclass(ModelMetaclass):
                 )
         # check for properties defined on the class, so we can allow them
         # in EventedModel.__setattr__ and create events
-        cls.__properties__ = {}
+        # Current implementation ignores properties defined in mixins
+        cls.__properties__ = {**getattr(cls, '__properties__', {})}
         for name, attr in namespace.items():
             if isinstance(attr, property):
                 cls.__properties__[name] = attr
@@ -75,6 +76,12 @@ class EventedMetaclass(ModelMetaclass):
                     cls.__eq_operators__[name] = pick_equality_operator(
                         attr.fget.__annotations__['return']
                     )
+        cls.__properties__.pop(
+            'events', None
+        )  # we don't want to treat events as a usual property
+        cls.__properties__.pop(
+            '_defaults', None
+        )  # don't want to treat _defaults as a usual property
 
         cls.__field_dependents__ = _get_field_dependents(cls)
         return cls

--- a/src/napari/utils/events/evented_model.py
+++ b/src/napari/utils/events/evented_model.py
@@ -41,7 +41,11 @@ class EventedMetaclass(ModelMetaclass):
 
     def __new__(mcs, name, bases, namespace, **kwargs):
         cls = super().__new__(mcs, name, bases, namespace, **kwargs)
-        cls.__eq_operators__ = {}
+        non_evented_properties = getattr(
+            cls, '__non_evented_properties__', set()
+        )
+
+        cls.__eq_operators__ = {**getattr(cls, '__eq_operators__', {})}
         for n, f in cls.model_fields.items():
             field_type = get_outer_type(f.annotation)
             cls.__eq_operators__[n] = pick_equality_operator(field_type)
@@ -63,6 +67,8 @@ class EventedMetaclass(ModelMetaclass):
         # Current implementation ignores properties defined in mixins
         cls.__properties__ = {**getattr(cls, '__properties__', {})}
         for name, attr in namespace.items():
+            if name in non_evented_properties:
+                continue
             if isinstance(attr, property):
                 cls.__properties__[name] = attr
                 # determine compare operator
@@ -76,12 +82,6 @@ class EventedMetaclass(ModelMetaclass):
                     cls.__eq_operators__[name] = pick_equality_operator(
                         attr.fget.__annotations__['return']
                     )
-        cls.__properties__.pop(
-            'events', None
-        )  # we don't want to treat events as a usual property
-        cls.__properties__.pop(
-            '_defaults', None
-        )  # don't want to treat _defaults as a usual property
 
         cls.__field_dependents__ = _get_field_dependents(cls)
         return cls
@@ -187,6 +187,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
 
     # mapping of name -> property obj for methods that are properties
     __properties__: ClassVar[dict[str, property]]
+    __non_evented_properties__: ClassVar[set[str]] = {'events', '_defaults'}
     # mapping of field name -> dependent set of property names
     # when field is changed, an event for dependent properties will be emitted.
     __field_dependents__: ClassVar[dict[str, set[str]]]
@@ -376,7 +377,7 @@ class EventedModel(BaseModel, metaclass=EventedMetaclass):
                 getattr(self.events, name).source = self
 
     @property
-    def _defaults(self):
+    def _defaults(self) -> dict[str, Any]:
         return get_defaults(self)
 
     def reset(self):


### PR DESCRIPTION
# References and relevant issues

Extracted from #9473

# Description

During the development of #9473 when checking how it works with #9463 I found that we calculate `__properties__` and `__eq_operators__` only for properties defined in this class. Missing all from the parent class. 

This PR fixes it but only for parent classes that inherit from `EventedModel`. So the `KeymapProvider.keymap` property will not have its event in `ViewerModel`

It will also do not work with multiple inheritace, but I dont think that we want to support it in EventedModel. 