### PR TITLE
Fix --pre testing workflows to run only specific subset of environments

### DIFF
--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -77,9 +77,8 @@ jobs:
           attempt_limit: 3
           attempt_delay: 30000 # 30s
           retry_condition: github.ref_name == 'main'  # avoid restart in PR
-          command: python -m tox -v --pre  --recreate --runner virtualenv-pep-723
+          command: python -m tox -v --pre  --recreate # --runner virtualenv-pep-723
         env:
-          PLATFORM: ${{ matrix.platform }}
           BACKEND: ${{ matrix.backend }}
           PYTHON: ${{ matrix.python }}
           COVERAGE: "no_cov"

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install setuptools tox tox-gh-actions
+          pip install setuptools tox tox-gh-actions tox-uv tox-min-req
 
       - name: Test with tox (with retry)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
@@ -77,7 +77,7 @@ jobs:
           attempt_limit: 3
           attempt_delay: 30000 # 30s
           retry_condition: github.ref_name == 'main'  # avoid restart in PR
-          command: python -m tox -v --pre  --recreate
+          command: python -m tox -v --pre  --recreate --runner virtualenv-pep-723
         env:
           PLATFORM: ${{ matrix.platform }}
           BACKEND: ${{ matrix.backend }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -77,7 +77,7 @@ jobs:
           attempt_limit: 3
           attempt_delay: 30000 # 30s
           retry_condition: github.ref_name == 'main'  # avoid restart in PR
-          command: python -m tox -v --pre --recreate
+          command: python -m tox -v --pre --recreate  --runner virtualenv
         env:
           BACKEND: ${{ matrix.backend }}
           PYTHON: ${{ matrix.python }}

--- a/.github/workflows/test_prereleases.yml
+++ b/.github/workflows/test_prereleases.yml
@@ -77,11 +77,10 @@ jobs:
           attempt_limit: 3
           attempt_delay: 30000 # 30s
           retry_condition: github.ref_name == 'main'  # avoid restart in PR
-          command: python -m tox -v --pre  --recreate # --runner virtualenv-pep-723
+          command: python -m tox -v --pre --recreate
         env:
           BACKEND: ${{ matrix.backend }}
           PYTHON: ${{ matrix.python }}
-          COVERAGE: "no_cov"
           PYVISTA_OFF_SCREEN: True  # required for opengl on windows
           PIP_CONSTRAINT: resources/constraints/version_denylist.txt
           PIP_EXTRA_INDEX_URL: https://www.riverbankcomputing.com/pypi/simple/

--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,6 @@ BACKEND =
     pyqt6_no_numba: pyqt6_no_numba
     pyqt5_no_numba: pyqt5_no_numba
     headless: headless
-COVERAGE =
-    cov: cov
-    no_cov: no_cov
 
 # Settings defined in the top-level testenv section are automatically
 # inherited by individual environments unless overridden.


### PR DESCRIPTION
# References and relevant issues

<img width="1385" height="1061" alt="image" src="https://github.com/user-attachments/assets/1fb775a2-b42b-44b7-bf22-077e8f25e4b5" />


This workflow was broken by #9309

# Description

For over a month our --pre tests are timing out. Because of the timeout, the steep-to-open issue is not triggered. 

It happens as tox recreates the environment without `tox-gh-actions` in it (as it is not present in required section) 

https://github.com/napari/napari/blob/522e4f16ef6d9f88dbf0c8b11f3edfcf3844d97a/tox.ini#L22-L25

Maybe we should add this plugin to the list of required ones, but the current fix should be minimal. 