### PR TITLE
Bump vispy: rgb volumes, fixed perspective and overlay bleed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "toolz>=0.12.1",
     "tqdm>=4.56.0",
     "typing_extensions>=4.12",
-    "vispy>=0.16.2,<0.17",
+    "vispy>=0.17.0,<0.18",
     "wrapt>=1.14.1",
 ]
 dynamic = [

--- a/resources/constraints/constraints_py3.11.txt
+++ b/resources/constraints/constraints_py3.11.txt
@@ -566,7 +566,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.7.7
     # via napari (pyproject.toml)
-vispy==0.16.2
+vispy==0.17.0
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.12.txt
+++ b/resources/constraints/constraints_py3.12.txt
@@ -561,7 +561,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.7.7
     # via napari (pyproject.toml)
-vispy==0.16.2
+vispy==0.17.0
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.12_docs.txt
+++ b/resources/constraints/constraints_py3.12_docs.txt
@@ -1073,7 +1073,7 @@ uvicorn==0.52.4
     # via sphinx-autobuild
 virtualenv==21.7.7
     # via napari (pyproject.toml)
-vispy==0.16.2
+vispy==0.17.0
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.12_examples.txt
+++ b/resources/constraints/constraints_py3.12_examples.txt
@@ -753,7 +753,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.7.7
     # via napari (pyproject.toml)
-vispy==0.16.2
+vispy==0.17.0
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.13.txt
+++ b/resources/constraints/constraints_py3.13.txt
@@ -558,7 +558,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.7.7
     # via napari (pyproject.toml)
-vispy==0.16.2
+vispy==0.17.0
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/resources/constraints/constraints_py3.14.txt
+++ b/resources/constraints/constraints_py3.14.txt
@@ -558,7 +558,7 @@ urllib3==2.7.0
     # via requests
 virtualenv==21.7.7
     # via napari (pyproject.toml)
-vispy==0.16.2
+vispy==0.17.0
     # via
     #   napari (pyproject.toml)
     #   napari-svg

--- a/src/napari/_vispy/visuals/colorbar.py
+++ b/src/napari/_vispy/visuals/colorbar.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
     from vispy.color import Colormap as VispyColormap
+    from vispy.visuals.filters.clipper import Clipper
 
     from napari._vispy.utils.qt_font import FontInfo
     from napari.utils.color import ColorValue
@@ -124,7 +125,7 @@ class ColorBar(Node):
         width, _ = text.get_width_height()
         return width + self.ticks.tick_label_margin, text.get_line_height()
 
-    def _set_clipper(self, node, clipper):
+    def _set_clipper(self, node: Node, clipper: Clipper) -> None:
         """Propagate clipper to child visuals.
 
         ColorBar is just a Node (not VisualNode) so it doesn't have the filter

--- a/src/napari/_vispy/visuals/colorbar.py
+++ b/src/napari/_vispy/visuals/colorbar.py
@@ -123,3 +123,14 @@ class ColorBar(Node):
 
         width, _ = text.get_width_height()
         return width + self.ticks.tick_label_margin, text.get_line_height()
+
+    def _set_clipper(self, node, clipper):
+        """Propagate clipper to child visuals.
+
+        ColorBar is just a Node (not VisualNode) so it doesn't have the filter
+        attach/detach logic; using Compound instead of Node is an alternative
+        that doesn't require these extra tricks, but has other issues (due to
+        our parenting hijacking) which are more complex to solve.
+        """
+        for child in self.children:
+            child._set_clipper(node, clipper)

--- a/src/napari/layers/image/_tests/test_image.py
+++ b/src/napari/layers/image/_tests/test_image.py
@@ -575,7 +575,7 @@ def test_value():
         ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'translucent', 0),
         # not quite as expected for additive
         ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'additive', 2),
-        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'iso', None),
+        ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'iso', 1),
         ((2, 2, 2), [1, 0, 0], [0, 1, 2], False, 'attenuated_mip', 0),
         ((0, 2, 2, 2), [0, 1, 0, 0], [1, 2, 3], False, 'mip', 1),
     ],

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -698,9 +698,9 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         # all the following cases are returning the *actual* value of the image at the
         # "selected" pixel, whose position changes depending on the rendering mode.
         if self.rendering == ImageRendering.MIP:
-            return values[np.nanargmax(luminance, axis=0)]
+            return values[np.nanargmax(luminance)]
         if self.rendering == ImageRendering.MINIP:
-            return values[np.nanargmin(luminance, axis=0)]
+            return values[np.nanargmin(luminance)]
         if self.rendering == ImageRendering.ATTENUATED_MIP:
             # normalize values so attenuation applies from 0 to 1
             attenuated = (

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -27,6 +27,7 @@ from napari.layers.intensity_mixin import IntensityVisualizationMixin
 from napari.layers.utils.layer_utils import calc_data_range
 from napari.types import LayerDataType
 from napari.utils._dtype import get_dtype_limits, normalize_dtype
+from napari.utils.color import rgb_to_luminance
 from napari.utils.colormaps import ensure_colormap
 from napari.utils.colormaps.colormap_utils import _coerce_contrast_limits
 
@@ -657,8 +658,6 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
             finally:
                 self._auto_contrast = prev
 
-        return
-
     def _calculate_value_from_ray(
         self, values: npt.NDArray
     ) -> float | npt.NDArray | None:
@@ -674,12 +673,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         if np.all(np.isnan(values)):
             return None
 
-        if self.rgb:
-            luminance = values @ np.array(
-                [0.2126, 0.7152, 0.0722], dtype=np.float32
-            )
-        else:
-            luminance = values
+        luminance = rgb_to_luminance(values) if self.rgb else values
 
         # in isosurface we return the value at the hit surface;
         # in non-rgb it's ~= iso_threshold. Return None if nothing was hit.

--- a/src/napari/layers/image/image.py
+++ b/src/napari/layers/image/image.py
@@ -235,6 +235,7 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
         3D Depiction mode used by vispy. Must be one of our supported modes.
     iso_threshold : float
         Threshold for isosurface.
+        When in RGB, this threshold applies to the perceived luminance.
     attenuation : float
         Attenuation rate for attenuated maximum intensity projection.
     plane : SlicingPlane or dict
@@ -656,50 +657,70 @@ class Image(IntensityVisualizationMixin, ScalarFieldBase):
             finally:
                 self._auto_contrast = prev
 
-    def _calculate_value_from_ray(self, values: npt.NDArray) -> float | None:
+        return
+
+    def _calculate_value_from_ray(
+        self, values: npt.NDArray
+    ) -> float | npt.NDArray | None:
+        if not values.size:
+            return None
+
         # translucent is special: just return the first value, no matter what
         if self.rendering == ImageRendering.TRANSLUCENT:
-            return np.ravel(values)[0]
-        # iso is weird too: just return None always
-        if self.rendering == ImageRendering.ISO:
-            return None
+            return values[0]
 
         # if the whole ray is NaN, we should see nothing, so return None
         # this check saves us some warnings later as well, so better do it now
         if np.all(np.isnan(values)):
             return None
 
+        if self.rgb:
+            luminance = values @ np.array(
+                [0.2126, 0.7152, 0.0722], dtype=np.float32
+            )
+        else:
+            luminance = values
+
+        # in isosurface we return the value at the hit surface;
+        # in non-rgb it's ~= iso_threshold. Return None if nothing was hit.
+        if self.rendering == ImageRendering.ISO:
+            hits = luminance >= self.iso_threshold
+            if np.any(hits):
+                return values[np.nanargmax(hits)]
+            return None
+
         # "summary" renderings; they do not represent a specific pixel, so we just
         # return the summary value. We should probably differentiate these somehow.
         # these are also probably not the same as how the gpu does it...
+        # TODO: this is "broken" cause same pixel gets multisampled, getting worse
+        #       when the sampling rate is high (and especially bad for additive).
+        #       But it looks like it's also similarly overdoing it in vispy vis too.
+        #       I don't know if there's a way to *not* do it...
         if self.rendering == ImageRendering.AVERAGE:
-            return np.nanmean(values)
+            return np.nanmean(values, axis=0)
         if self.rendering == ImageRendering.ADDITIVE:
-            # TODO: this is "broken" cause same pixel gets multisampled...
-            #       but it looks like it's also overdoing it in vispy vis too?
-            #       I don't know if there's a way to *not* do it...
-            return np.nansum(values)
+            return np.nansum(values, axis=0)
 
         # all the following cases are returning the *actual* value of the image at the
         # "selected" pixel, whose position changes depending on the rendering mode.
         if self.rendering == ImageRendering.MIP:
-            return np.nanmax(values)
+            return values[np.nanargmax(luminance, axis=0)]
         if self.rendering == ImageRendering.MINIP:
-            return np.nanmin(values)
+            return values[np.nanargmin(luminance, axis=0)]
         if self.rendering == ImageRendering.ATTENUATED_MIP:
             # normalize values so attenuation applies from 0 to 1
-            values_attenuated = (
-                values - self.contrast_limits[0]
+            attenuated = (
+                luminance - self.contrast_limits[0]
             ) / self.contrast_limits[1]
             # approx, step size is actually calculated with int(lenght(ray) * 2)
             step_size = 0.5
             sumval = (
                 step_size
-                * np.cumsum(np.clip(values_attenuated, 0, 1))
-                * len(values_attenuated)
+                * np.cumsum(np.clip(attenuated, 0, 1))
+                * len(attenuated)
             )
             scale = np.exp(-self.attenuation * (sumval - 1))
-            return values[np.nanargmin(values_attenuated * scale)]
+            return values[np.nanargmin(attenuated * scale)]
 
         raise RuntimeError(  # pragma: no cover
             f'ray value calculation not implemented for {self.rendering}'

--- a/src/napari/utils/color.py
+++ b/src/napari/utils/color.py
@@ -208,6 +208,13 @@ def rgb_to_luminance(
     | np.ndarray[tuple[int], np.dtype[np.floating]]
     | np.ndarray[tuple[int, ...], np.dtype[np.floating]]
 ):
+    """Convert RGB(A) values to perceived luminance.
+
+    Uses ITU-R BT.709 coefficients, compositing with the alpha channel
+    if present.
+
+    .. versionadded: 0.10.0
+    """
     if rgb.shape[-1] == 3:
         return rgb @ np.array([0.2126, 0.7152, 0.0722], dtype=np.float32)
     if rgb.shape[-1] == 4:

--- a/src/napari/utils/color.py
+++ b/src/napari/utils/color.py
@@ -209,9 +209,11 @@ def rgb_to_luminance(
     | np.ndarray[tuple[int, ...], np.dtype[np.floating]]
 ):
     if rgb.shape[-1] == 3:
-        factor = np.array([0.2126, 0.7152, 0.0722], dtype=np.float32)
-    elif rgb.shape[-1] == 4:
-        factor = np.array([0.2126, 0.7152, 0.0722, 1], dtype=np.float32)
-    else:
-        raise ValueError('can only convert rgb or rgba')
-    return rgb @ factor
+        return rgb @ np.array([0.2126, 0.7152, 0.0722], dtype=np.float32)
+    if rgb.shape[-1] == 4:
+        return (
+            rgb[..., :3]
+            @ np.array([0.2126, 0.7152, 0.0722], dtype=np.float32)
+            * rgb[..., 4]
+        )
+    raise ValueError('can only convert rgb or rgba')

--- a/src/napari/utils/color.py
+++ b/src/napari/utils/color.py
@@ -196,12 +196,18 @@ def rgb_to_luminance(
 
 # can also work on more arbitrarily shaped arrays and with values outside of [0, 1]
 @overload
-def rgb_to_luminance(rgb: np.ndarray) -> np.ndarray: ...
+def rgb_to_luminance(
+    rgb: np.ndarray[tuple[int, ...]],
+) -> np.ndarray[tuple[int, ...], np.dtype[np.floating]]: ...
 
 
 def rgb_to_luminance(
     rgb: ColorValue | ColorArray | np.ndarray,
-) -> float | np.ndarray[tuple[int], np.dtype[np.floating]]:
+) -> (
+    float
+    | np.ndarray[tuple[int], np.dtype[np.floating]]
+    | np.ndarray[tuple[int, ...], np.dtype[np.floating]]
+):
     if rgb.shape[-1] == 3:
         factor = np.array([0.2126, 0.7152, 0.0722], dtype=np.float32)
     elif rgb.shape[-1] == 4:

--- a/src/napari/utils/color.py
+++ b/src/napari/utils/color.py
@@ -1,6 +1,6 @@
 """Contains napari color constants and utilities."""
 
-from typing import Any, Self
+from typing import Any, Self, overload
 
 import numpy as np
 from pydantic import GetCoreSchemaHandler
@@ -182,3 +182,30 @@ class ColorArray(np.ndarray):
         if isinstance(value, np.ndarray | list | tuple) and len(value) == 0:
             return np.empty((0, 4), np.float32).view(cls)
         return transform_color(value).view(cls)
+
+
+@overload
+def rgb_to_luminance(rgb: ColorValue) -> float: ...
+
+
+@overload
+def rgb_to_luminance(
+    rgb: ColorArray,
+) -> np.ndarray[tuple[int], np.dtype[np.floating]]: ...
+
+
+# can also work on more arbitrarily shaped arrays and with values outside of [0, 1]
+@overload
+def rgb_to_luminance(rgb: np.ndarray) -> np.ndarray: ...
+
+
+def rgb_to_luminance(
+    rgb: ColorValue | ColorArray | np.ndarray,
+) -> float | np.ndarray[tuple[int], np.dtype[np.floating]]:
+    if rgb.shape[-1] == 3:
+        factor = np.array([0.2126, 0.7152, 0.0722], dtype=np.float32)
+    elif rgb.shape[-1] == 4:
+        factor = np.array([0.2126, 0.7152, 0.0722, 1], dtype=np.float32)
+    else:
+        raise ValueError('can only convert rgb or rgba')
+    return rgb @ factor

--- a/src/napari_builtins/_skimage_data.py
+++ b/src/napari_builtins/_skimage_data.py
@@ -32,6 +32,7 @@ def _load_skimage_data(name, **kwargs):
                 skimage.data.kidney(),
                 {
                     'name': 'Kidney (nuclei, WGA and actin)',
+                    'rgb': True,
                 },
             )
         ]

--- a/src/napari_builtins/_skimage_data.py
+++ b/src/napari_builtins/_skimage_data.py
@@ -26,6 +26,15 @@ def _load_skimage_data(name, **kwargs):
                 },
             )
         ]
+    if name == 'kidney_rgb':
+        return [
+            (
+                skimage.data.kidney(),
+                {
+                    'name': 'Kidney (nuclei, WGA and actin)',
+                },
+            )
+        ]
     if name == 'lily':
         return [
             (
@@ -62,7 +71,7 @@ SKIMAGE_DATA = [
     'astronaut', 'binary_blobs', 'binary_blobs_3D', 'brain', 'brick', 'camera', 'cat',
     'cell', 'cells3d', 'checkerboard', 'clock', 'coffee', 'coins', 'colorwheel',
     'eagle', 'grass', 'gravel', 'horse', 'hubble_deep_field', 'human_mitosis',
-    'immunohistochemistry', 'kidney', 'lfw_subset', 'lily', 'microaneurysms', 'moon',
+    'immunohistochemistry', 'kidney', 'kidney_rgb', 'lfw_subset', 'lily', 'microaneurysms', 'moon',
     'page', 'retina', 'rocket', 'shepp_logan_phantom', 'skin', 'text',
 ]
 

--- a/src/napari_builtins/builtins.yaml
+++ b/src/napari_builtins/builtins.yaml
@@ -96,10 +96,10 @@ contributions:
       title: Generate immunohistochemistry sample
       python_name: napari_builtins._skimage_data:immunohistochemistry
     - id: napari.data.kidney
-      title: generate kidney sample
+      title: Generate kidney sample
       python_name: napari_builtins._skimage_data:kidney
     - id: napari.data.kidney_rgb
-      title: generate kidney rgb sample
+      title: Generate kidney rgb sample
       python_name: napari_builtins._skimage_data:kidney_rgb
     - id: napari.data.lfw_subset
       title: Generate lfw_subset sample

--- a/src/napari_builtins/builtins.yaml
+++ b/src/napari_builtins/builtins.yaml
@@ -265,7 +265,7 @@ contributions:
     - display_name: Cell
       key: cell
       command: napari.data.cell
-    - display_name: Cells (3D+2Ch)
+    - display_name: Cells (3D, 2Ch)
       key: cells3d
       command: napari.data.cells3d
     - display_name: Checkerboard
@@ -307,10 +307,10 @@ contributions:
     - display_name: Immunohistochemistry (RGB)
       key: immunohistochemistry
       command: napari.data.immunohistochemistry
-    - display_name: Kidney (3D + 3 split channels)
+    - display_name: Kidney (3D, 3Ch)
       key: kidney
       command: napari.data.kidney
-    - display_name: Kidney (3D in RGB)
+    - display_name: Kidney (3D, RGB)
       key: kidney_rgb
       command: napari.data.kidney_rgb
     - display_name: Labeled Faces in the Wild

--- a/src/napari_builtins/builtins.yaml
+++ b/src/napari_builtins/builtins.yaml
@@ -96,8 +96,11 @@ contributions:
       title: Generate immunohistochemistry sample
       python_name: napari_builtins._skimage_data:immunohistochemistry
     - id: napari.data.kidney
-      title: Generate kidney sample
+      title: generate kidney sample
       python_name: napari_builtins._skimage_data:kidney
+    - id: napari.data.kidney_rgb
+      title: generate kidney rgb sample
+      python_name: napari_builtins._skimage_data:kidney_rgb
     - id: napari.data.lfw_subset
       title: Generate lfw_subset sample
       python_name: napari_builtins._skimage_data:lfw_subset
@@ -304,9 +307,12 @@ contributions:
     - display_name: Immunohistochemistry (RGB)
       key: immunohistochemistry
       command: napari.data.immunohistochemistry
-    - display_name: Kidney (3D+3Ch)
+    - display_name: Kidney (3D + 3 split channels)
       key: kidney
       command: napari.data.kidney
+    - display_name: Kidney (3D in RGB)
+      key: kidney_rgb
+      command: napari.data.kidney_rgb
     - display_name: Labeled Faces in the Wild
       key: lfw_subset
       command: napari.data.lfw_subset


### PR DESCRIPTION
# References and relevant issues
- closes #8802. Same issue mentioned in https://github.com/napari/napari/pull/9083#issuecomment-4795114872 (via https://github.com/vispy/vispy/pull/2781)
- closes #8872 (via https://github.com/vispy/vispy/pull/2774)
- closes #9089 (via https://github.com/vispy/vispy/pull/2773)
- partially addresses #3973 (only supports basic rgb using perceived luminance for ray casting, no arbitrary channels or arbitrary transfer function) (via https://github.com/vispy/vispy/pull/2758)
- closes https://github.com/napari/napari/issues/7442 (via local changes)

# Description
__Note, to test this properly you need to actually update the vispy dep in your env!__

This vispy bump includes a few fixes and enhancements. For us, it fixes 3 things:

- fixes bleed-over of overlays into other viewboxes. This will be more relevant for #9082, but can already happen in some cases (#8802)

- perspective rendering of markers and text: on main, if you run `examples/add_points_with_multicolor_text.py`, switch to 3D and `shift+right-click-drag` to increase the FOV, everything disappears. With the new vispy, it works as expected.

<img width="1280" height="705" alt="image" src="https://github.com/user-attachments/assets/ae3da187-4556-4528-87ae-ab8604e6e542" />

- rgb volumes: on main, you cannot render rgb data in 3D (it will render it as grayscale). With the new vispy, you can! I added a variant of the kidney sample to make that easy to test.

<img width="1280" height="705" alt="image" src="https://github.com/user-attachments/assets/6c1bae78-0a85-4cb6-a7d4-b6bd42c12156" />


---

Since with this PR we would officially support rgb volumes, I included changes to how we treat rgb 3D data locally to fix a few issues (notably #7442 and related get_value problems). There is still something off with the isosurface, that I can't quite get; I think it's a bug in the vispy rendering...