### PR TITLE
Change default image proj mode to none

### DIFF
--- a/src/napari/_qt/layer_controls/dynamic/_tests/test_general_widgets.py
+++ b/src/napari/_qt/layer_controls/dynamic/_tests/test_general_widgets.py
@@ -309,14 +309,24 @@ class TestQtProjectionModeControl:
         control = QtProjectionModeControl([image])
         qt_wrap.add_control(control)
 
+        # check default
+        default_proj_mode = 'none'
+        assert image.projection_mode == default_proj_mode
+        assert control.projection_combobox.currentText() == default_proj_mode
+
+        # check changing control changes layer
+        control.projection_combobox.setCurrentText('mean')
         assert image.projection_mode == 'mean'
-        assert control.projection_combobox.currentText() == 'mean'
 
         control.projection_combobox.setCurrentText('max')
         assert image.projection_mode == 'max'
 
+        # check changing layer mode changes control
         image.projection_mode = 'sum'
         assert control.projection_combobox.currentText() == 'sum'
+
+        image.projection_mode = 'none'
+        assert control.projection_combobox.currentText() == 'none'
 
 
 class TestQtOpacityBlendingControls:

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -284,7 +284,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         name: str | None = None,
         opacity: float = 1.0,
         plane: dict | None = None,
-        projection_mode: str = 'mean',
+        projection_mode: str = 'none',
         rendering: str = 'mip',
         rgb: bool | None = None,
         rotate: float | Sequence[float] | npt.NDArray | None = None,


### PR DESCRIPTION
See https://forum.image.sc/t/deprecation-of-out-of-slice-display/122287

Users of thick slicing in the context of other layers find
it confusing that image layers default to mean. Draga and I
think 'none' is less intrusive in most contexts.
