### PR TITLE
Revert the str cast of shortcut in `bind_shortcut` from #9076

### DIFF
--- a/src/napari/_qt/qt_viewer.py
+++ b/src/napari/_qt/qt_viewer.py
@@ -419,7 +419,7 @@ class QtViewer(QSplitter):
         for action, shortcuts in get_settings().shortcuts.shortcuts.items():
             action_manager.unbind_shortcut(action)
             for shortcut in shortcuts:
-                action_manager.bind_shortcut(action, str(shortcut))
+                action_manager.bind_shortcut(action, shortcut)
 
     def _create_performance_dock_widget(self) -> QtViewerDockWidget | None:
         """Create the dock widget that shows performance metrics."""

--- a/src/napari/utils/action_manager.py
+++ b/src/napari/utils/action_manager.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from concurrent.futures import Future
     from typing import Protocol
 
+    from app_model.types import KeyBinding
+
     from napari.utils.key_bindings import KeymapProvider
 
     class SignalInstance(Protocol):

--- a/src/napari/utils/action_manager.py
+++ b/src/napari/utils/action_manager.py
@@ -235,7 +235,7 @@ class ActionManager:
         until = getattr(button, 'destroyed', None)
         self.events.shortcut_changed.connect(_update_tt, until=until)
 
-    def bind_shortcut(self, name: str, shortcut: str) -> None:
+    def bind_shortcut(self, name: str, shortcut: KeyBinding | str) -> None:
         """
         bind shortcut `shortcut` to trigger action `name`
 
@@ -243,7 +243,7 @@ class ActionManager:
         ----------
         name : str
             name of the corresponding action in the form ``packagename:name``
-        shortcut : str
+        shortcut : KeyBinding | str
             Shortcut to assign to this action use dash as separator. See
             `Shortcut` for known modifiers.
 


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/napari/issues/9457

# Description
Bisecting the linked issue pointed to typing PR https://github.com/napari/napari/pull/9076 
Looking at that PR, the only obvious candidate is the cast to `str` presumably to make mypy happy (see: https://github.com/napari/napari/commit/d7560bcacbce7c9aa19ffba215120183df975745#r197719034)
So in this PR I revert just that one change instead of the whole PR.
I tested locally and this fixes the issue with the brush size keybinding.

I expected mypy to re-flag this when run locally, but it flagged instead the qtpy imports?
Have I mentioned how much I dislike mypy?