### PR TITLE
Add `RenamedEmitter` subclass of `WarningEmitter` to simplify renaming

### DIFF
--- a/src/napari/utils/events/__init__.py
+++ b/src/napari/utils/events/__init__.py
@@ -2,6 +2,8 @@ from napari.utils.events.event import (  # isort:skip
     EmitterGroup,
     Event,
     EventEmitter,
+    WarningEmitter,
+    RenamedEmitter,
     set_event_tracing_enabled,
 )
 from napari.utils.events.containers._evented_dict import (
@@ -30,10 +32,12 @@ __all__ = [
     'EventedModel',
     'EventedSet',
     'NestableEventedList',
+    'RenamedEmitter',
     'SelectableEventedList',
     'Selection',
     'SupportsEvents',
     'TypedMutableSequence',
+    'WarningEmitter',
     'disconnect_events',
     'set_event_tracing_enabled',
 ]

--- a/src/napari/utils/events/_tests/test_event_emitter.py
+++ b/src/napari/utils/events/_tests/test_event_emitter.py
@@ -1,9 +1,10 @@
 import weakref
 from functools import partial
+from unittest.mock import Mock
 
 import pytest
 
-from napari.utils.events import EventEmitter
+from napari.utils.events import EventEmitter, RenamedEmitter, WarningEmitter
 
 
 def test_event_blocker_count_none():
@@ -351,3 +352,91 @@ def test_none_disconnect():
     e.connect(fun2)
     e()
     assert count_list == [1, 2]
+
+
+def test_warning_emitter():
+    mock = Mock()
+    e = WarningEmitter(
+        type_name='test', message='This is a warning', category=FutureWarning
+    )
+
+    with pytest.warns(FutureWarning, match='This is a warning'):
+        e.connect(mock)
+
+    assert e.callbacks
+
+    mock.assert_not_called()
+    e()
+
+    mock.assert_called_once()
+
+
+def test_renamed_emitter_simple():
+    class DummyEventEmitter:
+        def __init__(self, parent):
+            self.new_event = EventEmitter(type_name='new_event')
+            self.old_event = RenamedEmitter(
+                type_name='old_event',
+                new_name='new_event',
+                source=parent,
+                message='Warning message',
+            )
+
+    class NewNamespace:
+        def __init__(self):
+            self.events = DummyEventEmitter(self)
+
+    mock = Mock()
+
+    n = NewNamespace()
+
+    assert not n.events.new_event.callbacks
+
+    with pytest.warns(FutureWarning, match='Warning message'):
+        n.events.old_event.connect(mock)
+    assert n.events.new_event.callbacks
+
+    mock.assert_not_called()
+
+    n.events.new_event()
+
+    mock.assert_called_once()
+
+
+def test_renamed_emitter_composite():
+    class DummyEventEmitterComposite:
+        def __init__(self, parent):
+            self.new_event = EventEmitter(type_name='new_event')
+
+    class DummyEventEmitterBase:
+        def __init__(self, parent):
+            self.old_event = RenamedEmitter(
+                type_name='old_event',
+                new_name='composite.new_event',
+                source=parent,
+                message='Warning message',
+            )
+
+    class CompositeNamespace:
+        def __init__(self):
+            self.events = DummyEventEmitterComposite(self)
+
+    class OldNamespace:
+        def __init__(self):
+            self.events = DummyEventEmitterBase(self)
+            self.composite = CompositeNamespace()
+
+    mock = Mock()
+
+    o = OldNamespace()
+
+    assert not o.composite.events.new_event.callbacks
+    with pytest.warns(FutureWarning, match='Warning message'):
+        o.events.old_event.connect(mock)
+    assert o.composite.events.new_event.callbacks
+
+    mock.assert_not_called()
+
+    o.composite.events.new_event()
+
+    mock.assert_called_once()

--- a/src/napari/utils/events/_tests/test_event_emitter.py
+++ b/src/napari/utils/events/_tests/test_event_emitter.py
@@ -402,6 +402,10 @@ def test_renamed_emitter_simple():
 
     mock.assert_called_once()
 
+    n.events.old_event.disconnect(mock)
+
+    assert not n.events.new_event.callbacks
+
 
 def test_renamed_emitter_composite():
     class DummyEventEmitterComposite:

--- a/src/napari/utils/events/event.py
+++ b/src/napari/utils/events/event.py
@@ -862,7 +862,7 @@ class RenamedEmitter(WarningEmitter):
     """
     Warning emitter to be used when an attribute was renamed or moved to a composition object.
     It will connect to the new event once the callback is connected to the old one.
-     It will also warn the user that the attribute was renamed.
+    It will also warn the user that the attribute was renamed.
     """
 
     def __init__(

--- a/src/napari/utils/events/event.py
+++ b/src/napari/utils/events/event.py
@@ -824,17 +824,21 @@ class WarningEmitter(EventEmitter):
         *args,
         **kwargs,
     ) -> None:
+        super().__init__(*args, **kwargs)
         self._message = message
         self._warned = False
         self._category = category
         self._stacklevel = stacklevel
-        EventEmitter.__init__(self, *args, **kwargs)
 
     def connect(self, cb, *args, **kwargs):
         self._warn(cb)
         return EventEmitter.connect(self, cb, *args, **kwargs)
 
     def _invoke_callback(self, cb, event):
+        """invoke callback with warn if not warned yet."""
+        # check if this is needed. The _invoke_callback is not called if there is a callback.
+        # but if there is a callback, then _warn was called in the connect.
+        # And warn emmit a warning only once.
         self._warn(cb)
         return EventEmitter._invoke_callback(self, cb, event)
 
@@ -852,6 +856,51 @@ class WarningEmitter(EventEmitter):
             self._message, category=self._category, stacklevel=self._stacklevel
         )
         self._warned = True
+
+
+class RenamedEmitter(WarningEmitter):
+    """
+    Warning emitter to be used when an attribute was renamed or moved to a composition object.
+    It will connect to the new event once the callback is connected to the old one.
+     It will also warn the user that the attribute was renamed.
+    """
+
+    def __init__(
+        self,
+        new_name: str,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        *self._new_name_path, self._new_name = new_name.split('.')
+        self._connected = False
+
+    def _get_new_emitter(self):
+        target = self.source
+        if self.source is None:
+            raise RuntimeError(
+                f'Cannot connect to renamed emitter {self._new_name} because source is None'
+            )
+        for attr in self._new_name_path:
+            target = getattr(target, attr)
+        new_emitter = getattr(target.events, self._new_name)
+        return new_emitter
+
+    def connect(self, cb, *args, **kwargs):
+        if not self._connected:
+            new_emitter = self._get_new_emitter()
+            new_emitter.connect(self)
+            self._connected = True
+        super().connect(cb, *args, **kwargs)
+
+    def disconnect(
+        self, callback: Callback | CallbackRef | object | None = None
+    ):
+        super().disconnect(callback)
+        if not self.callbacks:
+            new_emitter = self._get_new_emitter()
+            new_emitter.disconnect(self)
+            self._connected = False
 
 
 class EmitterGroup(EventEmitter):

--- a/src/napari/utils/events/event.py
+++ b/src/napari/utils/events/event.py
@@ -877,7 +877,7 @@ class RenamedEmitter(WarningEmitter):
 
     def _get_new_emitter(self):
         target = self.source
-        if self.source is None:
+        if self.source is None:  # pragma: no cover
             raise RuntimeError(
                 f'Cannot connect to renamed emitter {self._new_name} because source is None'
             )


### PR DESCRIPTION
# References and relevant issues

#9463

# Description

Create a specialized subclass of `WarningEmitter` for renamed or moved properties/attributes. 
It connects to the new event as a callback only if it has its callback. It allows avoiding comparisons in the evented model. 

For #9463, it will require developing a specialized decorator to declare a new path. It will be a follow-up PR. 