### PR TITLE
Revert widget size policy change

### DIFF
--- a/src/napari/_qt/qt_main_window.py
+++ b/src/napari/_qt/qt_main_window.py
@@ -1140,7 +1140,7 @@ class Window:
         area: str | None = None,
         allowed_areas: Sequence[str] | None = None,
         shortcut=_sentinel,
-        add_vertical_stretch=False,
+        add_vertical_stretch=True,
         tabify: bool = False,
         menu: QMenu | None = None,
     ):

--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -333,7 +333,6 @@ class QtViewer(QSplitter):
             layerListLayout.addWidget(self.viewerButtons)
             layerListLayout.setContentsMargins(8, 4, 8, 6)
             layerList.setLayout(layerListLayout)
-            prev_policy = layerList.sizePolicy()
             self._dockLayerList = QtViewerDockWidget(
                 self,
                 layerList,
@@ -343,9 +342,6 @@ class QtViewer(QSplitter):
                 object_name='layer list',
                 close_btn=False,
             )
-            # restore policy to avoid empty space below buttons
-            # See https://github.com/napari/napari/pull/9447
-            layerList.setSizePolicy(prev_policy)
         return self._dockLayerList
 
     @property

--- a/src/napari/_qt/widgets/_tests/test_qt_dock_widget.py
+++ b/src/napari/_qt/widgets/_tests/test_qt_dock_widget.py
@@ -128,9 +128,7 @@ def test_adding_stretch(make_napari_viewer):
     widg.setLayout(QVBoxLayout())
     widg.layout().addWidget(QPushButton())
     assert widg.layout().count() == 1
-    dw = viewer.window.add_dock_widget(
-        widg, area='right', add_vertical_stretch=True
-    )
+    dw = viewer.window.add_dock_widget(widg, area='right')
     assert widg.layout().count() == 2
     dw.close()
 
@@ -139,9 +137,7 @@ def test_adding_stretch(make_napari_viewer):
     widg.setLayout(QVBoxLayout())
     widg.layout().addWidget(QTextEdit())
     assert widg.layout().count() == 1
-    dw = viewer.window.add_dock_widget(
-        widg, area='right', add_vertical_stretch=True
-    )
+    dw = viewer.window.add_dock_widget(widg, area='right')
     assert widg.layout().count() == 1
     dw.close()
 
@@ -150,9 +146,7 @@ def test_adding_stretch(make_napari_viewer):
     widg.setLayout(QHBoxLayout())
     widg.layout().addWidget(QPushButton())
     assert widg.layout().count() == 1
-    dw = viewer.window.add_dock_widget(
-        widg, area='bottom', add_vertical_stretch=True
-    )
+    dw = viewer.window.add_dock_widget(widg, area='bottom')
     assert widg.layout().count() == 1
     dw.close()
 

--- a/src/napari/_qt/widgets/qt_viewer_dock_widget.py
+++ b/src/napari/_qt/widgets/qt_viewer_dock_widget.py
@@ -80,7 +80,7 @@ class QtViewerDockWidget(QDockWidget):
         allowed_areas: list[str] | None = None,
         shortcut=_sentinel,
         object_name: str = '',
-        add_vertical_stretch=False,
+        add_vertical_stretch=True,
         close_btn=True,
     ) -> None:
         self._ref_qt_viewer: ReferenceType[QtViewer] = ref(qt_viewer)
@@ -128,10 +128,6 @@ class QtViewerDockWidget(QDockWidget):
 
         is_vertical = area in {'left', 'right'}
         widget_ = combine_widgets(widget, vertical=is_vertical)
-        widget_.setSizePolicy(
-            QSizePolicy.Policy.Preferred,
-            QSizePolicy.Policy.Maximum,
-        )
         self.setWidget(widget_)
         if is_vertical and add_vertical_stretch:
             self._maybe_add_vertical_stretch(widget_)


### PR DESCRIPTION
# References and relevant issues
- https://napari.zulipchat.com/#narrow/channel/212875-general/topic/Widget.20not.20stretchable/with/621145947
- bug introduced in github.com/napari/napari/pull/9393

# Description
This PR reverts #9393 (and its followup #9447) as they introduced more issues than they solved.

Will follow up either with #9462 or something else to fix properly.
