### PR TITLE
Fix surface lighting

### DIFF
--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -266,7 +266,12 @@ class VispyCanvas:
         self.viewer.scene.camera.events.mouse_zoom.connect(
             self._on_interactive
         )
-        self.viewer.scene.camera.events.zoom.connect(self._on_cursor)
+        self.viewer.scene.camera.events.angles.connect(
+            self._on_view_direction_change
+        )
+        self.viewer.dims.events.ndisplay.connect(
+            self._on_view_direction_change
+        )
 
         self.viewer.canvas.overlays._zoom_box.events.zoom_area.connect(
             self._on_boxzoom
@@ -801,15 +806,25 @@ class VispyCanvas:
         napari_layer._overlays.events.changed.connect(overlay_callback)
         napari_layer.events.units.connect(self._deferred_world_units_update)
         self._overlay_callbacks[napari_layer] = overlay_callback
-        self.viewer.scene.camera.events.angles.connect(
-            vispy_layer._on_camera_move
-        )
         self._deferred_world_units_update()
 
         # we need to trigger _on_matrix_change once after adding the overlays so that
         # all children nodes are assigned the correct transforms
         vispy_layer._on_matrix_change()
         self._update_scenegraph()
+
+    def _on_view_direction_change(self):
+        """Update view direction for anything in vispy that requires this information."""
+        # take displayed up and view directions and flip zyx for vispy
+        if self.viewer.dims.ndisplay == 2:
+            view = np.array((0, 0, -1))
+            up = np.array((0, -1, 0))
+        else:
+            view = np.array(self.viewer.scene.camera.view_direction)[::-1]
+            up = np.array(self.viewer.scene.camera.up_direction)[::-1]
+
+        for vispy_layer in self.layer_to_visual.values():
+            vispy_layer._on_view_direction_change(view, up)
 
     def _deferred_world_units_update(self):
         """Defer the world units update until the next draw event."""

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -266,6 +266,7 @@ class VispyCanvas:
         self.viewer.scene.camera.events.mouse_zoom.connect(
             self._on_interactive
         )
+        self.viewer.scene.camera.events.zoom.connect(self._on_cursor)
         self.viewer.scene.camera.events.angles.connect(
             self._on_view_direction_change
         )
@@ -811,6 +812,9 @@ class VispyCanvas:
         # we need to trigger _on_matrix_change once after adding the overlays so that
         # all children nodes are assigned the correct transforms
         vispy_layer._on_matrix_change()
+        # also make sure we communicate update the view direction of the new layer
+        # (needed e.g for lighting by mesh)
+        self._on_view_direction_change()
         self._update_scenegraph()
 
     def _on_view_direction_change(self):

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -311,7 +311,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
                 self.layer.experimental_clipping_planes.as_array()[..., ::-1]
             )
 
-    def _on_view_direction_change(self, view, up):
+    def _on_view_direction_change(self, view=None, up=None):
         return
 
     def reset(self):

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -320,6 +320,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
         self._on_blending_change()
         self._on_matrix_change()
         self._on_experimental_clipping_planes_change()
+        self._on_view_direction_change()
 
     def _on_poll(self, event=None):
         """Called when camera moves, before we are drawn.

--- a/src/napari/_vispy/layers/base.py
+++ b/src/napari/_vispy/layers/base.py
@@ -311,7 +311,7 @@ class VispyBaseLayer(ABC, Generic[_L]):
                 self.layer.experimental_clipping_planes.as_array()[..., ::-1]
             )
 
-    def _on_camera_move(self, event=None):
+    def _on_view_direction_change(self, view, up):
         return
 
     def reset(self):
@@ -320,7 +320,6 @@ class VispyBaseLayer(ABC, Generic[_L]):
         self._on_blending_change()
         self._on_matrix_change()
         self._on_experimental_clipping_planes_change()
-        self._on_camera_move()
 
     def _on_poll(self, event=None):
         """Called when camera moves, before we are drawn.

--- a/src/napari/_vispy/layers/surface.py
+++ b/src/napari/_vispy/layers/surface.py
@@ -163,7 +163,7 @@ class VispySurfaceLayer(VispyBaseLayer):
         shading = None if self.layer.shading == 'none' else self.layer.shading
         if not self.node.mesh_data.is_empty():
             self.node.shading = shading
-            self._on_camera_move()
+            self._on_view_direction_change()
         self.node.update()
 
     def _on_wireframe_visible_change(self):
@@ -200,16 +200,8 @@ class VispySurfaceLayer(VispyBaseLayer):
                 primitive='vertex',
             )
 
-    def _on_camera_move(self, event=None):
-        if (
-            event is not None
-            and event.type == 'angles'
-            and self.layer._slice_input.ndisplay == 3
-        ):
-            camera = event.source
-            # take displayed up and view directions and flip zyx for vispy
-            up = np.array(camera.up_direction)[::-1]
-            view = np.array(camera.view_direction)[::-1]
+    def _on_view_direction_change(self, view=None, up=None):
+        if view is not None and up is not None:
             # combine to get light behind the camera on the top right
             self._light_direction = up - view - np.cross(up, view)
         if (
@@ -229,4 +221,3 @@ class VispySurfaceLayer(VispyBaseLayer):
         self._on_wireframe_color_change()
         self._on_face_normals_change()
         self._on_vertex_normals_change()
-        self._on_camera_move()


### PR DESCRIPTION
# References and relevant issues
- closes (maybe?) https://github.com/napari/napari/issues/9273

# Description
Currently, surface lighting is initialized wrong when switching to 3D; you need to move the camera once in order to set the light direction correctly. This is because the current machinery does nothing when called directly via `on_camera_move()`, it only does something when an event reaches it (so only on actual camera moves).

Additionally, once modified in 3D, lighting remains messed up in 2D, which can make the whole surface look dark.

To see the current behaviour, launch `examples/surface_texture_and_colors.py`; you'll see that until you move the camera, the light is bad. After that, switch to 2D and see how everything is dark (unless you happened to rotate it so it's correctly aligned to the 2D view).

This PR changes it so:
1. 2D is always defaulting to the correct angles
2. The machinery also fires on switching ndisplay
3. the callback now lives on the vispy canvas and it loops the layers, instead of connecting the vispy layer itself, which simplifies the code quite a bit.
