### PR TITLE
Default projection mode to none, and add warnings and tooltips

### DIFF
--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
@@ -73,9 +73,11 @@ class QtProjectionModeControl(QtWidgetControlsBase):
         self.projection_combobox_label = QtWrappedLabel('projection mode:')
 
         self.projection_combobox.setToolTip(
-            'the projection_mode determines how data that is part of the current thick slice is '
-            'projected onto the displayed dimensions. For it to have an effect, slice thickness must be '
-            'greater than zero. Right click on a dimension slider to open the slice thickness popup.'
+            'Choose how data contained in the current thick slice is\n'
+            'projected onto the displayed dimensions.\n'
+            'For this to have an effect, slice thickness must be\n'
+            'greater than zero. Right click on a dimension slider\n'
+            'to set slice thickness for that dimension.'
         )
 
     def _on_projection_mode_change(self) -> None:

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
@@ -72,6 +72,12 @@ class QtProjectionModeControl(QtWidgetControlsBase):
 
         self.projection_combobox_label = QtWrappedLabel('projection mode:')
 
+        self.projection_combobox.setToolTip(
+            'the projection_mode determines how data that is part of the current thick slice is '
+            'projected onto the displayed dimensions. For it to have an effect, slice thickness must be '
+            'greater than zero. Right click on a dimension slider to open the slice thickness popup.'
+        )
+
     def _on_projection_mode_change(self) -> None:
         with qt_signals_blocked(self.projection_combobox):
             self.projection_combobox.setCurrentText(

--- a/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
@@ -52,6 +52,12 @@ class QtProjectionModeControl(QtWidgetControlsBase):
 
         self.projection_combobox_label = QtWrappedLabel('projection mode:')
 
+        self.projection_combobox.setToolTip(
+            'the projection_mode determines how data that is part of the current thick slice is '
+            'projected onto the displayed dimensions. For it to have an effect, slice thickness must be '
+            'greater than zero. Right click on a dimension slider to open the slice thickness popup.'
+        )
+
     def _on_projection_mode_change(self) -> None:
         with qt_signals_blocked(self.projection_combobox):
             self.projection_combobox.setCurrentText(

--- a/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
@@ -53,9 +53,11 @@ class QtProjectionModeControl(QtWidgetControlsBase):
         self.projection_combobox_label = QtWrappedLabel('projection mode:')
 
         self.projection_combobox.setToolTip(
-            'the projection_mode determines how data that is part of the current thick slice is '
-            'projected onto the displayed dimensions. For it to have an effect, slice thickness must be '
-            'greater than zero. Right click on a dimension slider to open the slice thickness popup.'
+            'Choose how data contained in the current thick slice is\n'
+            'projected onto the displayed dimensions.\n'
+            'For this to have an effect, slice thickness must be\n'
+            'greater than zero. Right click on a dimension slider\n'
+            'to set slice thickness for that dimension.'
         )
 
     def _on_projection_mode_change(self) -> None:

--- a/src/napari/_qt/widgets/qt_dims_slider.py
+++ b/src/napari/_qt/widgets/qt_dims_slider.py
@@ -184,6 +184,11 @@ class QtDimSliderWidget(QWidget):
         slider.setPageStep(1)
         slider.setValue(self.dims.current_step[self.axis])
 
+        slider.setToolTip(
+            'Dimension slider: move to scroll through this non-displayed dimension.\n'
+            'Right click to open the thich slicing controls.'
+        )
+
         # Listener to be used for sending events back to model:
         slider.valueChanged.connect(self._on_value_changed)
 

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -1125,7 +1125,7 @@ class ViewerModel(KeymapProvider, MousemapProviderPydantic, EventedModel):
         name=None,
         opacity=1.0,
         plane=None,
-        projection_mode='mean',
+        projection_mode='none',
         rendering='mip',
         rgb=None,
         rotate=None,

--- a/src/napari/layers/_scalar_field/_slice.py
+++ b/src/napari/layers/_scalar_field/_slice.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -7,7 +8,11 @@ import numpy as np
 import numpy.typing as npt
 
 from napari.layers.base._slice import _next_request_id
-from napari.layers.utils._slice_input import _SliceInput, _ThickNDSlice
+from napari.layers.utils._slice_input import (
+    _THICK_WARNING,
+    _SliceInput,
+    _ThickNDSlice,
+)
 from napari.types import ArrayLike
 from napari.utils._dask_utils import DaskIndexer
 from napari.utils._dtype import normalize_dtype
@@ -338,6 +343,9 @@ class _ScalarFieldSliceRequest:
         slices = self._data_slice_to_slices(
             data_slice, self.slice_input.displayed
         )
+
+        if not self.data_slice.is_thick(self.slice_input.not_displayed):
+            warnings.warn(_THICK_WARNING.format(self.projection_mode))
 
         return self._project_slice(
             data=np.asarray(data[slices]),

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -284,7 +284,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         name: str | None = None,
         opacity: float = 1.0,
         plane: dict | None = None,
-        projection_mode: str = 'mean',
+        projection_mode: str = 'none',
         rendering: str = 'mip',
         rgb: bool | None = None,
         rotate: float | Sequence[float] | npt.NDArray | None = None,

--- a/src/napari/layers/points/_slice.py
+++ b/src/napari/layers/points/_slice.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -6,7 +7,11 @@ import numpy.typing as npt
 
 from napari.layers.base._slice import _next_request_id
 from napari.layers.points._points_constants import PointsProjectionMode
-from napari.layers.utils._slice_input import _SliceInput, _ThickNDSlice
+from napari.layers.utils._slice_input import (
+    _THICK_WARNING,
+    _SliceInput,
+    _ThickNDSlice,
+)
 
 
 @dataclass(frozen=True)
@@ -108,6 +113,9 @@ class _PointSliceRequest:
         else:
             low = point - m_left
             high = point + m_right
+
+            if not self.data_slice.is_thick(not_disp):
+                warnings.warn(_THICK_WARNING.format(self.projection_mode))
 
         # assume slice thickness of 1 in data pixels
         # (same as before thick slices were implemented)

--- a/src/napari/layers/points/points.py
+++ b/src/napari/layers/points/points.py
@@ -398,7 +398,7 @@ class Points(Layer):
         metadata=None,
         name=None,
         opacity=1.0,
-        projection_mode='all',
+        projection_mode='none',
         properties=None,
         property_choices=None,
         rotate=None,

--- a/src/napari/layers/surface/surface.py
+++ b/src/napari/layers/surface/surface.py
@@ -253,7 +253,7 @@ class Surface(IntensityVisualizationMixin, Layer):
         name=None,
         normals=None,
         opacity=1.0,
-        projection_mode='all',
+        projection_mode='none',
         rotate=None,
         scale=None,
         shading='flat',

--- a/src/napari/layers/utils/_slice_input.py
+++ b/src/napari/layers/utils/_slice_input.py
@@ -20,6 +20,15 @@ if TYPE_CHECKING:
 
 _T = TypeVar('_T')
 
+_THICK_WARNING = (
+    'Projection mode is set to "{}", but the slice '
+    'thickness is zero. For projection_mode to have an effect, you must '
+    'increase the dims margins by either:\n'
+    '- right clicking on the dims slider\n'
+    '- `viewer.dims.margin_left/right`\n'
+    '- `viewer.dims.thickness`'
+)
+
 
 @dataclass(frozen=True)
 class _ThickNDSlice(Generic[_T]):
@@ -32,6 +41,11 @@ class _ThickNDSlice(Generic[_T]):
     @property
     def ndim(self):
         return len(self.point)
+
+    def is_thick(self, axes: list[int] | None = None):
+        if axes is None:
+            axes = list(range(len(self.point)))
+        return np.any(self.as_array()[1:, axes])
 
     @classmethod
     def make_full(

--- a/src/napari/layers/vectors/_slice.py
+++ b/src/napari/layers/vectors/_slice.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -5,7 +6,11 @@ import numpy as np
 import numpy.typing as npt
 
 from napari.layers.base._slice import _next_request_id
-from napari.layers.utils._slice_input import _SliceInput, _ThickNDSlice
+from napari.layers.utils._slice_input import (
+    _THICK_WARNING,
+    _SliceInput,
+    _ThickNDSlice,
+)
 from napari.layers.vectors._vectors_constants import VectorsProjectionMode
 
 
@@ -104,6 +109,9 @@ class _VectorSliceRequest:
         else:
             low = point - m_left
             high = point + m_right
+
+            if not self.data_slice.is_thick(not_disp):
+                warnings.warn(_THICK_WARNING.format(self.projection_mode))
 
         # assume slice thickness of 1 in data pixels
         # (same as before thick slices were implemented)

--- a/src/napari/layers/vectors/vectors.py
+++ b/src/napari/layers/vectors/vectors.py
@@ -224,7 +224,7 @@ class Vectors(Layer):
         name=None,
         ndim=None,
         opacity=0.7,
-        projection_mode='all',
+        projection_mode='none',
         properties=None,
         property_choices=None,
         rotate=None,


### PR DESCRIPTION
# References and relevant issues
- alternative to #9487
- includes #9497 

# Description
As mentioned in https://github.com/napari/napari/pull/9487#issuecomment-5566671930, I think we should do `none` for everythign and improve the documentation.


This PR sets the default to `none` for all layers, adds tooltips to boith the projection mode combobox and the dimension slider to improve discoverability, and add a warning for the `layer.projection_mode != 'none' and viewer.dims.thickness == 0` path (which can only happen when a user opts in to non-none projection mode but did not set any thickness), so users cannot be left confused as to why nothing happens.

The other way around (`layer.projection_mode == 'none' and viewer.dims.thickness != 0`) is not covered, because this will happen for every layer where a user did *not* opt in to projection mode (e.g: the typical use case of "I want to project *just* this specific layer"); this is also less likely to confuse, because it's harder to discover the thick slicing accidentally than it is to discover the projection mode. 
