### PR TITLE
Settable canvas_ratio for scale bar

### DIFF
--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -26,6 +26,8 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
     def __init__(self, *, font_info: FontInfo, **kwargs) -> None:
         self._canvas_length = 150.0
+        self._canvas_tick_length = 10.0
+        self._canvas_thickness = 3
         self._scale = 1.0
         self._unit = pint.Quantity('1 pixel')
 
@@ -141,11 +143,13 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         scale = 1 / self.viewer.scene.camera.zoom
 
         if self.overlay.gridded:
-            ref_length = self.viewer.canvas.viewbox_size(self.viewer.layers)[0]
+            view_height, view_width = self.viewer.canvas.viewbox_size(
+                self.viewer.layers
+            )
         else:
-            ref_length = self.viewer.canvas.size[0]
-        target_canvas_length = ref_length / 4
+            view_height, view_width = self.viewer.canvas.size
 
+        target_canvas_length = view_width / 4
         # If scale or canvas size has not changed, do not redraw
         if (
             abs(np.log10(self._scale) - np.log10(scale)) < 1e-4
@@ -171,6 +175,13 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self._canvas_length = canvas_length
         self._scale = scale
 
+        # some magic numbers
+        self._canvas_tick_length = max(view_height // 70, 11)
+        self._canvas_thickness = max((view_width + view_height) // 700, 3)
+        # prefer odd numbers as they look nicer
+        self._canvas_tick_length += (self._canvas_tick_length + 1) % 2
+        self._canvas_thickness += (self._canvas_thickness + 1) % 2
+
         # Update scalebar and text
         self.node.text.text = f'{dim_with_unit:g~#P}'
         self._on_rendering_change()
@@ -187,9 +198,10 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
         width, height = self.node.set_data(
             length=self._canvas_length,
-            color=color,
-            ticks=self.overlay.ticks,
+            tick_length=self._canvas_tick_length if self.overlay.ticks else 0,
+            thickness=self._canvas_thickness,
             font_size=self.overlay.font_size,
+            color=color,
         )
 
         size_changed = width != self.x_size or height != self.y_size

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -57,6 +57,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             self._on_rendering_change
         )
         self.viewer.canvas.events.size.connect(self._on_size_or_zoom_change)
+        self.viewer.canvas.grid.events.connect(self._on_size_or_zoom_change)
 
         self.reset()
 

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -44,6 +44,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.overlay.events.unit.connect(self._on_unit_change)
         self.overlay.events.length.connect(self._on_size_or_zoom_change)
         self.overlay.events.visible.connect(self._on_rendering_change)
+        self.overlay.events.gridded.connect(self._on_size_or_zoom_change)
 
         self.viewer.scene.camera.events.zoom.connect(
             self._on_size_or_zoom_change
@@ -143,7 +144,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             ref_length = self.viewer.canvas.viewbox_size(self.viewer.layers)[0]
         else:
             ref_length = self.viewer.canvas.size[0]
-        target_canvas_length = ref_length / 5
+        target_canvas_length = ref_length / 4
 
         # If scale or canvas size has not changed, do not redraw
         if (

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -157,14 +157,6 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             view_height, view_width = self.viewer.canvas.size
 
         target_canvas_length = max(view_width / 4, self._min_canvas_length)
-        # If scale or canvas size has not changed, do not redraw
-        if (
-            abs(np.log10(self._scale) - np.log10(scale)) < 1e-4
-            and target_canvas_length == self._canvas_length
-            and not force
-        ):
-            return
-
         # convert desired length to world size
         target_world_pixels = scale * target_canvas_length
 

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -25,11 +25,17 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     node: ScaleBar
 
     def __init__(self, *, font_info: FontInfo, **kwargs) -> None:
+        # starting values, don't really matter as they get updated immediately
         self._canvas_length = 150.0
-        self._canvas_tick_length = 10.0
+        self._canvas_tick_length = 11.0
         self._canvas_thickness = 3
         self._scale = 1.0
         self._unit = pint.Quantity('1 pixel')
+
+        # minimum dimesnions, to avoid degenerate cases
+        self._min_canvas_length = 75
+        self._min_canvas_tick_length = 11.0
+        self._min_canvas_thickness = 3
 
         super().__init__(
             node=ScaleBar(font_info=font_info),
@@ -150,7 +156,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         else:
             view_height, view_width = self.viewer.canvas.size
 
-        target_canvas_length = view_width / 4
+        target_canvas_length = max(view_width / 4, self._min_canvas_length)
         # If scale or canvas size has not changed, do not redraw
         if (
             abs(np.log10(self._scale) - np.log10(scale)) < 1e-4
@@ -177,11 +183,15 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self._scale = scale
 
         # some magic numbers
-        self._canvas_tick_length = max(view_height // 70, 11)
-        self._canvas_thickness = max((view_width + view_height) // 700, 3)
+        self._canvas_thickness = max(
+            (view_width + view_height) // 700, self._min_canvas_thickness
+        )
         # prefer odd numbers as they look nicer
-        self._canvas_tick_length += (self._canvas_tick_length + 1) % 2
         self._canvas_thickness += (self._canvas_thickness + 1) % 2
+
+        self._canvas_tick_length = max(
+            self._canvas_thickness * 3, self._min_canvas_tick_length
+        )
 
         # Update scalebar and text
         self.node.text.text = f'{dim_with_unit:g~#P}'

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -25,8 +25,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     node: ScaleBar
 
     def __init__(self, *, font_info: FontInfo, **kwargs) -> None:
-        self._target_length = 150.0
-        self._current_length = 150.0
+        self._canvas_length = 150.0
         self._scale = 1.0
         self._unit = pint.Quantity('1 pixel')
 
@@ -54,6 +53,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         self.viewer.canvas.events.background_color.connect(
             self._on_rendering_change
         )
+        self.viewer.canvas.events.size.connect(self._on_size_or_zoom_change)
 
         self.reset()
 
@@ -137,34 +137,35 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     def _on_size_or_zoom_change(self, *, force: bool = False):
         """Update length based on scale bar size and zoom."""
 
-        # If scale has not changed, do not redraw
+        # If scale or canvas size has not changed, do not redraw
         scale = 1 / self.viewer.scene.camera.zoom
-        if abs(np.log10(self._scale) - np.log10(scale)) < 1e-4 and not force:
+        target_canvas_length = self.viewer.canvas.size[1] / 6
+        if (
+            abs(np.log10(self._scale) - np.log10(scale)) < 1e-4
+            and target_canvas_length == self._canvas_length
+            and not force
+        ):
             return
-        self._scale = scale
 
-        scale_canvas2world = self._scale
-        target_canvas_pixels = self._target_length
         # convert desired length to world size
-        target_world_pixels = scale_canvas2world * target_canvas_pixels
+        target_world_pixels = scale * target_canvas_length
 
         # If length is set, use that value to calculate the scale bar length
         if self.overlay.length is not None:
-            target_canvas_pixels = self.overlay.length / scale_canvas2world
-            new_dim = self.overlay.length * self._unit.units
+            canvas_length = self.overlay.length / scale
+            dim_with_unit = self.overlay.length * self._unit.units
         else:
             # calculate the desired length as well as update the value and units
-            target_world_pixels_rounded, new_dim = self._calculate_best_length(
-                target_world_pixels
+            target_world_pixels_rounded, dim_with_unit = (
+                self._calculate_best_length(target_world_pixels)
             )
-            target_canvas_pixels = (
-                target_world_pixels_rounded / scale_canvas2world
-            )
+            canvas_length = target_world_pixels_rounded / scale
 
-        self._current_length = target_canvas_pixels
+        self._canvas_length = canvas_length
+        self._scale = scale
 
         # Update scalebar and text
-        self.node.text.text = f'{new_dim:g~#P}'
+        self.node.text.text = f'{dim_with_unit:g~#P}'
         self._on_rendering_change()
 
     def _on_rendering_change(self):
@@ -178,7 +179,7 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             color = self._get_fgcolor()
 
         width, height = self.node.set_data(
-            length=self._current_length,
+            length=self._canvas_length,
             color=color,
             ticks=self.overlay.ticks,
             font_size=self.overlay.font_size,

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -137,9 +137,15 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
     def _on_size_or_zoom_change(self, *, force: bool = False):
         """Update length based on scale bar size and zoom."""
 
-        # If scale or canvas size has not changed, do not redraw
         scale = 1 / self.viewer.scene.camera.zoom
-        target_canvas_length = self.viewer.canvas.size[1] / 6
+
+        if self.overlay.gridded:
+            ref_length = self.viewer.canvas.viewbox_size(self.viewer.layers)[0]
+        else:
+            ref_length = self.viewer.canvas.size[0]
+        target_canvas_length = ref_length / 5
+
+        # If scale or canvas size has not changed, do not redraw
         if (
             abs(np.log10(self._scale) - np.log10(scale)) < 1e-4
             and target_canvas_length == self._canvas_length

--- a/src/napari/_vispy/visuals/scale_bar.py
+++ b/src/napari/_vispy/visuals/scale_bar.py
@@ -15,18 +15,12 @@ class ScaleBar(Compound):
     """Scale bar visual with text and line components.
 
     Layout of Scale Bar Elements (from top to bottom):
-    - Padding
     - Text
     - Gap between text and line
     - Scale line (with optional ticks)
-    - Padding
     """
 
     def __init__(self, font_info: FontInfo) -> None:
-        # Layout constants
-        self.PADDING = 6  # Space around the entire scale bar
-        self.TICK_LENGTH = 11  # Height of tick marks (odd numbers look better)
-
         # Line geometry: main line + optional tick marks
         self._line_data = np.array(
             [
@@ -49,13 +43,13 @@ class ScaleBar(Compound):
             font_size=10,
             font_info=font_info,
         )
-        self.line = Line(
-            connect='segments', method='gl', width=3, antialias=True
-        )
+        self.line = Line(connect='segments', method='gl', antialias=True)
         # order matters (last is drawn on top)
         super().__init__([self.text, self.line])
 
-    def _calculate_layout(self, length: float) -> dict:
+    def _calculate_layout(
+        self, length: float, tick_length: float, thickness: float
+    ) -> dict:
         """Calculate all layout dimensions and positions."""
         # Text dimensions
         text_width, text_height = self.text.get_width_height()
@@ -65,12 +59,12 @@ class ScaleBar(Compound):
         text_height = np.ceil(text_height)
 
         width = max(
-            length + self.line.width,
+            length + thickness,
             text_width,
         )
-        height = text_height + self.TICK_LENGTH
+        height = text_height + tick_length + thickness
 
-        line_center_y = text_height + (self.TICK_LENGTH / 2)
+        line_center_y = text_height + (tick_length / 2)
 
         return {
             'width': width,
@@ -78,23 +72,21 @@ class ScaleBar(Compound):
             'line_center_y': line_center_y,
         }
 
-    def set_data(self, *, length, color, ticks, font_size):
+    def set_data(self, *, length, tick_length, thickness, font_size, color):
         """Update scale bar with new dimensions and styling."""
         # font size need to be set first cause layout calculations depend on it
         self.text.font_size = font_size
 
-        layout = self._calculate_layout(length)
-
-        # Choose line data based on whether ticks are enabled
-        line_data = self._line_data if ticks else self._line_data[:2]
+        layout = self._calculate_layout(length, tick_length, thickness)
 
         # Position and scale the line
         self.line.set_data(
-            pos=line_data * (length / 2, self.TICK_LENGTH / 2)
+            pos=self._line_data * (length / 2, tick_length / 2)
             + (
                 layout['width'] / 2,  # Center horizontally
                 layout['line_center_y'],  # Position vertically
             ),
+            width=thickness,
             color=color,
         )
 
@@ -103,5 +95,4 @@ class ScaleBar(Compound):
         self.text.color = color
 
         # Return dimensions for the overlay system
-        # Extra padding needed for proper canvas positioning (not sure why padding is needed here, ugh)
         return layout['width'], layout['height']

--- a/src/napari/_vispy/visuals/scale_bar.py
+++ b/src/napari/_vispy/visuals/scale_bar.py
@@ -50,7 +50,13 @@ class ScaleBar(Compound):
     def _calculate_layout(
         self, length: float, tick_length: float, thickness: float
     ) -> dict:
-        """Calculate all layout dimensions and positions."""
+        """Calculate all layout dimensions and positions.
+
+            text
+        |          |
+        |----------|
+        |          |
+        """
         # Text dimensions
         text_width, text_height = self.text.get_width_height()
 
@@ -62,14 +68,18 @@ class ScaleBar(Compound):
             length + thickness,
             text_width,
         )
-        height = text_height + tick_length + thickness
-
-        line_center_y = text_height + (tick_length / 2)
+        # padding below the text to ensure space from the line, if the ticks+thickness
+        # are not enough to push the text higher (e.g: if ticks have 0 length)
+        text_padding = text_height * 0.2
+        tick_padding = (tick_length + thickness) / 2
+        # from the top!
+        line_y = text_height + max(tick_padding, text_padding)
+        height = line_y + tick_padding
 
         return {
             'width': width,
             'height': height,
-            'line_center_y': line_center_y,
+            'line_y': line_y,
         }
 
     def set_data(self, *, length, tick_length, thickness, font_size, color):
@@ -84,7 +94,7 @@ class ScaleBar(Compound):
             pos=self._line_data * (length / 2, tick_length / 2)
             + (
                 layout['width'] / 2,  # Center horizontally
-                layout['line_center_y'],  # Position vertically
+                layout['line_y'],  # Position vertically
             ),
             width=thickness,
             color=color,


### PR DESCRIPTION
# References and relevant issues
- depends on #9474

# Description
As discussed in #9474, this adds a public API to set how much of the canvas width the scale bar should target with its automatic resizing.

Only actual changes here are a few lines: [relative diff](https://github.com/brisvag/napari/compare/feature%2Frescaling-bar...feature%2Fset-rescaling-bar-size).
