### PR TITLE
Fix fuzzy finding and command highlighting in palette

### DIFF
--- a/src/napari/_app_model/actions/_view.py
+++ b/src/napari/_app_model/actions/_view.py
@@ -207,7 +207,7 @@ VIEW_ACTIONS: list[Action] = [
     ),
     Action(
         id='napari.scene.toggle_synced_camera',
-        title='Toggle Synced scene.overlays.axes.Camera',
+        title='Toggle Synced Camera',
         menus=[
             {
                 'id': MenuId.MENUBAR_VIEW,

--- a/src/napari/_qt/widgets/qt_command_palette.py
+++ b/src/napari/_qt/widgets/qt_command_palette.py
@@ -377,7 +377,6 @@ class QCommandList(QtW.QListView):
             if row >= max_matches:
                 self._current_max_index = max_matches
                 break
-            row = row + 1
         else:
             # if the loop completes without break
             self._current_max_index = row
@@ -488,12 +487,26 @@ def _iter_matched_actions(
     names = list(name_to_command)
     commands = list(name_to_command.values())
 
+    def custom_scorer(query, candidate, *, score_cutoff=0):
+        # this acts mainly like partial_token_set_ratio (scoring
+        # higher the more tokens in any order are in the candidate),
+        # but down-weighs a bit those that are in the wrong order.
+        # this makes it so that
+        token_score = fuzz.partial_token_set_ratio(query, candidate)
+
+        order_score = fuzz.WRatio(query, candidate)
+
+        # Weighted combination
+        score = 0.7 * token_score + 0.3 * order_score
+
+        return score if score >= score_cutoff else 0
+
     for _, score, command_idx in process.extract(
         input_text,
         names,
         limit=100,
         score_cutoff=exp.command_palette_fuzzy_search_threshold,
-        scorer=fuzz.partial_token_sort_ratio,
+        scorer=custom_scorer,
         processor=utils.default_process,
     ):
         yield score, commands[command_idx]

--- a/src/napari/_qt/widgets/qt_command_palette.py
+++ b/src/napari/_qt/widgets/qt_command_palette.py
@@ -490,8 +490,8 @@ def _iter_matched_actions(
     def custom_scorer(query, candidate, *, score_cutoff=0):
         # this acts mainly like partial_token_set_ratio (scoring
         # higher the more tokens in any order are in the candidate),
-        # but down-weighs a bit those that are in the wrong order.
-        # this makes it so that
+        # but down-weighs a bit those that are in the wrong order or
+        # contain the wrong tokens
         token_score = fuzz.partial_token_set_ratio(query, candidate)
 
         order_score = fuzz.WRatio(query, candidate)

--- a/src/napari/_qt/widgets/qt_command_palette.py
+++ b/src/napari/_qt/widgets/qt_command_palette.py
@@ -370,6 +370,7 @@ class QCommandList(QtW.QListView):
                 break
             lw.set_command(action)
             if _enabled(action, self._app_model_context):
+                lw.setEnabled(True)
                 lw.set_text_colors(input_text, color=self._match_color)
             else:
                 lw.setDisabled(True)

--- a/src/napari/_qt/widgets/qt_command_palette.py
+++ b/src/napari/_qt/widgets/qt_command_palette.py
@@ -487,19 +487,21 @@ def _iter_matched_actions(
     names = list(name_to_command)
     commands = list(name_to_command.values())
 
-    def custom_scorer(query, candidate, *, score_cutoff=0):
+    def custom_scorer(
+        s1: str, s2: str, *, score_cutoff: float | None = 0
+    ) -> float:
         # this acts mainly like partial_token_set_ratio (scoring
         # higher the more tokens in any order are in the candidate),
         # but down-weighs a bit those that are in the wrong order or
         # contain the wrong tokens
-        token_score = fuzz.partial_token_set_ratio(query, candidate)
+        token_score = fuzz.partial_token_set_ratio(s1, s2)
 
-        order_score = fuzz.WRatio(query, candidate)
+        order_score = fuzz.WRatio(s1, s2)
 
         # Weighted combination
         score = 0.7 * token_score + 0.3 * order_score
 
-        return score if score >= score_cutoff else 0
+        return score if score_cutoff and score >= score_cutoff else 0
 
     for _, score, command_idx in process.extract(
         input_text,


### PR DESCRIPTION
# References and relevant issues
- closes #9500
- depends on #9512 

# Description
This PR changes the current scorer from `fuzz.partial_token_set_ratio` to a custom mix scorer with `fuzz.WRatio`. Adding a sprinkle of the latter ensures that matches that have the correct *order* of tokens as well as no *extra* tokens are upweighted over the rest. I found that this mix with these numbers works well for a variety of cases.

@psobolewkyPhD how does this play for you? You can adjust the ratio in the code and the cutoff in the experimental settings to see if you find a better setup.

---

Additionally, this PR fixes a bug that surfaced when playing with this PR but that somehow was already there for a long time and just slipped through: the row was incremented twice! This resulted in the wrong row being marked as enabled/disabled in a variety of cases :/

---

One more thing: the specific example from #9500 was extra bad because the action name itself was bad, due all the search/replace I did in #9363. This one slipped through :P