### PR TITLE
Hide projection mode combobox when appropriate

### DIFF
--- a/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
@@ -307,6 +307,9 @@ class QtDynamicLayerControls(QFrame):
         for control in self._controls:
             control._change_ndisplay(self._ndisplay)
 
+    def set_thick(self, is_thick: bool) -> None:
+        self._projection_mode_control.set_thick(is_thick)
+
     def _on_surface_coloring_change(
         self,
     ) -> None:

--- a/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
@@ -307,8 +307,18 @@ class QtDynamicLayerControls(QFrame):
         for control in self._controls:
             control._change_ndisplay(self._ndisplay)
 
-    def set_thick(self, is_thick: bool) -> None:
-        self._projection_mode_control.set_thick(is_thick)
+    @property
+    def is_thick(self) -> bool:
+        return self._is_thick
+
+    @is_thick.setter
+    def is_thick(self, is_thick: bool) -> None:
+        self._is_thick = is_thick
+        self._on_is_thick_change()
+
+    def _on_is_thick_change(self):
+        for control in self._controls:
+            control._change_is_thick(self._is_thick)
 
     def _on_surface_coloring_change(
         self,

--- a/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
+++ b/src/napari/_qt/layer_controls/dynamic/qt_dynamic_layer_controls.py
@@ -225,6 +225,7 @@ class QtDynamicLayerControls(QFrame):
         super().__init__()
 
         self._ndisplay: int = 2
+        self._is_thick: bool = False
         self._layers = layers
         self._controls = []
 

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
@@ -10,7 +10,6 @@ from napari._qt.layer_controls.dynamic.widgets.qt_widget_controls_base import (
 )
 from napari._qt.utils import (
     qt_signals_blocked,
-    set_widgets_enabled_with_opacity,
 )
 from napari.utils.events.event_utils import connect_setattr
 
@@ -83,11 +82,8 @@ class QtProjectionModeControl(QtWidgetControlsBase):
 
     def _change_is_thick(self, is_thick: bool) -> None:
         super()._change_is_thick(is_thick)
-        set_widgets_enabled_with_opacity(
-            self.parent(),
-            [self.projection_combobox_label, self.projection_combobox],
-            is_thick,
-        )
+        self.projection_combobox_label.setVisible(is_thick)
+        self.projection_combobox.setVisible(is_thick)
 
     def get_widget_controls(
         self,

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_projection_mode_control.py
@@ -8,7 +8,10 @@ from napari._qt.layer_controls.dynamic.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
     QtWrappedLabel,
 )
-from napari._qt.utils import qt_signals_blocked
+from napari._qt.utils import (
+    qt_signals_blocked,
+    set_widgets_enabled_with_opacity,
+)
 from napari.utils.events.event_utils import connect_setattr
 
 if TYPE_CHECKING:
@@ -77,6 +80,14 @@ class QtProjectionModeControl(QtWidgetControlsBase):
             self.projection_combobox.setCurrentText(
                 str(self._layers[0].projection_mode)
             )
+
+    def _change_is_thick(self, is_thick: bool) -> None:
+        super()._change_is_thick(is_thick)
+        set_widgets_enabled_with_opacity(
+            self.parent(),
+            [self.projection_combobox_label, self.projection_combobox],
+            is_thick,
+        )
 
     def get_widget_controls(
         self,

--- a/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
+++ b/src/napari/_qt/layer_controls/dynamic/widgets/qt_widget_controls_base.py
@@ -98,6 +98,17 @@ class QtWidgetControlsBase(QObject, metaclass=_QtABCMeta):
         """
         self._ndisplay = ndisplay
 
+    def _change_is_thick(self, is_thick: bool) -> None:
+        """
+        Change whether the slice is thick.
+
+        Parameters
+        ----------
+        is_thick : bool
+            The new is_thick value.
+        """
+        self._is_thick = is_thick
+
     def deleteLater(self) -> None:
         self.disconnect_widget_controls()
         super().deleteLater()

--- a/src/napari/_qt/layer_controls/qt_image_controls.py
+++ b/src/napari/_qt/layer_controls/qt_image_controls.py
@@ -44,8 +44,6 @@ class QtImageControls(QtBaseImageControls):
     def __init__(self, layer) -> None:
         super().__init__(layer)
         # Setup widgets controls
-        self._projection_mode_control = QtProjectionModeControl(self, layer)
-        self._add_widget_controls(self._projection_mode_control)
         self._interpolation_control = QtInterpolationComboBoxControl(
             self, layer
         )
@@ -56,6 +54,8 @@ class QtImageControls(QtBaseImageControls):
         self._add_widget_controls(self._render_control)
         self._multiscale_level_control = QtMultiscaleLevelControl(self, layer)
         self._add_widget_controls(self._multiscale_level_control)
+        self._projection_mode_control = QtProjectionModeControl(self, layer)
+        self._add_widget_controls(self._projection_mode_control)
 
         self._on_ndisplay_changed()
 

--- a/src/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -257,7 +257,8 @@ class QtLayerControls(QFrame):
     @is_thick.setter
     def is_thick(self, is_thick: bool) -> None:
         self._is_thick = is_thick
-        self._projection_mode_control._change_is_thick(is_thick)
+        if hasattr(self, '_projection_mode_control'):
+            self._projection_mode_control._change_is_thick(is_thick)
 
     def _set_transform_tool_state(self):
         """

--- a/src/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -71,7 +71,7 @@ class QtLayerControls(QFrame):
         super().__init__()
 
         self._ndisplay: int = 2
-        self._thick: bool = False
+        self._is_thick: bool = False
         self._EDIT_BUTTONS: tuple = ()
         self._MODE_BUTTONS: dict = {}
 
@@ -251,16 +251,13 @@ class QtLayerControls(QFrame):
         self._set_transform_tool_state()
 
     @property
-    def thick(self) -> bool:
-        return self._thick
+    def is_thick(self) -> bool:
+        return self._is_thick
 
-    @thick.setter
-    def thick(self, thick: bool) -> None:
-        self._thick = thick
-        self._on_thick_change()
-
-    def _on_thick_change(self):
-        self._projection_mode_control.set_thick(self.thick)
+    @is_thick.setter
+    def is_thick(self, is_thick: bool) -> None:
+        self._is_thick = is_thick
+        self._projection_mode_control._change_is_thick(is_thick)
 
     def _set_transform_tool_state(self):
         """

--- a/src/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -71,6 +71,7 @@ class QtLayerControls(QFrame):
         super().__init__()
 
         self._ndisplay: int = 2
+        self._thick: bool = False
         self._EDIT_BUTTONS: tuple = ()
         self._MODE_BUTTONS: dict = {}
 
@@ -248,6 +249,18 @@ class QtLayerControls(QFrame):
         to 2D or 3D visualization only like the transform mode button.
         """
         self._set_transform_tool_state()
+
+    @property
+    def thick(self) -> bool:
+        return self._thick
+
+    @thick.setter
+    def thick(self, thick: bool) -> None:
+        self._thick = thick
+        self._on_thick_change()
+
+    def _on_thick_change(self):
+        self._projection_mode_control.set_thick(self.thick)
 
     def _set_transform_tool_state(self):
         """

--- a/src/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -97,10 +97,14 @@ class QtLayerControlsContainer(QStackedWidget):
         self.addWidget(self.empty_widget)
         self.setCurrentWidget(self.empty_widget)
 
-        self.viewer.layers.events.inserted.connect(self._add)
-        self.viewer.layers.events.removed.connect(self._remove)
+        viewer.layers.events.inserted.connect(self._add)
+        viewer.layers.events.removed.connect(self._remove)
         viewer.layers.selection.events.changed.connect(self._populate)
         viewer.dims.events.ndisplay.connect(self._on_ndisplay_changed)
+        viewer.dims.events.thickness.connect(self._on_slice_thickness_change)
+        viewer.dims.events.not_displayed.connect(
+            self._on_slice_thickness_change
+        )
         viewer.events.theme.connect(self._on_viewer_theme_changed)
 
     def _on_ndisplay_changed(self, event):
@@ -117,6 +121,15 @@ class QtLayerControlsContainer(QStackedWidget):
 
         if self.panel is not None:
             self.panel.ndisplay = event.value
+
+    def _on_slice_thickness_change(self):
+        is_thick = self.viewer.dims.is_thick()
+        for panel in self.widgets.values():
+            if panel is not self.empty_widget:
+                panel.thick = is_thick
+
+        if self.panel is not None:
+            self.panel.thick = is_thick
 
     def _on_viewer_theme_changed(self, event=None):
         """Respond to viewer.theme changes from keybindings (Ctrl+Shift+T).

--- a/src/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -101,10 +101,7 @@ class QtLayerControlsContainer(QStackedWidget):
         viewer.layers.events.removed.connect(self._remove)
         viewer.layers.selection.events.changed.connect(self._populate)
         viewer.dims.events.ndisplay.connect(self._on_ndisplay_changed)
-        viewer.dims.events.thickness.connect(self._on_slice_thickness_change)
-        viewer.dims.events.not_displayed.connect(
-            self._on_slice_thickness_change
-        )
+        viewer.dims.events.is_thick.connect(self._on_is_thick_change)
         viewer.events.theme.connect(self._on_viewer_theme_changed)
 
     def _on_ndisplay_changed(self, event):
@@ -122,7 +119,7 @@ class QtLayerControlsContainer(QStackedWidget):
         if self.panel is not None:
             self.panel.ndisplay = event.value
 
-    def _on_slice_thickness_change(self):
+    def _on_is_thick_change(self):
         is_thick = self.viewer.dims.is_thick
         for panel in self.widgets.values():
             if panel is not self.empty_widget:
@@ -205,6 +202,7 @@ class QtLayerControlsContainer(QStackedWidget):
         layer = event.value
         controls = create_qt_layer_controls(layer)
         controls.ndisplay = self.viewer.dims.ndisplay
+        controls.is_thick = self.viewer.dims.is_thick
         self.addWidget(controls)
         self.widgets[layer] = controls
 

--- a/src/napari/_qt/layer_controls/qt_layer_controls_container.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_container.py
@@ -123,13 +123,13 @@ class QtLayerControlsContainer(QStackedWidget):
             self.panel.ndisplay = event.value
 
     def _on_slice_thickness_change(self):
-        is_thick = self.viewer.dims.is_thick()
+        is_thick = self.viewer.dims.is_thick
         for panel in self.widgets.values():
             if panel is not self.empty_widget:
-                panel.thick = is_thick
+                panel.is_thick = is_thick
 
         if self.panel is not None:
-            self.panel.thick = is_thick
+            self.panel.is_thick = is_thick
 
     def _on_viewer_theme_changed(self, event=None):
         """Respond to viewer.theme changes from keybindings (Ctrl+Shift+T).
@@ -187,6 +187,7 @@ class QtLayerControlsContainer(QStackedWidget):
             ]
             self.panel = QtDynamicLayerControls(layers)
             self.panel.ndisplay = self.viewer.dims.ndisplay
+            self.panel.is_thick = self.viewer.dims.is_thick
             self.addWidget(self.panel)
             self.setCurrentWidget(self.panel)
 

--- a/src/napari/_qt/layer_controls/qt_points_controls.py
+++ b/src/napari/_qt/layer_controls/qt_points_controls.py
@@ -94,8 +94,6 @@ class QtPointsControls(QtLayerControls):
         self.button_grid.addWidget(self.select_button, 0, 5)
 
         # Setup widgets controls
-        self._projection_mode_control = QtProjectionModeControl(self, layer)
-        self._add_widget_controls(self._projection_mode_control)
         self._current_size_slider_control = QtCurrentSizeSliderControl(
             self, layer
         )
@@ -112,6 +110,8 @@ class QtPointsControls(QtLayerControls):
         self._add_widget_controls(self._border_color_control)
         self._text_visibility_control = QtTextVisibilityControl(self, layer)
         self._add_widget_controls(self._text_visibility_control)
+        self._projection_mode_control = QtProjectionModeControl(self, layer)
+        self._add_widget_controls(self._projection_mode_control)
 
     def _on_mode_change(self, event):
         """Update ticks in checkbox widgets when points layer mode is changed.

--- a/src/napari/_qt/layer_controls/qt_vectors_controls.py
+++ b/src/napari/_qt/layer_controls/qt_vectors_controls.py
@@ -50,8 +50,6 @@ class QtVectorsControls(QtLayerControls):
         self._add_widget_controls(self._width_spinbox_control)
         self._length_spinbox_control = QtLengthSpinBoxControl(self, layer)
         self._add_widget_controls(self._length_spinbox_control)
-        self._projection_mode_control = QtProjectionModeControl(self, layer)
-        self._add_widget_controls(self._projection_mode_control)
         self._vector_style_combobox_control = QtVectorStyleComboBoxControl(
             self, layer
         )
@@ -60,3 +58,5 @@ class QtVectorsControls(QtLayerControls):
             self, layer
         )
         self._add_widget_controls(self._edge_color_feature_control)
+        self._projection_mode_control = QtProjectionModeControl(self, layer)
+        self._add_widget_controls(self._projection_mode_control)

--- a/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
@@ -4,7 +4,10 @@ from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
     QtWidgetControlsBase,
     QtWrappedLabel,
 )
-from napari._qt.utils import qt_signals_blocked
+from napari._qt.utils import (
+    qt_signals_blocked,
+    set_widgets_enabled_with_opacity,
+)
 from napari.layers import Image, Points, Vectors
 from napari.utils.events.event_utils import connect_setattr
 
@@ -57,6 +60,13 @@ class QtProjectionModeControl(QtWidgetControlsBase):
             self.projection_combobox.setCurrentText(
                 str(self._layer.projection_mode)
             )
+
+    def set_thick(self, thick) -> None:
+        set_widgets_enabled_with_opacity(
+            self,
+            [self.projection_combobox_label, self.projection_combobox],
+            thick,
+        )
 
     def get_widget_controls(
         self,

--- a/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
@@ -6,7 +6,6 @@ from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
 )
 from napari._qt.utils import (
     qt_signals_blocked,
-    set_widgets_enabled_with_opacity,
 )
 from napari.layers import Image, Points, Vectors
 from napari.utils.events.event_utils import connect_setattr
@@ -62,11 +61,8 @@ class QtProjectionModeControl(QtWidgetControlsBase):
             )
 
     def _change_is_thick(self, is_thick) -> None:
-        set_widgets_enabled_with_opacity(
-            self.parent(),
-            [self.projection_combobox_label, self.projection_combobox],
-            is_thick,
-        )
+        self.projection_combobox_label.setVisible(is_thick)
+        self.projection_combobox.setVisible(is_thick)
 
     def get_widget_controls(
         self,

--- a/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
+++ b/src/napari/_qt/layer_controls/widgets/qt_projection_mode_control.py
@@ -61,11 +61,11 @@ class QtProjectionModeControl(QtWidgetControlsBase):
                 str(self._layer.projection_mode)
             )
 
-    def set_thick(self, thick) -> None:
+    def _change_is_thick(self, is_thick) -> None:
         set_widgets_enabled_with_opacity(
-            self,
+            self.parent(),
             [self.projection_combobox_label, self.projection_combobox],
-            thick,
+            is_thick,
         )
 
     def get_widget_controls(

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -319,6 +319,7 @@ class Dims(EventedModel):
             val // 2 for val in value
         )
 
+    @property
     def is_thick(self) -> bool:
         """Return whether the current slice is thick.
 

--- a/src/napari/components/dims.py
+++ b/src/napari/components/dims.py
@@ -319,6 +319,14 @@ class Dims(EventedModel):
             val // 2 for val in value
         )
 
+    def is_thick(self) -> bool:
+        """Return whether the current slice is thick.
+
+        A slice is thick if the currently non-displayed dimensions
+        have nonzero margins.
+        """
+        return bool(np.any(np.array(self.thickness)[list(self.not_displayed)]))
+
     @property
     def displayed(self) -> tuple[int, ...]:
         """Tuple: Dimensions that are displayed."""


### PR DESCRIPTION
# References and relevant issues
- https://github.com/napari/napari/pull/9487#issuecomment-5573135037

# Description
This PR adds a path to the qt controls mirroring the one for `ndisplay` changes, which updates controls based on the slice thickness. Specifically, the projection mode combobox will be enabled only if it has an effect on the current view: if the currently non-displayed dimensions have non-zero margins. I added a helper property for this on the `Dims` object.

The code is basically mirrored on the dynamic layer controls.


